### PR TITLE
[FLINK-33434][runtime-web] Support invoke async-profiler on TaskManager via REST API

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.html
@@ -37,30 +37,12 @@
             nz-button
             nzType="primary"
             [nzLoading]="isCreating"
-            [disabled]="!isEnabled"
+            [disabled]="duration === null || !isEnabled"
             (click)="createProfilingInstance()"
             style="margin-left: 10px"
           >
             Create Profiling Instance
           </button>
-          <i
-            class="header-icon"
-            style="margin-left: 10px"
-            nz-icon
-            nz-tooltip
-            [nzTooltipTitle]="titleTemplate"
-            nzTooltipTitle=""
-            nzType="info-circle"
-          ></i>
-          <ng-template #titleTemplate>
-            <span>
-              Please refer to
-              <a href="https://github.com/async-profiler/async-profiler/wiki">
-                async-profiler's wiki
-              </a>
-              for more detailed info of this feature.
-            </span>
-          </ng-template>
         </nz-form-control>
       </nz-form-item>
     </form>
@@ -69,7 +51,7 @@
       nzType="warning"
       style="margin-top: 10px"
       nzShowIcon
-      nzMessage="Please set the config `rest.profiling.enabled: true` to enable this experimental profiler feature."
+      nzMessage="You need to set the config `rest.profiler.enabled: true` to enable this experimental profiler feature."
     ></nz-alert>
   </div>
   <nz-table

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.less
@@ -16,16 +16,28 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.taskexecutor;
+@import "theme";
 
-/** Different file types to request from the {@link TaskExecutor}. */
-public enum FileType {
-    /** The log file type for taskmanager. */
-    LOG,
+:host {
+  display: flex;
+  flex: 1;
 
-    /** The stdout file type for taskmanager. */
-    STDOUT,
+  ::ng-deep {
+    .ant-table-cell {
+      font-size: @font-size-sm;
+    }
 
-    /** The profiler file type for taskmanager. */
-    PROFILER,
+    ::-webkit-scrollbar {
+      display: none;
+    }
+
+    nz-table,
+    nz-spin,
+    cdk-virtual-scroll-viewport,
+    nz-table-inner-scroll,
+    .ant-spin-container,
+    .ant-table {
+      height: 100%;
+    }
+  }
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.ts
@@ -1,0 +1,153 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { Subject } from 'rxjs';
+import { mergeMap, startWith, takeUntil } from 'rxjs/operators';
+
+import {
+  HumanizeWatermarkPipe,
+  HumanizeWatermarkToDatetimePipe
+} from '@flink-runtime-web/components/humanize-watermark.pipe';
+import { ProfilingDetail } from '@flink-runtime-web/interfaces/job-profiler';
+import { StatusService, TaskManagerService } from '@flink-runtime-web/services';
+import { NzAlertModule } from 'ng-zorro-antd/alert';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { NzFormModule } from 'ng-zorro-antd/form';
+import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
+import { NzMessageModule, NzMessageService } from 'ng-zorro-antd/message';
+import { NzSelectModule } from 'ng-zorro-antd/select';
+import { NzSpaceModule } from 'ng-zorro-antd/space';
+import { NzTableModule } from 'ng-zorro-antd/table';
+
+@Component({
+  selector: 'flink-task-manager-profiler',
+  templateUrl: './task-manager-profiler.component.html',
+  styleUrls: ['./task-manager-profiler.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    NzCardModule,
+    NzFormModule,
+    NzInputNumberModule,
+    HumanizeWatermarkPipe,
+    FormsModule,
+    NzButtonModule,
+    NzAlertModule,
+    NzTableModule,
+    NzMessageModule,
+    CommonModule,
+    NzSpaceModule,
+    HumanizeWatermarkToDatetimePipe,
+    NzSelectModule
+  ],
+  standalone: true
+})
+export class TaskManagerProfilerComponent implements OnInit, OnDestroy {
+  private readonly destroy$ = new Subject<void>();
+  profilingList: ProfilingDetail[] = [];
+  isLoading = true;
+  isCreating = false;
+  duration = 30;
+  selectMode = 'CPU';
+  isEnabled = false;
+  formatterDuration = (value: number): string => `${value} s`;
+  parserDuration = (value: string): string => value.replace(' s', '');
+
+  constructor(
+    private taskManagerService: TaskManagerService,
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly statusService: StatusService,
+    private message: NzMessageService,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  public createProfilingInstance(): void {
+    if (this.profilingList.length > 0 && this.profilingList[0].status === 'RUNNING') {
+      this.message.warning('Please wait for last profiling finished.');
+      return;
+    }
+    this.isCreating = true;
+    const taskManagerId = this.activatedRoute.parent!.snapshot.params.taskManagerId;
+    this.taskManagerService.createProfilingInstance(taskManagerId, this.selectMode, this.duration).subscribe({
+      next: profilingDetail => {
+        this.profilingList.unshift(profilingDetail);
+        this.isCreating = false;
+        this.cdr.markForCheck();
+      },
+      error: () => {
+        this.isCreating = false;
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  public ngOnInit(): void {
+    const taskManagerId = this.activatedRoute.parent!.snapshot.params.taskManagerId;
+    this.statusService.refresh$
+      .pipe(
+        startWith(true),
+        mergeMap(() => {
+          this.isLoading = true;
+          this.cdr.markForCheck();
+          return this.taskManagerService.loadProfilingList(taskManagerId);
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe({
+        next: data => {
+          this.profilingList = data.profilingList;
+          this.isLoading = false;
+          this.isEnabled = true;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.isLoading = false;
+          this.destroy$.next();
+          this.destroy$.complete();
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  public downloadProfilingResult(filePath: string): void {
+    const taskManagerId = this.activatedRoute.parent!.snapshot.params.taskManagerId;
+    this.isLoading = true;
+    this.cdr.markForCheck();
+
+    this.taskManagerService.loadProfilingResult(taskManagerId, filePath).subscribe({
+      next: data => {
+        const anchor = document.createElement('a');
+        anchor.href = data.url;
+        anchor.download = data.url;
+        document.body.appendChild(anchor);
+        anchor.click();
+      },
+      complete: () => {
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      }
+    });
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/routes.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/routes.ts
@@ -55,6 +55,14 @@ export const TASK_MANAGER_ROUTES: Routes = [
         }
       },
       {
+        path: 'profiler',
+        loadComponent: () =>
+          import('./profiler/task-manager-profiler.component').then(m => m.TaskManagerProfilerComponent),
+        data: {
+          path: 'profiler'
+        }
+      },
+      {
         path: 'log-list/:logName',
         loadComponent: () =>
           import('./log-detail/task-manager-log-detail.component').then(m => m.TaskManagerLogDetailComponent),

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/status/task-manager-status.component.ts
@@ -52,7 +52,8 @@ export class TaskManagerStatusComponent implements OnInit, OnDestroy {
     { path: 'logs', title: 'Logs' },
     { path: 'stdout', title: 'Stdout' },
     { path: 'log-list', title: 'Log List' },
-    { path: 'thread-dump', title: 'Thread Dump' }
+    { path: 'thread-dump', title: 'Thread Dump' },
+    { path: 'profiler', title: 'Profiler' }
   ];
   public taskManagerDetail?: TaskManagerDetail;
   public loading = true;

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
@@ -31,6 +31,7 @@ import {
   TaskManagersItem,
   TaskManagerThreadDump
 } from '@flink-runtime-web/interfaces';
+import { ProfilingDetail, ProfilingList } from '@flink-runtime-web/interfaces/job-profiler';
 
 import { ConfigService } from './config.service';
 
@@ -118,5 +119,31 @@ export class TaskManagerService {
     return this.httpClient
       .get<{ url: string }>(`${this.configService.BASE_URL}/jobs/${jobId}/taskmanagers/${taskManagerId}/log-url`)
       .pipe(map(data => data.url));
+  }
+
+  loadProfilingList(taskManagerId: string): Observable<ProfilingList> {
+    return this.httpClient.get<ProfilingList>(`${this.configService.BASE_URL}/taskmanagers/${taskManagerId}/profiler`);
+  }
+
+  createProfilingInstance(taskManagerId: string, mode: string, duration: number): Observable<ProfilingDetail> {
+    const requestParam = { mode, duration };
+    return this.httpClient.post<ProfilingDetail>(
+      `${this.configService.BASE_URL}/taskmanagers/${taskManagerId}/profiler`,
+      requestParam
+    );
+  }
+
+  loadProfilingResult(taskManagerId: string, filePath: string): Observable<Record<string, string>> {
+    const url = `${this.configService.BASE_URL}/taskmanagers/${taskManagerId}/profiler/${filePath}`;
+    return this.httpClient
+      .get(url, { responseType: 'text', headers: new HttpHeaders().append('Cache-Control', 'no-cache') })
+      .pipe(
+        map(data => {
+          return {
+            data,
+            url
+          };
+        })
+      );
   }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -37,6 +37,8 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.rest.messages.LogInfo;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo.ProfilingMode;
 import org.apache.flink.runtime.rest.messages.ThreadDumpInfo;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rpc.FencedRpcGateway;
@@ -288,4 +290,30 @@ public interface ResourceManagerGateway
      */
     CompletableFuture<TaskExecutorThreadInfoGateway> requestTaskExecutorThreadInfoGateway(
             ResourceID taskManagerId, @RpcTimeout Time timeout);
+
+    /**
+     * Request profiling list from the given {@link TaskExecutor}.
+     *
+     * @param taskManagerId identifying the {@link TaskExecutor} to get profiling list from
+     * @param timeout for the asynchronous operation
+     * @return Future which is completed with the historical profiling list
+     */
+    CompletableFuture<Collection<ProfilingInfo>> requestTaskManagerProfilingList(
+            ResourceID taskManagerId, @RpcTimeout Duration timeout);
+
+    /**
+     * Requests the profiling instance from the given {@link TaskExecutor}.
+     *
+     * @param taskManagerId taskManagerId identifying the {@link TaskExecutor} to get the profiling
+     *     from
+     * @param duration profiling duration
+     * @param mode profiling mode {@link ProfilingMode}
+     * @param timeout timeout of the asynchronous operation
+     * @return Future containing the created profiling information
+     */
+    CompletableFuture<ProfilingInfo> requestProfiling(
+            ResourceID taskManagerId,
+            int duration,
+            ProfilingInfo.ProfilingMode mode,
+            @RpcTimeout Duration timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorThreadInfoGateway;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
@@ -225,16 +226,38 @@ public interface ResourceManagerGateway
 
     /**
      * Request the file upload from the given {@link TaskExecutor} to the cluster's {@link
-     * BlobServer}. The corresponding {@link TransientBlobKey} is returned.
+     * BlobServer}. The corresponding {@link TransientBlobKey} is returned. To support different
+     * type file upload with name, using {@link
+     * ResourceManager#requestTaskManagerFileUploadByNameAndType} as instead.
      *
      * @param taskManagerId identifying the {@link TaskExecutor} to upload the specified file
      * @param fileName name of the file to upload
      * @param timeout for the asynchronous operation
      * @return Future which is completed with the {@link TransientBlobKey} after uploading the file
      *     to the {@link BlobServer}.
+     * @deprecated use {@link #requestTaskManagerFileUploadByNameAndType(ResourceID, String,
+     *     FileType, Duration)} as instead.
      */
+    @Deprecated
     CompletableFuture<TransientBlobKey> requestTaskManagerFileUploadByName(
             ResourceID taskManagerId, String fileName, @RpcTimeout Time timeout);
+
+    /**
+     * Request the file upload from the given {@link TaskExecutor} to the cluster's {@link
+     * BlobServer}. The corresponding {@link TransientBlobKey} is returned.
+     *
+     * @param taskManagerId identifying the {@link TaskExecutor} to upload the specified file
+     * @param fileName name of the file to upload
+     * @param fileType type of the file to upload
+     * @param timeout for the asynchronous operation
+     * @return Future which is completed with the {@link TransientBlobKey} after uploading the file
+     *     to the {@link BlobServer}.
+     */
+    CompletableFuture<TransientBlobKey> requestTaskManagerFileUploadByNameAndType(
+            ResourceID taskManagerId,
+            String fileName,
+            FileType fileType,
+            @RpcTimeout Duration timeout);
 
     /**
      * Request log list from the given {@link TaskExecutor}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/LeaderRetrievalHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/LeaderRetrievalHandler.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.time.Duration;
 import java.util.Map;
 
 /**
@@ -65,6 +66,10 @@ public abstract class LeaderRetrievalHandler<T extends RestfulGateway>
         this.leaderRetriever = Preconditions.checkNotNull(leaderRetriever);
         this.timeout = Preconditions.checkNotNull(timeout);
         this.responseHeaders = Preconditions.checkNotNull(responseHeaders);
+    }
+
+    protected Duration getTimeout() {
+        return Duration.ofMillis(timeout.toMilliseconds());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerCustomLogHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerCustomLogHandler.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.LogFileNamePathParameter;
 import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerFileMessageParameters;
+import org.apache.flink.runtime.taskexecutor.FileType;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
@@ -67,8 +68,11 @@ public class TaskManagerCustomLogHandler
     protected CompletableFuture<TransientBlobKey> requestFileUpload(
             ResourceManagerGateway resourceManagerGateway,
             Tuple2<ResourceID, String> taskManagerIdAndFileName) {
-        return resourceManagerGateway.requestTaskManagerFileUploadByName(
-                taskManagerIdAndFileName.f0, taskManagerIdAndFileName.f1, timeout);
+        return resourceManagerGateway.requestTaskManagerFileUploadByNameAndType(
+                taskManagerIdAndFileName.f0,
+                taskManagerIdAndFileName.f1,
+                FileType.LOG,
+                getTimeout());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingFileHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingFileHandler.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.taskmanager;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.blob.TransientBlobKey;
+import org.apache.flink.runtime.blob.TransientBlobService;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.ProfilingFileNamePathParameter;
+import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerProfilingFileMessageParameters;
+import org.apache.flink.runtime.taskexecutor.FileType;
+import org.apache.flink.runtime.taskexecutor.TaskExecutor;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Rest handler which serves the profiling result file of the {@link TaskExecutor}. */
+public class TaskManagerProfilingFileHandler
+        extends AbstractTaskManagerFileHandler<TaskManagerProfilingFileMessageParameters> {
+
+    public TaskManagerProfilingFileHandler(
+            @Nonnull GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+            @Nonnull Time timeout,
+            @Nonnull Map<String, String> responseHeaders,
+            @Nonnull
+                    UntypedResponseMessageHeaders<
+                                    EmptyRequestBody, TaskManagerProfilingFileMessageParameters>
+                            untypedResponseMessageHeaders,
+            @Nonnull GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            @Nonnull TransientBlobService transientBlobService,
+            @Nonnull Time cacheEntryDuration) {
+        super(
+                leaderRetriever,
+                timeout,
+                responseHeaders,
+                untypedResponseMessageHeaders,
+                resourceManagerGatewayRetriever,
+                transientBlobService,
+                cacheEntryDuration);
+    }
+
+    @Override
+    protected CompletableFuture<TransientBlobKey> requestFileUpload(
+            ResourceManagerGateway resourceManagerGateway,
+            Tuple2<ResourceID, String> taskManagerIdAndFileName) {
+        return resourceManagerGateway.requestTaskManagerFileUploadByNameAndType(
+                taskManagerIdAndFileName.f0,
+                taskManagerIdAndFileName.f1,
+                FileType.PROFILER,
+                getTimeout());
+    }
+
+    @Override
+    protected String getFileName(HandlerRequest<EmptyRequestBody> handlerRequest) {
+        return handlerRequest.getPathParameter(ProfilingFileNamePathParameter.class);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingHandler.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.taskmanager;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.resourcemanager.AbstractResourceManagerHandler;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
+import org.apache.flink.runtime.rest.messages.cluster.ProfilingRequestBody;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMessageParameters;
+import org.apache.flink.runtime.taskexecutor.TaskExecutor;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Rest handler which serves the profiling service from a {@link TaskExecutor}. */
+public class TaskManagerProfilingHandler
+        extends AbstractResourceManagerHandler<
+                RestfulGateway, ProfilingRequestBody, ProfilingInfo, TaskManagerMessageParameters> {
+    private final long maxDurationInSeconds;
+
+    public TaskManagerProfilingHandler(
+            GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+            Time timeout,
+            Map<String, String> responseHeaders,
+            MessageHeaders<ProfilingRequestBody, ProfilingInfo, TaskManagerMessageParameters>
+                    messageHeaders,
+            GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+            final Configuration configuration) {
+        super(
+                leaderRetriever,
+                timeout,
+                responseHeaders,
+                messageHeaders,
+                resourceManagerGatewayRetriever);
+        this.maxDurationInSeconds =
+                configuration.get(RestOptions.MAX_PROFILING_DURATION).getSeconds();
+    }
+
+    @Override
+    protected CompletableFuture<ProfilingInfo> handleRequest(
+            @Nonnull HandlerRequest<ProfilingRequestBody> request,
+            @Nonnull ResourceManagerGateway gateway)
+            throws RestHandlerException {
+        ProfilingRequestBody profilingRequest = request.getRequestBody();
+        int duration = profilingRequest.getDuration();
+        if (duration <= 0 || duration > maxDurationInSeconds) {
+            return FutureUtils.completedExceptionally(
+                    new IllegalArgumentException(
+                            String.format(
+                                    "`duration` must be set between (0s, %ds].",
+                                    maxDurationInSeconds)));
+        }
+        final ResourceID taskManagerId = request.getPathParameter(TaskManagerIdPathParameter.class);
+        return gateway.requestProfiling(
+                taskManagerId, duration, profilingRequest.getMode(), getTimeout());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingListHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingListHandler.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.taskmanager;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.resourcemanager.AbstractResourceManagerHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
+import org.apache.flink.runtime.rest.messages.ProfilingInfoList;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMessageParameters;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/** Handler which serves detailed TaskManager profiling list information. */
+public class TaskManagerProfilingListHandler
+        extends AbstractResourceManagerHandler<
+                RestfulGateway, EmptyRequestBody, ProfilingInfoList, TaskManagerMessageParameters> {
+
+    private final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
+
+    public TaskManagerProfilingListHandler(
+            GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+            Time timeout,
+            Map<String, String> responseHeaders,
+            MessageHeaders<EmptyRequestBody, ProfilingInfoList, TaskManagerMessageParameters>
+                    messageHeaders,
+            GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever) {
+        super(
+                leaderRetriever,
+                timeout,
+                responseHeaders,
+                messageHeaders,
+                resourceManagerGatewayRetriever);
+
+        this.resourceManagerGatewayRetriever =
+                Preconditions.checkNotNull(resourceManagerGatewayRetriever);
+    }
+
+    @Override
+    protected CompletableFuture<ProfilingInfoList> handleRequest(
+            @Nonnull HandlerRequest<EmptyRequestBody> request,
+            @Nonnull ResourceManagerGateway gateway)
+            throws RestHandlerException {
+        final ResourceID taskManagerId = request.getPathParameter(TaskManagerIdPathParameter.class);
+        final ResourceManagerGateway resourceManagerGateway =
+                getResourceManagerGateway(resourceManagerGatewayRetriever);
+        final CompletableFuture<Collection<ProfilingInfo>> profilingListFuture =
+                resourceManagerGateway.requestTaskManagerProfilingList(taskManagerId, getTimeout());
+
+        return profilingListFuture
+                .thenApply(ProfilingInfoList::new)
+                .exceptionally(
+                        (throwable) -> {
+                            final Throwable strippedThrowable =
+                                    ExceptionUtils.stripCompletionException(throwable);
+                            if (strippedThrowable instanceof UnknownTaskExecutorException) {
+                                throw new CompletionException(
+                                        new RestHandlerException(
+                                                "Could not find TaskExecutor " + taskManagerId,
+                                                HttpResponseStatus.NOT_FOUND,
+                                                strippedThrowable));
+                            } else {
+                                throw new CompletionException(throwable);
+                            }
+                        });
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerProfilingFileHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerProfilingFileHeaders.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerProfilingFileHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.LogFileNamePathParameter;
+import org.apache.flink.runtime.rest.messages.RuntimeUntypedResponseMessageHeaders;
+
+/** Headers for the {@link TaskManagerProfilingFileHandler}. */
+public class TaskManagerProfilingFileHeaders
+        implements RuntimeUntypedResponseMessageHeaders<
+                EmptyRequestBody, TaskManagerProfilingFileMessageParameters> {
+
+    private static final TaskManagerProfilingFileHeaders INSTANCE =
+            new TaskManagerProfilingFileHeaders();
+
+    private static final String URL =
+            String.format(
+                    "/taskmanagers/:%s/profiler/:%s",
+                    TaskManagerIdPathParameter.KEY, LogFileNamePathParameter.KEY);
+
+    @Override
+    public Class<EmptyRequestBody> getRequestClass() {
+        return EmptyRequestBody.class;
+    }
+
+    @Override
+    public TaskManagerProfilingFileMessageParameters getUnresolvedMessageParameters() {
+        return new TaskManagerProfilingFileMessageParameters();
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.GET;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    public static TaskManagerProfilingFileHeaders getInstance() {
+        return INSTANCE;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerProfilingFileMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerProfilingFileMessageParameters.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerProfilingFileHandler;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.ProfilingFileNamePathParameter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/** Parameters for {@link TaskManagerProfilingFileHandler}. */
+public class TaskManagerProfilingFileMessageParameters extends TaskManagerMessageParameters {
+
+    public final ProfilingFileNamePathParameter profilingFileNamePathParameter =
+            new ProfilingFileNamePathParameter();
+
+    @Override
+    public Collection<MessagePathParameter<?>> getPathParameters() {
+        return Collections.unmodifiableCollection(
+                Arrays.asList(profilingFileNamePathParameter, taskManagerIdParameter));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerProfilingHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerProfilingHeaders.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerProfilingHandler;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
+import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+import org.apache.flink.runtime.rest.messages.cluster.ProfilingRequestBody;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/** Headers for the {@link TaskManagerProfilingHandler}. */
+public class TaskManagerProfilingHeaders
+        implements RuntimeMessageHeaders<
+                ProfilingRequestBody, ProfilingInfo, TaskManagerMessageParameters> {
+
+    private static final TaskManagerProfilingHeaders INSTANCE = new TaskManagerProfilingHeaders();
+
+    private static final String URL =
+            String.format("/taskmanagers/:%s/profiler", TaskManagerIdPathParameter.KEY);
+
+    private TaskManagerProfilingHeaders() {}
+
+    @Override
+    public Class<ProfilingRequestBody> getRequestClass() {
+        return ProfilingRequestBody.class;
+    }
+
+    @Override
+    public TaskManagerMessageParameters getUnresolvedMessageParameters() {
+        return new TaskManagerMessageParameters();
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.POST;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    public static TaskManagerProfilingHeaders getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Class<ProfilingInfo> getResponseClass() {
+        return ProfilingInfo.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Returns the profiling instance of the requested TaskManager.";
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerProfilingListHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerProfilingListHeaders.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerProfilingListHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.ProfilingInfoList;
+import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/** Headers for the {@link TaskManagerProfilingListHandler}. */
+public class TaskManagerProfilingListHeaders
+        implements RuntimeMessageHeaders<
+                EmptyRequestBody, ProfilingInfoList, TaskManagerMessageParameters> {
+
+    private static final TaskManagerProfilingListHeaders INSTANCE =
+            new TaskManagerProfilingListHeaders();
+
+    private static final String URL =
+            String.format("/taskmanagers/:%s/profiler", TaskManagerIdPathParameter.KEY);
+
+    private TaskManagerProfilingListHeaders() {}
+
+    public static TaskManagerProfilingListHeaders getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Class<ProfilingInfoList> getResponseClass() {
+        return ProfilingInfoList.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Returns the list of profiling result files on a TaskManager.";
+    }
+
+    @Override
+    public Class<EmptyRequestBody> getRequestClass() {
+        return EmptyRequestBody.class;
+    }
+
+    @Override
+    public TaskManagerMessageParameters getUnresolvedMessageParameters() {
+        return new TaskManagerMessageParameters();
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.GET;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1291,14 +1291,27 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<TransientBlobKey> requestFileUploadByName(
-            String fileName, Time timeout) {
+            String fileName, Duration timeout) {
+        return requestFileUploadByNameAndType(fileName, FileType.LOG, timeout);
+    }
+
+    @Override
+    public CompletableFuture<TransientBlobKey> requestFileUploadByNameAndType(
+            String fileName, FileType fileType, Duration timeout) {
         final String filePath;
-        final String logDir = taskManagerConfiguration.getTaskManagerLogDir();
-        if (StringUtils.isNullOrWhitespaceOnly(logDir)
+        final String baseDir;
+        switch (fileType) {
+            case LOG:
+                baseDir = taskManagerConfiguration.getTaskManagerLogDir();
+                break;
+            default:
+                baseDir = null;
+        }
+        if (StringUtils.isNullOrWhitespaceOnly(baseDir)
                 || StringUtils.isNullOrWhitespaceOnly(fileName)) {
             filePath = null;
         } else {
-            filePath = new File(logDir, new File(fileName).getName()).getPath();
+            filePath = new File(baseDir, new File(fileName).getName()).getPath();
         }
         return requestFileUploadByFilePath(filePath, fileName);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -92,6 +92,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
 import org.apache.flink.runtime.rest.messages.LogInfo;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
 import org.apache.flink.runtime.rest.messages.ThreadDumpInfo;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
@@ -134,6 +135,7 @@ import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
 import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.util.GroupCache;
+import org.apache.flink.runtime.util.profiler.ProfilingService;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
 import org.apache.flink.types.SerializableOptional;
 import org.apache.flink.util.CollectionUtil;
@@ -305,6 +307,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     private final GroupCache<JobID, PermanentBlobKey, ShuffleDescriptorGroup>
             shuffleDescriptorsCache;
 
+    private final ProfilingService profilingService;
+
     public TaskExecutor(
             RpcService rpcService,
             TaskManagerConfiguration taskManagerConfiguration,
@@ -375,6 +379,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         ScheduledExecutorService sampleExecutor =
                 Executors.newSingleThreadScheduledExecutor(sampleThreadFactory);
         this.threadInfoSampleService = new ThreadInfoSampleService(sampleExecutor);
+        this.profilingService =
+                ProfilingService.getInstance(taskManagerConfiguration.getConfiguration());
 
         this.slotAllocationSnapshotPersistenceService =
                 taskExecutorServices.getSlotAllocationSnapshotPersistenceService();
@@ -1304,6 +1310,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             case LOG:
                 baseDir = taskManagerConfiguration.getTaskManagerLogDir();
                 break;
+            case PROFILER:
+                baseDir = profilingService.getProfilingResultDir();
+                break;
             default:
                 baseDir = null;
         }
@@ -1409,6 +1418,18 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             ExceptionUtils.rethrowIfFatalError(t);
             return FutureUtils.completedExceptionally(t);
         }
+    }
+
+    @Override
+    public CompletableFuture<ProfilingInfo> requestProfiling(
+            int duration, ProfilingInfo.ProfilingMode mode, Duration timeout) {
+        return profilingService.requestProfiling(
+                getResourceID().getResourceIdString(), duration, mode);
+    }
+
+    @Override
+    public CompletableFuture<Collection<ProfilingInfo>> requestProfilingList(Duration timeout) {
+        return profilingService.getProfilingList(getResourceID().getResourceIdString());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.types.SerializableOptional;
 import org.apache.flink.util.SerializedValue;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -255,7 +256,19 @@ public interface TaskExecutorGateway
      * @return Future which is completed with the {@link TransientBlobKey} of the uploaded file.
      */
     CompletableFuture<TransientBlobKey> requestFileUploadByName(
-            String fileName, @RpcTimeout Time timeout);
+            String fileName, @RpcTimeout Duration timeout);
+
+    /**
+     * Requests the file upload of the specified name and file type to the cluster's {@link
+     * BlobServer}.
+     *
+     * @param fileName to upload
+     * @param fileType to upload
+     * @param timeout for the asynchronous operation
+     * @return Future which is completed with the {@link TransientBlobKey} of the uploaded file.
+     */
+    CompletableFuture<TransientBlobKey> requestFileUploadByNameAndType(
+            String fileName, FileType fileType, @RpcTimeout Duration timeout);
 
     /**
      * Returns the gateway of Metric Query Service on the TaskManager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.messages.LogInfo;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
 import org.apache.flink.runtime.rest.messages.ThreadDumpInfo;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
@@ -314,4 +315,22 @@ public interface TaskExecutorGateway
      */
     CompletableFuture<Acknowledge> updateDelegationTokens(
             ResourceManagerId resourceManagerId, byte[] tokens);
+
+    /**
+     * Requests the profiling from this TaskManager.
+     *
+     * @param duration profiling duration
+     * @param mode profiling mode {@link ProfilingInfo.ProfilingMode}
+     * @param timeout timeout for the asynchronous operation
+     * @return the {@link ProfilingInfo} for this TaskManager.
+     */
+    CompletableFuture<ProfilingInfo> requestProfiling(
+            int duration, ProfilingInfo.ProfilingMode mode, @RpcTimeout Duration timeout);
+
+    /**
+     * Requests for the historical profiling file names on the TaskManager.
+     *
+     * @return A Collection with all profiling instances information.
+     */
+    CompletableFuture<Collection<ProfilingInfo>> requestProfilingList(@RpcTimeout Duration timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.messages.TaskThreadInfoResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.messages.LogInfo;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
 import org.apache.flink.runtime.rest.messages.ThreadDumpInfo;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
 import org.apache.flink.types.SerializableOptional;
@@ -243,6 +244,17 @@ public class TaskExecutorGatewayDecoratorBase implements TaskExecutorGateway {
     public CompletableFuture<Acknowledge> updateDelegationTokens(
             ResourceManagerId resourceManagerId, byte[] tokens) {
         return originalGateway.updateDelegationTokens(resourceManagerId, tokens);
+    }
+
+    @Override
+    public CompletableFuture<ProfilingInfo> requestProfiling(
+            int duration, ProfilingInfo.ProfilingMode mode, Duration timeout) {
+        return originalGateway.requestProfiling(duration, mode, timeout);
+    }
+
+    @Override
+    public CompletableFuture<Collection<ProfilingInfo>> requestProfilingList(Duration timeout) {
+        return originalGateway.requestProfilingList(timeout);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGatewayDecoratorBase.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
 import org.apache.flink.types.SerializableOptional;
 import org.apache.flink.util.SerializedValue;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -201,8 +202,14 @@ public class TaskExecutorGatewayDecoratorBase implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<TransientBlobKey> requestFileUploadByName(
-            String fileName, Time timeout) {
+            String fileName, Duration timeout) {
         return originalGateway.requestFileUploadByName(fileName, timeout);
+    }
+
+    @Override
+    public CompletableFuture<TransientBlobKey> requestFileUploadByNameAndType(
+            String fileName, FileType fileType, Duration timeout) {
+        return originalGateway.requestFileUploadByNameAndType(fileName, fileType, timeout);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/profiler/ProfilingService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/profiler/ProfilingService.java
@@ -168,9 +168,10 @@ public class ProfilingService implements Closeable {
             if (!scheduledExecutor.isShutdown()) {
                 scheduledExecutor.shutdownNow();
             }
-            instance = null;
         } catch (Exception e) {
             LOG.error("Exception thrown during stopping profiling service. ", e);
+        } finally {
+            instance = null;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/profiler/ProfilingService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/profiler/ProfilingService.java
@@ -179,6 +179,10 @@ public class ProfilingService implements Closeable {
                 profilingMap.getOrDefault(resourceID, new ArrayDeque<>()));
     }
 
+    public String getProfilingResultDir() {
+        return profilingResultDir;
+    }
+
     @VisibleForTesting
     ArrayDeque<ProfilingInfo> getProfilingListForTest(String resourceID) {
         return profilingMap.getOrDefault(resourceID, new ArrayDeque<>());
@@ -192,11 +196,6 @@ public class ProfilingService implements Closeable {
     @VisibleForTesting
     ProfilingFuture getProfilingFuture() {
         return profilingFuture;
-    }
-
-    @VisibleForTesting
-    public String getProfilingResultDir() {
-        return profilingResultDir;
     }
 
     enum ProfilerConstants {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -101,6 +101,9 @@ import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerCustomLogHan
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerDetailsHandler;
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogFileHandler;
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogListHandler;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerProfilingFileHandler;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerProfilingHandler;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerProfilingListHandler;
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerStdoutFileHandler;
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerThreadDumpHandler;
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagersHandler;
@@ -152,6 +155,9 @@ import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerCustomLogHe
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogFileHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogsHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerProfilingFileHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerProfilingHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerProfilingListHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerStdoutFileHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerThreadDumpHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
@@ -964,6 +970,8 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
         handlers.add(
                 Tuple2.of(JobManagerThreadDumpHeaders.getInstance(), jobManagerThreadDumpHandler));
 
+        final Time cacheEntryDuration = Time.milliseconds(restConfiguration.getRefreshInterval());
+
         // load profiler relative handlers
         if (clusterConfiguration.get(RestOptions.ENABLE_PROFILER)) {
             final JobManagerProfilingHandler jobManagerProfilingHandler =
@@ -987,6 +995,32 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                             responseHeaders,
                             JobManagerProfilingFileHeaders.getInstance(),
                             clusterConfiguration);
+
+            final TaskManagerProfilingHandler taskManagerProfilingHandler =
+                    new TaskManagerProfilingHandler(
+                            leaderRetriever,
+                            timeout,
+                            responseHeaders,
+                            TaskManagerProfilingHeaders.getInstance(),
+                            resourceManagerRetriever,
+                            clusterConfiguration);
+
+            final TaskManagerProfilingListHandler taskManagerProfilingListHandler =
+                    new TaskManagerProfilingListHandler(
+                            leaderRetriever,
+                            timeout,
+                            responseHeaders,
+                            TaskManagerProfilingListHeaders.getInstance(),
+                            resourceManagerRetriever);
+            final TaskManagerProfilingFileHandler taskManagerProfilingFileHandler =
+                    new TaskManagerProfilingFileHandler(
+                            leaderRetriever,
+                            timeout,
+                            responseHeaders,
+                            TaskManagerProfilingFileHeaders.getInstance(),
+                            resourceManagerRetriever,
+                            transientBlobService,
+                            cacheEntryDuration);
             handlers.add(
                     Tuple2.of(
                             JobManagerProfilingHeaders.getInstance(), jobManagerProfilingHandler));
@@ -998,11 +1032,21 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                     Tuple2.of(
                             JobManagerProfilingFileHeaders.getInstance(),
                             jobManagerProfilingFileHandler));
+            handlers.add(
+                    Tuple2.of(
+                            TaskManagerProfilingHeaders.getInstance(),
+                            taskManagerProfilingHandler));
+            handlers.add(
+                    Tuple2.of(
+                            TaskManagerProfilingListHeaders.getInstance(),
+                            taskManagerProfilingListHandler));
+            handlers.add(
+                    Tuple2.of(
+                            TaskManagerProfilingFileHeaders.getInstance(),
+                            taskManagerProfilingFileHandler));
         }
 
         // TaskManager log and stdout file handler
-
-        final Time cacheEntryDuration = Time.milliseconds(restConfiguration.getRefreshInterval());
 
         final TaskManagerLogFileHandler taskManagerLogFileHandler =
                 new TaskManagerLogFileHandler(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -59,6 +59,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.QuadFunction;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -94,6 +95,10 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 
     private volatile Function<Tuple2<ResourceID, String>, CompletableFuture<TransientBlobKey>>
             requestTaskManagerFileUploadByNameFunction;
+
+    private volatile Function<
+                    Tuple3<ResourceID, String, FileType>, CompletableFuture<TransientBlobKey>>
+            requestTaskManagerFileUploadByNameAndTypeFunction;
 
     private volatile Consumer<Tuple2<ResourceID, Throwable>> disconnectTaskExecutorConsumer;
 
@@ -185,6 +190,13 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
                     requestTaskManagerFileUploadByNameFunction) {
         this.requestTaskManagerFileUploadByNameFunction =
                 requestTaskManagerFileUploadByNameFunction;
+    }
+
+    public void setRequestTaskManagerFileUploadByNameAndTypeFunction(
+            Function<Tuple3<ResourceID, String, FileType>, CompletableFuture<TransientBlobKey>>
+                    requestTaskManagerFileUploadByNameAndTypeFunction) {
+        this.requestTaskManagerFileUploadByNameAndTypeFunction =
+                requestTaskManagerFileUploadByNameAndTypeFunction;
     }
 
     public void setRequestTaskManagerLogListFunction(
@@ -436,6 +448,19 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 
         if (function != null) {
             return function.apply(Tuple2.of(taskManagerId, fileName));
+        } else {
+            return CompletableFuture.completedFuture(new TransientBlobKey());
+        }
+    }
+
+    @Override
+    public CompletableFuture<TransientBlobKey> requestTaskManagerFileUploadByNameAndType(
+            ResourceID taskManagerId, String fileName, FileType fileType, Duration timeout) {
+        final Function<Tuple3<ResourceID, String, FileType>, CompletableFuture<TransientBlobKey>>
+                function = requestTaskManagerFileUploadByNameAndTypeFunction;
+
+        if (function != null) {
+            return function.apply(Tuple3.of(taskManagerId, fileName, fileType));
         } else {
             return CompletableFuture.completedFuture(new TransientBlobKey());
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingHandlerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.taskmanager;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
+import org.apache.flink.runtime.rest.messages.cluster.ProfilingRequestBody;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMessageParameters;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerProfilingHeaders;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for the {@link TaskManagerProfilingHandler}. */
+class TaskManagerProfilingHandlerTest {
+
+    private static final ResourceID EXPECTED_TASK_MANAGER_ID = ResourceID.generate();
+    private TestingResourceManagerGateway resourceManagerGateway;
+    private TaskManagerProfilingHandler taskManagerProfilingHandler;
+    private HandlerRequest<ProfilingRequestBody> handlerRequest;
+
+    @BeforeEach
+    void setUp(@TempDir Path tempDir) throws HandlerRequestException {
+        Configuration clusterConfiguration = new Configuration();
+        clusterConfiguration.set(RestOptions.MAX_PROFILING_HISTORY_SIZE, 3);
+        clusterConfiguration.set(RestOptions.PROFILING_RESULT_DIR, tempDir.toString());
+        resourceManagerGateway = new TestingResourceManagerGateway();
+        taskManagerProfilingHandler =
+                new TaskManagerProfilingHandler(
+                        () -> CompletableFuture.completedFuture(null),
+                        TestingUtils.TIMEOUT,
+                        Collections.emptyMap(),
+                        TaskManagerProfilingHeaders.getInstance(),
+                        () -> CompletableFuture.completedFuture(resourceManagerGateway),
+                        clusterConfiguration);
+        handlerRequest = createRequest(EXPECTED_TASK_MANAGER_ID);
+    }
+
+    @Test
+    void testGetTaskManagerProfiling() throws Exception {
+        ProfilingInfo profilingInfo = ProfilingInfo.create(30, ProfilingInfo.ProfilingMode.ITIMER);
+        resourceManagerGateway.setRequestProfilingFunction(
+                EXPECTED_TASK_MANAGER_ID -> CompletableFuture.completedFuture(profilingInfo));
+        ProfilingInfo profilingInfoResp =
+                taskManagerProfilingHandler
+                        .handleRequest(handlerRequest, resourceManagerGateway)
+                        .get();
+        assertThat(profilingInfoResp).isEqualTo(profilingInfo);
+    }
+
+    @Test
+    void testGetTaskManagerProfilingForUnknownTaskExecutorException() throws Exception {
+        resourceManagerGateway.setRequestProfilingListFunction(
+                EXPECTED_TASK_MANAGER_ID ->
+                        FutureUtils.completedExceptionally(
+                                new UnknownTaskExecutorException(EXPECTED_TASK_MANAGER_ID)));
+        try {
+            taskManagerProfilingHandler.handleRequest(handlerRequest, resourceManagerGateway).get();
+        } catch (ExecutionException e) {
+            final Throwable cause = e.getCause();
+            assertThat(cause).isInstanceOf(UnknownTaskExecutorException.class);
+
+            final UnknownTaskExecutorException unknownTaskExecutorException =
+                    (UnknownTaskExecutorException) cause;
+            assertThat(unknownTaskExecutorException.getMessage())
+                    .contains("No TaskExecutor registered under " + EXPECTED_TASK_MANAGER_ID);
+        }
+    }
+
+    private static HandlerRequest<ProfilingRequestBody> createRequest(ResourceID taskManagerId)
+            throws HandlerRequestException {
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put(TaskManagerIdPathParameter.KEY, taskManagerId.toString());
+        Map<String, List<String>> queryParameters = Collections.emptyMap();
+        ProfilingRequestBody requestBody =
+                new ProfilingRequestBody(ProfilingInfo.ProfilingMode.ITIMER, 10);
+        return HandlerRequest.resolveParametersAndCreate(
+                requestBody,
+                new TaskManagerMessageParameters(),
+                pathParameters,
+                queryParameters,
+                Collections.emptyList());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingListHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerProfilingListHandlerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.taskmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
+import org.apache.flink.runtime.rest.messages.ProfilingInfoList;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMessageParameters;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerProfilingListHeaders;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for the {@link TaskManagerProfilingListHandler}. */
+class TaskManagerProfilingListHandlerTest {
+
+    private static final ResourceID EXPECTED_TASK_MANAGER_ID = ResourceID.generate();
+    private TestingResourceManagerGateway resourceManagerGateway;
+    private TaskManagerProfilingListHandler taskManagerProfilingListHandler;
+    private HandlerRequest<EmptyRequestBody> handlerRequest;
+
+    @BeforeEach
+    void setUp() throws HandlerRequestException {
+        resourceManagerGateway = new TestingResourceManagerGateway();
+        taskManagerProfilingListHandler =
+                new TaskManagerProfilingListHandler(
+                        () -> CompletableFuture.completedFuture(null),
+                        TestingUtils.TIMEOUT,
+                        Collections.emptyMap(),
+                        TaskManagerProfilingListHeaders.getInstance(),
+                        () -> CompletableFuture.completedFuture(resourceManagerGateway));
+        handlerRequest = createRequest(EXPECTED_TASK_MANAGER_ID);
+    }
+
+    @Test
+    void testGetTaskManagerProfilingList() throws Exception {
+        ProfilingInfoList profilingInfoList =
+                new ProfilingInfoList(
+                        Arrays.asList(
+                                ProfilingInfo.create(30, ProfilingInfo.ProfilingMode.ITIMER),
+                                ProfilingInfo.create(10, ProfilingInfo.ProfilingMode.CPU),
+                                ProfilingInfo.create(15, ProfilingInfo.ProfilingMode.ALLOC)));
+        resourceManagerGateway.setRequestProfilingListFunction(
+                EXPECTED_TASK_MANAGER_ID ->
+                        CompletableFuture.completedFuture(profilingInfoList.getProfilingInfos()));
+        ProfilingInfoList profilingInfoListResp =
+                taskManagerProfilingListHandler
+                        .handleRequest(handlerRequest, resourceManagerGateway)
+                        .get();
+        assertThat(profilingInfoListResp.getProfilingInfos())
+                .containsExactlyInAnyOrderElementsOf(profilingInfoList.getProfilingInfos());
+    }
+
+    @Test
+    void testGetTaskManagerProfilingListForUnknownTaskExecutorException() throws Exception {
+        resourceManagerGateway.setRequestProfilingListFunction(
+                EXPECTED_TASK_MANAGER_ID ->
+                        FutureUtils.completedExceptionally(
+                                new UnknownTaskExecutorException(EXPECTED_TASK_MANAGER_ID)));
+        try {
+            taskManagerProfilingListHandler
+                    .handleRequest(handlerRequest, resourceManagerGateway)
+                    .get();
+        } catch (ExecutionException e) {
+            final Throwable cause = e.getCause();
+            assertThat(cause).isInstanceOf(RestHandlerException.class);
+
+            final RestHandlerException restHandlerException = (RestHandlerException) cause;
+            assertThat(restHandlerException.getHttpResponseStatus())
+                    .isEqualTo(HttpResponseStatus.NOT_FOUND);
+            assertThat(restHandlerException.getMessage())
+                    .contains("Could not find TaskExecutor " + EXPECTED_TASK_MANAGER_ID);
+        }
+    }
+
+    private static HandlerRequest<EmptyRequestBody> createRequest(ResourceID taskManagerId)
+            throws HandlerRequestException {
+        Map<String, String> pathParameters = new HashMap<>();
+        pathParameters.put(TaskManagerIdPathParameter.KEY, taskManagerId.toString());
+        Map<String, List<String>> queryParameters = Collections.emptyMap();
+
+        return HandlerRequest.resolveParametersAndCreate(
+                EmptyRequestBody.getInstance(),
+                new TaskManagerMessageParameters(),
+                pathParameters,
+                queryParameters,
+                Collections.emptyList());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.messages.TaskThreadInfoResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.messages.LogInfo;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
 import org.apache.flink.runtime.rest.messages.ThreadDumpInfo;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoSamplesRequest;
 import org.apache.flink.types.SerializableOptional;
@@ -105,6 +106,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
     private final Supplier<CompletableFuture<ThreadDumpInfo>> requestThreadDumpSupplier;
 
+    private final Supplier<CompletableFuture<ProfilingInfo>> requestProfilingSupplier;
+
     private final Supplier<CompletableFuture<TaskThreadInfoResponse>>
             requestThreadInfoSamplesSupplier;
 
@@ -153,6 +156,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
                             CompletableFuture<Acknowledge>>
                     operatorEventHandler,
             Supplier<CompletableFuture<ThreadDumpInfo>> requestThreadDumpSupplier,
+            Supplier<CompletableFuture<ProfilingInfo>> requestProfilingSupplier,
             Supplier<CompletableFuture<TaskThreadInfoResponse>> requestThreadInfoSamplesSupplier,
             QuadFunction<
                             ExecutionAttemptID,
@@ -182,6 +186,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
         this.releaseClusterPartitionsConsumer = releaseClusterPartitionsConsumer;
         this.operatorEventHandler = operatorEventHandler;
         this.requestThreadDumpSupplier = requestThreadDumpSupplier;
+        this.requestProfilingSupplier = requestProfilingSupplier;
         this.requestThreadInfoSamplesSupplier = requestThreadInfoSamplesSupplier;
         this.triggerCheckpointFunction = triggerCheckpointFunction;
         this.confirmCheckpointFunction = confirmCheckpointFunction;
@@ -350,6 +355,17 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
     public CompletableFuture<Acknowledge> updateDelegationTokens(
             ResourceManagerId resourceManagerId, byte[] tokens) {
         return CompletableFuture.completedFuture(Acknowledge.get());
+    }
+
+    @Override
+    public CompletableFuture<ProfilingInfo> requestProfiling(
+            int duration, ProfilingInfo.ProfilingMode mode, Duration timeout) {
+        return requestProfilingSupplier.get();
+    }
+
+    @Override
+    public CompletableFuture<Collection<ProfilingInfo>> requestProfilingList(Duration timeout) {
+        return FutureUtils.completedExceptionally(new UnsupportedOperationException());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -49,6 +49,7 @@ import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.QuadFunction;
 import org.apache.flink.util.function.TriFunction;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -313,7 +314,13 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
     @Override
     public CompletableFuture<TransientBlobKey> requestFileUploadByName(
-            String fileName, Time timeout) {
+            String fileName, Duration timeout) {
+        return FutureUtils.completedExceptionally(new UnsupportedOperationException());
+    }
+
+    @Override
+    public CompletableFuture<TransientBlobKey> requestFileUploadByNameAndType(
+            String fileName, FileType fileType, Duration timeout) {
         return FutureUtils.completedExceptionally(new UnsupportedOperationException());
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.TaskThreadInfoResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
+import org.apache.flink.runtime.rest.messages.ProfilingInfo;
 import org.apache.flink.runtime.rest.messages.ThreadDumpInfo;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -96,6 +97,9 @@ public class TestingTaskExecutorGatewayBuilder {
                     (a, b, c) -> CompletableFuture.completedFuture(Acknowledge.get());
     private static final Supplier<CompletableFuture<ThreadDumpInfo>> DEFAULT_THREAD_DUMP_SUPPLIER =
             () -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
+
+    private static final Supplier<CompletableFuture<ProfilingInfo>> DEFAULT_PROFILING_SUPPLIER =
+            () -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
     private static final Supplier<CompletableFuture<TaskThreadInfoResponse>>
             DEFAULT_THREAD_INFO_SAMPLES_SUPPLIER =
                     () -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
@@ -151,6 +155,8 @@ public class TestingTaskExecutorGatewayBuilder {
             operatorEventHandler = DEFAULT_OPERATOR_EVENT_HANDLER;
     private Supplier<CompletableFuture<ThreadDumpInfo>> requestThreadDumpSupplier =
             DEFAULT_THREAD_DUMP_SUPPLIER;
+    private Supplier<CompletableFuture<ProfilingInfo>> requestProfilingSupplier =
+            DEFAULT_PROFILING_SUPPLIER;
 
     private Supplier<CompletableFuture<TaskThreadInfoResponse>> requestThreadInfoSamplesSupplier =
             DEFAULT_THREAD_INFO_SAMPLES_SUPPLIER;
@@ -281,6 +287,11 @@ public class TestingTaskExecutorGatewayBuilder {
         this.requestThreadDumpSupplier = requestThreadDumpSupplier;
     }
 
+    public void setRequestProfilingSupplier(
+            Supplier<CompletableFuture<ProfilingInfo>> requestProfilingSupplier) {
+        this.requestProfilingSupplier = requestProfilingSupplier;
+    }
+
     public TestingTaskExecutorGatewayBuilder setRequestThreadInfoSamplesSupplier(
             Supplier<CompletableFuture<TaskThreadInfoResponse>> requestThreadInfoSamplesSupplier) {
         this.requestThreadInfoSamplesSupplier = requestThreadInfoSamplesSupplier;
@@ -325,6 +336,7 @@ public class TestingTaskExecutorGatewayBuilder {
                 releaseClusterPartitionsConsumer,
                 operatorEventHandler,
                 requestThreadDumpSupplier,
+                requestProfilingSupplier,
                 requestThreadInfoSamplesSupplier,
                 triggerCheckpointFunction,
                 confirmCheckpointFunction);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/profiler/ProfilingServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/profiler/ProfilingServiceTest.java
@@ -113,7 +113,7 @@ public class ProfilingServiceTest extends TestLogger {
                     ProfilingInfo.ProfilingMode.ITIMER, DEFAULT_PROFILING_DURATION, true);
         }
         // Due to the configuration of MAX_PROFILING_HISTORY_SIZE=2,
-        // the profiling result directory should container no more than 2 files.
+        // the profiling result directory shouldn't contain more than 2 files.
         verifyRollingDeletionWorks();
     }
 
@@ -162,7 +162,15 @@ public class ProfilingServiceTest extends TestLogger {
         Set<String> resultFileNames = new HashSet<>();
         File configuredDir = new File(profilingService.getProfilingResultDir());
         for (File f : Objects.requireNonNull(configuredDir.listFiles())) {
-            resultFileNames.add(f.getName());
+            if (f.getName().startsWith(RESOURCE_ID)) {
+                resultFileNames.add(f.getName());
+            }
+        }
+        if (profilingList.size() != resultFileNames.size()) {
+            log.error(
+                    "Found unexpected profiling file size: profilingList={},resultFileNames={}",
+                    profilingList,
+                    resultFileNames);
         }
         Assertions.assertEquals(profilingList.size(), resultFileNames.size());
         for (ProfilingInfo profilingInfo : profilingList) {


### PR DESCRIPTION
## What is the purpose of the change

This is a subtask of [FLIP-375](https://cwiki.apache.org/confluence/x/64lEE), which introduces the async-profiler for profiling Taskmanager. 

## Brief change log
- Generalized file upload from TaskManager to support different `FileType` uploading (different `fileType` could have different `baseDir`)
- Introduce APIs for Creating Profiling Instances / Downloading Profiling Results / Retrieving Profiling List on TaskManager
- Provide a web page for profiling TaskManager on  Flink WEB

## Verifying this change

This change added tests and can be verified as follows:

Added test that validates that `TaskManagerProfilingHandler` works fine.
Added test that validates that `TaskManagerProfilingListHandler` works fine.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no** 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no** 
  - The runtime per-record code paths (performance sensitive): **no** 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no** 
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? not documented, it will be added in [FLINK-33436](https://issues.apache.org/jira/browse/FLINK-33436)
