### PR TITLE
[FLINK-34013][runtime] Remove duplicated stopProfiling() in `ProfilingService`

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/profiler/ProfilingService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/profiler/ProfilingService.java
@@ -114,8 +114,6 @@ public class ProfilingService implements Closeable {
                     profilingInfo.fail("Start profiler failed. " + e));
         }
 
-        scheduledExecutor.schedule(() -> stopProfiling(resourceID), duration, TimeUnit.SECONDS);
-
         this.profilingFuture = new ProfilingFuture(duration, () -> stopProfiling(resourceID));
         return CompletableFuture.completedFuture(profilingInfo);
     }


### PR DESCRIPTION

## What is the purpose of the change

Remove the duplicated `stopProfiling()` call in `ProfilingService` to avoid profiling instances stopped unexpectedly when repeating profiling quickly.


## Brief change log

- Remove duplicate scheduled stopProfiling task.


## Verifying this change

This change is already covered by existing tests, such as `ProfilingServiceTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
