### PR TITLE
fix: missing serialVersionUID of serializable classes

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/BufferedRequestState.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/BufferedRequestState.java
@@ -36,6 +36,7 @@ import java.util.List;
  */
 @PublicEvolving
 public class BufferedRequestState<RequestEntryT extends Serializable> implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final List<RequestEntryWrapper<RequestEntryT>> bufferedRequestEntries;
     private final long stateSize;
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSource.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSource.java
@@ -204,6 +204,7 @@ public class HybridSource<T> implements Source<T, HybridSourceSplit, HybridSourc
 
     /** Entry for list of underlying sources. */
     static class SourceListEntry implements Serializable {
+        private static final long serialVersionUID = 1L;
         protected final SourceFactory factory;
         protected final Boundedness boundedness;
 
@@ -221,6 +222,7 @@ public class HybridSource<T> implements Source<T, HybridSourceSplit, HybridSourc
     @PublicEvolving
     public static class HybridSourceBuilder<T, EnumT extends SplitEnumerator>
             implements Serializable {
+        private static final long serialVersionUID = 1L;
         private final List<SourceListEntry> sources;
 
         public HybridSourceBuilder() {

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSinkCommittable.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSinkCommittable.java
@@ -36,6 +36,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class FileSinkCommittable implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final String bucketId;
 
     @Nullable private final InProgressFileWriter.PendingFileRecoverable pendingFile;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/ConcatFileCompactor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/ConcatFileCompactor.java
@@ -37,6 +37,8 @@ import java.util.List;
 @PublicEvolving
 public class ConcatFileCompactor extends OutputStreamBasedFileCompactor {
 
+    private static final long serialVersionUID = 1L;     
+
     private static final int CHUNK_SIZE = 4 * 1024 * 1024;
 
     private final byte[] fileDelimiter;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/DecoderBasedReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/DecoderBasedReader.java
@@ -82,6 +82,8 @@ public class DecoderBasedReader<T> implements RecordWiseFileCompactor.Reader<T> 
 
     /** Factory for {@link DecoderBasedReader}. */
     public static class Factory<T> implements RecordWiseFileCompactor.Reader.Factory<T> {
+        private static final long serialVersionUID = 1L;
+        
         private final Decoder.Factory<T> decoderFactory;
 
         public Factory(Decoder.Factory<T> decoderFactory) {

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/IdenticalFileCompactor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/IdenticalFileCompactor.java
@@ -33,6 +33,8 @@ import static org.apache.flink.util.Preconditions.checkState;
 @Internal
 public class IdenticalFileCompactor extends ConcatFileCompactor {
 
+    private static final long serialVersionUID = 1L;
+
     public IdenticalFileCompactor() {
         super();
     }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/InputFormatBasedReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/InputFormatBasedReader.java
@@ -61,6 +61,8 @@ public class InputFormatBasedReader<T> implements RecordWiseFileCompactor.Reader
 
     /** Factory for {@link InputFormatBasedReader}. */
     public static class Factory<T> implements RecordWiseFileCompactor.Reader.Factory<T> {
+        private static final long serialVersionUID = 1L;
+        
         private final SerializableSupplierWithException<FileInputFormat<T>, IOException>
                 inputFormatFactory;
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/RecordWiseFileCompactor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/RecordWiseFileCompactor.java
@@ -31,6 +31,8 @@ import java.util.List;
  */
 @PublicEvolving
 public class RecordWiseFileCompactor<IN> implements FileCompactor {
+    private static final long serialVersionUID = 1L;
+    
     private final Reader.Factory<IN> readerFactory;
 
     public RecordWiseFileCompactor(Reader.Factory<IN> readerFactory) {

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/SimpleStringDecoder.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/SimpleStringDecoder.java
@@ -34,6 +34,8 @@ import java.io.InputStreamReader;
 @PublicEvolving
 public class SimpleStringDecoder implements Decoder<String> {
 
+    private static final long serialVersionUID = 1L;
+
     private BufferedReader reader;
 
     @Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinator.java
@@ -63,6 +63,8 @@ public class CompactCoordinator extends AbstractStreamOperator<CompactorRequest>
         implements OneInputStreamOperator<
                         CommittableMessage<FileSinkCommittable>, CompactorRequest>,
                 BoundedOneInput {
+    
+    private static final long serialVersionUID = 1L;
 
     static final ListStateDescriptor<byte[]> REMAINING_COMMITTABLE_RAW_STATES_DESC =
             new ListStateDescriptor<>(

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinatorFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinatorFactory.java
@@ -37,6 +37,8 @@ public class CompactCoordinatorFactory extends AbstractStreamOperatorFactory<Com
         implements OneInputStreamOperatorFactory<
                 CommittableMessage<FileSinkCommittable>, CompactorRequest> {
 
+    private static final long serialVersionUID = 1L;
+
     private final FileCompactStrategy strategy;
     private final SerializableSupplierWithException<
                     SimpleVersionedSerializer<FileSinkCommittable>, IOException>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinatorStateHandler.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinatorStateHandler.java
@@ -47,6 +47,8 @@ public class CompactCoordinatorStateHandler
                 BoundedOneInput,
                 CheckpointListener {
 
+    private static final long serialVersionUID = 1L;
+
     private final SimpleVersionedSerializer<FileSinkCommittable> committableSerializer;
 
     public CompactCoordinatorStateHandler(

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinatorStateHandlerFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinatorStateHandlerFactory.java
@@ -40,6 +40,8 @@ public class CompactCoordinatorStateHandlerFactory
                 CommittableMessage<FileSinkCommittable>,
                 Either<CommittableMessage<FileSinkCommittable>, CompactorRequest>> {
 
+    private static final long serialVersionUID = 1L;                    
+
     private final SerializableSupplierWithException<
                     SimpleVersionedSerializer<FileSinkCommittable>, IOException>
             committableSerializerSupplier;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperator.java
@@ -80,6 +80,8 @@ public class CompactorOperator
                 BoundedOneInput,
                 CheckpointListener {
 
+    private static final long serialVersionUID = 1L;
+
     private static final long SUBMITTED_ID = -1L;
 
     static final ListStateDescriptor<byte[]> REMAINING_REQUESTS_RAW_STATES_DESC =

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorFactory.java
@@ -39,6 +39,8 @@ public class CompactorOperatorFactory
         extends AbstractStreamOperatorFactory<CommittableMessage<FileSinkCommittable>>
         implements OneInputStreamOperatorFactory<
                 CompactorRequest, CommittableMessage<FileSinkCommittable>> {
+                        
+    private static final long serialVersionUID = 1L;
 
     private final FileCompactStrategy strategy;
     private final FileCompactor fileCompactor;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorStateHandler.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorStateHandler.java
@@ -60,6 +60,8 @@ public class CompactorOperatorStateHandler
                 BoundedOneInput,
                 CheckpointListener {
 
+    private static final long serialVersionUID = 1L;                
+
     private final SimpleVersionedSerializer<FileSinkCommittable> committableSerializer;
     private final BucketWriter<?, String> bucketWriter;
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorStateHandlerFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorStateHandlerFactory.java
@@ -40,6 +40,8 @@ public class CompactorOperatorStateHandlerFactory
                 Either<CommittableMessage<FileSinkCommittable>, CompactorRequest>,
                 CommittableMessage<FileSinkCommittable>> {
 
+    private static final long serialVersionUID = 1L;
+
     private final SerializableSupplierWithException<
                     SimpleVersionedSerializer<FileSinkCommittable>, IOException>
             committableSerializerSupplier;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequest.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequest.java
@@ -31,6 +31,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 /** Request of file compacting for {@link FileSink}. */
 @Internal
 public class CompactorRequest implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final String bucketId;
     private final List<FileSinkCommittable> committableToCompact;
     private final List<FileSinkCommittable> committableToPassthrough;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestTypeInfo.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestTypeInfo.java
@@ -34,6 +34,8 @@ import java.util.Objects;
 @Internal
 public class CompactorRequestTypeInfo extends TypeInformation<CompactorRequest> {
 
+    private static final long serialVersionUID = 1L;
+
     private final SerializableSupplierWithException<
                     SimpleVersionedSerializer<FileSinkCommittable>, IOException>
             committableSerializerSupplier;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/DefaultFileWriterBucketFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/DefaultFileWriterBucketFactory.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 /** A factory returning {@link FileWriter writer}. */
 @Internal
 public class DefaultFileWriterBucketFactory<IN> implements FileWriterBucketFactory<IN> {
+    private static final long serialVersionUID = 1L;
 
     @Override
     public FileWriterBucket<IN> getNewBucket(

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactBucketWriter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactBucketWriter.java
@@ -57,6 +57,8 @@ public class CompactBucketWriter<T> implements CompactWriter<T> {
     /** Factory to create {@link CompactBucketWriter}. */
     private static class Factory<T> implements CompactWriter.Factory<T> {
 
+        private static final long serialVersionUID = 1L;
+
         private final SupplierWithException<BucketWriter<T, String>, IOException> factory;
 
         private BucketWriter<T, String> bucketWriter;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/FileInputFormatCompactReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/FileInputFormatCompactReader.java
@@ -53,6 +53,7 @@ public class FileInputFormatCompactReader<T> implements CompactReader<T> {
 
     /** Factory to create {@link FileInputFormatCompactReader}. */
     private static class Factory<T> implements CompactReader.Factory<T> {
+        private static final long serialVersionUID = 1L;
 
         private final FileInputFormat<T> format;
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunctionWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunctionWrapper.java
@@ -42,7 +42,7 @@ import static org.apache.hadoop.hive.ql.exec.SerializationUtilities.releaseKryo;
 @Internal
 public class HiveFunctionWrapper<UDFType> implements Serializable {
 
-    public static final long serialVersionUID = 393313529306818205L;
+    private static final long serialVersionUID = 393313529306818205L;
 
     private final Class<UDFType> functionClz;
     // a field to hold the bytes serialized for the UDF.

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/hive/service/rpc/thrift/TGetQueryIdReq.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/hive/service/rpc/thrift/TGetQueryIdReq.java
@@ -26,7 +26,9 @@ public class TGetQueryIdReq
         implements org.apache.thrift.TBase<TGetQueryIdReq, TGetQueryIdReq._Fields>,
                 java.io.Serializable,
                 Cloneable,
-                Comparable<TGetQueryIdReq> {
+        Comparable<TGetQueryIdReq> {
+    private static final long serialVersionUID = 1L;
+    
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC =
             new org.apache.thrift.protocol.TStruct("TGetQueryIdReq");
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/hive/service/rpc/thrift/TGetQueryIdResp.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/hive/service/rpc/thrift/TGetQueryIdResp.java
@@ -26,7 +26,9 @@ public class TGetQueryIdResp
         implements org.apache.thrift.TBase<TGetQueryIdResp, TGetQueryIdResp._Fields>,
                 java.io.Serializable,
                 Cloneable,
-                Comparable<TGetQueryIdResp> {
+        Comparable<TGetQueryIdResp> {
+    private static final long serialVersionUID = 1L;
+    
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC =
             new org.apache.thrift.protocol.TStruct("TGetQueryIdResp");
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/hive/service/rpc/thrift/TSetClientInfoReq.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/hive/service/rpc/thrift/TSetClientInfoReq.java
@@ -26,7 +26,9 @@ public class TSetClientInfoReq
         implements org.apache.thrift.TBase<TSetClientInfoReq, TSetClientInfoReq._Fields>,
                 java.io.Serializable,
                 Cloneable,
-                Comparable<TSetClientInfoReq> {
+        Comparable<TSetClientInfoReq> {
+    private static final long serialVersionUID = 1L;
+    
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC =
             new org.apache.thrift.protocol.TStruct("TSetClientInfoReq");
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/hive/service/rpc/thrift/TSetClientInfoResp.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/hive/service/rpc/thrift/TSetClientInfoResp.java
@@ -26,7 +26,9 @@ public class TSetClientInfoResp
         implements org.apache.thrift.TBase<TSetClientInfoResp, TSetClientInfoResp._Fields>,
                 java.io.Serializable,
                 Cloneable,
-                Comparable<TSetClientInfoResp> {
+        Comparable<TSetClientInfoResp> {
+    private static final long serialVersionUID = 1L;
+    
     private static final org.apache.thrift.protocol.TStruct STRUCT_DESC =
             new org.apache.thrift.protocol.TStruct("TSetClientInfoResp");
 

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputFileConfig.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputFileConfig.java
@@ -28,6 +28,8 @@ import java.io.Serializable;
  */
 public class OutputFileConfig implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final String partPrefix;
 
     private final String partSuffix;

--- a/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
@@ -58,6 +58,8 @@ public class DistributedCache {
      */
     public static class DistributedCacheEntry implements Serializable {
 
+        private static final long serialVersionUID = 1L;
+
         public String filePath;
         public Boolean isExecutable;
         public boolean isZipped;

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkAlignmentParams.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkAlignmentParams.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 /** Configuration parameters for watermark alignment. */
 @PublicEvolving
 public final class WatermarkAlignmentParams implements Serializable {
+    private static final long serialVersionUID = 1L;
     public static final WatermarkAlignmentParams WATERMARK_ALIGNMENT_DISABLED =
             new WatermarkAlignmentParams(Long.MAX_VALUE, "", 0);
     private final long maxAllowedWatermarkDrift;

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/SinkUtils.java
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeoutException;
 @Experimental
 public class SinkUtils implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Acquire permits on the given semaphore within a given allowed timeout and deal with errors.
      *

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LocalDateComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LocalDateComparator.java
@@ -35,6 +35,8 @@ import java.time.LocalDate;
 @Internal
 public final class LocalDateComparator extends TypeComparator<LocalDate> implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+    
     private transient LocalDate reference;
 
     protected final boolean ascendingComparison;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LocalDateTimeComparator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/LocalDateTimeComparator.java
@@ -36,6 +36,8 @@ import java.time.LocalDateTime;
 public final class LocalDateTimeComparator extends TypeComparator<LocalDateTime>
         implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+            
     private transient LocalDateTime reference;
 
     protected final boolean ascendingComparison;

--- a/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxy.java
+++ b/flink-core/src/main/java/org/apache/flink/core/io/SimpleVersionedSerializerTypeSerializerProxy.java
@@ -40,6 +40,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class SimpleVersionedSerializerTypeSerializerProxy<T> extends TypeSerializer<T> {
 
+    private static final long serialVersionUID = 1L;
+
     private final SerializableSupplier<SimpleVersionedSerializer<T>> serializerSupplier;
     private transient SimpleVersionedSerializer<T> cachedSerializer;
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDeserializationSchema.java
@@ -85,6 +85,9 @@ import java.util.TimeZone;
 @PublicEvolving
 @Deprecated
 public class AvroRowDeserializationSchema extends AbstractDeserializationSchema<Row> {
+
+    private static final long serialVersionUID = 1L;
+    
     /** Used for time conversions into SQL types. */
     private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
 

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
@@ -73,6 +73,8 @@ import java.util.TimeZone;
 @Deprecated
 public class AvroRowSerializationSchema implements SerializationSchema<Row> {
 
+    private static final long serialVersionUID = 1L;
+
     /** Used for time conversions from SQL types. */
     private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
 

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowCsvInputFormat.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowCsvInputFormat.java
@@ -148,6 +148,8 @@ public class RowCsvInputFormat extends AbstractCsvInputFormat<Row> {
     /** A builder for creating a {@link RowCsvInputFormat}. */
     public static class Builder implements Serializable {
 
+        private static final long serialVersionUID = 1L;
+
         private final Path[] filePaths;
         private final TypeInformation[] fieldTypes;
         private CsvSchema csvSchema;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserRowDataDeserializationSchema.java
@@ -42,6 +42,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class JsonParserRowDataDeserializationSchema extends AbstractJsonDeserializationSchema {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Runtime converter that converts {@link JsonParser}s into objects of Flink SQL internal data
      * structures.

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbRowDataSerializationSchema.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/PbRowDataSerializationSchema.java
@@ -37,7 +37,7 @@ import com.google.protobuf.Descriptors;
  * <p>Failures during deserialization are forwarded as wrapped {@link FlinkRuntimeException}.
  */
 public class PbRowDataSerializationSchema implements SerializationSchema<RowData> {
-    public static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     private final RowType rowType;
     private final PbFormatConfig pbFormatConfig;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/configuration/SharedBufferCacheConfig.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/configuration/SharedBufferCacheConfig.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 
 /** Configuration immutable class. */
 public final class SharedBufferCacheConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final int eventsBufferCacheSlots;
     private final int entryCacheSlots;
     private final Duration cacheStatisticsInterval;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/OperatorIdentifier.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/OperatorIdentifier.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 /** Identifies an operator, either based on a {@code uid} or {@code uidHash}. */
 @PublicEvolving
 public final class OperatorIdentifier implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
     // this is only used for logging purposes
     @Nullable private final String uid;
     // this is the runtime representation of a uid hash

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConnectorUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConnectorUtils.java
@@ -55,6 +55,8 @@ public class PythonConnectorUtils {
     /** The serializable {@link InvocationHandler} as the proxy for first column selector. */
     public static class FirstColumnTopicSelectorInvocationHandler
             implements InvocationHandler, Serializable {
+        
+        private static final long serialVersionUID = 1L;
 
         @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobStatusMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/client/JobStatusMessage.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.common.JobStatus;
 /** A simple message that holds the state of a job execution. */
 public class JobStatusMessage implements java.io.Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final JobID jobId;
 
     private final String jobName;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IndexRange.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IndexRange.java
@@ -25,6 +25,8 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 /** This class represents the range of index. The range is inclusive. */
 public class IndexRange implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final int startIndex;
     private final int endIndex;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ResultPartitionBytes.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ResultPartitionBytes.java
@@ -25,6 +25,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** This class represents a snapshot of the result partition bytes metrics. */
 public class ResultPartitionBytes implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final long[] subpartitionBytes;
 
     public ResultPartitionBytes(long[] subpartitionBytes) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
@@ -31,6 +31,7 @@ import java.util.function.ToIntFunction;
 
 /** Container for meta-data of a data set. */
 public final class DataSetMetaInfo implements Serializable {
+    private static final long serialVersionUID = 1L;
     private static final int UNKNOWN = -1;
 
     private final int numRegisteredPartitions;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexResourceRequirements.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexResourceRequirements.java
@@ -34,6 +34,7 @@ public class JobVertexResourceRequirements implements Serializable {
     private static final String FIELD_NAME_PARALLELISM = "parallelism";
 
     public static class Parallelism implements Serializable {
+        private static final long serialVersionUID = 2L;
 
         private static final String FIELD_NAME_LOWER_BOUND = "lowerBound";
         private static final String FIELD_NAME_UPPER_BOUND = "upperBound";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/ThreadInfoSample.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/ThreadInfoSample.java
@@ -33,6 +33,8 @@ import java.util.stream.Collectors;
  */
 public class ThreadInfoSample implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final Thread.State threadState;
     private final StackTraceElement[] stackTrace;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/webmonitor/JobDetails.java
@@ -360,6 +360,8 @@ public class JobDetails implements Serializable {
      * reached terminal state.
      */
     public static final class CurrentAttempts implements Serializable {
+        private static final long serialVersionUID = 1L;
+        
         private final int representativeAttempt;
 
         private final Set<Integer> currentAttempts;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenContainer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenContainer.java
@@ -27,6 +27,8 @@ import java.util.Map;
 /** Container for delegation tokens. */
 @Experimental
 public class DelegationTokenContainer implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
     private Map<String, byte[]> tokens = new HashMap<>();
 
     public Map<String, byte[]> getTokens() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/AccumulatorReport.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 /** A report about the current values of all accumulators of the TaskExecutor for a given job. */
 public class AccumulatorReport implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
     private final Collection<AccumulatorSnapshot> accumulatorSnapshots;
 
     public AccumulatorReport(List<AccumulatorSnapshot> accumulatorSnapshots) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorMemoryConfiguration.java
@@ -43,6 +43,8 @@ import static org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils.ca
 
 /** TaskExecutorConfiguration collects the configuration of a TaskExecutor instance. */
 public class TaskExecutorMemoryConfiguration implements Serializable {
+    private static final long serialVersionUID = 1L;
+    
     public static final String FIELD_NAME_FRAMEWORK_HEAP = "frameworkHeap";
     public static final String FIELD_NAME_TASK_HEAP = "taskHeap";
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -53,7 +53,7 @@ public class RocksDBConfigurableOptions implements Serializable {
     // --------------------------------------------------------------------------
     // Provided configurable DBOptions within Flink
     // --------------------------------------------------------------------------
-
+    private static final long serialVersionUID = 1L;     
     public static final ConfigOption<Integer> MAX_BACKGROUND_THREADS =
             key("state.backend.rocksdb.thread.num")
                     .intType()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -854,6 +854,7 @@ public class StreamConfig implements Serializable {
 
     /** A representation of a Network {@link InputConfig}. */
     public static class NetworkInputConfig implements InputConfig {
+        private static final long serialVersionUID = 1L;
         private final TypeSerializer<?> typeSerializer;
         private final InputRequirement inputRequirement;
 
@@ -887,6 +888,7 @@ public class StreamConfig implements Serializable {
 
     /** A serialized representation of an input. */
     public static class SourceInputConfig implements InputConfig {
+        private static final long serialVersionUID = 1L;
         private final StreamEdge inputEdge;
 
         public SourceInputConfig(StreamEdge inputEdge) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/KeyAndValueSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/KeyAndValueSerializer.java
@@ -42,6 +42,8 @@ import java.util.Objects;
  * </pre>
  */
 final class KeyAndValueSerializer<IN> extends TypeSerializer<Tuple2<byte[], StreamRecord<IN>>> {
+    private static final long serialVersionUID = 1L;
+    
     private static final int TIMESTAMP_LENGTH = 8;
     private final TypeSerializer<IN> valueSerializer;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/typeutils/FieldAccessorFactory.java
@@ -43,6 +43,8 @@ import java.util.regex.Pattern;
 @Internal
 public class FieldAccessorFactory implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private static final Logger LOG = LoggerFactory.getLogger(FieldAccessorFactory.class);
 
     @Nullable

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/DataGeneratorMapper.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/DataGeneratorMapper.java
@@ -30,6 +30,8 @@ import java.util.concurrent.ThreadLocalRandom;
 @Internal
 public class DataGeneratorMapper<A, B> implements DataGenerator<B> {
 
+    private static final long serialVersionUID = 1L;
+
     private final DataGenerator<A> generator;
 
     private final SerializableFunction<A, B> mapper;

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/DecimalDataRandomGenerator.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/types/DecimalDataRandomGenerator.java
@@ -34,6 +34,8 @@ import java.util.concurrent.ThreadLocalRandom;
 @Internal
 public class DecimalDataRandomGenerator implements DataGenerator<DecimalData> {
 
+    private static final long serialVersionUID = 1L;
+
     private final int precision;
 
     private final int scale;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/UnresolvedReferenceExpression.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/UnresolvedReferenceExpression.java
@@ -35,6 +35,8 @@ import java.util.Objects;
 @PublicEvolving
 public final class UnresolvedReferenceExpression implements Expression, Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final String name;
 
     UnresolvedReferenceExpression(String name) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectIdentifier.java
@@ -46,6 +46,8 @@ import static org.apache.flink.table.utils.EncodingUtils.escapeIdentifier;
 @PublicEvolving
 public final class ObjectIdentifier implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     static final String UNKNOWN = "<UNKNOWN>";
 
     private final @Nullable String catalogName;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectPath.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ObjectPath.java
@@ -29,6 +29,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 /** A database name and object (table/view/function) name combo in a catalog. */
 @PublicEvolving
 public class ObjectPath implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final String databaseName;
     private final String objectName;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/DynamicFilteringData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/DynamicFilteringData.java
@@ -47,6 +47,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @PublicEvolving
 public class DynamicFilteringData implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final TypeInformation<RowData> typeInfo;
     private final RowType rowType;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/DynamicFilteringEvent.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/DynamicFilteringEvent.java
@@ -30,6 +30,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @PublicEvolving
 public class DynamicFilteringEvent implements SourceEvent {
+    private static final long serialVersionUID = 1L;
     private final DynamicFilteringData data;
 
     public DynamicFilteringEvent(DynamicFilteringData data) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunctionInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunctionInfo.java
@@ -28,6 +28,8 @@ import org.apache.flink.annotation.Internal;
 @Internal
 public class PythonAggregateFunctionInfo extends PythonFunctionInfo {
 
+    private static final long serialVersionUID = 1L;
+
     private final int filterArg;
     private final boolean distinct;
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/HashJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/HashJoinOperator.java
@@ -423,6 +423,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
             this.keyType = keyType;
             this.sortMergeJoinFunction = sortMergeJoinFunction;
         }
+
+        private static final long serialVersionUID = 1L;
     }
 
     /**
@@ -443,6 +445,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
                 }
             }
         }
+
+        private static final long serialVersionUID = 1L;
     }
 
     /**
@@ -466,6 +470,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
                 }
             }
         }
+
+        private static final long serialVersionUID = 1L;
     }
 
     /**
@@ -489,6 +495,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
                 collect(buildSideNullRow, probeRow);
             }
         }
+
+        private static final long serialVersionUID = 1L;
     }
 
     /**
@@ -514,6 +522,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
                 collect(buildSideNullRow, probeRow);
             }
         }
+
+        private static final long serialVersionUID = 1L;
     }
 
     /** Semi join. Output probe side row when probe side row matched build side row. */
@@ -530,6 +540,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
                 collector.collect(probeRow);
             }
         }
+
+        private static final long serialVersionUID = 1L;
     }
 
     /** Anti join. Output probe side row when probe side row not matched build side row. */
@@ -546,6 +558,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
                 collector.collect(probeRow);
             }
         }
+
+        private static final long serialVersionUID = 1L;
     }
 
     /**
@@ -565,7 +579,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
                 if (probeRow != null) { // Probe phase
                     // we must iterator to set probedSet.
                     //noinspection StatementWithEmptyBody
-                    while (buildIter.advanceNext()) {}
+                    while (buildIter.advanceNext()) {
+                    }
                 } else { // End Probe phase, iterator build side elements.
                     collector.collect(buildIter.getRow());
                     while (buildIter.advanceNext()) {
@@ -574,5 +589,7 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
                 }
             }
         }
+        
+        private static final long serialVersionUID = 1L;
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinFunction.java
@@ -55,6 +55,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** This function is used to process the main logic of sort merge join. */
 public class SortMergeJoinFunction implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final double externalBufferMemRatio;
     private final FlinkJoinType type;
     private final boolean leftIsSmaller;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ExternalSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ExternalSerializer.java
@@ -286,7 +286,7 @@ public final class ExternalSerializer<I, E> extends TypeSerializer<E> {
         @Override
         protected TypeSerializer<?>[] getNestedSerializers(
                 ExternalSerializer<I, E> outerSerializer) {
-            return new TypeSerializer[] {outerSerializer.internalSerializer};
+            return new TypeSerializer[] { outerSerializer.internalSerializer };
         }
 
         @Override
@@ -297,4 +297,6 @@ public final class ExternalSerializer<I, E> extends TypeSerializer<E> {
                     dataType, (TypeSerializer<I>) nestedSerializers[0], isInternalInput);
         }
     }
+    
+    private static final long serialVersionUID = 1L;
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
@@ -292,14 +292,10 @@ public class MapDataSerializer extends TypeSerializer<MapData> {
                 throws IOException {
             try {
                 DataInputViewStream inStream = new DataInputViewStream(in);
-                this.previousKeyType =
-                        InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
-                this.previousValueType =
-                        InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
-                this.previousKeySerializer =
-                        InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
-                this.previousValueSerializer =
-                        InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
+                this.previousKeyType = InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
+                this.previousValueType = InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
+                this.previousKeySerializer = InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
+                this.previousValueSerializer = InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
             } catch (ClassNotFoundException e) {
                 throw new IOException(e);
             }
@@ -332,4 +328,6 @@ public class MapDataSerializer extends TypeSerializer<MapData> {
             }
         }
     }
+    
+    private static final long serialVersionUID = 1L;
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/connector/upserttest/table/UpsertTestDynamicTableSink.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/connector/upserttest/table/UpsertTestDynamicTableSink.java
@@ -152,6 +152,8 @@ class UpsertTestDynamicTableSink implements DynamicTableSink {
      */
     private static class UpsertKeySerializationSchema implements SerializationSchema<RowData> {
 
+        private static final long serialVersionUID = 1L;
+        
         private final SerializationSchema<RowData> serializationSchema;
 
         private final int[] primaryKeyIndexes;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In several files there are some classes that are serializable but they do not contain any serialVersionUID field. The compiler generates one by default in such scenarios, but the generated id is dependent on compiler implementation and may cause unwanted problems during deserialization.

## The Role of serialVersionUID:

The primary role of serialVersionUID is to provide version control during deserialization. When deserialize an object, the JVM checks whether the serialVersionUID of the serialized data matches the serialVersionUID of the class in the current classpath. If they match, the deserialization proceeds without issues. However, if they do not match, programmers encounter InvalidClassException.

As, serialVersionUID servers the purpose of version control of class during serialization-deserialization, without a serialVersionUID, we risk breaking backward compatibility when making changes to classes, which can lead to unexpected issues and errors during deserialization.

## Does this pull request potentially affect one of the following parts:
  - The serializers: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)

## Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
