### PR TITLE
[FLINK-33997] [docs] Typo in the doc 'classloader.parent-first-patter…

### DIFF
--- a/docs/content.zh/docs/ops/debugging/debugging_classloading.md
+++ b/docs/content.zh/docs/ops/debugging/debugging_classloading.md
@@ -87,7 +87,7 @@ created for an job/application and will contain the job/application's jar files.
 
 对于用户代码的类加载，您可以通过调整Flink的[`classloader.resolve-order`]({{< ref "docs/deployment/config" >}}#classloader-resolve-order)配置将ClassLoader解析顺序还原至Java的默认模式（从Flink默认的`child-first`调整为`parent-first`）。
 
-请注意由于有些类在Flink内核与插件或用户代码间共享，它们总是以*parent-first*方式进行解析的。这些类相关的包通过[`classloader.parent-first-patterns-default`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-default)和[`classloader.parent-first-patterns-additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-additional)进行配置。如果需要新添加*parent-first* 方式的包，请调整`classloader.parent-first-patterns-additional` 配置选项。
+请注意由于有些类在Flink内核与插件或用户代码间共享，它们总是以*parent-first*方式进行解析的。这些类相关的包通过[`classloader.parent-first-patterns.default`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-default)和[`classloader.parent-first-patterns.additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns.additional)进行配置。如果需要新添加*parent-first* 方式的包，请调整`classloader.parent-first-patterns.additional` 配置选项。
 
 
 ## 避免用户代码的动态类加载
@@ -116,7 +116,7 @@ Flink的组件（JobManager, TaskManager, Client, ApplicationMaster等）在启�
 当进行动态类加载时，您可能会遇到类似`com.foo.X cannot be cast to com.foo.X`类型的异常。
 出现这种异常代表不同的类加载器加载了不同版本的`com.foo.X`类，并且它们互相之间尝试进行类型指定转换。
 
-发生这种情况的通常原因是这个库与Flink的*倒置类加载*（*inverted classloading*）方式不兼容造成的。您可以通过关闭倒置类加载（inverted classloading）来进行验证（在Flink设置中调整[`classloader.resolve-order: parent-first`]({{< ref "docs/deployment/config" >}}#classloader-resolve-order)），或者将库排除在inverted classloading之外（通过设置[`classloader.parent-first-patterns-additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-additional)）。
+发生这种情况的通常原因是这个库与Flink的*倒置类加载*（*inverted classloading*）方式不兼容造成的。您可以通过关闭倒置类加载（inverted classloading）来进行验证（在Flink设置中调整[`classloader.resolve-order: parent-first`]({{< ref "docs/deployment/config" >}}#classloader-resolve-order)），或者将库排除在inverted classloading之外（通过设置[`classloader.parent-first-patterns.additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-additional)）。
 
 另一种原因可能是由缓存的对象实例引起的，比如类似*Apache Avro*或者Guava的Interners类型的对象。
 解决办法是设置没有任何动态类加载，或者确保相应的库完全是动态加载代码的一部分。后者意味着库不能添加到Flink的`/lib`目录下，但必须作为应用程序的fat-jar或uber-jar的一部分。
@@ -137,7 +137,7 @@ Flink的组件（JobManager, TaskManager, Client, ApplicationMaster等）在启�
 
   - *Interners*: 避免缓存超出function/sources/sinks生命周期的特殊结构中的对象。比如Guava的Interner，或是Avro的序列化器中的类或对象。
 
-  - *JDBC*: JDBC驱动会在用户类加载器之外泄漏引用。为了确保这些类只被加载一次，您可以将驱动JAR包放在Flink的`lib/`目录下，或者将驱动类通过[`classloader.parent-first-patterns-additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-additional)加到父级优先加载类的列表中。
+  - *JDBC*: JDBC驱动会在用户类加载器之外泄漏引用。为了确保这些类只被加载一次，您可以将驱动JAR包放在Flink的`lib/`目录下，或者将驱动类通过[`classloader.parent-first-patterns.additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-additional)加到父级优先加载类的列表中。
 
 释放用户代码类加载器的钩子（hook）可以帮助卸载动态加载的类。这种钩子在类加载器卸载前执行。通常情况下最好把关闭和卸载资源作为正常函数生命周期操作的一部分（比如典型的`close()`方法）。有些情况下（比如静态字段）最好确定类加载器不再需要后就立即卸载。
 

--- a/docs/content/docs/ops/debugging/debugging_classloading.md
+++ b/docs/content/docs/ops/debugging/debugging_classloading.md
@@ -100,9 +100,9 @@ For user code classloading, you can revert back to Java's default mode by config
 
 Please note that certain classes are always resolved in a *parent-first* way (through the parent ClassLoader first), because they
 are shared between Flink's core and the plugin/user code or the plugin/user-code facing APIs. The packages for these classes are configured via 
-[`classloader.parent-first-patterns-default`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-default) and
-[`classloader.parent-first-patterns-additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-additional).
-To add new packages to be *parent-first* loaded, please set the `classloader.parent-first-patterns-additional` config option.
+[`classloader.parent-first-patterns.default`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns.default) and
+[`classloader.parent-first-patterns.additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns.additional).
+To add new packages to be *parent-first* loaded, please set the `classloader.parent-first-patterns.additional` config option.
 
 
 ## Avoiding Dynamic Classloading for User Code
@@ -139,7 +139,7 @@ This means that multiple versions of the class `com.foo.X` have been loaded by d
 
 One common reason is that a library is not compatible with Flink's *inverted classloading* approach. You can turn off inverted classloading
 to verify this (set [`classloader.resolve-order: parent-first`]({{< ref "docs/deployment/config" >}}#classloader-resolve-order) in the Flink config) or exclude
-the library from inverted classloading (set [`classloader.parent-first-patterns-additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-additional)
+the library from inverted classloading (set [`classloader.parent-first-patterns.additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns.additional)
 in the Flink config).
 
 Another cause can be cached object instances, as produced by some libraries like *Apache Avro*, or by interning objects (for example via Guava's Interners).
@@ -168,7 +168,7 @@ Common causes for class leaks and suggested fixes:
   - *JDBC*: JDBC drivers leak references outside the user code classloader. To ensure that these classes are only loaded once
    you should add the driver jars to Flink's `lib/` folder instead of bundling them in the user-jar. 
    If you can't guarantee that none of your user-jars bundle the driver, you have to additionally add the driver classes to the list of parent-first
-   loaded classes via [`classloader.parent-first-patterns-additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns-additional).
+   loaded classes via [`classloader.parent-first-patterns.additional`]({{< ref "docs/deployment/config" >}}#classloader-parent-first-patterns.additional).
 
 A helpful tool for unloading dynamically loaded classes are the user code class loader release hooks. These are hooks which are executed prior to the unloading of a classloader. It is generally recommended to shutdown and unload resources as part of the regular function lifecycle (typically the `close()` methods). But in some cases (for example for static fields), it is better to unload once a classloader is certainly not needed anymore.
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a typo found in our documentation:
`classloader.parent-first-patterns-additional` should be `classloader.parent-first-patterns.additional`
and
`classloader.parent-first-patterns-default` should be `classloader.parent-first-patterns.default`

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
