### PR TITLE
[FLINK-33881]Avoid copy and update value in TtlListState#getUnexpiredOrNull

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlListState.java
@@ -127,14 +127,11 @@ class TtlListState<K, N, T>
         List<TtlValue<T>> unexpired = new ArrayList<>(ttlValues.size());
         for (int i = 0; i < ttlValues.size(); i++) {
             TtlValue<T> ttlValue = ttlValues.get(i);
-            if (i < firstExpireElementIndex) {
+            if (i < firstExpireElementIndex
+                    || (i > firstExpireElementIndex
+                            && !TtlUtils.expired(ttlValue, ttl, currentTimestamp))) {
                 // we have to do the defensive copy to update the value
                 unexpired.add(elementSerializer.copy(ttlValue));
-            } else if (i > firstExpireElementIndex) {
-                if (!TtlUtils.expired(ttlValue, ttl, currentTimestamp)) {
-                    // we have to do the defensive copy to update the value
-                    unexpired.add(elementSerializer.copy(ttlValue));
-                }
             }
         }
         if (!unexpired.isEmpty()) {


### PR DESCRIPTION
## What is the purpose of the change

This pull request optimize TtlListState clean up process by avoiding copy and update value in TtlListState#getUnexpiredOrNull

## Brief change log

  - refactor TtlListState#getUnexpiredOrNull

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
org.apache.flink.runtime.state.ttl.TtlStateTestBase +  TtlFixedLenElemListStateTestContext/TtlNonFixedLenElemListStateTestContext

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
