### PR TITLE
[BP-1.18][FLINK-33907][ci] Makes copying test jars being done in the package phase

### DIFF
--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -157,7 +157,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>copy-dependencies</id>
-						<phase>process-test-resources</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>copy-dependencies</goal>
 						</goals>


### PR DESCRIPTION
1.18 backport PR for parent PR #23965 

No conflicts appeared during backport.

This fixes the following error when compiling the test artifacts of flink-clients: Error: 2.054 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.2.0:copy-dependencies (copy-dependencies) on project flink-clients: Artifact has not been packaged yet. When used on reactor artifact, copy should be executed after packaging: see MDEP-187. -> [Help 1]

