### PR TITLE
[FLINK-34047][ci] Make CI scripts agnostic to CI environment

### DIFF
--- a/tools/azure-pipelines/debug_files_utils.sh
+++ b/tools/azure-pipelines/debug_files_utils.sh
@@ -18,9 +18,17 @@
 ################################################################################
 
 function prepare_debug_files {
-	MODULE=$@
-	export DEBUG_FILES_OUTPUT_DIR="$AGENT_TEMPDIRECTORY/debug_files"
-	export DEBUG_FILES_NAME="$(echo $MODULE | tr -c '[:alnum:]\n\r' '_')-$(date +%s)"
+	if [ "$#" != "2" ]; then
+		echo "[ERROR] Invalid number of parameters passed. Expected parameters for $0: <parent-directory> <module-label>"
+		exit 1
+	fi
+
+	local parent_directory module
+	parent_directory="$1"
+	module="$2"
+
+	export DEBUG_FILES_OUTPUT_DIR="${parent_directory}/debug_files"
+	export DEBUG_FILES_NAME="$(echo "${module}" | tr -c '[:alnum:]\n\r' '_')-$(date +%s)"
 	echo "##vso[task.setvariable variable=DEBUG_FILES_OUTPUT_DIR]$DEBUG_FILES_OUTPUT_DIR"
 	echo "##vso[task.setvariable variable=DEBUG_FILES_NAME]$DEBUG_FILES_NAME"
 	mkdir -p $DEBUG_FILES_OUTPUT_DIR || { echo "FAILURE: cannot create debug files directory '${DEBUG_FILES_OUTPUT_DIR}'." ; exit 1; }

--- a/tools/azure-pipelines/uploading_watchdog.sh
+++ b/tools/azure-pipelines/uploading_watchdog.sh
@@ -30,7 +30,7 @@ fi
 source "${HERE}/../ci/controller_utils.sh"
 
 source ./tools/azure-pipelines/debug_files_utils.sh
-prepare_debug_files "$AGENT_JOBNAME"
+prepare_debug_files "$AGENT_TEMPDIRECTORY" "$AGENT_JOBNAME"
 export FLINK_LOG_DIR="$DEBUG_FILES_OUTPUT_DIR/flink-logs"
 mkdir $FLINK_LOG_DIR || { echo "FAILURE: cannot create log directory '${FLINK_LOG_DIR}'." ; exit 1; }
 sudo apt-get install -y moreutils

--- a/tools/azure-pipelines/uploading_watchdog.sh
+++ b/tools/azure-pipelines/uploading_watchdog.sh
@@ -27,16 +27,45 @@ if [ -z "$HERE" ] ; then
   exit 1
 fi
 
+if [ -n "${TF_BUILD+x}" ]; then
+  echo "[INFO] Azure Pipelines environment detected: $0 will rely on Azure-specific environment variables."
+  job_name="$AGENT_JOBNAME"
+  temporary_folder="$AGENT_TEMPDIRECTORY"
+  job_timeout="$SYSTEM_JOBTIMEOUT"
+  pipeline_start_time="${SYSTEM_PIPELINESTARTTIME}"
+elif [ -n "${GITHUB_ACTIONS+x}" ]; then
+  echo "[INFO] GitHub Actions environment detected: $0 will rely on GHA-specific environment variables."
+  job_name="${GITHUB_JOB}"
+  temporary_folder="${RUNNER_TEMP}"
+
+  if [ -n "${GHA_JOB_TIMEOUT+x}" ]; then
+    job_timeout="${GHA_JOB_TIMEOUT}"
+  else
+    echo "[ERROR] GHA_JOB_TIMEOUT is not set: GHA_JOB_TIMEOUT needs to be set by the workflow because there is no pre-defined environment variable available for this parameter for now."
+    exit 1
+  fi
+
+  if [ -n "${GHA_PIPELINE_START_TIME+x}" ]; then
+    pipeline_start_time="${GHA_PIPELINE_START_TIME}"
+  else
+    echo "[ERROR] GHA_PIPELINE_START_TIME is not set: GHA_PIPELINE_START_TIME needs to be set by the workflow because there is no pre-defined environment variable available for this parameter for now."
+    exit 1
+  fi
+else
+  echo "[ERROR] No CI environment detected that could be used for injecting the parameters which are needed by $0."
+  exit 1
+fi
+
 source "${HERE}/../ci/controller_utils.sh"
 
 source ./tools/azure-pipelines/debug_files_utils.sh
-prepare_debug_files "$AGENT_TEMPDIRECTORY" "$AGENT_JOBNAME"
+prepare_debug_files "${temporary_folder}" "${job_name}"
 export FLINK_LOG_DIR="$DEBUG_FILES_OUTPUT_DIR/flink-logs"
 mkdir $FLINK_LOG_DIR || { echo "FAILURE: cannot create log directory '${FLINK_LOG_DIR}'." ; exit 1; }
 sudo apt-get install -y moreutils
 
 REAL_START_SECONDS=$(date +"%s")
-REAL_END_SECONDS=$(date -d "$SYSTEM_PIPELINESTARTTIME + $SYSTEM_JOBTIMEOUT minutes" +"%s")
+REAL_END_SECONDS=$(date -d "${pipeline_start_time} + ${job_timeout} minutes" +"%s")
 REAL_TIMEOUT_SECONDS=$(($REAL_END_SECONDS - $REAL_START_SECONDS))
 KILL_SECONDS_BEFORE_TIMEOUT=$((2 * 60))
 


### PR DESCRIPTION


## What is the purpose of the change

Azure Pipelines (see [pre-defined env variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)) and GitHub (see [pre-defined env variables](https://docs.github.com/en/actions/learn-github-actions/variables)) use a different set of environment variables. The CI tools rely on some of the environment variables that are provided by Azure Pipelines. With the migration to GitHub Actions we need to make the scripts CI environment agnostic.

## Brief change log

* Made `tools/azure-pipelines/debug_files_utils.sh` use parameters instead of relying on environment variables
* Made `tools/azure-pipelines/uploading_watchdog.sh` consider Azure Pipelines and GitHub Actions environments
* I checked for occurrences of the following substrings (based on [Azure Pipelines pre-defined env variables](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)) in the code to verify that we're not missing any other env variables:
  * `$AGENT_`
  * `$SYSTEM_`
  * `$BUILD_`
  * `$COMMON_`
  * `$ENV_`
  * `$CHECKS`

## Verifying this change

* PR CI should still work w/o errors
* The [follow-up FLINK-33914 PR](https://github.com/apache/flink/pull/23970) should fail without the right environment variables being set in the fork XComp/flink's project being set
* We should see a successful build with the necessary environment variables being set for FLINK-33914

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? in-code documentation