### PR TITLE
[FLINK-32852][JUnit5 migration] Migrate ExceptionHistoryEntryTest and RootExceptionHistoryEntryTest to Junit5 and Assertj

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -101,7 +101,6 @@ import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
@@ -111,6 +110,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -145,7 +145,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link DefaultScheduler}. */
-public class DefaultSchedulerTest extends TestLogger {
+public class DefaultSchedulerTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultSchedulerTest.class);
 
     private static final int TIMEOUT_MS = 1000;
 
@@ -1785,7 +1787,7 @@ public class DefaultSchedulerTest extends TestLogger {
                         }
                     },
                     executorService,
-                    log);
+                    LOG);
         } finally {
             executorService.shutdownNow();
         }
@@ -2115,7 +2117,7 @@ public class DefaultSchedulerTest extends TestLogger {
                         executor,
                         scheduledExecutorService,
                         taskRestartExecutor)
-                .setLogger(log)
+                .setLogger(LOG)
                 .setJobMasterConfiguration(configuration)
                 .setSchedulingStrategyFactory(new PipelinedRegionSchedulingStrategy.Factory())
                 .setFailoverStrategyFactory(new RestartPipelinedRegionFailoverStrategy.Factory())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/ArchivedTaskManagerLocationMatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/ArchivedTaskManagerLocationMatcher.java
@@ -21,11 +21,8 @@ package org.apache.flink.runtime.scheduler.exceptionhistory;
 import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry.ArchivedTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
-
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import static org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry.ArchivedTaskManagerLocation.fromTaskManagerLocation;
 
@@ -33,12 +30,11 @@ import static org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHisto
  * {@code ArchivedTaskManagerLocationMatcher} can be used to match {@link TaskManagerLocation} with
  * {@link ArchivedTaskManagerLocation} instances.
  */
-class ArchivedTaskManagerLocationMatcher
-        extends TypeSafeDiagnosingMatcher<ArchivedTaskManagerLocation> {
+class ArchivedTaskManagerLocationMatcher implements Predicate<ArchivedTaskManagerLocation> {
 
     private final ArchivedTaskManagerLocation expectedLocation;
 
-    public static Matcher<ArchivedTaskManagerLocation> isArchivedTaskManagerLocation(
+    public static Predicate<ArchivedTaskManagerLocation> isArchivedTaskManagerLocation(
             TaskManagerLocation actualLocation) {
         return new ArchivedTaskManagerLocationMatcher(actualLocation);
     }
@@ -52,7 +48,7 @@ class ArchivedTaskManagerLocationMatcher
     }
 
     @Override
-    protected boolean matchesSafely(ArchivedTaskManagerLocation actual, Description description) {
+    public boolean test(ArchivedTaskManagerLocation actual) {
         if (actual == null) {
             return expectedLocation == null;
         } else if (expectedLocation == null) {
@@ -61,35 +57,25 @@ class ArchivedTaskManagerLocationMatcher
 
         boolean match = true;
         if (!Objects.equals(actual.getAddress(), expectedLocation.getAddress())) {
-            description.appendText(" address=").appendText(actual.getAddress());
             match = false;
         }
 
         if (!Objects.equals(actual.getFQDNHostname(), expectedLocation.getFQDNHostname())) {
-            description.appendText(" FQDNHostname=").appendText(actual.getFQDNHostname());
             match = false;
         }
 
         if (!Objects.equals(actual.getHostname(), expectedLocation.getHostname())) {
-            description.appendText(" hostname=").appendText(actual.getHostname());
             match = false;
         }
 
         if (!Objects.equals(actual.getResourceID(), expectedLocation.getResourceID())) {
-            description.appendText(" resourceID=").appendText(actual.getResourceID().toString());
             match = false;
         }
 
         if (!Objects.equals(actual.getPort(), expectedLocation.getPort())) {
-            description.appendText(" port=").appendText(String.valueOf(actual.getPort()));
             match = false;
         }
 
         return match;
-    }
-
-    @Override
-    public void describeTo(Description description) {
-        description.appendText(String.valueOf(expectedLocation));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntryMatcher.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntryMatcher.java
@@ -19,19 +19,15 @@
 package org.apache.flink.runtime.scheduler.exceptionhistory;
 
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.util.ExceptionUtils;
-
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /** Matches {@link ExceptionHistoryEntry} instances. */
-public class ExceptionHistoryEntryMatcher extends TypeSafeDiagnosingMatcher<ExceptionHistoryEntry> {
+public class ExceptionHistoryEntryMatcher implements Predicate<ExceptionHistoryEntry> {
 
-    public static Matcher<ExceptionHistoryEntry> matchesGlobalFailure(
+    public static Predicate<ExceptionHistoryEntry> matchesGlobalFailure(
             Throwable expectedException,
             long expectedTimestamp,
             Map<String, String> expectedFailureLabels) {
@@ -39,7 +35,7 @@ public class ExceptionHistoryEntryMatcher extends TypeSafeDiagnosingMatcher<Exce
                 expectedException, expectedTimestamp, expectedFailureLabels, null, null);
     }
 
-    public static Matcher<ExceptionHistoryEntry> matchesFailure(
+    public static Predicate<ExceptionHistoryEntry> matchesFailure(
             Throwable expectedException,
             long expectedTimestamp,
             String expectedTaskName,
@@ -52,7 +48,7 @@ public class ExceptionHistoryEntryMatcher extends TypeSafeDiagnosingMatcher<Exce
                 expectedTaskManagerLocation);
     }
 
-    public static Matcher<ExceptionHistoryEntry> matchesFailure(
+    public static Predicate<ExceptionHistoryEntry> matchesFailure(
             Throwable expectedException,
             long expectedTimestamp,
             Map<String, String> expectedFailureLabels,
@@ -87,68 +83,33 @@ public class ExceptionHistoryEntryMatcher extends TypeSafeDiagnosingMatcher<Exce
     }
 
     @Override
-    protected boolean matchesSafely(
-            ExceptionHistoryEntry exceptionHistoryEntry, Description description) {
+    public boolean test(ExceptionHistoryEntry exceptionHistoryEntry) {
         boolean match = true;
         if (!exceptionHistoryEntry
                 .getException()
                 .deserializeError(ClassLoader.getSystemClassLoader())
                 .equals(expectedException)) {
-            description
-                    .appendText(" actualException=")
-                    .appendText(
-                            ExceptionUtils.stringifyException(
-                                    exceptionHistoryEntry
-                                            .getException()
-                                            .deserializeError(ClassLoader.getSystemClassLoader())));
             match = false;
         }
 
         if (exceptionHistoryEntry.getTimestamp() != expectedTimestamp) {
-            description
-                    .appendText(" actualTimestamp=")
-                    .appendText(String.valueOf(exceptionHistoryEntry.getTimestamp()));
             match = false;
         }
 
         if (!exceptionHistoryEntry.getFailureLabelsFuture().equals(expectedFailureLabels)) {
-            description
-                    .appendText(" actualFailureLabels=")
-                    .appendText(String.valueOf(exceptionHistoryEntry.getFailureLabelsFuture()));
             match = false;
         }
 
         if (exceptionHistoryEntry.getFailingTaskName() == null) {
             if (expectedTaskName != null) {
-                description.appendText(" actualTaskName=null");
                 match = false;
             }
         } else if (exceptionHistoryEntry.getFailingTaskName().equals(expectedTaskName)) {
-            description
-                    .appendText(" actualTaskName=")
-                    .appendText(exceptionHistoryEntry.getFailingTaskName());
             match = false;
         }
 
-        match |=
-                taskManagerLocationMatcher.matchesSafely(
-                        exceptionHistoryEntry.getTaskManagerLocation(), description);
+        match |= taskManagerLocationMatcher.test(exceptionHistoryEntry.getTaskManagerLocation());
 
         return match;
-    }
-
-    @Override
-    public void describeTo(Description description) {
-        description
-                .appendText("expectedException=")
-                .appendText(ExceptionUtils.stringifyException(expectedException))
-                .appendText(" expectedTimestamp=")
-                .appendText(String.valueOf(expectedTimestamp))
-                .appendText(" expectedFailureLabels=")
-                .appendText(String.valueOf(expectedFailureLabels))
-                .appendText(" expectedTaskName=")
-                .appendText(expectedTaskName)
-                .appendText(" expectedTaskManagerLocation=");
-        taskManagerLocationMatcher.describeTo(description);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntryTest.java
@@ -23,24 +23,22 @@ import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.scheduler.exceptionhistory.ArchivedTaskManagerLocationMatcher.isArchivedTaskManagerLocation;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** {@code ExceptionHistoryEntryTest} tests the creation of {@link ExceptionHistoryEntry}. */
-public class ExceptionHistoryEntryTest extends TestLogger {
+class ExceptionHistoryEntryTest {
 
     @Test
-    public void testCreate() {
+    void testCreate() {
         final Throwable failure = new RuntimeException("Expected exception");
         final long timestamp = System.currentTimeMillis();
         final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
@@ -56,48 +54,61 @@ public class ExceptionHistoryEntryTest extends TestLogger {
                 ExceptionHistoryEntry.create(
                         execution, taskName, CompletableFuture.completedFuture(failureLabels));
 
-        assertThat(
-                entry.getException().deserializeError(ClassLoader.getSystemClassLoader()),
-                is(failure));
-        assertThat(entry.getTimestamp(), is(timestamp));
-        assertThat(entry.getFailingTaskName(), is(taskName));
-        assertThat(
-                entry.getTaskManagerLocation(), isArchivedTaskManagerLocation(taskManagerLocation));
-        assertThat(entry.isGlobal(), is(false));
-        assertThat(entry.getFailureLabels(), is(failureLabels));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testCreationFailure() {
-        ExceptionHistoryEntry.create(
-                TestingAccessExecution.newBuilder()
-                        .withTaskManagerLocation(new LocalTaskManagerLocation())
-                        .build(),
-                "task name",
-                FailureEnricherUtils.EMPTY_FAILURE_LABELS);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testNullExecution() {
-        ExceptionHistoryEntry.create(null, "task name", FailureEnricherUtils.EMPTY_FAILURE_LABELS);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testNullTaskName() {
-        ExceptionHistoryEntry.create(
-                TestingAccessExecution.newBuilder()
-                        .withErrorInfo(
-                                new ErrorInfo(
-                                        new Exception("Expected failure"),
-                                        System.currentTimeMillis()))
-                        .withTaskManagerLocation(new LocalTaskManagerLocation())
-                        .build(),
-                null,
-                FailureEnricherUtils.EMPTY_FAILURE_LABELS);
+        assertThat(entry.getException().deserializeError(ClassLoader.getSystemClassLoader()))
+                .isEqualTo(failure);
+        assertThat(entry.getTimestamp()).isEqualTo(timestamp);
+        assertThat(entry.getFailingTaskName()).isEqualTo(taskName);
+        assertThat(entry.getTaskManagerLocation())
+                .matches(isArchivedTaskManagerLocation(taskManagerLocation));
+        assertThat(entry.isGlobal()).isFalse();
+        assertThat(entry.getFailureLabels()).isEqualTo(failureLabels);
     }
 
     @Test
-    public void testWithMissingTaskManagerLocation() {
+    void testCreationFailure() {
+        assertThatThrownBy(
+                        () ->
+                                ExceptionHistoryEntry.create(
+                                        TestingAccessExecution.newBuilder()
+                                                .withTaskManagerLocation(
+                                                        new LocalTaskManagerLocation())
+                                                .build(),
+                                        "task name",
+                                        FailureEnricherUtils.EMPTY_FAILURE_LABELS))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testNullExecution() {
+        assertThatThrownBy(
+                        () ->
+                                ExceptionHistoryEntry.create(
+                                        null,
+                                        "task name",
+                                        FailureEnricherUtils.EMPTY_FAILURE_LABELS))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testNullTaskName() {
+        assertThatThrownBy(
+                        () ->
+                                ExceptionHistoryEntry.create(
+                                        TestingAccessExecution.newBuilder()
+                                                .withErrorInfo(
+                                                        new ErrorInfo(
+                                                                new Exception("Expected failure"),
+                                                                System.currentTimeMillis()))
+                                                .withTaskManagerLocation(
+                                                        new LocalTaskManagerLocation())
+                                                .build(),
+                                        null,
+                                        FailureEnricherUtils.EMPTY_FAILURE_LABELS))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testWithMissingTaskManagerLocation() {
         final Exception failure = new Exception("Expected failure");
         final long timestamp = System.currentTimeMillis();
         final String taskName = "task name";
@@ -111,12 +122,11 @@ public class ExceptionHistoryEntryTest extends TestLogger {
                         taskName,
                         FailureEnricherUtils.EMPTY_FAILURE_LABELS);
 
-        assertThat(
-                entry.getException().deserializeError(ClassLoader.getSystemClassLoader()),
-                is(failure));
-        assertThat(entry.getTimestamp(), is(timestamp));
-        assertThat(entry.getFailingTaskName(), is(taskName));
-        assertThat(entry.getTaskManagerLocation(), is(nullValue()));
-        assertThat(entry.isGlobal(), is(false));
+        assertThat(entry.getException().deserializeError(ClassLoader.getSystemClassLoader()))
+                .isEqualTo(failure);
+        assertThat(entry.getTimestamp()).isEqualTo(timestamp);
+        assertThat(entry.getFailingTaskName()).isEqualTo(taskName);
+        assertThat(entry.getTaskManagerLocation()).isNull();
+        assertThat(entry.isGlobal()).isFalse();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/RootExceptionHistoryEntryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/RootExceptionHistoryEntryTest.java
@@ -31,39 +31,38 @@ import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Iterables;
 
-import org.hamcrest.collection.IsIterableContainingInAnyOrder;
-import org.hamcrest.collection.IsIterableContainingInOrder;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * {@code RootExceptionHistoryEntryTest} tests the creation of {@link RootExceptionHistoryEntry}.
  */
-public class RootExceptionHistoryEntryTest extends TestLogger {
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
+class RootExceptionHistoryEntryTest {
+
+    @RegisterExtension
+    private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     private ExecutionGraph executionGraph;
 
-    @Before
-    public void setup() throws JobException, JobExecutionException {
+    @BeforeEach
+    void setup() throws JobException, JobExecutionException {
         final JobGraph jobGraph = JobGraphTestUtils.singleNoOpJobGraph();
         jobGraph.getVertices().forEach(v -> v.setParallelism(3));
 
@@ -75,8 +74,7 @@ public class RootExceptionHistoryEntryTest extends TestLogger {
     }
 
     @Test
-    public void testFromFailureHandlingResultSnapshot()
-            throws ExecutionException, InterruptedException {
+    void testFromFailureHandlingResultSnapshot() throws ExecutionException, InterruptedException {
         final Throwable rootException = new RuntimeException("Expected root failure");
         final ExecutionVertex rootExecutionVertex = extractExecutionVertex(0);
         final long rootTimestamp = triggerFailure(rootExecutionVertex, rootException);
@@ -99,27 +97,27 @@ public class RootExceptionHistoryEntryTest extends TestLogger {
         final RootExceptionHistoryEntry actualEntry =
                 RootExceptionHistoryEntry.fromFailureHandlingResultSnapshot(snapshot);
 
-        assertThat(
-                actualEntry,
-                ExceptionHistoryEntryMatcher.matchesFailure(
-                        rootException,
-                        rootTimestamp,
-                        rootFailureLabels.get(),
-                        rootExecutionVertex.getTaskNameWithSubtaskIndex(),
-                        rootExecutionVertex.getCurrentAssignedResourceLocation()));
-        assertThat(
-                actualEntry.getConcurrentExceptions(),
-                IsIterableContainingInOrder.contains(
+        assertThat(actualEntry)
+                .matches(
+                        ExceptionHistoryEntryMatcher.matchesFailure(
+                                rootException,
+                                rootTimestamp,
+                                rootFailureLabels.get(),
+                                rootExecutionVertex.getTaskNameWithSubtaskIndex(),
+                                rootExecutionVertex.getCurrentAssignedResourceLocation()));
+        assertThat(actualEntry.getConcurrentExceptions())
+                .hasSize(1)
+                .allMatch(
                         ExceptionHistoryEntryMatcher.matchesFailure(
                                 concurrentException,
                                 concurrentExceptionTimestamp,
                                 concurrentlyFailedExecutionVertex.getTaskNameWithSubtaskIndex(),
                                 concurrentlyFailedExecutionVertex
-                                        .getCurrentAssignedResourceLocation())));
+                                        .getCurrentAssignedResourceLocation()));
     }
 
     @Test
-    public void testFromGlobalFailure() throws ExecutionException, InterruptedException {
+    void testFromGlobalFailure() throws ExecutionException, InterruptedException {
         final Throwable concurrentException0 =
                 new RuntimeException("Expected concurrent failure #0");
         final ExecutionVertex concurrentlyFailedExecutionVertex0 = extractExecutionVertex(0);
@@ -147,25 +145,28 @@ public class RootExceptionHistoryEntryTest extends TestLogger {
                                 .map(ExecutionVertex::getCurrentExecutionAttempt)
                                 .collect(Collectors.toSet()));
 
-        assertThat(
-                actualEntry,
-                ExceptionHistoryEntryMatcher.matchesGlobalFailure(
-                        rootCause, rootTimestamp, rootFailureLabels.get()));
-        assertThat(
-                actualEntry.getConcurrentExceptions(),
-                IsIterableContainingInAnyOrder.containsInAnyOrder(
-                        ExceptionHistoryEntryMatcher.matchesFailure(
-                                concurrentException0,
-                                concurrentExceptionTimestamp0,
-                                concurrentlyFailedExecutionVertex0.getTaskNameWithSubtaskIndex(),
-                                concurrentlyFailedExecutionVertex0
-                                        .getCurrentAssignedResourceLocation()),
-                        ExceptionHistoryEntryMatcher.matchesFailure(
-                                concurrentException1,
-                                concurrentExceptionTimestamp1,
-                                concurrentlyFailedExecutionVertex1.getTaskNameWithSubtaskIndex(),
-                                concurrentlyFailedExecutionVertex1
-                                        .getCurrentAssignedResourceLocation())));
+        assertThat(actualEntry)
+                .matches(
+                        ExceptionHistoryEntryMatcher.matchesGlobalFailure(
+                                rootCause, rootTimestamp, rootFailureLabels.get()));
+
+        final Predicate<ExceptionHistoryEntry> exception0Predicate =
+                ExceptionHistoryEntryMatcher.matchesFailure(
+                        concurrentException0,
+                        concurrentExceptionTimestamp0,
+                        concurrentlyFailedExecutionVertex0.getTaskNameWithSubtaskIndex(),
+                        concurrentlyFailedExecutionVertex0.getCurrentAssignedResourceLocation());
+        final Predicate<ExceptionHistoryEntry> exception1Predicate =
+                ExceptionHistoryEntryMatcher.matchesFailure(
+                        concurrentException1,
+                        concurrentExceptionTimestamp1,
+                        concurrentlyFailedExecutionVertex1.getTaskNameWithSubtaskIndex(),
+                        concurrentlyFailedExecutionVertex1.getCurrentAssignedResourceLocation());
+        assertThat(actualEntry.getConcurrentExceptions())
+                .allMatch(
+                        exceptionHistoryEntry ->
+                                exception0Predicate.test(exceptionHistoryEntry)
+                                        || exception1Predicate.test(exceptionHistoryEntry));
     }
 
     private long triggerFailure(ExecutionVertex executionVertex, Throwable throwable) {


### PR DESCRIPTION
-  [FLINK-32852][JUnit5 migration] Migrate ExceptionHistoryEntryTest and RootExceptionHistoryEntryTest to Junit5 and Assertj

## Purpose 

I'm working on FLINK-33565, this is a pre-PR to migrate some tests. 

It will reduce the work load for code review of FLINK-33565.