### PR TITLE
[FLINK-34066][table-planner] Fix LagFunction throw NPE when input argument are not null

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -1941,14 +1941,15 @@ class AggregateITCase(aggMode: AggMode, miniBatch: MiniBatchMode, backend: State
     val sql =
       s"""
          |select
-         |  LAG(len, 1, cast(null as int)) OVER w AS prev_quantity,
+         |  LAG(len, 1, cast(null as int)) OVER w AS nullable_prev_quantity,
+         |  LAG(len, 1, 1) OVER w AS prev_quantity,
          |  LAG(len) OVER w AS prev_quantity
          |from src
          |WINDOW w AS (ORDER BY proctime)
          |""".stripMargin
     tEnv.sqlQuery(sql).toRetractStream[Row].addSink(sink).setParallelism(1)
     env.execute()
-    val expected = List("null,null", "15,15", "11,11")
+    val expected = List("null,1,null", "15,15,15", "11,11,11")
     assertThat(sink.getRetractResults).isEqualTo(expected)
   }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/LagAggFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/LagAggFunction.java
@@ -78,7 +78,8 @@ public class LagAggFunction<T> extends BuiltInAggregateFunction<T, LagAggFunctio
         return DataTypes.STRUCTURED(
                 LagAcc.class,
                 DataTypes.FIELD("offset", DataTypes.INT()),
-                DataTypes.FIELD("defaultValue", valueDataTypes[0]),
+                // The initial accumulator's default value is null.
+                DataTypes.FIELD("defaultValue", valueDataTypes[0].nullable()),
                 DataTypes.FIELD("buffer", getLinkedListType()));
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix LagFunction throw NPE when input argument are not null.

This issue is related to https://issues.apache.org/jira/browse/FLINK-31967. In [FLINK-31967](https://issues.apache.org/jira/browse/FLINK-31967), the NPE error has not been thoroughly fixed. If the select value  LAG(len, 1, cast(null as int)) and  LAG(len, 1, 1) exists together in test case AggregateITCase.testLagAggFunction() as:

```
val sql =
  s"""
     |select
     |  LAG(len, 1, cast(null as int)) OVER w AS nullable_prev_quantity,
     |  LAG(len, 1, 1) OVER w AS prev_quantity,
     |  LAG(len) OVER w AS prev_quantity
     |from src
     |WINDOW w AS (ORDER BY proctime)
     |""".stripMargin 
```
before is:

```
val sql =
  s"""
     |select
     |  LAG(len, 1, cast(null as int)) OVER w AS prev_quantity,
     |  LAG(len) OVER w AS prev_quantity
     |from src
     |WINDOW w AS (ORDER BY proctime)
     |""".stripMargin 
```

NPE will throw.

## Brief change log

- Fix LagFunction throw NPE when input argument are not null
- Adding test to cover the npe case.


## Verifying this change

- Adding test to cover the npe case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no docs
