### PR TITLE
[FLINK-34067] Fix javacc warnings in flink-sql-parser

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -728,6 +728,7 @@ SqlAlterTable SqlAlterTable() :
     |
         <ADD>
         (
+            LOOKAHEAD(2)
             AlterTableAddPartition(addPartitionCtx)
             {
                 return new SqlAddPartitions(startPos.plus(getPos()),
@@ -782,6 +783,7 @@ SqlAlterTable SqlAlterTable() :
     |
      <DROP>
         (
+            LOOKAHEAD(2)
             AlterTableDropPartitions(dropPartitionsCtx) {
                 return new SqlDropPartitions(
                         startPos.plus(getPos()),


### PR DESCRIPTION
## What is the purpose of the change

Address the two warnings in the build for the Flink SQL Parser:

```
[INFO] — javacc:2.4:javacc (javacc) @ flink-sql-parser ---                                                 
Java Compiler Compiler Version 4.0 (Parser Generator)                                                       
(type "javacc" with no arguments for help)                                                                                                 
Reading from file .../flink-table/flink-sql-parser/target/generated-sources/javacc/Parser.jj . . .               
Note: UNICODE_INPUT option is specified. Please make sure you create the parser/lexer using a Reader with the correct character encoding.  
Warning: Choice conflict involving two expansions at                                                           
         line 2043, column 13 and line 2052, column 9 respectively.                                        
         A common prefix is: "IF"        
        Consider using a lookahead of 2 for earlier expansion.                                                
Warning: Choice conflict involving two expansions at                                                          
         line 2097, column 13 and line 2105, column 8 respectively.                                         
         A common prefix is: "IF"                                                                                                  
         Consider using a lookahead of 2 for earlier expansion.     
```

## Brief change log
Adds `LOOKAHEAD(2)` to the necessary places in `parserImpls.ftl`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
One can verify the change by building with `mvn -Pfast -f flink-table/flink-sql-parser install`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
