### PR TITLE
[Flink 32701] [cep] Fix CEP Operator Memory Leak Issue 

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
@@ -273,7 +273,7 @@ public class SharedBuffer<V> {
             }
         }
 
-        //memory leak resolution
+        // memory leak resolution
         if (eventsCount.isEmpty()) {
             eventsCount.clear();
         }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBuffer.java
@@ -272,6 +272,11 @@ public class SharedBuffer<V> {
                 iterator.remove();
             }
         }
+
+        //memory leak resolution
+        if (eventsCount.isEmpty()) {
+            eventsCount.clear();
+        }
     }
 
     EventId registerEvent(V value, long timestamp) throws Exception {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -326,6 +326,11 @@ public class CepOperator<IN, KEY, OUT>
 
         // STEP 4
         updateNFA(nfaState);
+
+        // In order to remove dangling partial matches.
+        if (nfaState.getPartialMatches().size() == 1 && nfaState.getCompletedMatches().isEmpty()) {
+            computationStates.clear();
+        }
     }
 
     @Override

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAStateAccessTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAStateAccessTest.java
@@ -81,8 +81,8 @@ public class NFAStateAccessTest {
         nfaTestHarness.consumeRecords(inputEvents);
 
         assertEquals(58, sharedBuffer.getStateReads());
-        assertEquals(33, sharedBuffer.getStateWrites());
-        assertEquals(91, sharedBuffer.getStateAccesses());
+        assertEquals(41, sharedBuffer.getStateWrites());
+        assertEquals(99, sharedBuffer.getStateAccesses());
     }
 
     @Test
@@ -149,7 +149,7 @@ public class NFAStateAccessTest {
         nfaTestHarness.consumeRecords(inputEvents);
 
         assertEquals(90, sharedBuffer.getStateReads());
-        assertEquals(31, sharedBuffer.getStateWrites());
-        assertEquals(121, sharedBuffer.getStateAccesses());
+        assertEquals(34, sharedBuffer.getStateWrites());
+        assertEquals(124, sharedBuffer.getStateAccesses());
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Resolve memory leak issue of CEP operator caused by NFA State and SharedBuffer.eventsCount. Details have been added to [32701](https://issues.apache.org/jira/browse/FLINK-32701)


## Verifying this change

This change is already covered by existing tests.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.flink.cep.nfa.DeweyNumberTest
[INFO] Running org.apache.flink.cep.nfa.NFAStateAccessTest
[INFO] Running org.apache.flink.cep.nfa.NFATest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 s -- in org.apache.flink.cep.nfa.DeweyNumberTest
[INFO] Running org.apache.flink.cep.nfa.NFAIterativeConditionTimeContextTest
[INFO] Running org.apache.flink.cep.nfa.sharedbuffer.LockableTypeSerializerUpgradeTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.276 s -- in org.apache.flink.cep.nfa.NFAIterativeConditionTimeContextTest
[INFO] Running org.apache.flink.cep.nfa.sharedbuffer.LockableTypeSerializerTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.327 s -- in org.apache.flink.cep.nfa.NFAStateAccessTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s -- in org.apache.flink.cep.nfa.sharedbuffer.LockableTypeSerializerTest
[INFO] Running org.apache.flink.cep.nfa.sharedbuffer.SharedBufferTest
[INFO] Running org.apache.flink.cep.nfa.compiler.NFACompilerTest
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.388 s -- in org.apache.flink.cep.nfa.NFATest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.036 s -- in org.apache.flink.cep.nfa.compiler.NFACompilerTest
[INFO] Running org.apache.flink.cep.pattern.PatternTest
[INFO] Running org.apache.flink.cep.NFASerializerUpgradeTest
[INFO] Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.286 s -- in org.apache.flink.cep.pattern.PatternTest
[INFO] Running org.apache.flink.cep.operator.CEPRescalingTest
1
[WARNING] Tests run: 40, Failures: 0, Errors: 0, Skipped: 16, Time elapsed: 0.842 s -- in org.apache.flink.cep.nfa.sharedbuffer.LockableTypeSerializerUpgradeTest
[INFO] Running org.apache.flink.cep.operator.CEPOperatorTest
4
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.886 s -- in org.apache.flink.cep.nfa.sharedbuffer.SharedBufferTest
[INFO] Running org.apache.flink.cep.operator.CEPMigrationTest
[WARNING] Tests run: 200, Failures: 0, Errors: 0, Skipped: 80, Time elapsed: 1.395 s -- in org.apache.flink.cep.NFASerializerUpgradeTest
[INFO] Running org.apache.flink.cep.operator.CepRuntimeContextTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.285 s -- in org.apache.flink.cep.operator.CepRuntimeContextTest
[INFO] Running org.apache.flink.cep.operator.CepProcessFunctionContextTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.097 s -- in org.apache.flink.cep.operator.CepProcessFunctionContextTest
[INFO] Tests run: 44, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.190 s -- in org.apache.flink.cep.operator.CEPMigrationTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.216 s -- in org.apache.flink.cep.operator.CEPRescalingTest
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.478 s -- in org.apache.flink.cep.operator.CEPOperatorTest
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 373, Failures: 0, Errors: 0, Skipped: 96
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
