### PR TITLE
[FLINK-33768] Support dynamic source parallelism inference for batch jobs

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/DynamicFilteringInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/DynamicFilteringInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * A decorative interface that indicates it holds the dynamic partition filtering data. The actual
+ * information needs to be obtained from the implementing class
+ * org.apache.flink.table.connector.source.DynamicFilteringEvent.
+ */
+@PublicEvolving
+public interface DynamicFilteringInfo {}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/DynamicParallelismInference.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/DynamicParallelismInference.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Optional;
+
+/**
+ * Sources that implement this interface will dynamically infer the source’s parallelism when it is
+ * unspecified. It will be invoked during the Flink runtime before the source vertex is scheduled.
+ *
+ * <p>The implementations typically work together with the {@link Source} and are currently only
+ * effective for batch jobs that use the adaptive batch scheduler.
+ */
+@PublicEvolving
+public interface DynamicParallelismInference {
+    /** A context that provides dynamic parallelism decision infos. */
+    @PublicEvolving
+    interface Context {
+        /**
+         * Get the dynamic filtering info of the source vertex.
+         *
+         * @return the dynamic filter instance.
+         */
+        Optional<DynamicFilteringInfo> getDynamicFilteringInfo();
+
+        /**
+         * Get the upper bound for the inferred parallelism.
+         *
+         * @return the upper bound for the inferred parallelism.
+         */
+        int getParallelismInferenceUpperBound();
+
+        /**
+         * Get the average size of data volume (in bytes) to expect each task instance to process.
+         *
+         * @return the data volume per task in bytes.
+         */
+        long getDataVolumePerTask();
+    }
+
+    /**
+     * The method is invoked on the master (JobManager) before the initialization of the source
+     * vertex.
+     *
+     * @param context The context to get dynamic parallelism decision infos.
+     */
+    int inferParallelism(Context context);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -219,17 +219,13 @@ public interface ExecutionGraph extends AccessExecutionGraph {
     @Nonnull
     ComponentMainThreadExecutor getJobMasterMainThreadExecutor();
 
-    default void initializeJobVertex(
-            ExecutionJobVertex ejv,
-            long createTimestamp,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup)
+    default void initializeJobVertex(ExecutionJobVertex ejv, long createTimestamp)
             throws JobException {
         initializeJobVertex(
                 ejv,
                 createTimestamp,
                 VertexInputInfoComputationUtils.computeVertexInputInfos(
-                        ejv, getAllIntermediateResults()::get),
-                jobManagerJobMetricGroup);
+                        ejv, getAllIntermediateResults()::get));
     }
 
     /**
@@ -244,8 +240,7 @@ public interface ExecutionGraph extends AccessExecutionGraph {
     void initializeJobVertex(
             ExecutionJobVertex ejv,
             long createTimestamp,
-            Map<IntermediateDataSetID, JobVertexInputInfo> jobVertexInputInfos,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup)
+            Map<IntermediateDataSetID, JobVertexInputInfo> jobVertexInputInfos)
             throws JobException;
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -46,7 +46,9 @@ import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinatorStore;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
+import org.apache.flink.runtime.operators.coordination.RecreateOnResetOperatorCoordinator;
 import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
+import org.apache.flink.runtime.source.coordinator.SourceCoordinator;
 import org.apache.flink.types.Either;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.OptionalFailure;
@@ -118,7 +120,7 @@ public class ExecutionJobVertex
     private Either<SerializedValue<TaskInformation>, PermanentBlobKey> taskInformationOrBlobKey =
             null;
 
-    @Nullable private Collection<OperatorCoordinatorHolder> operatorCoordinators;
+    private final Collection<OperatorCoordinatorHolder> operatorCoordinators;
 
     @Nullable private InputSplitAssigner splitAssigner;
 
@@ -126,7 +128,9 @@ public class ExecutionJobVertex
     public ExecutionJobVertex(
             InternalExecutionGraphAccessor graph,
             JobVertex jobVertex,
-            VertexParallelismInformation parallelismInfo)
+            VertexParallelismInformation parallelismInfo,
+            CoordinatorStore coordinatorStore,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws JobException {
 
         if (graph == null || jobVertex == null) {
@@ -154,15 +158,38 @@ public class ExecutionJobVertex
         // take the sharing group
         this.slotSharingGroup = checkNotNull(jobVertex.getSlotSharingGroup());
         this.coLocationGroup = jobVertex.getCoLocationGroup();
+
+        final List<SerializedValue<OperatorCoordinator.Provider>> coordinatorProviders =
+                getJobVertex().getOperatorCoordinators();
+        if (coordinatorProviders.isEmpty()) {
+            this.operatorCoordinators = Collections.emptyList();
+        } else {
+            final ArrayList<OperatorCoordinatorHolder> coordinators =
+                    new ArrayList<>(coordinatorProviders.size());
+            try {
+                for (final SerializedValue<OperatorCoordinator.Provider> provider :
+                        coordinatorProviders) {
+                    coordinators.add(
+                            createOperatorCoordinatorHolder(
+                                    provider,
+                                    graph.getUserClassLoader(),
+                                    coordinatorStore,
+                                    jobManagerJobMetricGroup));
+                }
+            } catch (Exception | LinkageError e) {
+                IOUtils.closeAllQuietly(coordinators);
+                throw new JobException(
+                        "Cannot instantiate the coordinator for operator " + getName(), e);
+            }
+            this.operatorCoordinators = Collections.unmodifiableList(coordinators);
+        }
     }
 
     protected void initialize(
             int executionHistorySizeLimit,
             Time timeout,
             long createTimestamp,
-            SubtaskAttemptNumberStore initialAttemptCounts,
-            CoordinatorStore coordinatorStore,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup)
+            SubtaskAttemptNumberStore initialAttemptCounts)
             throws JobException {
 
         checkState(parallelismInfo.getParallelism() > 0);
@@ -209,31 +236,6 @@ public class ExecutionJobVertex
                 throw new RuntimeException(
                         "The intermediate result's partitions were not correctly assigned.");
             }
-        }
-
-        final List<SerializedValue<OperatorCoordinator.Provider>> coordinatorProviders =
-                getJobVertex().getOperatorCoordinators();
-        if (coordinatorProviders.isEmpty()) {
-            this.operatorCoordinators = Collections.emptyList();
-        } else {
-            final ArrayList<OperatorCoordinatorHolder> coordinators =
-                    new ArrayList<>(coordinatorProviders.size());
-            try {
-                for (final SerializedValue<OperatorCoordinator.Provider> provider :
-                        coordinatorProviders) {
-                    coordinators.add(
-                            createOperatorCoordinatorHolder(
-                                    provider,
-                                    graph.getUserClassLoader(),
-                                    coordinatorStore,
-                                    jobManagerJobMetricGroup));
-                }
-            } catch (Exception | LinkageError e) {
-                IOUtils.closeAllQuietly(coordinators);
-                throw new JobException(
-                        "Cannot instantiate the coordinator for operator " + getName(), e);
-            }
-            this.operatorCoordinators = Collections.unmodifiableList(coordinators);
         }
 
         // set up the input splits, if the vertex has any
@@ -406,6 +408,26 @@ public class ExecutionJobVertex
     public Collection<OperatorCoordinatorHolder> getOperatorCoordinators() {
         checkState(isInitialized());
         return operatorCoordinators;
+    }
+
+    public List<SourceCoordinator<?, ?>> getSourceCoordinators() {
+        List<SourceCoordinator<?, ?>> sourceCoordinators = new ArrayList<>();
+        for (OperatorCoordinatorHolder oph : operatorCoordinators) {
+            if (oph.coordinator() instanceof RecreateOnResetOperatorCoordinator) {
+                RecreateOnResetOperatorCoordinator opc =
+                        (RecreateOnResetOperatorCoordinator) oph.coordinator();
+                try {
+                    if (opc.getInternalCoordinator() instanceof SourceCoordinator) {
+                        sourceCoordinators.add(
+                                (SourceCoordinator<?, ?>) opc.getInternalCoordinator());
+                    }
+                } catch (Throwable e) {
+                    throw new RuntimeException(
+                            "Unexpected error occurred when get sourceCoordinators.", e);
+                }
+            }
+        }
+        return sourceCoordinators;
     }
 
     int getNumExecutionVertexFinished() {
@@ -642,9 +664,12 @@ public class ExecutionJobVertex
         ExecutionJobVertex createExecutionJobVertex(
                 InternalExecutionGraphAccessor graph,
                 JobVertex jobVertex,
-                VertexParallelismInformation parallelismInfo)
+                VertexParallelismInformation parallelismInfo,
+                CoordinatorStore coordinatorStore,
+                JobManagerJobMetricGroup jobManagerJobMetricGroup)
                 throws JobException {
-            return new ExecutionJobVertex(graph, jobVertex, parallelismInfo);
+            return new ExecutionJobVertex(
+                    graph, jobVertex, parallelismInfo, coordinatorStore, jobManagerJobMetricGroup);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
@@ -34,9 +34,11 @@ public class SpeculativeExecutionJobVertex extends ExecutionJobVertex {
     public SpeculativeExecutionJobVertex(
             InternalExecutionGraphAccessor graph,
             JobVertex jobVertex,
-            VertexParallelismInformation parallelismInfo)
+            VertexParallelismInformation parallelismInfo,
+            CoordinatorStore coordinatorStore,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws JobException {
-        super(graph, jobVertex, parallelismInfo);
+        super(graph, jobVertex, parallelismInfo, coordinatorStore, jobManagerJobMetricGroup);
     }
 
     @Override
@@ -81,9 +83,12 @@ public class SpeculativeExecutionJobVertex extends ExecutionJobVertex {
         ExecutionJobVertex createExecutionJobVertex(
                 InternalExecutionGraphAccessor graph,
                 JobVertex jobVertex,
-                VertexParallelismInformation parallelismInfo)
+                VertexParallelismInformation parallelismInfo,
+                CoordinatorStore coordinatorStore,
+                JobManagerJobMetricGroup jobManagerJobMetricGroup)
                 throws JobException {
-            return new SpeculativeExecutionJobVertex(graph, jobVertex, parallelismInfo);
+            return new SpeculativeExecutionJobVertex(
+                    graph, jobVertex, parallelismInfo, coordinatorStore, jobManagerJobMetricGroup);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -149,7 +149,6 @@ public class OperatorCoordinatorHolder
 
         this.globalFailureHandler = globalFailureHandler;
         this.mainThreadExecutor = mainThreadExecutor;
-        context.lazyInitialize(globalFailureHandler, mainThreadExecutor, checkpointCoordinator);
 
         context.lazyInitialize(globalFailureHandler, mainThreadExecutor, checkpointCoordinator);
         setupAllSubtaskGateways();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -162,7 +162,6 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
 
     // ---------------------
 
-    @VisibleForTesting
     public OperatorCoordinator getInternalCoordinator() throws Exception {
         waitForAllAsyncCallsFinish();
         return coordinator.internalCoordinator;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
@@ -153,14 +153,16 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
     @Override
     public void registerAndStartNewCoordinators(
             Collection<OperatorCoordinatorHolder> coordinators,
-            ComponentMainThreadExecutor mainThreadExecutor) {
+            ComponentMainThreadExecutor mainThreadExecutor,
+            final int parallelism) {
 
         for (OperatorCoordinatorHolder coordinator : coordinators) {
             coordinatorMap.put(coordinator.operatorId(), coordinator);
             coordinator.lazyInitialize(
                     globalFailureHandler,
                     mainThreadExecutor,
-                    executionGraph.getCheckpointCoordinator());
+                    executionGraph.getCheckpointCoordinator(),
+                    parallelism);
         }
         startOperatorCoordinators(coordinators);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
@@ -78,5 +78,6 @@ public interface OperatorCoordinatorHandler {
      */
     void registerAndStartNewCoordinators(
             Collection<OperatorCoordinatorHolder> coordinators,
-            ComponentMainThreadExecutor mainThreadExecutor);
+            ComponentMainThreadExecutor mainThreadExecutor,
+            final int parallelism);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDecider.java
@@ -106,27 +106,34 @@ public class DefaultVertexParallelismAndInputInfosDecider
             JobVertexID jobVertexId,
             List<BlockingResultInfo> consumedResults,
             int vertexInitialParallelism,
+            int vertexMinParallelism,
             int vertexMaxParallelism) {
         checkArgument(
                 vertexInitialParallelism == ExecutionConfig.PARALLELISM_DEFAULT
                         || vertexInitialParallelism > 0);
-        checkArgument(vertexMaxParallelism > 0 && vertexMaxParallelism >= vertexInitialParallelism);
+        checkArgument(
+                vertexMinParallelism == ExecutionConfig.PARALLELISM_DEFAULT
+                        || vertexMinParallelism > 0);
+        checkArgument(
+                vertexMaxParallelism > 0
+                        && vertexMaxParallelism >= vertexInitialParallelism
+                        && vertexMaxParallelism >= vertexMinParallelism);
 
         if (consumedResults.isEmpty()) {
             // source job vertex
             int parallelism =
                     vertexInitialParallelism > 0
                             ? vertexInitialParallelism
-                            : computeSourceParallelism(jobVertexId, vertexMaxParallelism);
+                            : computeSourceParallelismUpperBound(jobVertexId, vertexMaxParallelism);
             return new ParallelismAndInputInfos(parallelism, Collections.emptyMap());
         } else {
-            int minParallelism = globalMinParallelism;
+            int minParallelism = Math.max(globalMinParallelism, vertexMinParallelism);
             int maxParallelism = globalMaxParallelism;
 
             if (vertexInitialParallelism == ExecutionConfig.PARALLELISM_DEFAULT
                     && vertexMaxParallelism < minParallelism) {
                 LOG.info(
-                        "The vertex maximum parallelism {} is smaller than the global minimum parallelism {}. "
+                        "The vertex maximum parallelism {} is smaller than the minimum parallelism {}. "
                                 + "Use {} as the lower bound to decide parallelism of job vertex {}.",
                         vertexMaxParallelism,
                         minParallelism,
@@ -167,11 +174,12 @@ public class DefaultVertexParallelismAndInputInfosDecider
         }
     }
 
-    private int computeSourceParallelism(JobVertexID jobVertexId, int maxParallelism) {
+    @Override
+    public int computeSourceParallelismUpperBound(JobVertexID jobVertexId, int maxParallelism) {
         if (globalDefaultSourceParallelism > maxParallelism) {
             LOG.info(
                     "The global default source parallelism {} is larger than the maximum parallelism {}. "
-                            + "Use {} as the parallelism of source job vertex {}.",
+                            + "Use {} as the upper bound parallelism of source job vertex {}.",
                     globalDefaultSourceParallelism,
                     maxParallelism,
                     maxParallelism,
@@ -180,6 +188,11 @@ public class DefaultVertexParallelismAndInputInfosDecider
         } else {
             return globalDefaultSourceParallelism;
         }
+    }
+
+    @Override
+    public long getDataVolumePerTask() {
+        return dataVolumePerTask;
     }
 
     private static boolean areAllInputsAllToAll(List<BlockingResultInfo> consumedResults) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/VertexParallelismAndInputInfosDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/VertexParallelismAndInputInfosDecider.java
@@ -41,6 +41,7 @@ public interface VertexParallelismAndInputInfosDecider {
      *     number, it will be respected. If it's not set(equals to {@link
      *     ExecutionConfig#PARALLELISM_DEFAULT}), a parallelism will be automatically decided for
      *     the vertex.
+     * @param vertexMinParallelism The min parallelism of the job vertex.
      * @param vertexMaxParallelism The max parallelism of the job vertex.
      * @return the parallelism and vertex input infos.
      */
@@ -48,5 +49,22 @@ public interface VertexParallelismAndInputInfosDecider {
             JobVertexID jobVertexId,
             List<BlockingResultInfo> consumedResults,
             int vertexInitialParallelism,
+            int vertexMinParallelism,
             int vertexMaxParallelism);
+
+    /**
+     * Compute source parallelism upper bound for the source vertex.
+     *
+     * @param jobVertexId The job vertex id
+     * @param maxParallelism The max parallelism of the job vertex.
+     * @return the upper bound parallelism for the source vertex.
+     */
+    int computeSourceParallelismUpperBound(JobVertexID jobVertexId, int maxParallelism);
+
+    /**
+     * Get the average size of data volume to expect each task instance to process.
+     *
+     * @return the data volume.
+     */
+    long getDataVolumePerTask();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceSplit;
@@ -60,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
@@ -70,6 +72,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 import static org.apache.flink.runtime.operators.coordination.ComponentClosingUtils.shutdownExecutorForcefully;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -109,10 +112,10 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     private final SplitAssignmentTracker<SplitT> assignmentTracker;
     private final SourceCoordinatorProvider.CoordinatorExecutorThreadFactory
             coordinatorThreadFactory;
-    private final SubtaskGateways subtaskGateways;
+    private SubtaskGateways subtaskGateways;
     private final String coordinatorThreadName;
     private final boolean supportsConcurrentExecutionAttempts;
-    private final boolean[] subtaskHasNoMoreSplits;
+    private boolean[] subtaskHasNoMoreSplits;
     private volatile boolean closed;
     private volatile TernaryBoolean backlog = TernaryBoolean.UNDEFINED;
 
@@ -155,11 +158,6 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
         this.coordinatorThreadName = coordinatorThreadFactory.getCoordinatorThreadName();
         this.supportsConcurrentExecutionAttempts = supportsConcurrentExecutionAttempts;
 
-        final int parallelism = operatorCoordinatorContext.currentParallelism();
-        this.subtaskGateways = new SubtaskGateways(parallelism);
-        this.subtaskHasNoMoreSplits = new boolean[parallelism];
-        Arrays.fill(subtaskHasNoMoreSplits, false);
-
         final Executor errorHandlingCoordinatorExecutor =
                 (runnable) ->
                         coordinatorExecutor.execute(
@@ -180,6 +178,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 
     @Override
     public void sendEventToSourceReader(int subtaskId, SourceEvent event) {
+        checkAndLazyInitialize();
         checkState(
                 !supportsConcurrentExecutionAttempts,
                 "The split enumerator must invoke SplitEnumeratorContext"
@@ -201,6 +200,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 
     @Override
     public void sendEventToSourceReader(int subtaskId, int attemptNumber, SourceEvent event) {
+        checkAndLazyInitialize();
         checkSubtaskIndex(subtaskId);
 
         callInCoordinatorThread(
@@ -216,6 +216,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     }
 
     void sendEventToSourceOperator(int subtaskId, OperatorEvent event) {
+        checkAndLazyInitialize();
         checkSubtaskIndex(subtaskId);
 
         callInCoordinatorThread(
@@ -229,6 +230,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     }
 
     void sendEventToSourceOperatorIfTaskReady(int subtaskId, OperatorEvent event) {
+        checkAndLazyInitialize();
         checkSubtaskIndex(subtaskId);
 
         callInCoordinatorThread(
@@ -389,18 +391,21 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     // --------- Package private additional methods for the SourceCoordinator ------------
 
     void attemptReady(OperatorCoordinator.SubtaskGateway gateway) {
+        checkAndLazyInitialize();
         checkState(coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
 
         subtaskGateways.registerSubtaskGateway(gateway);
     }
 
     void attemptFailed(int subtaskIndex, int attemptNumber) {
+        checkAndLazyInitialize();
         checkState(coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
 
         subtaskGateways.unregisterSubtaskGateway(subtaskIndex, attemptNumber);
     }
 
     void subtaskReset(int subtaskIndex) {
+        checkAndLazyInitialize();
         checkState(coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
 
         subtaskGateways.reset(subtaskIndex);
@@ -409,6 +414,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     }
 
     boolean hasNoMoreSplits(int subtaskIndex) {
+        checkAndLazyInitialize();
         return subtaskHasNoMoreSplits[subtaskIndex];
     }
 
@@ -527,6 +533,10 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
                 unit);
     }
 
+    CompletableFuture<?> supplyAsync(Supplier<?> task) {
+        return CompletableFuture.supplyAsync(task, coordinatorExecutor);
+    }
+
     // ---------------- private helper methods -----------------
 
     private void checkSubtaskIndex(int subtaskIndex) {
@@ -535,6 +545,16 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
                     String.format(
                             "Subtask index %d is out of bounds [0, %s)",
                             subtaskIndex, getCoordinatorContext().currentParallelism()));
+        }
+    }
+
+    private void checkAndLazyInitialize() {
+        if (subtaskGateways == null) {
+            final int parallelism = operatorCoordinatorContext.currentParallelism();
+            checkState(parallelism != ExecutionConfig.PARALLELISM_DEFAULT);
+            this.subtaskGateways = new SubtaskGateways(parallelism);
+            this.subtaskHasNoMoreSplits = new boolean[parallelism];
+            Arrays.fill(subtaskHasNoMoreSplits, false);
         }
     }
 
@@ -583,6 +603,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     }
 
     private void assignSplitsToAttempt(int subtaskIndex, int attemptNumber, List<SplitT> splits) {
+        checkAndLazyInitialize();
         if (splits.isEmpty()) {
             return;
         }
@@ -607,6 +628,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     }
 
     private void signalNoMoreSplitsToAttempt(int subtaskIndex, int attemptNumber) {
+        checkAndLazyInitialize();
         checkAttemptReaderReady(subtaskIndex, attemptNumber);
 
         final OperatorCoordinator.SubtaskGateway gateway =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
@@ -430,7 +430,7 @@ class DefaultExecutionGraphConstructionTest {
         eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         ExecutionJobVertex ejv1 = eg.getJobVertex(v1.getID());
-        eg.initializeJobVertex(ejv1, 0L, JOB_MANAGER_JOB_METRIC_GROUP);
+        eg.initializeJobVertex(ejv1, 0L);
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -444,7 +444,7 @@ class DefaultExecutionGraphConstructionTest {
         assertThat(partition1.getConsumedPartitionGroups()).isEmpty();
 
         ExecutionJobVertex ejv2 = eg.getJobVertex(v2.getID());
-        eg.initializeJobVertex(ejv2, 0L, JOB_MANAGER_JOB_METRIC_GROUP);
+        eg.initializeJobVertex(ejv2, 0L);
 
         ConsumedPartitionGroup consumedPartitionGroup =
                 partition1.getConsumedPartitionGroups().get(0);
@@ -468,7 +468,7 @@ class DefaultExecutionGraphConstructionTest {
         eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         ExecutionJobVertex ejv1 = eg.getJobVertex(v1.getID());
-        eg.initializeJobVertex(ejv1, 0L, JOB_MANAGER_JOB_METRIC_GROUP);
+        eg.initializeJobVertex(ejv1, 0L);
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -487,7 +487,7 @@ class DefaultExecutionGraphConstructionTest {
         assertThat(partition4.getConsumedPartitionGroups()).isEmpty();
 
         ExecutionJobVertex ejv2 = eg.getJobVertex(v2.getID());
-        eg.initializeJobVertex(ejv2, 0L, JOB_MANAGER_JOB_METRIC_GROUP);
+        eg.initializeJobVertex(ejv2, 0L);
 
         ConsumedPartitionGroup consumedPartitionGroup1 =
                 partition1.getConsumedPartitionGroups().get(0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
@@ -100,17 +100,12 @@ class EdgeManagerBuildUtilTest {
         final ExecutionJobVertex consumer = vertexIterator.next();
 
         // initialize producer and consumer
-        eg.initializeJobVertex(
-                producer,
-                1L,
-                Collections.emptyMap(),
-                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.initializeJobVertex(producer, 1L, Collections.emptyMap());
         eg.initializeJobVertex(
                 consumer,
                 1L,
                 Collections.singletonMap(
-                        producer.getProducedDataSets()[0].getId(), jobVertexInputInfo),
-                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+                        producer.getProducedDataSets()[0].getId(), jobVertexInputInfo));
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(producer.getJobVertexId()))
@@ -175,17 +170,12 @@ class EdgeManagerBuildUtilTest {
         final ExecutionJobVertex consumer = vertexIterator.next();
 
         // initialize producer and consumer
-        eg.initializeJobVertex(
-                producer,
-                1L,
-                Collections.emptyMap(),
-                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.initializeJobVertex(producer, 1L, Collections.emptyMap());
         eg.initializeJobVertex(
                 consumer,
                 1L,
                 Collections.singletonMap(
-                        producer.getProducedDataSets()[0].getId(), jobVertexInputInfo),
-                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+                        producer.getProducedDataSets()[0].getId(), jobVertexInputInfo));
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(producer.getJobVertexId()))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
@@ -159,9 +159,7 @@ class ExecutionJobVertexTest {
                 1,
                 Time.milliseconds(1L),
                 1L,
-                new DefaultSubtaskAttemptNumberStore(Collections.emptyList()),
-                new CoordinatorStoreImpl(),
-                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+                new DefaultSubtaskAttemptNumberStore(Collections.emptyList()));
     }
 
     private static ExecutionJobVertex createDynamicExecutionJobVertex() throws Exception {
@@ -192,6 +190,11 @@ class ExecutionJobVertexTest {
         final VertexParallelismInformation vertexParallelismInfo =
                 vertexParallelismStore.getParallelismInfo(jobVertex.getID());
 
-        return new ExecutionJobVertex(eg, jobVertex, vertexParallelismInfo);
+        return new ExecutionJobVertex(
+                eg,
+                jobVertex,
+                vertexParallelismInfo,
+                new CoordinatorStoreImpl(),
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.TestingOperatorCoordinator;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
@@ -64,17 +63,17 @@ public class DefaultOperatorCoordinatorHandlerTest {
         ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
         executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
-        executionGraph.initializeJobVertex(
-                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(ejv1, 0L);
 
         DefaultOperatorCoordinatorHandler handler =
                 new DefaultOperatorCoordinatorHandler(executionGraph, throwable -> {});
         assertThat(handler.getCoordinatorMap().keySet(), containsInAnyOrder(operatorId1));
 
-        executionGraph.initializeJobVertex(
-                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(ejv2, 0L);
         handler.registerAndStartNewCoordinators(
-                ejv2.getOperatorCoordinators(), executionGraph.getJobMasterMainThreadExecutor());
+                ejv2.getOperatorCoordinators(),
+                executionGraph.getJobMasterMainThreadExecutor(),
+                ejv2.getParallelism());
 
         assertThat(
                 handler.getCoordinatorMap().keySet(), containsInAnyOrder(operatorId1, operatorId2));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -54,7 +54,6 @@ import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProvider;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
@@ -407,9 +406,7 @@ public class SchedulerTestingUtils {
             JobVertexID jobVertex, ExecutionGraph executionGraph) {
         try {
             executionGraph.initializeJobVertex(
-                    executionGraph.getJobVertex(jobVertex),
-                    System.currentTimeMillis(),
-                    UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+                    executionGraph.getJobVertex(jobVertex), System.currentTimeMillis());
             executionGraph.notifyNewlyInitializedJobVertices(
                     Collections.singletonList(executionGraph.getJobVertex(jobVertex)));
         } catch (JobException exception) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
@@ -34,7 +34,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchScheduler;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
@@ -153,18 +152,15 @@ public class SsgNetworkMemoryCalculationUtilsTest {
         ExecutionJobVertex map = jobVertices.next();
         ExecutionJobVertex sink = jobVertices.next();
 
-        executionGraph.initializeJobVertex(
-                source, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(source, 0L);
         triggerComputeNumOfSubpartitions(source.getProducedDataSets()[0]);
 
         map.setParallelism(5);
-        executionGraph.initializeJobVertex(
-                map, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(map, 0L);
         triggerComputeNumOfSubpartitions(map.getProducedDataSets()[0]);
 
         sink.setParallelism(7);
-        executionGraph.initializeJobVertex(
-                sink, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(sink, 0L);
 
         assertNetworkMemory(
                 slotSharingGroups,
@@ -229,18 +225,12 @@ public class SsgNetworkMemoryCalculationUtilsTest {
         final ExecutionJobVertex producer = vertexIterator.next();
         final ExecutionJobVertex consumer = vertexIterator.next();
 
-        eg.initializeJobVertex(
-                producer,
-                0L,
-                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.initializeJobVertex(producer, 0L);
         final IntermediateResult result = producer.getProducedDataSets()[0];
         triggerComputeNumOfSubpartitions(result);
 
         consumer.setParallelism(decidedConsumerParallelism);
-        eg.initializeJobVertex(
-                consumer,
-                0L,
-                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.initializeJobVertex(consumer, 0L);
 
         Map<IntermediateDataSetID, Integer> maxInputChannelNums = new HashMap<>();
         Map<IntermediateDataSetID, ResultPartitionType> inputPartitionTypes = new HashMap<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
@@ -178,13 +177,11 @@ class DefaultExecutionTopologyTest {
         final ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
         final ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
 
-        executionGraph.initializeJobVertex(
-                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(ejv1, 0L);
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv1));
         assertThat(adapter.getVertices()).hasSize(3);
 
-        executionGraph.initializeJobVertex(
-                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(ejv2, 0L);
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv2));
         assertThat(adapter.getVertices()).hasSize(6);
 
@@ -200,12 +197,10 @@ class DefaultExecutionTopologyTest {
         final ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
         final ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
 
-        executionGraph.initializeJobVertex(
-                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(ejv1, 0L);
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv1));
 
-        executionGraph.initializeJobVertex(
-                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(ejv2, 0L);
         assertThatThrownBy(
                         () ->
                                 adapter.notifyExecutionGraphUpdated(
@@ -222,14 +217,12 @@ class DefaultExecutionTopologyTest {
         final ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
         final ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
 
-        executionGraph.initializeJobVertex(
-                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(ejv1, 0L);
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv1));
         SchedulingPipelinedRegion regionOld =
                 adapter.getPipelinedRegionOfVertex(new ExecutionVertexID(ejv1.getJobVertexId(), 0));
 
-        executionGraph.initializeJobVertex(
-                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        executionGraph.initializeJobVertex(ejv2, 0L);
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv2));
         SchedulingPipelinedRegion regionNew =
                 adapter.getPipelinedRegionOfVertex(new ExecutionVertexID(ejv1.getJobVertexId(), 0));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -961,15 +961,15 @@ public class ExecutingTest extends TestLogger {
             super(
                     new MockInternalExecutionGraphAccessor(),
                     new JobVertex("test"),
-                    new DefaultVertexParallelismInfo(1, 1, max -> Optional.empty()));
+                    new DefaultVertexParallelismInfo(1, 1, max -> Optional.empty()),
+                    new CoordinatorStoreImpl(),
+                    UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
             initialize(
                     1,
                     Time.milliseconds(1L),
                     1L,
-                    new DefaultSubtaskAttemptNumberStore(Collections.emptyList()),
-                    new CoordinatorStoreImpl(),
-                    UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+                    new DefaultSubtaskAttemptNumberStore(Collections.emptyList()));
             mockExecutionVertex = executionVertexSupplier.apply(this);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
@@ -390,8 +390,7 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
     public void initializeJobVertex(
             ExecutionJobVertex ejv,
             long createTimestamp,
-            Map<IntermediateDataSetID, JobVertexInputInfo> jobVertexInputInfos,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup)
+            Map<IntermediateDataSetID, JobVertexInputInfo> jobVertexInputInfos)
             throws JobException {
         throw new UnsupportedOperationException();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
@@ -69,7 +69,8 @@ class TestingOperatorCoordinatorHandler implements OperatorCoordinatorHandler {
     @Override
     public void registerAndStartNewCoordinators(
             Collection<OperatorCoordinatorHolder> coordinators,
-            ComponentMainThreadExecutor mainThreadExecutor) {
+            ComponentMainThreadExecutor mainThreadExecutor,
+            final int parallelism) {
         throw new UnsupportedOperationException();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptivebatch;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.core.failure.FailureEnricher;
@@ -58,6 +59,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -65,6 +67,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
@@ -75,7 +78,6 @@ import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.createFin
 import static org.apache.flink.runtime.scheduler.adaptivebatch.DefaultVertexParallelismAndInputInfosDeciderTest.createDecider;
 import static org.apache.flink.shaded.guava32.com.google.common.collect.Iterables.getOnlyElement;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link AdaptiveBatchScheduler}. */
 class AdaptiveBatchSchedulerTest {
@@ -106,7 +108,7 @@ class AdaptiveBatchSchedulerTest {
         final SchedulerBase scheduler =
                 createScheduler(jobGraph, Collections.singleton(failureEnricher), restartStrategy);
         // Triggered failure on initializeJobVertex that should be labeled
-        assertThatThrownBy(scheduler::startScheduling).isInstanceOf(IllegalStateException.class);
+        scheduler.startScheduling();
         final Iterable<RootExceptionHistoryEntry> exceptionHistory =
                 scheduler.requestJob().getExceptionHistory();
         final RootExceptionHistoryEntry failure = exceptionHistory.iterator().next();
@@ -349,6 +351,34 @@ class AdaptiveBatchSchedulerTest {
 
         // check source's parallelism
         assertThat(source.getParallelism()).isEqualTo(8);
+    }
+
+    @Test
+    void testMergeDynamicParallelismFutures() {
+        List<CompletableFuture<Integer>> sourceParallelismFutures = new ArrayList<>();
+
+        CompletableFuture<Integer> sourceParallelismFuture =
+                CompletableFuture.completedFuture(ExecutionConfig.PARALLELISM_DEFAULT);
+        sourceParallelismFutures.add(sourceParallelismFuture);
+
+        // Testing scenarios without effective parallelism
+        CompletableFuture<Integer> mergedSourceParallelismFuture =
+                AdaptiveBatchScheduler.mergeDynamicParallelismFutures(sourceParallelismFutures);
+        assertThat(mergedSourceParallelismFuture.join())
+                .isEqualTo(ExecutionConfig.PARALLELISM_DEFAULT);
+
+        CompletableFuture<Integer> sourceParallelismFuture1 = CompletableFuture.completedFuture(1);
+        CompletableFuture<Integer> sourceParallelismFuture2 = CompletableFuture.completedFuture(2);
+        CompletableFuture<Integer> sourceParallelismFuture4 = CompletableFuture.completedFuture(4);
+
+        sourceParallelismFutures.add(sourceParallelismFuture1);
+        sourceParallelismFutures.add(sourceParallelismFuture2);
+        sourceParallelismFutures.add(sourceParallelismFuture4);
+
+        // Testing scenarios with multiple sources in ExecutionJobVertex
+        mergedSourceParallelismFuture =
+                AdaptiveBatchScheduler.mergeDynamicParallelismFutures(sourceParallelismFutures);
+        assertThat(mergedSourceParallelismFuture.join()).isEqualTo(4);
     }
 
     void testUserConfiguredMaxParallelism(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.api.common.eventtime.WatermarkAlignmentParams;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.DynamicFilteringInfo;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReader;
@@ -534,6 +535,25 @@ class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         coordinator.start();
 
         assertThat(store.get(listeningID)).isNotNull().isSameAs(coordinator);
+    }
+
+    @Test
+    public void testInferSourceParallelismAsync() throws Exception {
+        final String listeningID = "testListeningID";
+
+        class TestDynamicFilteringEvent implements SourceEvent, DynamicFilteringInfo {}
+
+        CoordinatorStore store = new CoordinatorStoreImpl();
+        store.putIfAbsent(listeningID, new SourceEventWrapper(new TestDynamicFilteringEvent()));
+        final SourceCoordinator<?, ?> coordinator =
+                new SourceCoordinator<>(
+                        OPERATOR_NAME,
+                        createMockSource(),
+                        context,
+                        store,
+                        WatermarkAlignmentParams.WATERMARK_ALIGNMENT_DISABLED,
+                        listeningID);
+        assertThat(coordinator.inferSourceParallelismAsync(2, 1).get()).isEqualTo(2);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/TestingSplitEnumerator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/TestingSplitEnumerator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.DynamicParallelismInference;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceReader;
@@ -218,7 +219,7 @@ public class TestingSplitEnumerator<SplitT extends SourceSplit>
 
     @SuppressWarnings("serial")
     static class FactorySource<T, SplitT extends SourceSplit>
-            implements Source<T, SplitT, Set<SplitT>> {
+            implements Source<T, SplitT, Set<SplitT>>, DynamicParallelismInference {
 
         private final SimpleVersionedSerializer<SplitT> splitSerializer;
         private final SimpleVersionedSerializer<Set<SplitT>> checkpointSerializer;
@@ -260,6 +261,11 @@ public class TestingSplitEnumerator<SplitT extends SourceSplit>
         @Override
         public SimpleVersionedSerializer<Set<SplitT>> getEnumeratorCheckpointSerializer() {
             return checkpointSerializer;
+        }
+
+        @Override
+        public int inferParallelism(Context context) {
+            return context.getParallelismInferenceUpperBound();
         }
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/DynamicFilteringEvent.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/DynamicFilteringEvent.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.connector.source;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.DynamicFilteringInfo;
 import org.apache.flink.api.connector.source.SourceEvent;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -29,7 +30,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * dynamic filtering, via DynamicFilteringDataCollectorCoordinator and SourceCoordinator.
  */
 @PublicEvolving
-public class DynamicFilteringEvent implements SourceEvent {
+public class DynamicFilteringEvent implements SourceEvent, DynamicFilteringInfo {
     private final DynamicFilteringData data;
 
     public DynamicFilteringEvent(DynamicFilteringData data) {

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
@@ -19,8 +19,11 @@
 package org.apache.flink.test.scheduling;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.operators.SlotSharingGroup;
+import org.apache.flink.api.connector.source.DynamicParallelismInference;
+import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
 import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
@@ -66,6 +69,16 @@ class AdaptiveBatchSchedulerITCase {
                         .collect(Collectors.toMap(Function.identity(), i -> 2L));
 
         numberCountResults = new ConcurrentLinkedQueue<>();
+    }
+
+    @Test
+    void testScheduling() throws Exception {
+        testSchedulingBase(false);
+    }
+
+    @Test
+    void testSchedulingWithDynamicSourceParallelismInference() throws Exception {
+        testSchedulingBase(true);
     }
 
     @Test
@@ -117,9 +130,8 @@ class AdaptiveBatchSchedulerITCase {
         env.execute();
     }
 
-    @Test
-    void testScheduling() throws Exception {
-        executeJob();
+    private void testSchedulingBase(Boolean useSourceParallelismInference) throws Exception {
+        executeJob(useSourceParallelismInference);
 
         Map<Long, Long> numberCountResultMap =
                 numberCountResults.stream()
@@ -138,7 +150,7 @@ class AdaptiveBatchSchedulerITCase {
         assertThat(numberCountResultMap).isEqualTo(expectedResult);
     }
 
-    private void executeJob() throws Exception {
+    private void executeJob(Boolean useSourceParallelismInference) throws Exception {
         final Configuration configuration = createConfiguration();
         configuration.set(ClusterOptions.FINE_GRAINED_SHUFFLE_MODE_ALL_BLOCKING, true);
 
@@ -157,17 +169,36 @@ class AdaptiveBatchSchedulerITCase {
             slotSharingGroups.add(group);
         }
 
-        final DataStream<Long> source1 =
-                env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
-                        .setParallelism(SOURCE_PARALLELISM_1)
-                        .name("source1")
-                        .slotSharingGroup(slotSharingGroups.get(0));
+        DataStream<Long> source1;
+        DataStream<Long> source2;
 
-        final DataStream<Long> source2 =
-                env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
-                        .setParallelism(SOURCE_PARALLELISM_2)
-                        .name("source2")
-                        .slotSharingGroup(slotSharingGroups.get(1));
+        if (useSourceParallelismInference) {
+            source1 =
+                    env.fromSource(
+                                    new TestingParallelismInferenceNumberSequenceSource(
+                                            0, NUMBERS_TO_PRODUCE - 1, SOURCE_PARALLELISM_1),
+                                    WatermarkStrategy.noWatermarks(),
+                                    "source1")
+                            .slotSharingGroup(slotSharingGroups.get(0));
+            source2 =
+                    env.fromSource(
+                                    new TestingParallelismInferenceNumberSequenceSource(
+                                            0, NUMBERS_TO_PRODUCE - 1, SOURCE_PARALLELISM_2),
+                                    WatermarkStrategy.noWatermarks(),
+                                    "source2")
+                            .slotSharingGroup(slotSharingGroups.get(1));
+        } else {
+            source1 =
+                    env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
+                            .setParallelism(SOURCE_PARALLELISM_1)
+                            .name("source1")
+                            .slotSharingGroup(slotSharingGroups.get(0));
+            source2 =
+                    env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
+                            .setParallelism(SOURCE_PARALLELISM_2)
+                            .name("source2")
+                            .slotSharingGroup(slotSharingGroups.get(1));
+        }
 
         source1.union(source2)
                 .rescale()
@@ -208,6 +239,23 @@ class AdaptiveBatchSchedulerITCase {
         @Override
         public void close() throws Exception {
             numberCountResults.add(numberCountResult);
+        }
+    }
+
+    private static class TestingParallelismInferenceNumberSequenceSource
+            extends NumberSequenceSource implements DynamicParallelismInference {
+        private static final long serialVersionUID = 1L;
+        private final int expectedParallelism;
+
+        public TestingParallelismInferenceNumberSequenceSource(
+                long from, long to, int expectedParallelism) {
+            super(from, to);
+            this.expectedParallelism = expectedParallelism;
+        }
+
+        @Override
+        public int inferParallelism(Context context) {
+            return expectedParallelism;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, for JobVertices without parallelism configured, the AdaptiveBatchScheduler dynamically infers the vertex parallelism based on the volume of input data. Specifically, for Source vertices, it uses the value of `execution.batch.adaptive.auto-parallelism.default-source-parallelism` as the fixed parallelism. If this is not set by the user, the default value of 1  is used as the source parallelism, which is actually a temporary implementation solution.

We aim to support dynamic source parallelism inference for batch jobs
## Brief change log

  - *Lazily initialize the parallelism of the OperatorCoordinator.*
  - *Add the `DynamicParallelismInference` and `DynamicFilteringInfo` interfaces, and enable the `SourceCoordinator` to invoke corresponding methods for dynamic parallelism inference.*
  - *The `AdaptiveBatchScheduler` applies dynamic source parallelism inference, and to avoid blocking the main thread by calling external systems, we have transformed the scheduling process to be asynchronous.*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added integration tests to verify the end-to-end logic of dynamic parallelism inference, see `AdaptiveBatchSchedulerITCase#testSchedulingWithDynamicSourceParallelismInference` for details.*
  - *Added unit tests for the newly added methods in classes such as `SourceCoordinator` and `AdaptiveBatchScheduler`.*
  - *Manually verified the feature on a Flink session cluster (1 JobManager, 77 TaskManagers), including dynamic inference of parallelism, asynchronous scheduling, and execution exceptions in `DynamicParallelismInference`, all performing as expected.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs / JavaDocs)
