### PR TITLE
[FLINK-34080][configuration] Simplify the Configuration

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -160,16 +160,17 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
     }
 
     /**
-     * Returns the value associated with the given key as a string.
+     * Returns the value associated with the given key as a string. We encourage users and
+     * developers to always use ConfigOption for getting the configurations if possible, for its
+     * rich description, type, default-value and other supports. The string-key-based getter should
+     * only be used when ConfigOption is not applicable, e.g., the key is programmatically generated
+     * in runtime.
      *
      * @param key the key pointing to the associated value
      * @param defaultValue the default value which is returned in case there is no value associated
      *     with the given key
      * @return the (default) value associated with the given key
-     * @deprecated use {@link #getString(ConfigOption, String)} or {@link
-     *     #getOptional(ConfigOption)}
      */
-    @Deprecated
     public String getString(String key, String defaultValue) {
         return getRawValue(key)
                 .map(o -> ConfigurationUtils.convertToString(o, standardYaml))
@@ -205,7 +206,11 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
     }
 
     /**
-     * Adds the given key/value pair to the configuration object.
+     * Adds the given key/value pair to the configuration object. We encourage users and developers
+     * to always use ConfigOption for setting the configurations if possible, for its rich
+     * description, type, default-value and other supports. The string-key-based setter should only
+     * be used when ConfigOption is not applicable, e.g., the key is programmatically generated in
+     * runtime.
      *
      * @param key the key of the key/value pair to be added
      * @param value the value of the key/value pair to be added

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -737,6 +737,20 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
         return getOptional(option).orElseGet(option::defaultValue);
     }
 
+    /**
+     * Returns the value associated with the given config option as a T. If no value is mapped under
+     * any key of the option, it returns the specified default instead of the option's default
+     * value.
+     *
+     * @param configOption The configuration option
+     * @param overrideDefault The value to return if no value was mapper for any key of the option
+     * @return the configured value associated with the given config option, or the overrideDefault
+     */
+    @PublicEvolving
+    public <T> T get(ConfigOption<T> configOption, T overrideDefault) {
+        return getOptional(configOption).orElse(overrideDefault);
+    }
+
     @Override
     public <T> Optional<T> getOptional(ConfigOption<T> option) {
         Optional<Object> rawValue = getRawValueFromOption(option);

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -125,6 +125,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @return The value associated with the given key, or the default value, if to entry for the
      *     key exists.
      */
+    @Deprecated
     @SuppressWarnings("unchecked")
     public <T> Class<T> getClass(
             String key, Class<? extends T> defaultValue, ClassLoader classLoader)
@@ -153,6 +154,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param klazz The value of the pair to be added
      * @see #getClass(String, Class, ClassLoader)
      */
+    @Deprecated
     public void setClass(String key, Class<?> klazz) {
         setValueInternal(key, klazz.getName());
     }
@@ -179,7 +181,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param configOption The configuration option
      * @return the (default) value associated with the given config option
+     * @deprecated use {@link #get(ConfigOption)} or {@link #getOptional(ConfigOption)}
      */
+    @Deprecated
     @PublicEvolving
     public String getString(ConfigOption<String> configOption) {
         return getOptional(configOption).orElseGet(configOption::defaultValue);
@@ -192,7 +196,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param configOption The configuration option
      * @return the (default) value associated with the given config option
+     * @deprecated use {@link #get(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public String getString(ConfigOption<String> configOption, String overrideDefault) {
         return getOptional(configOption).orElse(overrideDefault);
@@ -214,7 +220,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the option specifying the key to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public void setString(ConfigOption<String> key, String value) {
         setValueInternal(key.key(), value);
@@ -227,7 +235,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param defaultValue the default value which is returned in case there is no value associated
      *     with the given key
      * @return the (default) value associated with the given key
-     * @deprecated use {@link #getInteger(ConfigOption, int)} or {@link #getOptional(ConfigOption)}
+     * @deprecated use {@link #get(ConfigOption)}, {@link #get(ConfigOption, Object)} or {@link
+     *     #getOptional(ConfigOption)}
      */
     @Deprecated
     public int getInteger(String key, int defaultValue) {
@@ -239,7 +248,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param configOption The configuration option
      * @return the (default) value associated with the given config option
+     * @deprecated use {@link #get(ConfigOption)} or {@link #getOptional(ConfigOption)}
      */
+    @Deprecated
     @PublicEvolving
     public int getInteger(ConfigOption<Integer> configOption) {
         return getOptional(configOption).orElseGet(configOption::defaultValue);
@@ -253,7 +264,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param configOption The configuration option
      * @param overrideDefault The value to return if no value was mapper for any key of the option
      * @return the configured value associated with the given config option, or the overrideDefault
+     * @deprecated use {@link #get(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public int getInteger(ConfigOption<Integer> configOption, int overrideDefault) {
         return getOptional(configOption).orElse(overrideDefault);
@@ -264,7 +277,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the key of the key/value pair to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     public void setInteger(String key, int value) {
         setValueInternal(key, value);
     }
@@ -275,7 +290,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the option specifying the key to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public void setInteger(ConfigOption<Integer> key, int value) {
         setValueInternal(key.key(), value);
@@ -288,7 +305,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param defaultValue the default value which is returned in case there is no value associated
      *     with the given key
      * @return the (default) value associated with the given key
-     * @deprecated use {@link #getLong(ConfigOption, long)} or {@link #getOptional(ConfigOption)}
+     * @deprecated use {@link #get(ConfigOption)}, {@link #get(ConfigOption, Object)} or {@link
+     *     #getOptional(ConfigOption)}
      */
     @Deprecated
     public long getLong(String key, long defaultValue) {
@@ -300,7 +318,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param configOption The configuration option
      * @return the (default) value associated with the given config option
+     * @deprecated use {@link #get(ConfigOption)} or {@link #getOptional(ConfigOption)}
      */
+    @Deprecated
     @PublicEvolving
     public long getLong(ConfigOption<Long> configOption) {
         return getOptional(configOption).orElseGet(configOption::defaultValue);
@@ -314,7 +334,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param configOption The configuration option
      * @param overrideDefault The value to return if no value was mapper for any key of the option
      * @return the configured value associated with the given config option, or the overrideDefault
+     * @deprecated use {@link #get(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public long getLong(ConfigOption<Long> configOption, long overrideDefault) {
         return getOptional(configOption).orElse(overrideDefault);
@@ -325,7 +347,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the key of the key/value pair to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     public void setLong(String key, long value) {
         setValueInternal(key, value);
     }
@@ -336,7 +360,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the option specifying the key to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public void setLong(ConfigOption<Long> key, long value) {
         setValueInternal(key.key(), value);
@@ -349,7 +375,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param defaultValue the default value which is returned in case there is no value associated
      *     with the given key
      * @return the (default) value associated with the given key
-     * @deprecated use {@link #getBoolean(ConfigOption, boolean)} or {@link
+     * @deprecated use {@link #get(ConfigOption)}, {@link #get(ConfigOption, Object)} or {@link
      *     #getOptional(ConfigOption)}
      */
     @Deprecated
@@ -362,7 +388,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param configOption The configuration option
      * @return the (default) value associated with the given config option
+     * @deprecated use {@link #get(ConfigOption)} or {@link #getOptional(ConfigOption)}
      */
+    @Deprecated
     @PublicEvolving
     public boolean getBoolean(ConfigOption<Boolean> configOption) {
         return getOptional(configOption).orElseGet(configOption::defaultValue);
@@ -376,7 +404,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param configOption The configuration option
      * @param overrideDefault The value to return if no value was mapper for any key of the option
      * @return the configured value associated with the given config option, or the overrideDefault
+     * @deprecated use {@link #get(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public boolean getBoolean(ConfigOption<Boolean> configOption, boolean overrideDefault) {
         return getOptional(configOption).orElse(overrideDefault);
@@ -387,7 +417,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the key of the key/value pair to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     public void setBoolean(String key, boolean value) {
         setValueInternal(key, value);
     }
@@ -398,7 +430,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the option specifying the key to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public void setBoolean(ConfigOption<Boolean> key, boolean value) {
         setValueInternal(key.key(), value);
@@ -411,7 +445,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param defaultValue the default value which is returned in case there is no value associated
      *     with the given key
      * @return the (default) value associated with the given key
-     * @deprecated use {@link #getFloat(ConfigOption, float)} or {@link #getOptional(ConfigOption)}
+     * @deprecated use {@link #get(ConfigOption)}, {@link #get(ConfigOption, Object)} or {@link
+     *     #getOptional(ConfigOption)}
      */
     @Deprecated
     public float getFloat(String key, float defaultValue) {
@@ -423,7 +458,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param configOption The configuration option
      * @return the (default) value associated with the given config option
+     * @deprecated use {@link #get(ConfigOption)} or {@link #getOptional(ConfigOption)}
      */
+    @Deprecated
     @PublicEvolving
     public float getFloat(ConfigOption<Float> configOption) {
         return getOptional(configOption).orElseGet(configOption::defaultValue);
@@ -437,7 +474,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param configOption The configuration option
      * @param overrideDefault The value to return if no value was mapper for any key of the option
      * @return the configured value associated with the given config option, or the overrideDefault
+     * @deprecated use {@link #get(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public float getFloat(ConfigOption<Float> configOption, float overrideDefault) {
         return getOptional(configOption).orElse(overrideDefault);
@@ -448,7 +487,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the key of the key/value pair to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     public void setFloat(String key, float value) {
         setValueInternal(key, value);
     }
@@ -459,7 +500,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the option specifying the key to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public void setFloat(ConfigOption<Float> key, float value) {
         setValueInternal(key.key(), value);
@@ -472,7 +515,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param defaultValue the default value which is returned in case there is no value associated
      *     with the given key
      * @return the (default) value associated with the given key
-     * @deprecated use {@link #getDouble(ConfigOption, double)} or {@link
+     * @deprecated use {@link #get(ConfigOption)}, {@link #get(ConfigOption, Object)} or {@link
      *     #getOptional(ConfigOption)}
      */
     @Deprecated
@@ -485,7 +528,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param configOption The configuration option
      * @return the (default) value associated with the given config option
+     * @deprecated use {@link #get(ConfigOption)} or {@link #getOptional(ConfigOption)}
      */
+    @Deprecated
     @PublicEvolving
     public double getDouble(ConfigOption<Double> configOption) {
         return getOptional(configOption).orElseGet(configOption::defaultValue);
@@ -499,7 +544,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param configOption The configuration option
      * @param overrideDefault The value to return if no value was mapper for any key of the option
      * @return the configured value associated with the given config option, or the overrideDefault
+     * @deprecated use {@link #get(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public double getDouble(ConfigOption<Double> configOption, double overrideDefault) {
         return getOptional(configOption).orElse(overrideDefault);
@@ -510,7 +557,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the key of the key/value pair to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     public void setDouble(String key, double value) {
         setValueInternal(key, value);
     }
@@ -521,7 +570,9 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *
      * @param key the option specifying the key to be added
      * @param value the value of the key/value pair to be added
+     * @deprecated use {@link #set(ConfigOption, Object)}
      */
+    @Deprecated
     @PublicEvolving
     public void setDouble(ConfigOption<Double> key, double value) {
         setValueInternal(key.key(), value);

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -363,6 +363,11 @@ public final class DelegatingConfiguration extends Configuration {
     }
 
     @Override
+    public <T> T get(ConfigOption<T> configOption, T overrideDefault) {
+        return backingConfig.get(prefixOption(configOption, prefix), overrideDefault);
+    }
+
+    @Override
     public <T> Optional<T> getOptional(ConfigOption<T> option) {
         return backingConfig.getOptional(prefixOption(option, prefix));
     }

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -554,6 +554,45 @@ public class ConfigurationTest {
                                         .doesNotContain("secret_value"));
     }
 
+    @TestTemplate
+    void testGetWithOverrideDefault() {
+        final Configuration conf = new Configuration(standardYaml);
+
+        // Test for integer without default value.
+        ConfigOption<Integer> integerOption0 =
+                ConfigOptions.key("integer.key0").intType().noDefaultValue();
+        // integerOption0 doesn't exist in conf, and it should be overrideDefault.
+        assertThat(conf.get(integerOption0, 2)).isEqualTo(2);
+        // integerOption0 exists in conf, and it should be value that set before.
+        conf.set(integerOption0, 3);
+        assertThat(conf.get(integerOption0, 2)).isEqualTo(3);
+
+        // Test for integer with default value, the default value should be ignored.
+        ConfigOption<Integer> integerOption1 =
+                ConfigOptions.key("integer.key1").intType().defaultValue(4);
+        assertThat(conf.get(integerOption1, 5)).isEqualTo(5);
+        // integerOption1 is changed.
+        conf.set(integerOption1, 6);
+        assertThat(conf.get(integerOption1, 5)).isEqualTo(6);
+
+        // Test for string without default value.
+        ConfigOption<String> stringOption0 =
+                ConfigOptions.key("string.key0").stringType().noDefaultValue();
+        // stringOption0 doesn't exist in conf, and it should be overrideDefault.
+        assertThat(conf.get(stringOption0, "a")).isEqualTo("a");
+        // stringOption0 exists in conf, and it should be value that set before.
+        conf.set(stringOption0, "b");
+        assertThat(conf.get(stringOption0, "a")).isEqualTo("b");
+
+        // Test for string with default value, the default value should be ignored.
+        ConfigOption<String> stringOption1 =
+                ConfigOptions.key("string.key1").stringType().defaultValue("c");
+        assertThat(conf.get(stringOption1, "d")).isEqualTo("d");
+        // stringOption1 is changed.
+        conf.set(stringOption1, "e");
+        assertThat(conf.get(stringOption1, "d")).isEqualTo("e");
+    }
+
     // --------------------------------------------------------------------------------------------
     // Test classes
     // --------------------------------------------------------------------------------------------

--- a/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
@@ -157,41 +157,51 @@ class DelegatingConfigurationTest {
         // integerOption doesn't exist in delegatingConf, and it should be overrideDefault.
         original.setInteger(integerOption, 1);
         assertThat(delegatingConf.getInteger(integerOption, 2)).isEqualTo(2);
+        assertThat(delegatingConf.get(integerOption, 2)).isEqualTo(2);
 
         // integerOption exists in delegatingConf, and it should be value that set before.
         delegatingConf.setInteger(integerOption, 3);
         assertThat(delegatingConf.getInteger(integerOption, 2)).isEqualTo(3);
+        assertThat(delegatingConf.get(integerOption, 2)).isEqualTo(3);
 
         // Test for float
         ConfigOption<Float> floatOption =
                 ConfigOptions.key("float.key").floatType().noDefaultValue();
         original.setFloat(floatOption, 4f);
         assertThat(delegatingConf.getFloat(floatOption, 5f)).isEqualTo(5f);
+        assertThat(delegatingConf.get(floatOption, 5f)).isEqualTo(5f);
         delegatingConf.setFloat(floatOption, 6f);
         assertThat(delegatingConf.getFloat(floatOption, 5f)).isEqualTo(6f);
+        assertThat(delegatingConf.get(floatOption, 5f)).isEqualTo(6f);
 
         // Test for double
         ConfigOption<Double> doubleOption =
                 ConfigOptions.key("double.key").doubleType().noDefaultValue();
         original.setDouble(doubleOption, 7d);
         assertThat(delegatingConf.getDouble(doubleOption, 8d)).isEqualTo(8d);
+        assertThat(delegatingConf.get(doubleOption, 8d)).isEqualTo(8d);
         delegatingConf.setDouble(doubleOption, 9f);
         assertThat(delegatingConf.getDouble(doubleOption, 8d)).isEqualTo(9f);
+        assertThat(delegatingConf.get(doubleOption, 8d)).isEqualTo(9f);
 
         // Test for long
         ConfigOption<Long> longOption = ConfigOptions.key("long.key").longType().noDefaultValue();
         original.setLong(longOption, 10L);
         assertThat(delegatingConf.getLong(longOption, 11L)).isEqualTo(11L);
+        assertThat(delegatingConf.get(longOption, 11L)).isEqualTo(11L);
         delegatingConf.setLong(longOption, 12L);
         assertThat(delegatingConf.getLong(longOption, 11L)).isEqualTo(12L);
+        assertThat(delegatingConf.get(longOption, 11L)).isEqualTo(12L);
 
         // Test for boolean
         ConfigOption<Boolean> booleanOption =
                 ConfigOptions.key("boolean.key").booleanType().noDefaultValue();
         original.setBoolean(booleanOption, false);
         assertThat(delegatingConf.getBoolean(booleanOption, true)).isEqualTo(true);
+        assertThat(delegatingConf.get(booleanOption, true)).isEqualTo(true);
         delegatingConf.setBoolean(booleanOption, false);
         assertThat(delegatingConf.getBoolean(booleanOption, true)).isEqualTo(false);
+        assertThat(delegatingConf.get(booleanOption, true)).isEqualTo(false);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

See the part 2.2 of [FLIP-405](https://cwiki.apache.org/confluence/x/6Yr5E)


## Brief change log

- [FLINK-34080][configuration] Add the `T get(ConfigOption<T> configOption, T overrideDefault)` for Configuration
- [FLINK-34080][configuration] Deprecate all getXxx and setXxx methods for Configuration
- [FLINK-34080][configuration] Remove the `@Deprecated` for `getString(String key, String defaultValue)` of Configuration


## Verifying this change

  - Added `ConfigurationTest#testGetWithOverrideDefault`
  - Improved the `DelegatingConfigurationTest#testGetWithOverrideDefault`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
