### PR TITLE
[FLINK-34084][config] Deprecate unused configuration in BinaryInput/OutputFormat and FileInput/OutputFormat

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryInputFormat.java
@@ -61,7 +61,7 @@ public abstract class BinaryInputFormat<T> extends FileInputFormat<T>
     private static final Logger LOG = LoggerFactory.getLogger(BinaryInputFormat.class);
 
     /** The config parameter which defines the fixed length of a record. */
-    public static final String BLOCK_SIZE_PARAMETER_KEY = "input.block_size";
+    @Deprecated public static final String BLOCK_SIZE_PARAMETER_KEY = "input.block_size";
 
     public static final long NATIVE_BLOCK_SIZE = Long.MIN_VALUE;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/BinaryOutputFormat.java
@@ -33,7 +33,7 @@ public abstract class BinaryOutputFormat<T> extends FileOutputFormat<T> {
     private static final long serialVersionUID = 1L;
 
     /** The config parameter which defines the fixed length of a record. */
-    public static final String BLOCK_SIZE_PARAMETER_KEY = "output.block_size";
+    @Deprecated public static final String BLOCK_SIZE_PARAMETER_KEY = "output.block_size";
 
     public static final long NATIVE_BLOCK_SIZE = Long.MIN_VALUE;
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileInputFormat.java
@@ -1140,5 +1140,6 @@ public abstract class FileInputFormat<OT> extends RichInputFormat<OT, FileInputS
     private static final String FILE_PARAMETER_KEY = "input.file.path";
 
     /** The config parameter which defines whether input directories are recursively traversed. */
+    @Deprecated
     public static final String ENUMERATE_NESTED_FILES_FLAG = "recursive.file.enumeration";
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
@@ -92,7 +92,7 @@ public abstract class FileOutputFormat<IT> extends RichOutputFormat<IT>
     private static final Logger LOG = LoggerFactory.getLogger(FileOutputFormat.class);
 
     /** The key under which the name of the target path is stored in the configuration. */
-    public static final String FILE_PARAMETER_KEY = "flink.output.file";
+    @Deprecated public static final String FILE_PARAMETER_KEY = "flink.output.file";
 
     /** The path of the file to be written. */
     protected Path outputFilePath;


### PR DESCRIPTION
## What is the purpose of the change

This PR updates FileInputFormat.java, FileOutputFormat.java, BinaryInputFormat.java, and BinaryOutputFormat.java to deprecate unused string configuration keys.


## Brief change log

- Deprecate unused configuration in BinaryInput/OutputFormat and FileInput/OutputFormat


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
