### PR TITLE
[FLINK-33721][core] Extend BashJavaUtils to support reading and writing standard yaml file.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -28,6 +28,7 @@ import javax.annotation.Nonnull;
 import java.io.File;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -198,6 +199,62 @@ public class ConfigurationUtils {
         return separatedPaths.length() > 0
                 ? separatedPaths.split(",|" + File.pathSeparator)
                 : EMPTY;
+    }
+
+    /**
+     * Converts the provided configuration data into a format suitable for writing to a file, based
+     * on the {@code flattenYaml} flag and the {@code standardYaml} attribute of the configuration
+     * object.
+     *
+     * <p>Only when {@code flattenYaml} is set to {@code false} and the configuration object is
+     * standard yaml, a nested YAML format is used. Otherwise, a flat key-value pair format is
+     * output.
+     *
+     * <p>Each entry in the returned list represents a single line that can be written directly to a
+     * file.
+     *
+     * <p>Example input (flat map configuration data):
+     *
+     * <pre>{@code
+     * {
+     *      "parent.child": "value1",
+     *      "parent.child2": "value2"
+     * }
+     * }</pre>
+     *
+     * <p>Example output when {@code flattenYaml} is {@code false} and the configuration object is
+     * standard yaml:
+     *
+     * <pre>{@code
+     * parent:
+     *   child: value1
+     *   child2: value2
+     * }</pre>
+     *
+     * <p>Otherwise, the Example output is:
+     *
+     * <pre>{@code
+     * parent.child: value1
+     * parent.child2: value2
+     * }</pre>
+     *
+     * @param configuration The configuration to be converted.
+     * @param flattenYaml A boolean flag indicating if the configuration data should be output in a
+     *     flattened format.
+     * @return A list of strings, where each string represents a line of the file-writable data in
+     *     the chosen format.
+     */
+    public static List<String> convertConfigToWritableLines(
+            Configuration configuration, boolean flattenYaml) {
+        if (configuration.standardYaml && !flattenYaml) {
+            return YamlParserUtils.convertAndDumpYamlFromFlatMap(
+                    Collections.unmodifiableMap(configuration.confData));
+        } else {
+            Map<String, String> fileWritableMap = configuration.toFileWritableMap();
+            return fileWritableMap.entrySet().stream()
+                    .map(entry -> entry.getKey() + ": " + entry.getValue())
+                    .collect(Collectors.toList());
+        }
     }
 
     /**

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.apache.flink.util.TimeUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
@@ -94,6 +95,92 @@ public class ConfigurationUtilsTest {
                 .isEqualTo(expectedList);
         assertThat(configuration.get(ConfigOptions.key("mapKey").mapType().noDefaultValue()))
                 .isEqualTo(expectedMap);
+    }
+
+    @TestTemplate
+    void testConvertConfigToWritableLinesAndFlattenYaml() {
+        testConvertConfigToWritableLines(true);
+    }
+
+    @TestTemplate
+    void testConvertConfigToWritableLinesAndNoFlattenYaml() {
+        testConvertConfigToWritableLines(false);
+    }
+
+    private void testConvertConfigToWritableLines(boolean flattenYaml) {
+        final Configuration configuration = new Configuration(standardYaml);
+        ConfigOption<List<String>> nestedListOption =
+                ConfigOptions.key("nested.test-list-key").stringType().asList().noDefaultValue();
+        final String listValues = "value1;value2;value3";
+        final String yamlListValues = "[value1, value2, value3]";
+        configuration.set(nestedListOption, Arrays.asList(listValues.split(";")));
+
+        ConfigOption<Map<String, String>> nestedMapOption =
+                ConfigOptions.key("nested.test-map-key").mapType().noDefaultValue();
+        final String mapValues = "key1:value1,key2:value2";
+        final String yamlMapValues = "{key1: value1, key2: value2}";
+        configuration.set(
+                nestedMapOption,
+                Arrays.stream(mapValues.split(","))
+                        .collect(Collectors.toMap(e -> e.split(":")[0], e -> e.split(":")[1])));
+
+        ConfigOption<Duration> nestedDurationOption =
+                ConfigOptions.key("nested.test-duration-key").durationType().noDefaultValue();
+        final Duration duration = Duration.ofMillis(3000);
+        configuration.set(nestedDurationOption, duration);
+
+        ConfigOption<String> nestedStringOption =
+                ConfigOptions.key("nested.test-string-key").stringType().noDefaultValue();
+        final String strValues = "*";
+        final String yamlStrValues = "'*'";
+        configuration.set(nestedStringOption, strValues);
+
+        ConfigOption<Integer> intOption =
+                ConfigOptions.key("test-int-key").intType().noDefaultValue();
+        final int intValue = 1;
+        configuration.set(intOption, intValue);
+
+        List<String> actualData =
+                ConfigurationUtils.convertConfigToWritableLines(configuration, flattenYaml);
+        List<String> expected;
+        if (standardYaml) {
+            if (flattenYaml) {
+                expected =
+                        Arrays.asList(
+                                nestedListOption.key() + ": " + yamlListValues,
+                                nestedMapOption.key() + ": " + yamlMapValues,
+                                nestedDurationOption.key()
+                                        + ": "
+                                        + TimeUtils.formatWithHighestUnit(duration),
+                                nestedStringOption.key() + ": " + yamlStrValues,
+                                intOption.key() + ": " + intValue);
+            } else {
+                expected =
+                        Arrays.asList(
+                                "nested:",
+                                "  test-list-key:",
+                                "  - value1",
+                                "  - value2",
+                                "  - value3",
+                                "  test-map-key:",
+                                "    key1: value1",
+                                "    key2: value2",
+                                "  test-duration-key: 3 s",
+                                "  test-string-key: '*'",
+                                "test-int-key: 1");
+            }
+        } else {
+            expected =
+                    Arrays.asList(
+                            nestedListOption.key() + ": " + listValues,
+                            nestedMapOption.key() + ": " + mapValues,
+                            nestedDurationOption.key()
+                                    + ": "
+                                    + TimeUtils.formatWithHighestUnit(duration),
+                            nestedStringOption.key() + ": " + strValues,
+                            intOption.key() + ": " + intValue);
+        }
+        assertThat(expected).containsExactlyInAnyOrderElementsOf(actualData);
     }
 
     @TestTemplate

--- a/flink-core/src/test/java/org/apache/flink/configuration/YamlParserUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/YamlParserUtilsTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -148,6 +149,63 @@ class YamlParserUtilsTest {
         map.put("k2", "v2");
 
         assertThat(YamlParserUtils.convertToObject(s4, Map.class)).isEqualTo(map);
+    }
+
+    @Test
+    void testDumpNestedYamlFromFlatMap() {
+        Map<String, Object> flattenMap = new HashMap<>();
+        flattenMap.put("string", "stringValue");
+        flattenMap.put("integer", 42);
+        flattenMap.put("double", 3.14);
+        flattenMap.put("boolean", true);
+        flattenMap.put("enum", TestEnum.ENUM);
+        flattenMap.put("list1", Arrays.asList("item1", "item2", "item3"));
+        flattenMap.put("list2", "{item1, item2, item3}");
+        flattenMap.put("map1", Collections.singletonMap("k1", "v1"));
+        flattenMap.put("map2", "{k2: v2}");
+        flattenMap.put(
+                "listMap1",
+                Arrays.asList(
+                        Collections.singletonMap("k3", "v3"),
+                        Collections.singletonMap("k4", "v4")));
+        flattenMap.put("listMap2", "[{k5: v5}, {k6: v6}]");
+        flattenMap.put("nested.key1.subKey1", "value1");
+        flattenMap.put("nested.key2.subKey1", "value2");
+        flattenMap.put("nested.key3", "value3");
+        flattenMap.put("escaped1", "*");
+        flattenMap.put("escaped2", "1");
+        flattenMap.put("escaped3", "true");
+
+        List<String> values = YamlParserUtils.convertAndDumpYamlFromFlatMap(flattenMap);
+
+        assertThat(values)
+                .containsExactlyInAnyOrder(
+                        "string: stringValue",
+                        "integer: 42",
+                        "double: 3.14",
+                        "boolean: true",
+                        "enum: ENUM",
+                        "list1:",
+                        "- item1",
+                        "- item2",
+                        "- item3",
+                        "list2: '{item1, item2, item3}'",
+                        "map1:",
+                        "  k1: v1",
+                        "map2: '{k2: v2}'",
+                        "listMap1:",
+                        "- k3: v3",
+                        "- k4: v4",
+                        "listMap2: '[{k5: v5}, {k6: v6}]'",
+                        "nested:",
+                        "  key1:",
+                        "    subKey1: value1",
+                        "  key2:",
+                        "    subKey1: value2",
+                        "  key3: value3",
+                        "escaped1: '*'",
+                        "escaped2: '1'",
+                        "escaped3: 'true'");
     }
 
     private enum TestEnum {

--- a/flink-dist/src/main/flink-bin/bin/bash-java-utils.sh
+++ b/flink-dist/src/main/flink-bin/bin/bash-java-utils.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+UNAME=$(uname -s)
+if [ "${UNAME:0:6}" == "CYGWIN" ]; then
+    JAVA_RUN=java
+else
+    if [[ -d "$JAVA_HOME" ]]; then
+        JAVA_RUN="$JAVA_HOME"/bin/java
+    else
+        JAVA_RUN=java
+    fi
+fi
+
+manglePathList() {
+    UNAME=$(uname -s)
+    # a path list, for example a java classpath
+    if [ "${UNAME:0:6}" == "CYGWIN" ]; then
+        echo `cygpath -wp "$1"`
+    else
+        echo $1
+    fi
+}
+
+findFlinkDistJar() {
+    local FLINK_DIST
+    local LIB_DIR
+    if [[ -n "$1" ]]; then
+       LIB_DIR="$1"
+    else
+       LIB_DIR="$FLINK_LIB_DIR"
+    fi
+    FLINK_DIST="$(find "$LIB_DIR" -name 'flink-dist*.jar')"
+    local FLINK_DIST_COUNT
+    FLINK_DIST_COUNT="$(echo "$FLINK_DIST" | wc -l)"
+
+    # If flink-dist*.jar cannot be resolved write error messages to stderr since stdout is stored
+    # as the classpath and exit function with empty classpath to force process failure
+    if [[ "$FLINK_DIST" == "" ]]; then
+        (>&2 echo "[ERROR] Flink distribution jar not found in $FLINK_LIB_DIR.")
+        exit 1
+    elif [[ "$FLINK_DIST_COUNT" -gt 1 ]]; then
+        (>&2 echo "[ERROR] Multiple flink-dist*.jar found in $FLINK_LIB_DIR. Please resolve.")
+        exit 1
+    fi
+
+    echo "$FLINK_DIST"
+}
+
+runBashJavaUtilsCmd() {
+    local cmd=$1
+    local conf_dir=$2
+    local class_path=$3
+    local dynamic_args=${@:4}
+    class_path=`manglePathList "${class_path}"`
+
+    local output=`"${JAVA_RUN}" -classpath "${class_path}" org.apache.flink.runtime.util.bash.BashJavaUtils ${cmd} --configDir "${conf_dir}" $dynamic_args 2>&1 | tail -n 1000`
+    if [[ $? -ne 0 ]]; then
+        echo "[ERROR] Cannot run BashJavaUtils to execute command ${cmd}." 1>&2
+        # Print the output in case the user redirect the log to console.
+        echo "$output" 1>&2
+        exit 1
+    fi
+
+    echo "$output"
+}
+
+updateAndGetFlinkConfiguration() {
+    local FLINK_CONF_DIR="$1"
+    local FLINK_BIN_DIR="$2"
+    local FLINK_LIB_DIR="$3"
+    local command_result
+    command_result=$(parseConfigurationAndExportLogs "$FLINK_CONF_DIR" "$FLINK_BIN_DIR" "$FLINK_LIB_DIR" "UPDATE_AND_GET_FLINK_CONFIGURATION" "${@:4}")
+    echo "$command_result"
+}
+
+parseConfigurationAndExportLogs() {
+    local FLINK_CONF_DIR="$1"
+    local FLINK_BIN_DIR="$2"
+    local FLINK_LIB_DIR="$3"
+    local COMMAND="$4"
+    local EXECUTION_PREFIX="BASH_JAVA_UTILS_EXEC_RESULT:"
+
+    java_utils_output=$(runBashJavaUtilsCmd "${COMMAND}" "${FLINK_CONF_DIR}" "${FLINK_BIN_DIR}/bash-java-utils.jar:$(findFlinkDistJar ${FLINK_LIB_DIR})" "${@:5}")
+    logging_output=$(extractLoggingOutputs "${java_utils_output}")
+    execution_results=$(echo "${java_utils_output}" | grep ${EXECUTION_PREFIX})
+
+    if [[ $? -ne 0 ]]; then
+      echo "[ERROR] Could not parse configurations properly."
+      echo "[ERROR] Raw output from BashJavaUtils:"
+      echo "$java_utils_output"
+      exit 1
+    fi
+
+    echo "${execution_results//${EXECUTION_PREFIX}/}"
+}
+
+extractLoggingOutputs() {
+    local output="$1"
+    local EXECUTION_PREFIX="BASH_JAVA_UTILS_EXEC_RESULT:"
+
+    echo "${output}" | grep -v ${EXECUTION_PREFIX}
+}
+
+extractExecutionResults() {
+    local output="$1"
+    local expected_lines="$2"
+    local EXECUTION_PREFIX="BASH_JAVA_UTILS_EXEC_RESULT:"
+    local execution_results
+    local num_lines
+
+    execution_results=$(echo "${output}" | grep ${EXECUTION_PREFIX})
+    num_lines=$(echo "${execution_results}" | wc -l)
+    # explicit check for empty result, because if execution_results is empty, then wc returns 1
+    if [[ -z ${execution_results} ]]; then
+        echo "[ERROR] The execution result is empty." 1>&2
+        exit 1
+    fi
+    if [[ ${num_lines} -ne ${expected_lines} ]]; then
+        echo "[ERROR] The execution results has unexpected number of lines, expected: ${expected_lines}, actual: ${num_lines}." 1>&2
+        echo "[ERROR] An execution result line is expected following the prefix '${EXECUTION_PREFIX}'" 1>&2
+        echo "$output" 1>&2
+        exit 1
+    fi
+
+    echo "${execution_results//${EXECUTION_PREFIX}/}"
+}
+
+parseResourceParamsAndExportLogs() {
+  local cmd=$1
+  java_utils_output=$(runBashJavaUtilsCmd ${cmd} "${FLINK_CONF_DIR}" "${FLINK_BIN_DIR}/bash-java-utils.jar:$(findFlinkDistJar)" "${@:2}")
+  logging_output=$(extractLoggingOutputs "${java_utils_output}")
+  params_output=$(extractExecutionResults "${java_utils_output}" 2)
+
+  if [[ $? -ne 0 ]]; then
+    echo "[ERROR] Could not get JVM parameters and dynamic configurations properly."
+    echo "[ERROR] Raw output from BashJavaUtils:"
+    echo "$java_utils_output"
+    exit 1
+  fi
+
+  jvm_params=$(echo "${params_output}" | head -n1)
+  export JVM_ARGS="${JVM_ARGS} ${jvm_params}"
+  export DYNAMIC_PARAMETERS=$(IFS=" " echo "${params_output}" | tail -n1)
+
+  export FLINK_INHERITED_LOGS="
+$FLINK_INHERITED_LOGS
+
+RESOURCE_PARAMS extraction logs:
+jvm_params: $jvm_params
+dynamic_configs: $DYNAMIC_PARAMETERS
+logs: $logging_output
+"
+}

--- a/flink-dist/src/main/flink-bin/bin/config-parser-utils.sh
+++ b/flink-dist/src/main/flink-bin/bin/config-parser-utils.sh
@@ -17,22 +17,28 @@
 # limitations under the License.
 ################################################################################
 
-USAGE="Usage: runExtractLoggingOutputs.sh <input>"
+USAGE="Usage: config-parser-utils.sh FLINK_CONF_DIR FLINK_BIN_DIR FLINK_LIB_DIR [dynamic args...]"
 
-INPUT="$1"
+if [ "$#" -lt 3 ]; then
+    echo "$USAGE"
+    exit 1
+fi
 
-if [[ -z "${INPUT}" ]]; then
-  echo "$USAGE"
+source "$2"/bash-java-utils.sh
+
+ARGS=("${@:1}")
+result=$(updateAndGetFlinkConfiguration "${ARGS[@]}")
+
+if [[ $? -ne 0 ]]; then
+  echo "[ERROR] Could not get configurations properly, the result is :"
+  echo "$result"
   exit 1
 fi
 
-bin=`dirname "$0"`
-bin=`cd "$bin"; pwd`
+CONF_FILE="$1/flink-conf.yaml"
+if [ ! -e "$1/flink-conf.yaml" ]; then
+  CONF_FILE="$1/config.yaml"
+fi;
 
-FLINK_CONF_DIR=${bin}/../../main/resources
-FLINK_TARGET_DIR=${bin}/../../../target
-FLINK_DIST_JAR=`find $FLINK_TARGET_DIR -name 'flink-dist*.jar'`
-
-. ${bin}/../../main/flink-bin/bin/bash-java-utils.sh > /dev/null
-
-extractLoggingOutputs "${INPUT}"
+# Output the result
+echo "${result}" > "$CONF_FILE";

--- a/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
+++ b/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
@@ -37,7 +37,7 @@ FLINK_TARGET_DIR=${bin}/../../../target
 FLINK_DIST_JARS=(`find ${FLINK_TARGET_DIR} -maxdepth 1 -name 'flink-dist*.jar'`)
 FLINK_DIST_CLASSPATH=`echo ${FLINK_DIST_JARS[@]} | tr ' ' ':'`
 
-. ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
+. ${bin}/../../main/flink-bin/bin/bash-java-utils.sh > /dev/null
 
 output=$(runBashJavaUtilsCmd ${COMMAND} ${FLINK_CONF_DIR} "$FLINK_TARGET_DIR/bash-java-utils.jar:${FLINK_DIST_CLASSPATH}" $DYNAMIC_OPTS)
 extractExecutionResults "${output}" ${EXPECTED_LINES}

--- a/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
@@ -25,8 +25,7 @@ import org.apache.flink.runtime.util.bash.BashJavaUtils;
 
 import org.apache.flink.shaded.guava32.com.google.common.collect.Sets;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,10 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
-import static org.hamcrest.collection.IsIn.isIn;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for BashJavaUtils.
@@ -46,7 +42,7 @@ import static org.junit.Assert.assertThat;
  * <p>This test requires the distribution to be assembled and is hence marked as an IT case which
  * run after packaging.
  */
-public class BashJavaUtilsITCase extends JavaBashTestBase {
+class BashJavaUtilsITCase extends JavaBashTestBase {
 
     private static final String RUN_BASH_JAVA_UTILS_CMD_SCRIPT =
             "src/test/bin/runBashJavaUtilsCmd.sh";
@@ -54,7 +50,7 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
             "src/test/bin/runExtractLoggingOutputs.sh";
 
     @Test
-    public void testGetTmResourceParamsConfigs() throws Exception {
+    void testGetTmResourceParamsConfigs() throws Exception {
         int expectedResultLines = 2;
         String[] commands = {
             RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
@@ -63,13 +59,13 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
         };
         List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
 
-        assertThat(lines.size(), is(expectedResultLines));
+        assertThat(lines).hasSize(expectedResultLines);
         ConfigurationUtils.parseJvmArgString(lines.get(0));
         ConfigurationUtils.parseTmResourceDynamicConfigs(lines.get(1));
     }
 
     @Test
-    public void testGetTmResourceParamsConfigsWithDynamicProperties() throws Exception {
+    void testGetTmResourceParamsConfigsWithDynamicProperties() throws Exception {
         int expectedResultLines = 2;
         double cpuCores = 39.0;
         String[] commands = {
@@ -80,14 +76,15 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
         };
         List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
 
-        assertThat(lines.size(), is(expectedResultLines));
+        assertThat(lines).hasSize(expectedResultLines);
         Map<String, String> configs =
                 ConfigurationUtils.parseTmResourceDynamicConfigs(lines.get(1));
-        assertThat(Double.valueOf(configs.get(TaskManagerOptions.CPU_CORES.key())), is(cpuCores));
+        assertThat(Double.valueOf(configs.get(TaskManagerOptions.CPU_CORES.key())))
+                .isEqualTo(cpuCores);
     }
 
     @Test
-    public void testGetJmResourceParams() throws Exception {
+    void testGetJmResourceParams() throws Exception {
         int expectedResultLines = 2;
         String[] commands = {
             RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
@@ -96,7 +93,7 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
         };
         List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
 
-        assertThat(lines.size(), is(expectedResultLines));
+        assertThat(lines).hasSize(expectedResultLines);
 
         Map<String, String> jvmParams = ConfigurationUtils.parseJvmArgString(lines.get(0));
         Map<String, String> dynamicParams = parseAndAssertDynamicParameters(lines.get(1));
@@ -104,7 +101,7 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
     }
 
     @Test
-    public void testGetJmResourceParamsWithDynamicProperties() throws Exception {
+    void testGetJmResourceParamsWithDynamicProperties() throws Exception {
         int expectedResultLines = 2;
         long metaspace = 123456789L;
         String[] commands = {
@@ -115,12 +112,12 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
         };
         List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
 
-        assertThat(lines.size(), is(expectedResultLines));
+        assertThat(lines).hasSize(expectedResultLines);
 
         Map<String, String> jvmParams = ConfigurationUtils.parseJvmArgString(lines.get(0));
         Map<String, String> dynamicParams = parseAndAssertDynamicParameters(lines.get(1));
         assertJvmAndDynamicParametersMatch(jvmParams, dynamicParams);
-        assertThat(Long.valueOf(jvmParams.get("-XX:MaxMetaspaceSize=")), is(metaspace));
+        assertThat(Long.valueOf(jvmParams.get("-XX:MaxMetaspaceSize="))).isEqualTo(metaspace);
     }
 
     private static Map<String, String> parseAndAssertDynamicParameters(
@@ -135,15 +132,15 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
 
         Map<String, String> actualDynamicParameters = new HashMap<>();
         String[] dynamicParameterTokens = dynamicParametersStr.split(" ");
-        assertThat(dynamicParameterTokens.length % 2, Matchers.is(0));
+        assertThat(dynamicParameterTokens.length % 2).isZero();
         for (int i = 0; i < dynamicParameterTokens.length; ++i) {
             String parameterKeyValueStr = dynamicParameterTokens[i];
             if (i % 2 == 0) {
-                assertThat(parameterKeyValueStr, Matchers.is("-D"));
+                assertThat(parameterKeyValueStr).isEqualTo("-D");
             } else {
                 String[] parameterKeyValue = parameterKeyValueStr.split("=");
-                assertThat(parameterKeyValue, arrayWithSize(2));
-                assertThat(parameterKeyValue[0], isIn(expectedDynamicParameters));
+                assertThat(parameterKeyValue).hasSize(2);
+                assertThat(parameterKeyValue[0]).isIn(expectedDynamicParameters);
 
                 actualDynamicParameters.put(parameterKeyValue[0], parameterKeyValue[1]);
             }
@@ -154,19 +151,16 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
 
     private static void assertJvmAndDynamicParametersMatch(
             Map<String, String> jvmParams, Map<String, String> dynamicParams) {
-        assertThat(
-                jvmParams.get("-Xmx") + "b",
-                is(dynamicParams.get(JobManagerOptions.JVM_HEAP_MEMORY.key())));
-        assertThat(
-                jvmParams.get("-Xms") + "b",
-                is(dynamicParams.get(JobManagerOptions.JVM_HEAP_MEMORY.key())));
-        assertThat(
-                jvmParams.get("-XX:MaxMetaspaceSize=") + "b",
-                is(dynamicParams.get(JobManagerOptions.JVM_METASPACE.key())));
+        assertThat(jvmParams.get("-Xmx") + "b")
+                .isEqualTo(dynamicParams.get(JobManagerOptions.JVM_HEAP_MEMORY.key()));
+        assertThat(jvmParams.get("-Xms") + "b")
+                .isEqualTo(dynamicParams.get(JobManagerOptions.JVM_HEAP_MEMORY.key()));
+        assertThat(jvmParams.get("-XX:MaxMetaspaceSize=") + "b")
+                .isEqualTo(dynamicParams.get(JobManagerOptions.JVM_METASPACE.key()));
     }
 
     @Test
-    public void testExtractLoggingOutputs() throws Exception {
+    void testExtractLoggingOutputs() throws Exception {
         StringBuilder input = new StringBuilder();
         List<String> expectedOutput = new ArrayList<>();
 
@@ -184,6 +178,6 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
         List<String> actualOutput =
                 Arrays.asList(executeScript(commands).split(System.lineSeparator()));
 
-        assertThat(actualOutput, is(expectedOutput));
+        assertThat(actualOutput).isEqualTo(expectedOutput);
     }
 }

--- a/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
@@ -120,6 +120,100 @@ class BashJavaUtilsITCase extends JavaBashTestBase {
         assertThat(Long.valueOf(jvmParams.get("-XX:MaxMetaspaceSize="))).isEqualTo(metaspace);
     }
 
+    @Test
+    void testGetConfiguration() throws Exception {
+        int expectedResultLines = 13;
+        String[] commands = {
+            RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
+            BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
+            String.valueOf(expectedResultLines)
+        };
+        List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
+
+        assertThat(lines).hasSize(expectedResultLines);
+    }
+
+    @Test
+    void testGetConfigurationRemoveKey() throws Exception {
+        int expectedResultLines = 12;
+        String[] commands = {
+            RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
+            BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
+            String.valueOf(expectedResultLines),
+            "-rmKey",
+            "parallelism.default"
+        };
+        List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
+
+        assertThat(lines).hasSize(expectedResultLines);
+        assertThat(lines).doesNotContain("parallelism.default: 1");
+    }
+
+    @Test
+    void testGetConfigurationRemoveKeyValue() throws Exception {
+        int expectedResultLines = 12;
+        String[] commands = {
+            RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
+            BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
+            String.valueOf(expectedResultLines),
+            "-rmKV",
+            "parallelism.default=1"
+        };
+        List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
+
+        assertThat(lines).hasSize(expectedResultLines);
+        assertThat(lines).doesNotContain("parallelism.default: 1");
+    }
+
+    @Test
+    void testGetConfigurationRemoveKeyValueNotMatchingValue() throws Exception {
+        int expectedResultLines = 13;
+        String[] commands = {
+            RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
+            BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
+            String.valueOf(expectedResultLines),
+            "-rmKV",
+            "parallelism.default=2"
+        };
+        List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
+
+        assertThat(lines).hasSize(expectedResultLines);
+        assertThat(lines).contains("parallelism.default: 1");
+    }
+
+    @Test
+    void testGetConfigurationReplaceKeyValue() throws Exception {
+        int expectedResultLines = 13;
+        String[] commands = {
+            RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
+            BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
+            String.valueOf(expectedResultLines),
+            "-repKV",
+            "parallelism.default,1,2"
+        };
+        List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
+
+        assertThat(lines).hasSize(expectedResultLines);
+        assertThat(lines).doesNotContain("parallelism.default: 1");
+        assertThat(lines).contains("parallelism.default: 2");
+    }
+
+    @Test
+    void testGetConfigurationReplaceKeyValueNotMatchingValue() throws Exception {
+        int expectedResultLines = 13;
+        String[] commands = {
+            RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
+            BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
+            String.valueOf(expectedResultLines),
+            "-repKV",
+            "parallelism.default,2,3"
+        };
+        List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
+
+        assertThat(lines).hasSize(expectedResultLines);
+        assertThat(lines).doesNotContain("parallelism.default: 3");
+    }
+
     private static Map<String, String> parseAndAssertDynamicParameters(
             String dynamicParametersStr) {
         Set<String> expectedDynamicParameters =

--- a/flink-dist/src/test/java/org/apache/flink/dist/JavaBashTestBase.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/JavaBashTestBase.java
@@ -19,21 +19,21 @@
 package org.apache.flink.dist;
 
 import org.apache.flink.util.OperatingSystem;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Assume;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Abstract test class for executing bash scripts. */
-public abstract class JavaBashTestBase extends TestLogger {
-    @BeforeClass
+abstract class JavaBashTestBase {
+    @BeforeAll
     public static void checkOperatingSystem() {
-        Assume.assumeTrue(
-                "This test checks shell scripts which are not available on Windows.",
-                !OperatingSystem.isWindows());
+        assertThat(OperatingSystem.isWindows())
+                .as("This test checks shell scripts which are not available on Windows.")
+                .isFalse();
     }
 
     /**

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkDistribution.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkDistribution.java
@@ -20,6 +20,7 @@ package org.apache.flink.tests.util.flink;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.test.util.FileUtils;
@@ -417,15 +418,11 @@ public final class FlinkDistribution {
         mergedConfig.addAll(defaultConfig);
         mergedConfig.addAll(config);
 
-        final List<String> configurationLines =
-                mergedConfig.toFileWritableMap().entrySet().stream()
-                        .map(entry -> entry.getKey() + ": " + entry.getValue())
-                        .collect(Collectors.toList());
-
         // NOTE: Before we change the default conf file in the flink-dist to 'config.yaml', we
         // need to use the legacy flink conf file 'flink-conf.yaml' here.
         Files.write(
-                conf.resolve(GlobalConfiguration.LEGACY_FLINK_CONF_FILENAME), configurationLines);
+                conf.resolve(GlobalConfiguration.LEGACY_FLINK_CONF_FILENAME),
+                ConfigurationUtils.convertConfigToWritableLines(mergedConfig, true));
     }
 
     public void setTaskExecutorHosts(Collection<String> taskExecutorHosts) throws IOException {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestUtils.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestUtils.java
@@ -19,18 +19,19 @@
 package org.apache.flink.kubernetes;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.YamlParserUtils;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 
 import org.apache.flink.shaded.guava32.com.google.common.io.Files;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /** Utilities for the Kubernetes tests. */
 public class KubernetesTestUtils {
@@ -41,15 +42,25 @@ public class KubernetesTestUtils {
     }
 
     public static Configuration loadConfigurationFromString(String content) {
-        final Configuration configuration = new Configuration();
-        for (String line : content.split(System.lineSeparator())) {
-            final String[] splits = line.split(":");
-            if (splits.length >= 2) {
-                configuration.setString(
-                        splits[0].trim(), StringUtils.substringAfter(line, ":").trim());
-            }
-        }
-        return configuration;
+        Map<String, Object> map = YamlParserUtils.convertToObject(content, Map.class);
+        return Configuration.fromMap(flatten(map, ""));
+    }
+
+    private static Map<String, String> flatten(Map<String, Object> config, String keyPrefix) {
+        final Map<String, String> flattenedMap = new HashMap<>();
+
+        config.forEach(
+                (key, value) -> {
+                    String flattenedKey = keyPrefix + key;
+                    if (value instanceof Map) {
+                        Map<String, Object> e = (Map<String, Object>) value;
+                        flattenedMap.putAll(flatten(e, flattenedKey + "."));
+                    } else {
+                        flattenedMap.put(flattenedKey, YamlParserUtils.toYAMLString(value));
+                    }
+                });
+
+        return flattenedMap;
     }
 
     public static KubernetesTaskManagerParameters createTaskManagerParameters(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.kubeclient.factory;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.SecurityOptions;
@@ -367,11 +368,11 @@ class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBase {
         assertThat(resultDatas).hasSize(3);
         assertThat(resultDatas.get(CONFIG_FILE_LOG4J_NAME)).isEqualTo("some data");
         assertThat(resultDatas.get(CONFIG_FILE_LOGBACK_NAME)).isEqualTo("some data");
-        assertThat(resultDatas.get(FLINK_CONF_FILENAME))
-                .contains(
-                        KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS.key()
-                                + ": "
-                                + ENTRY_POINT_CLASS);
+        final Configuration resultFlinkConfig =
+                KubernetesTestUtils.loadConfigurationFromString(
+                        resultDatas.get(FLINK_CONF_FILENAME));
+        assertThat(resultFlinkConfig.get(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS))
+                .isEqualTo(ENTRY_POINT_CLASS);
     }
 
     @Test

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineOptions;
 import org.apache.flink.runtime.util.config.memory.ProcessMemoryUtils;
@@ -75,10 +76,8 @@ public class BootstrapTools {
     public static void writeConfiguration(Configuration cfg, File file) throws IOException {
         try (FileWriter fwrt = new FileWriter(file);
                 PrintWriter out = new PrintWriter(fwrt)) {
-            for (Map.Entry<String, String> entry : cfg.toFileWritableMap().entrySet()) {
-                out.print(entry.getKey());
-                out.print(": ");
-                out.println(entry.getValue());
+            for (String s : ConfigurationUtils.convertConfigToWritableLines(cfg, false)) {
+                out.println(s);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ModifiableClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ModifiableClusterConfiguration.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Configuration class which contains the parsed command line arguments for the {@link
+ * ClusterEntrypoint}.
+ */
+public class ModifiableClusterConfiguration {
+
+    private final boolean flattenConfig;
+
+    private final String configDir;
+
+    private final Properties dynamicProperties;
+
+    private final Properties removeKeyValues;
+
+    private final List<String> removeKeys;
+
+    private final List<Tuple3<String, String, String>> replaceKeyValues;
+
+    public ModifiableClusterConfiguration(
+            boolean flattenConfig,
+            String configDir,
+            Properties dynamicProperties,
+            Properties removeKeyValues,
+            List<String> removeKeys,
+            List<Tuple3<String, String, String>> replaceKeyValues) {
+        this.flattenConfig = flattenConfig;
+        this.configDir = configDir;
+        this.dynamicProperties = dynamicProperties;
+        this.removeKeyValues = removeKeyValues;
+        this.removeKeys = removeKeys;
+        this.replaceKeyValues = replaceKeyValues;
+    }
+
+    public boolean flattenConfig() {
+        return flattenConfig;
+    }
+
+    public Properties getRemoveKeyValues() {
+        return removeKeyValues;
+    }
+
+    public List<String> getRemoveKeys() {
+        return removeKeys;
+    }
+
+    public List<Tuple3<String, String, String>> getReplaceKeyValues() {
+        return replaceKeyValues;
+    }
+
+    public String getConfigDir() {
+        return configDir;
+    }
+
+    public Properties getDynamicProperties() {
+        return dynamicProperties;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ModifiableClusterConfigurationParserFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ModifiableClusterConfigurationParserFactory.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.ConfigurationCommandLineOptions.FLATTEN_CONFIG_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.ConfigurationCommandLineOptions.REMOVE_KEY_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.ConfigurationCommandLineOptions.REMOVE_KEY_VALUE_OPTION;
+import static org.apache.flink.runtime.entrypoint.parser.ConfigurationCommandLineOptions.REPLACE_KEY_VALUE_OPTION;
+
+/** A class can be used to extract the configuration from command line and modify it. */
+public class ModifiableClusterConfigurationParserFactory
+        implements ParserResultFactory<ModifiableClusterConfiguration> {
+
+    public static Options options() {
+        final Options options = new Options();
+        options.addOption(CONFIG_DIR_OPTION);
+        options.addOption(REMOVE_KEY_OPTION);
+        options.addOption(REMOVE_KEY_VALUE_OPTION);
+        options.addOption(REPLACE_KEY_VALUE_OPTION);
+        options.addOption(DYNAMIC_PROPERTY_OPTION);
+        options.addOption(FLATTEN_CONFIG_OPTION);
+
+        return options;
+    }
+
+    @Override
+    public Options getOptions() {
+        return options();
+    }
+
+    @Override
+    public ModifiableClusterConfiguration createResult(@Nonnull CommandLine commandLine) {
+        String configDir = commandLine.getOptionValue(CONFIG_DIR_OPTION.getOpt());
+
+        Properties dynamicProperties =
+                commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
+
+        List<String> removeKeyList = new ArrayList<>();
+        String[] removeKeys = commandLine.getOptionValues(REMOVE_KEY_OPTION.getOpt());
+        if (removeKeys != null) {
+            removeKeyList = Arrays.asList(removeKeys);
+        }
+
+        Properties removeKeyValues =
+                commandLine.getOptionProperties(REMOVE_KEY_VALUE_OPTION.getOpt());
+
+        List<Tuple3<String, String, String>> replaceKeyValueList = new ArrayList<>();
+        String[] replaceKeyValues = commandLine.getOptionValues(REPLACE_KEY_VALUE_OPTION.getOpt());
+        if (replaceKeyValues != null) {
+            for (int i = 0; i < replaceKeyValues.length; i += 3) {
+                replaceKeyValueList.add(
+                        new Tuple3<>(
+                                replaceKeyValues[i],
+                                replaceKeyValues[i + 1],
+                                replaceKeyValues[i + 2]));
+            }
+        }
+
+        return new ModifiableClusterConfiguration(
+                commandLine.hasOption(FLATTEN_CONFIG_OPTION),
+                configDir,
+                dynamicProperties,
+                removeKeyValues,
+                removeKeyList,
+                replaceKeyValueList);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/ConfigurationCommandLineOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/ConfigurationCommandLineOptions.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint.parser;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.commons.cli.Option;
+
+/** Represents the set of command-line options related to update and get configuration. */
+@Internal
+public class ConfigurationCommandLineOptions {
+
+    public static final Option REPLACE_KEY_VALUE_OPTION =
+            Option.builder("repKV")
+                    .argName("key,oldValue,newValue")
+                    .longOpt("replaceKeyValue")
+                    .numberOfArgs(3)
+                    .valueSeparator(',')
+                    .desc(
+                            "Replace the specified key's value with a new one if it matches the old value.")
+                    .build();
+
+    public static final Option REMOVE_KEY_VALUE_OPTION =
+            Option.builder("rmKV")
+                    .argName("key=value")
+                    .longOpt("removeKeyValue")
+                    .numberOfArgs(2)
+                    .valueSeparator('=')
+                    .desc("Remove the specified key-value pairs if it matches the old value.")
+                    .build();
+
+    public static final Option REMOVE_KEY_OPTION =
+            Option.builder("rmKey")
+                    .argName("Key")
+                    .longOpt("removeKey")
+                    .hasArg(true)
+                    .desc("Key to remove from the configuration.")
+                    .build();
+
+    public static final Option FLATTEN_CONFIG_OPTION =
+            Option.builder("flatten")
+                    .argName("flatten configuration")
+                    .longOpt("flattenConfig")
+                    .hasArg(false)
+                    .desc(
+                            "If present, the configuration will be output in a flattened format instead of nested YAML.")
+                    .build();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.util;
 
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -26,12 +28,18 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.entrypoint.ClusterConfiguration;
 import org.apache.flink.runtime.entrypoint.ClusterConfigurationParserFactory;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
+import org.apache.flink.runtime.entrypoint.ModifiableClusterConfiguration;
+import org.apache.flink.runtime.entrypoint.ModifiableClusterConfigurationParserFactory;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.util.MathUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
 
 import static org.apache.flink.util.MathUtils.checkedDownCast;
 
@@ -143,5 +151,65 @@ public class ConfigurationParserUtils {
                 ConfigurationUtils.createConfiguration(clusterConfiguration.getDynamicProperties());
         return GlobalConfiguration.loadConfiguration(
                 clusterConfiguration.getConfigDir(), dynamicProperties);
+    }
+
+    public static List<String> loadAndModifyConfiguration(String[] args, String cmdLineSyntax)
+            throws FlinkParseException {
+        final CommandLineParser<ModifiableClusterConfiguration> commandLineParser =
+                new CommandLineParser<>(new ModifiableClusterConfigurationParserFactory());
+
+        final ModifiableClusterConfiguration modifiableClusterConfiguration;
+        try {
+            modifiableClusterConfiguration = commandLineParser.parse(args);
+        } catch (FlinkParseException e) {
+            LOG.error("Could not parse the command line options.", e);
+            commandLineParser.printHelp(cmdLineSyntax);
+            throw e;
+        }
+
+        final Configuration dynamicProperties =
+                ConfigurationUtils.createConfiguration(
+                        modifiableClusterConfiguration.getDynamicProperties());
+        // 1. Load configuration and append dynamic properties to configuration.
+        Configuration configuration =
+                GlobalConfiguration.loadConfiguration(
+                        modifiableClusterConfiguration.getConfigDir(), dynamicProperties);
+
+        // 2. Replace the specified key's value with a new one if it matches the old value.
+        List<Tuple3<String, String, String>> replaceKeyValues =
+                modifiableClusterConfiguration.getReplaceKeyValues();
+        replaceKeyValues.forEach(
+                tuple3 -> {
+                    String key = tuple3.f0;
+                    String oldValue = tuple3.f1;
+                    String newValue = tuple3.f2;
+                    if (oldValue.equals(
+                            configuration.get(
+                                    ConfigOptions.key(key).stringType().noDefaultValue()))) {
+                        configuration.setString(key, newValue);
+                    }
+                });
+
+        // 3. Remove the specified key value pairs if the value matches.
+        Properties removeKeyValues = modifiableClusterConfiguration.getRemoveKeyValues();
+        final Set<String> propertyNames = removeKeyValues.stringPropertyNames();
+
+        for (String propertyName : propertyNames) {
+            if (removeKeyValues
+                    .getProperty(propertyName)
+                    .equals(
+                            configuration.getString(
+                                    ConfigOptions.key(propertyName)
+                                            .stringType()
+                                            .noDefaultValue()))) {
+                configuration.removeKey(propertyName);
+            }
+        }
+
+        // 4. Remove the specified key value pairs.
+        List<String> removeKeys = modifiableClusterConfiguration.getRemoveKeys();
+        removeKeys.forEach(configuration::removeKey);
+        return ConfigurationUtils.convertConfigToWritableLines(
+                configuration, modifiableClusterConfiguration.flattenConfig());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
@@ -61,12 +61,13 @@ public class BashJavaUtils {
 
     private static List<String> runCommand(Command command, String[] commandArgs)
             throws FlinkException {
-        Configuration configuration = FlinkConfigLoader.loadConfiguration(commandArgs);
         switch (command) {
             case GET_TM_RESOURCE_PARAMS:
-                return getTmResourceParams(configuration);
+                return getTmResourceParams(FlinkConfigLoader.loadConfiguration(commandArgs));
             case GET_JM_RESOURCE_PARAMS:
-                return getJmResourceParams(configuration);
+                return getJmResourceParams(FlinkConfigLoader.loadConfiguration(commandArgs));
+            case UPDATE_AND_GET_FLINK_CONFIGURATION:
+                return FlinkConfigLoader.loadAndModifyConfiguration(commandArgs);
             default:
                 // unexpected, Command#valueOf should fail if a unknown command is passed in
                 throw new RuntimeException("Unexpected, something is wrong.");
@@ -175,6 +176,9 @@ public class BashJavaUtils {
         GET_TM_RESOURCE_PARAMS,
 
         /** Get JVM parameters and dynamic configs of job manager resources. */
-        GET_JM_RESOURCE_PARAMS
+        GET_JM_RESOURCE_PARAMS,
+
+        /** Update and get configuration from conf file and dynamic configs of the FLINK cluster. */
+        UPDATE_AND_GET_FLINK_CONFIGURATION
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/FlinkConfigLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/FlinkConfigLoader.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.util.bash;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.entrypoint.ClusterConfigurationParserFactory;
+import org.apache.flink.runtime.entrypoint.ModifiableClusterConfigurationParserFactory;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.util.FlinkException;
 
@@ -36,22 +37,27 @@ import java.util.List;
  */
 public class FlinkConfigLoader {
 
-    private static final Options CMD_OPTIONS = ClusterConfigurationParserFactory.options();
-
     public static Configuration loadConfiguration(String[] args) throws FlinkException {
         return ConfigurationParserUtils.loadCommonConfiguration(
-                filterCmdArgs(args), BashJavaUtils.class.getSimpleName());
+                filterCmdArgs(args, ClusterConfigurationParserFactory.options()),
+                BashJavaUtils.class.getSimpleName());
     }
 
-    private static String[] filterCmdArgs(String[] args) {
+    public static List<String> loadAndModifyConfiguration(String[] args) throws FlinkException {
+        return ConfigurationParserUtils.loadAndModifyConfiguration(
+                filterCmdArgs(args, ModifiableClusterConfigurationParserFactory.options()),
+                BashJavaUtils.class.getSimpleName());
+    }
+
+    private static String[] filterCmdArgs(String[] args, Options options) {
         final List<String> filteredArgs = new ArrayList<>();
         final Iterator<String> iter = Arrays.asList(args).iterator();
 
         while (iter.hasNext()) {
             String token = iter.next();
-            if (CMD_OPTIONS.hasOption(token)) {
+            if (options.hasOption(token)) {
                 filteredArgs.add(token);
-                if (CMD_OPTIONS.getOption(token).hasArg() && iter.hasNext()) {
+                if (options.getOption(token).hasArg() && iter.hasNext()) {
                     filteredArgs.add(iter.next());
                 }
             } else if (token.startsWith("-D")) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ModifiableClusterConfigurationParserFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/ModifiableClusterConfigurationParserFactoryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.entrypoint;
+
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the {@link ModifiableClusterConfigurationParserFactory}. */
+class ModifiableClusterConfigurationParserFactoryTest {
+
+    private static final CommandLineParser<ModifiableClusterConfiguration> commandLineParser =
+            new CommandLineParser<>(new ModifiableClusterConfigurationParserFactory());
+
+    @Test
+    void testModifiableClusterConfigurationParsing() throws FlinkParseException {
+        final String configDir = "/foo/bar";
+        final String key = "key";
+        final String value = "value";
+        final String newValue = "value2";
+        final String[] args = {
+            "--configDir",
+            configDir,
+            "--removeKey",
+            key,
+            String.format("-D%s=%s", key, value),
+            "--removeKeyValue",
+            String.format("%s=%s", key, value),
+            "--replaceKeyValue",
+            String.format("%s,%s,%s", key, value, newValue),
+            "--flattenConfig"
+        };
+
+        ModifiableClusterConfiguration modifiableClusterConfiguration =
+                commandLineParser.parse(args);
+
+        assertThat(modifiableClusterConfiguration.getConfigDir()).isEqualTo(configDir);
+
+        Properties dynamicProperties = modifiableClusterConfiguration.getDynamicProperties();
+        assertThat(dynamicProperties).containsEntry(key, value);
+
+        List<String> removeKeys = modifiableClusterConfiguration.getRemoveKeys();
+        assertThat(removeKeys).containsExactly(key);
+
+        Properties removeKeyValues = modifiableClusterConfiguration.getRemoveKeyValues();
+        assertThat(removeKeyValues).containsEntry(key, value);
+
+        List<Tuple3<String, String, String>> replaceKeyValues =
+                modifiableClusterConfiguration.getReplaceKeyValues();
+        assertThat(replaceKeyValues).containsExactly(Tuple3.of(key, value, newValue));
+
+        assertThat(modifiableClusterConfiguration.flattenConfig()).isTrue();
+    }
+
+    @Test
+    void testOnlyRequiredArguments() throws FlinkParseException {
+        final String configDir = "/foo/bar";
+        final String[] args = {"--configDir", configDir};
+
+        ModifiableClusterConfiguration modifiableClusterConfiguration =
+                commandLineParser.parse(args);
+
+        assertThat(modifiableClusterConfiguration.getConfigDir()).isEqualTo(configDir);
+    }
+
+    @Test
+    void testMissingRequiredArgument() {
+        final String[] args = {};
+
+        assertThatThrownBy(() -> commandLineParser.parse(args))
+                .isInstanceOf(FlinkParseException.class);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/bash/FlinkConfigLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/bash/FlinkConfigLoaderTest.java
@@ -37,6 +37,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,10 +90,32 @@ public class FlinkConfigLoaderTest {
     }
 
     @TestTemplate
+    void testloadAndModifyConfigurationConfigDirLongOpt() throws Exception {
+        String[] args = {"--configDir", confDir.toFile().getAbsolutePath()};
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list).containsExactly("test:", "  key: " + TEST_CONFIG_VALUE);
+        } else {
+            assertThat(list).containsExactly(TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE);
+        }
+    }
+
+    @TestTemplate
     void testLoadConfigurationConfigDirShortOpt() throws Exception {
         String[] args = {"-c", confDir.toFile().getAbsolutePath()};
         Configuration configuration = FlinkConfigLoader.loadConfiguration(args);
         verifyConfiguration(configuration, TEST_CONFIG_KEY, TEST_CONFIG_VALUE);
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationConfigDirShortOpt() throws Exception {
+        String[] args = {"-c", confDir.toFile().getAbsolutePath()};
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list).containsExactly("test:", "  key: " + TEST_CONFIG_VALUE);
+        } else {
+            assertThat(list).containsExactly(TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE);
+        }
     }
 
     @TestTemplate
@@ -103,10 +126,36 @@ public class FlinkConfigLoaderTest {
     }
 
     @TestTemplate
+    void testloadAndModifyConfigurationDynamicPropertyWithSpace() throws Exception {
+        String[] args = {"--configDir", confDir.toFile().getAbsolutePath(), "-D", "key=value"};
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list).containsExactly("test:", "  key: " + TEST_CONFIG_VALUE, "key: value");
+        } else {
+            assertThat(list)
+                    .containsExactlyInAnyOrder(
+                            TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE, "key: value");
+        }
+    }
+
+    @TestTemplate
     void testLoadConfigurationDynamicPropertyWithoutSpace() throws Exception {
         String[] args = {"--configDir", confDir.toFile().getAbsolutePath(), "-Dkey=value"};
         Configuration configuration = FlinkConfigLoader.loadConfiguration(args);
         verifyConfiguration(configuration, "key", "value");
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationDynamicPropertyWithoutSpace() throws Exception {
+        String[] args = {"--configDir", confDir.toFile().getAbsolutePath(), "-Dkey=value"};
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list).containsExactly("test:", "  key: " + TEST_CONFIG_VALUE, "key: value");
+        } else {
+            assertThat(list)
+                    .containsExactlyInAnyOrder(
+                            TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE, "key: value");
+        }
     }
 
     @TestTemplate
@@ -122,6 +171,159 @@ public class FlinkConfigLoaderTest {
         Configuration configuration = FlinkConfigLoader.loadConfiguration(args);
         verifyConfiguration(configuration, TEST_CONFIG_KEY, TEST_CONFIG_VALUE);
         verifyConfiguration(configuration, "key", "value");
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationIgnoreUnknownToken() throws Exception {
+        String[] args = {
+            "unknown",
+            "-u",
+            "--configDir",
+            confDir.toFile().getAbsolutePath(),
+            "--unknown",
+            "-Dkey=value"
+        };
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list).containsExactly("test:", "  key: " + TEST_CONFIG_VALUE, "key: value");
+        } else {
+            assertThat(list)
+                    .containsExactlyInAnyOrder(
+                            TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE, "key: value");
+        }
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationRemoveKeysMatched() throws Exception {
+        String key = "key";
+
+        String[] args = {
+            "--configDir",
+            confDir.toFile().getAbsolutePath(),
+            String.format("-D%s=value", key),
+            "--removeKey",
+            key
+        };
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list).containsExactly("test:", "  key: " + TEST_CONFIG_VALUE);
+        } else {
+            assertThat(list).containsExactlyInAnyOrder(TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE);
+        }
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationRemoveKeysNotMatched() throws Exception {
+        String key = "key";
+        String value = "value";
+        String removeKey = "removeKey";
+
+        String[] args = {
+            "--configDir",
+            confDir.toFile().getAbsolutePath(),
+            String.format("-D%s=%s", key, value),
+            "--removeKey",
+            removeKey
+        };
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list)
+                    .containsExactly("test:", "  key: " + TEST_CONFIG_VALUE, key + ": " + value);
+        } else {
+            assertThat(list)
+                    .containsExactlyInAnyOrder(
+                            TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE, key + ": " + value);
+        }
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationRemoveKeyValuesMatched() throws Exception {
+        String removeKey = "removeKey";
+        String removeValue = "removeValue";
+
+        String[] args = {
+            "--configDir",
+            confDir.toFile().getAbsolutePath(),
+            String.format("-D%s=%s", removeKey, removeValue),
+            "--removeKeyValue",
+            String.format("%s=%s", removeKey, removeValue)
+        };
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list).containsExactly("test:", "  key: " + TEST_CONFIG_VALUE);
+        } else {
+            assertThat(list).containsExactlyInAnyOrder(TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE);
+        }
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationRemoveKeyValuesNotMatched() throws Exception {
+        String removeKey = "removeKey";
+        String removeValue = "removeValue";
+        String nonExistentValue = "nonExistentValue";
+
+        String[] args = {
+            "--configDir",
+            confDir.toFile().getAbsolutePath(),
+            String.format("-D%s=%s", removeKey, removeValue),
+            "--removeKeyValue",
+            String.format("%s=%s", removeKey, nonExistentValue)
+        };
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list)
+                    .containsExactlyInAnyOrder(
+                            "test:", "  key: " + TEST_CONFIG_VALUE, removeKey + ": " + removeValue);
+        } else {
+            assertThat(list)
+                    .containsExactlyInAnyOrder(
+                            TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE,
+                            removeKey + ": " + removeValue);
+        }
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationReplaceKeyValuesMatched() throws Exception {
+        String newValue = "newValue";
+
+        String[] args = {
+            "--configDir",
+            confDir.toFile().getAbsolutePath(),
+            "--replaceKeyValue",
+            String.format("%s,%s,%s", TEST_CONFIG_KEY, TEST_CONFIG_VALUE, newValue)
+        };
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list).containsExactly("test:", "  key: " + newValue);
+        } else {
+            assertThat(list).containsExactlyInAnyOrder(TEST_CONFIG_KEY + ": " + newValue);
+        }
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationReplaceKeyValuesNotMatched() throws Exception {
+        String nonExistentValue = "nonExistentValue";
+        String newValue = "newValue";
+
+        String[] args = {
+            "--configDir",
+            confDir.toFile().getAbsolutePath(),
+            "--replaceKeyValue",
+            String.format("%s,%s,%s", TEST_CONFIG_KEY, nonExistentValue, newValue)
+        };
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        if (standardYaml) {
+            assertThat(list).containsExactly("test:", "  key: " + TEST_CONFIG_VALUE);
+        } else {
+            assertThat(list).containsExactlyInAnyOrder(TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE);
+        }
+    }
+
+    @TestTemplate
+    void testloadAndModifyConfigurationWithFlatten() throws Exception {
+        String[] args = {"-c", confDir.toFile().getAbsolutePath(), "-flatten"};
+        List<String> list = FlinkConfigLoader.loadAndModifyConfiguration(args);
+        assertThat(list).containsExactly(TEST_CONFIG_KEY + ": " + TEST_CONFIG_VALUE);
     }
 
     private void verifyConfiguration(Configuration config, String key, String expectedValue) {

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkImageBuilder.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkImageBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.testframe.container;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.test.util.FileUtils;
 
@@ -40,7 +41,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -298,9 +298,7 @@ public class FlinkImageBuilder {
         Path flinkConfFile = tempDirectory.resolve(GlobalConfiguration.LEGACY_FLINK_CONF_FILENAME);
         Files.write(
                 flinkConfFile,
-                finalConfiguration.toFileWritableMap().entrySet().stream()
-                        .map(entry -> entry.getKey() + ": " + entry.getValue())
-                        .collect(Collectors.toList()));
+                ConfigurationUtils.convertConfigToWritableLines(finalConfiguration, true));
 
         return flinkConfFile;
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Because now FLINK shell scripts will read and modify the configuration file in flink-docker scenarios or when executing e2e tests, the transition from the default configuration file to a standard YAML file poses a challenge for command-line-based modifications. To support this behavior, we will extend the BashJavaUtils.


## Brief change log

1. Support dump configuration object to nested standard yaml.
2. Extend BashJavaUtils to support parsing and modifying standard yaml file.
3. Introduce new shell script bash-java-utils.sh to include all BashJavaUtils command.
4. Introduce new shell script config-parser-utils.sh to address the constraints of the DockerFile's RUN command, which cannot directly invoke a method within a shell script. 

## Verifying this change


This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
