### PR TITLE
[BP-1.18][FLINK-33907][ci] Moves tests in flink-clients relying on jars into the integration-test phase

### DIFF
--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -157,7 +157,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>copy-dependencies</id>
-						<phase>package</phase>
+						<phase>pre-integration-test</phase>
 						<goals>
 							<goal>copy-dependencies</goal>
 						</goals>

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/FromClasspathEntryClassInformationProviderITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/FromClasspathEntryClassInformationProviderITCase.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * {@code FromClasspathEntryClassInformationProviderTest} tests {@link
  * FromClasspathEntryClassInformationProvider}.
  */
-class FromClasspathEntryClassInformationProviderTest {
+class FromClasspathEntryClassInformationProviderITCase {
 
     @RegisterExtension
     ClasspathProviderExtension noEntryClassClasspathProvider =

--- a/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverITCase.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** {@code PackagedProgramRetrieverImplTest} tests {@link DefaultPackagedProgramRetriever}. */
-class DefaultPackagedProgramRetrieverTest {
+class DefaultPackagedProgramRetrieverITCase {
 
     @RegisterExtension
     ClasspathProviderExtension noEntryClassClasspathProvider =


### PR DESCRIPTION
backport PR of https://github.com/apache/flink/pull/24095