### PR TITLE
[FLINK-33907][ci] Moves tests in flink-clients relying on jars into the integration-test phase

### DIFF
--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -157,7 +157,7 @@ under the License.
 				<executions>
 					<execution>
 						<id>copy-dependencies</id>
-						<phase>package</phase>
+						<phase>pre-integration-test</phase>
 						<goals>
 							<goal>copy-dependencies</goal>
 						</goals>

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/FromClasspathEntryClassInformationProviderITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/FromClasspathEntryClassInformationProviderITCase.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * {@code FromClasspathEntryClassInformationProviderTest} tests {@link
  * FromClasspathEntryClassInformationProvider}.
  */
-class FromClasspathEntryClassInformationProviderTest {
+class FromClasspathEntryClassInformationProviderITCase {
 
     @RegisterExtension
     ClasspathProviderExtension noEntryClassClasspathProvider =

--- a/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverITCase.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** {@code PackagedProgramRetrieverImplTest} tests {@link DefaultPackagedProgramRetriever}. */
-class DefaultPackagedProgramRetrieverTest {
+class DefaultPackagedProgramRetrieverITCase {
 
     @RegisterExtension
     ClasspathProviderExtension noEntryClassClasspathProvider =


### PR DESCRIPTION
follow-up for PR https://github.com/apache/flink/pull/23965

## What is the purpose of the change

See discussion in FLINK-33907 for further context.

## Brief change log

* Transforms `FromClasspathEntryClassInformationProviderTest` and `DefaultPackedProgramRetrieverTest` to integration tests because they rely on jars
* Makes moving the test jars from {{flinlk-clients-test-utils}} into the {{pre-integration-test}} phase

## Verifying this change

Tests should be executed in the {{integration-test}} phase now instead of the {{test}} phase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable