### PR TITLE
[FLINK-33928][table-planner] Should not throw exception while creating view with specify field names

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -2229,6 +2229,19 @@ public class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversion
         catalogManager.createTable(
                 catalogTable, ObjectIdentifier.of("builtin", "default", "id_table"), false);
 
+        Operation operation =
+                parse("CREATE VIEW id_view(a, b) AS SELECT id, uid AS id FROM id_table");
+        assertThat(operation).isInstanceOf(CreateViewOperation.class);
+
+        assertThatThrownBy(
+                        () ->
+                                parse(
+                                        "CREATE VIEW id_view(a, a) AS SELECT id, uid AS id FROM id_table"))
+                .satisfies(
+                        FlinkAssertions.anyCauseMatches(
+                                SqlValidateException.class,
+                                "A column with the same name `a` has been defined at line 1, column 37."));
+
         assertThatThrownBy(
                         () -> parse("CREATE VIEW id_view AS\nSELECT id, uid AS id FROM id_table"))
                 .satisfies(


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In issue FLINK-33490, the view name need to validate to check whether the name is conflict in new view. However, for syntax: `create view view1(a, b) as select t1.name, t2.name from t1 join t1 t2 on t1.score = t2.score; `. If user specify the column name, planner should not throw exception while creating view with specify field names even if the query conflicts in field names.

## Brief change log

- support the syntax `create view view1(a, b) as select t1.name, t2.name from t1 join t1 t2 on t1.score = t2.score; ` not throw exception.
- add test to cover it.


## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  no docs
