### PR TITLE
[FLINK-34110] Bump janino from 3.1.10 to 3.1.11

### DIFF
--- a/flink-formats/flink-protobuf/pom.xml
+++ b/flink-formats/flink-protobuf/pom.xml
@@ -36,7 +36,7 @@ under the License.
 
 	<properties>
 		<!-- the same with flink-table/pom.xml -->
-		<janino.version>3.1.11</janino.version>
+		<janino.version>3.1.12</janino.version>
 	</properties>
 
 	<dependencies>

--- a/flink-formats/flink-protobuf/pom.xml
+++ b/flink-formats/flink-protobuf/pom.xml
@@ -36,7 +36,7 @@ under the License.
 
 	<properties>
 		<!-- the same with flink-table/pom.xml -->
-		<janino.version>3.1.10</janino.version>
+		<janino.version>3.1.11</janino.version>
 	</properties>
 
 	<dependencies>

--- a/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
@@ -7,5 +7,5 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.jayway.jsonpath:json-path:2.7.0
-- org.codehaus.janino:janino:3.1.10
-- org.codehaus.janino:commons-compiler:3.1.10
+- org.codehaus.janino:janino:3.1.11
+- org.codehaus.janino:commons-compiler:3.1.11

--- a/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
@@ -7,5 +7,5 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.jayway.jsonpath:json-path:2.7.0
-- org.codehaus.janino:janino:3.1.11
-- org.codehaus.janino:commons-compiler:3.1.11
+- org.codehaus.janino:janino:3.1.12
+- org.codehaus.janino:commons-compiler:3.1.12

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -82,7 +82,8 @@ under the License.
 		<!-- Calcite 1.32.0 depends on 3.1.8,
 		at the same time minimum 3.1.x Janino version passing Flink tests without WAs is 3.1.10,
 		more details are in FLINK-27995 -->
-		<janino.version>3.1.10</janino.version>
+		<janino.version>3.1.11</janino.version>
+		<jsonpath.version>2.7.0</jsonpath.version>
 		<guava.version>32.1.3-jre</guava.version>
 		<quartz.version>2.3.2</quartz.version>
 	</properties>

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -82,7 +82,7 @@ under the License.
 		<!-- Calcite 1.32.0 depends on 3.1.8,
 		at the same time minimum 3.1.x Janino version passing Flink tests without WAs is 3.1.10,
 		more details are in FLINK-27995 -->
-		<janino.version>3.1.11</janino.version>
+		<janino.version>3.1.12</janino.version>
 		<jsonpath.version>2.7.0</jsonpath.version>
 		<guava.version>32.1.3-jre</guava.version>
 		<quartz.version>2.3.2</quartz.version>


### PR DESCRIPTION
Bump janino to 3.1.11


## Verifying this change


This change is a trivial rework
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
