### PR TITLE
[FLINK-33974] Implement the Sink transformation depending on the new SinkV2 interfaces

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorFactory.java
@@ -19,9 +19,9 @@
 package org.apache.flink.streaming.runtime.operators.sink;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
-import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -41,14 +41,12 @@ public final class CommitterOperatorFactory<CommT>
         implements OneInputStreamOperatorFactory<
                 CommittableMessage<CommT>, CommittableMessage<CommT>> {
 
-    private final TwoPhaseCommittingSink<?, CommT> sink;
+    private final SupportsCommitter<CommT> sink;
     private final boolean isBatchMode;
     private final boolean isCheckpointingEnabled;
 
     public CommitterOperatorFactory(
-            TwoPhaseCommittingSink<?, CommT> sink,
-            boolean isBatchMode,
-            boolean isCheckpointingEnabled) {
+            SupportsCommitter<CommT> sink, boolean isBatchMode, boolean isCheckpointingEnabled) {
         this.sink = checkNotNull(sink);
         this.isBatchMode = isBatchMode;
         this.isCheckpointingEnabled = isCheckpointingEnabled;
@@ -65,7 +63,7 @@ public final class CommitterOperatorFactory<CommT>
                             processingTimeService,
                             sink.getCommittableSerializer(),
                             context -> sink.createCommitter(context),
-                            sink instanceof WithPostCommitTopology,
+                            sink instanceof SupportsPostCommitTopology,
                             isBatchMode,
                             isCheckpointingEnabled);
             committerOperator.setup(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
@@ -24,12 +24,12 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.connector.sink2.CommittingSinkWriter;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.Sink.InitContext;
 import org.apache.flink.api.connector.sink2.SinkWriter;
-import org.apache.flink.api.connector.sink2.StatefulSink;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.PrecommittingSinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
+import org.apache.flink.api.connector.sink2.SupportsWriterState;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
@@ -113,18 +113,17 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
         this.processingTimeService = checkNotNull(processingTimeService);
         this.mailboxExecutor = checkNotNull(mailboxExecutor);
         this.context = new Context<>();
-        this.emitDownstream = sink instanceof TwoPhaseCommittingSink;
+        this.emitDownstream = sink instanceof SupportsCommitter;
 
-        if (sink instanceof StatefulSink) {
+        if (sink instanceof SupportsWriterState) {
             writerStateHandler =
-                    new StatefulSinkWriterStateHandler<>((StatefulSink<InputT, ?>) sink);
+                    new StatefulSinkWriterStateHandler<>((SupportsWriterState<InputT, ?>) sink);
         } else {
             writerStateHandler = new StatelessSinkWriterStateHandler<>(sink);
         }
 
-        if (sink instanceof TwoPhaseCommittingSink) {
-            committableSerializer =
-                    ((TwoPhaseCommittingSink<InputT, CommT>) sink).getCommittableSerializer();
+        if (sink instanceof SupportsCommitter) {
+            committableSerializer = ((SupportsCommitter<CommT>) sink).getCommittableSerializer();
         } else {
             committableSerializer = null;
         }
@@ -188,13 +187,13 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
         if (!emitDownstream) {
             // To support SinkV1 topologies with only a writer we have to call prepareCommit
             // although no committables are forwarded
-            if (sinkWriter instanceof PrecommittingSinkWriter) {
-                ((PrecommittingSinkWriter<?, ?>) sinkWriter).prepareCommit();
+            if (sinkWriter instanceof CommittingSinkWriter) {
+                ((CommittingSinkWriter<?, ?>) sinkWriter).prepareCommit();
             }
             return;
         }
         Collection<CommT> committables =
-                ((PrecommittingSinkWriter<?, CommT>) sinkWriter).prepareCommit();
+                ((CommittingSinkWriter<?, CommT>) sinkWriter).prepareCommit();
         StreamingRuntimeContext runtimeContext = getRuntimeContext();
         final int indexOfThisSubtask = runtimeContext.getTaskInfo().getIndexOfThisSubtask();
         final int numberOfParallelSubtasks =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -223,13 +223,11 @@ public class SinkTransformationTranslator<Input, Output>
                             false);
 
             if (sink instanceof SupportsPostCommitTopology) {
-                DataStream<CommittableMessage<CommT>> postcommitted =
-                        addFailOverRegion(committed);
+                DataStream<CommittableMessage<CommT>> postcommitted = addFailOverRegion(committed);
                 adjustTransformations(
                         postcommitted,
                         pc -> {
-                            ((SupportsPostCommitTopology<CommT>) sink)
-                                    .addPostCommitTopology(pc);
+                            ((SupportsPostCommitTopology<CommT>) sink).addPostCommitTopology(pc);
                             return null;
                         },
                         true,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -24,15 +24,15 @@ import org.apache.flink.api.common.SupportsConcurrentExecutionAttempts;
 import org.apache.flink.api.common.operators.SlotSharingGroup;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.Sink;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessageTypeInfo;
 import org.apache.flink.streaming.api.connector.sink2.StandardSinkTopologies;
-import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
-import org.apache.flink.streaming.api.connector.sink2.WithPreCommitTopology;
-import org.apache.flink.streaming.api.connector.sink2.WithPreWriteTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
 import org.apache.flink.streaming.api.datastream.CustomSinkOperatorUidHashes;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -44,6 +44,7 @@ import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.streaming.runtime.operators.sink.CommitterOperatorFactory;
 import org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperatorFactory;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
@@ -135,16 +136,27 @@ public class SinkTransformationTranslator<Input, Output>
 
             DataStream<T> prewritten = inputStream;
 
-            if (sink instanceof WithPreWriteTopology) {
+            if (sink instanceof SupportsPreWriteTopology) {
                 prewritten =
                         adjustTransformations(
                                 prewritten,
-                                ((WithPreWriteTopology<T>) sink)::addPreWriteTopology,
+                                ((SupportsPreWriteTopology<T>) sink)::addPreWriteTopology,
                                 true,
                                 sink instanceof SupportsConcurrentExecutionAttempts);
             }
 
-            if (sink instanceof TwoPhaseCommittingSink) {
+            if (sink instanceof SupportsPreCommitTopology) {
+                Preconditions.checkArgument(
+                        sink instanceof SupportsCommitter,
+                        "Sink with SupportsPreCommitTopology should implement SupportsCommitter");
+            }
+            if (sink instanceof SupportsPostCommitTopology) {
+                Preconditions.checkArgument(
+                        sink instanceof SupportsCommitter,
+                        "Sink with SupportsPostCommitTopology should implement SupportsCommitter");
+            }
+
+            if (sink instanceof SupportsCommitter) {
                 addCommittingTopology(sink, prewritten);
             } else {
                 adjustTransformations(
@@ -173,13 +185,63 @@ public class SinkTransformationTranslator<Input, Output>
             }
         }
 
-        private <CommT> void addCommittingTopology(Sink<T> sink, DataStream<T> inputStream) {
-            TwoPhaseCommittingSink<T, CommT> committingSink =
-                    (TwoPhaseCommittingSink<T, CommT>) sink;
-            TypeInformation<CommittableMessage<CommT>> typeInformation =
+        private <CommittableT, WriteResultT> void addCommittingTopology(
+                Sink<T> sink, DataStream<T> inputStream) {
+            SupportsCommitter<CommittableT> committingSink = (SupportsCommitter<CommittableT>) sink;
+            TypeInformation<CommittableMessage<CommittableT>> committableTypeInformation =
                     CommittableMessageTypeInfo.of(committingSink::getCommittableSerializer);
 
-            DataStream<CommittableMessage<CommT>> written =
+            DataStream<CommittableMessage<CommittableT>> precommitted;
+            if (sink instanceof SupportsPreCommitTopology) {
+                SupportsPreCommitTopology<WriteResultT, CommittableT> preCommittingSink =
+                        (SupportsPreCommitTopology<WriteResultT, CommittableT>) sink;
+                TypeInformation<CommittableMessage<WriteResultT>> writeResultTypeInformation =
+                        CommittableMessageTypeInfo.of(preCommittingSink::getWriteResultSerializer);
+
+                DataStream<CommittableMessage<WriteResultT>> writerResult =
+                        addWriter(sink, inputStream, writeResultTypeInformation);
+
+                precommitted =
+                        adjustTransformations(
+                                writerResult, preCommittingSink::addPreCommitTopology, true, false);
+            } else {
+                precommitted = addWriter(sink, inputStream, committableTypeInformation);
+            }
+
+            DataStream<CommittableMessage<CommittableT>> committed =
+                    adjustTransformations(
+                            precommitted,
+                            pc ->
+                                    pc.transform(
+                                            COMMITTER_NAME,
+                                            committableTypeInformation,
+                                            new CommitterOperatorFactory<>(
+                                                    committingSink,
+                                                    isBatchMode,
+                                                    isCheckpointingEnabled)),
+                            false,
+                            false);
+
+            if (sink instanceof SupportsPostCommitTopology) {
+                DataStream<CommittableMessage<CommittableT>> postcommitted =
+                        addFailOverRegion(committed);
+                adjustTransformations(
+                        postcommitted,
+                        pc -> {
+                            ((SupportsPostCommitTopology<CommittableT>) sink)
+                                    .addPostCommitTopology(pc);
+                            return null;
+                        },
+                        true,
+                        false);
+            }
+        }
+
+        private <WriteResultT> DataStream<CommittableMessage<WriteResultT>> addWriter(
+                Sink<T> sink,
+                DataStream<T> inputStream,
+                TypeInformation<CommittableMessage<WriteResultT>> typeInformation) {
+            DataStream<CommittableMessage<WriteResultT>> written =
                     adjustTransformations(
                             inputStream,
                             input ->
@@ -190,42 +252,7 @@ public class SinkTransformationTranslator<Input, Output>
                             false,
                             sink instanceof SupportsConcurrentExecutionAttempts);
 
-            DataStream<CommittableMessage<CommT>> precommitted = addFailOverRegion(written);
-
-            if (sink instanceof WithPreCommitTopology) {
-                precommitted =
-                        adjustTransformations(
-                                precommitted,
-                                ((WithPreCommitTopology<T, CommT>) sink)::addPreCommitTopology,
-                                true,
-                                false);
-            }
-
-            DataStream<CommittableMessage<CommT>> committed =
-                    adjustTransformations(
-                            precommitted,
-                            pc ->
-                                    pc.transform(
-                                            COMMITTER_NAME,
-                                            typeInformation,
-                                            new CommitterOperatorFactory<>(
-                                                    committingSink,
-                                                    isBatchMode,
-                                                    isCheckpointingEnabled)),
-                            false,
-                            false);
-
-            if (sink instanceof WithPostCommitTopology) {
-                DataStream<CommittableMessage<CommT>> postcommitted = addFailOverRegion(committed);
-                adjustTransformations(
-                        postcommitted,
-                        pc -> {
-                            ((WithPostCommitTopology<T, CommT>) sink).addPostCommitTopology(pc);
-                            return null;
-                        },
-                        true,
-                        false);
-            }
+            return addFailOverRegion(written);
         }
 
         /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -185,16 +185,16 @@ public class SinkTransformationTranslator<Input, Output>
             }
         }
 
-        private <CommittableT, WriteResultT> void addCommittingTopology(
+        private <CommT, WriteResultT> void addCommittingTopology(
                 Sink<T> sink, DataStream<T> inputStream) {
-            SupportsCommitter<CommittableT> committingSink = (SupportsCommitter<CommittableT>) sink;
-            TypeInformation<CommittableMessage<CommittableT>> committableTypeInformation =
+            SupportsCommitter<CommT> committingSink = (SupportsCommitter<CommT>) sink;
+            TypeInformation<CommittableMessage<CommT>> committableTypeInformation =
                     CommittableMessageTypeInfo.of(committingSink::getCommittableSerializer);
 
-            DataStream<CommittableMessage<CommittableT>> precommitted;
+            DataStream<CommittableMessage<CommT>> precommitted;
             if (sink instanceof SupportsPreCommitTopology) {
-                SupportsPreCommitTopology<WriteResultT, CommittableT> preCommittingSink =
-                        (SupportsPreCommitTopology<WriteResultT, CommittableT>) sink;
+                SupportsPreCommitTopology<WriteResultT, CommT> preCommittingSink =
+                        (SupportsPreCommitTopology<WriteResultT, CommT>) sink;
                 TypeInformation<CommittableMessage<WriteResultT>> writeResultTypeInformation =
                         CommittableMessageTypeInfo.of(preCommittingSink::getWriteResultSerializer);
 
@@ -208,7 +208,7 @@ public class SinkTransformationTranslator<Input, Output>
                 precommitted = addWriter(sink, inputStream, committableTypeInformation);
             }
 
-            DataStream<CommittableMessage<CommittableT>> committed =
+            DataStream<CommittableMessage<CommT>> committed =
                     adjustTransformations(
                             precommitted,
                             pc ->
@@ -223,12 +223,12 @@ public class SinkTransformationTranslator<Input, Output>
                             false);
 
             if (sink instanceof SupportsPostCommitTopology) {
-                DataStream<CommittableMessage<CommittableT>> postcommitted =
+                DataStream<CommittableMessage<CommT>> postcommitted =
                         addFailOverRegion(committed);
                 adjustTransformations(
                         postcommitted,
                         pc -> {
-                            ((SupportsPostCommitTopology<CommittableT>) sink)
+                            ((SupportsPostCommitTopology<CommT>) sink)
                                     .addPostCommitTopology(pc);
                             return null;
                         },

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV2TransformationTranslatorITCase.java
@@ -67,10 +67,7 @@ public class SinkV2TransformationTranslatorITCase
                         .setWriterUidHash(writerHash)
                         .setCommitterUidHash(committerHash)
                         .build();
-        src.sinkTo(
-                        TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build(),
-                        operatorsUidHashes)
-                .name(NAME);
+        src.sinkTo(sinkWithCommitter(), operatorsUidHashes).name(NAME);
 
         final StreamGraph streamGraph = env.getStreamGraph();
 
@@ -87,9 +84,7 @@ public class SinkV2TransformationTranslatorITCase
         final String sinkUid = "f6b178ce445dc3ffaa06bad27a51fead";
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         final DataStreamSource<Integer> src = env.fromElements(1, 2);
-        src.sinkTo(TestSinkV2.<Integer>newBuilder().setDefaultCommitter().build())
-                .name(NAME)
-                .uid(sinkUid);
+        src.sinkTo(sinkWithCommitter()).name(NAME).uid(sinkUid);
 
         final StreamGraph streamGraph = env.getStreamGraph();
         assertEquals(findWriter(streamGraph).getTransformationUID(), sinkUid);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSinkWithMixin.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSinkWithMixin.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
+
+import java.io.IOException;
+
+/** A test sink that expands into a simple subgraph. Do not use in runtime. */
+public class TestExpandingSinkWithMixin
+        implements Sink<Integer>,
+                SupportsCommitter<Integer>,
+                SupportsPreWriteTopology<Integer>,
+                SupportsPreCommitTopology<Integer, Integer>,
+                SupportsPostCommitTopology<Integer> {
+
+    @Override
+    public void addPostCommitTopology(DataStream<CommittableMessage<Integer>> committables) {
+        committables.sinkTo(new DiscardingSink<>());
+    }
+
+    @Override
+    public DataStream<CommittableMessage<Integer>> addPreCommitTopology(
+            DataStream<CommittableMessage<Integer>> committables) {
+        return committables.map(value -> value).returns(committables.getType());
+    }
+
+    @Override
+    public DataStream<Integer> addPreWriteTopology(DataStream<Integer> inputDataStream) {
+        return inputDataStream.map(new NoOpIntMap());
+    }
+
+    @Override
+    public SinkWriter<Integer> createWriter(WriterInitContext context) throws IOException {
+        return null;
+    }
+
+    @Override
+    public SinkWriter<Integer> createWriter(InitContext context) throws IOException {
+        return null;
+    }
+
+    @Override
+    public Committer<Integer> createCommitter(CommitterInitContext context) {
+        return null;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Integer> getCommittableSerializer() {
+        return null;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Integer> getWriteResultSerializer() {
+        return null;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Implement the changes to the Sink transformation which should depend only on the new API interfaces. The tests should remain the same, to ensure backward compatibility.

## Brief change log

- SinkTransformationTranslator.java, CommitterOperatorFactory.java, SinkWriterOperator.java, StatefulSinkWriterStateHandler.java - to depend on the new API interfaces instead of the old ones
- Idenpotent change in SinkV2TransformationTranslatorITCase.java - this left out during the test refactor
- StreamGraphGeneratorTest.java, TestExpandingSinkWithMixin.java - Single specific test for the mixin interfaces


## Verifying this change

Added a single test method to the new API.
Kept all of the tests unchanged to make sure that the change is backward compatible.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
