### PR TITLE
[FLINK-34109][connectors] FileSystem sink connector restore job from historical checkpoint bugfix

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactOperator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.file.table.stream.compact;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.InternalCheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.ListSerializer;
@@ -65,7 +66,9 @@ import java.util.TreeMap;
  */
 @Internal
 public class CompactOperator<T> extends AbstractStreamOperator<PartitionCommitInfo>
-        implements OneInputStreamOperator<CoordinatorOutput, PartitionCommitInfo>, BoundedOneInput {
+        implements OneInputStreamOperator<CoordinatorOutput, PartitionCommitInfo>,
+                BoundedOneInput,
+                InternalCheckpointListener {
 
     private static final long serialVersionUID = 1L;
 
@@ -177,7 +180,14 @@ public class CompactOperator<T> extends AbstractStreamOperator<PartitionCommitIn
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         super.notifyCheckpointComplete(checkpointId);
-        clearExpiredFiles(checkpointId);
+    }
+
+    @Override
+    public void notifyCheckpointSubsumed(long checkpointId) throws Exception {
+        if (checkpointId > 0) {
+            clearExpiredFiles(checkpointId);
+            LOG.debug("Checkpoint {} subsumed and removed old uncompacted files.", checkpointId);
+        }
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapper.java
@@ -118,6 +118,10 @@ public class StreamOperatorWrapper<OUT, OP extends StreamOperator<OUT>> {
                 ((InternalCheckpointListener) keyedStateBackend)
                         .notifyCheckpointSubsumed(checkpointId);
             }
+
+            if (wrapped instanceof InternalCheckpointListener) {
+                ((InternalCheckpointListener) wrapped).notifyCheckpointSubsumed(checkpointId);
+            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Bugfix of FileSystem connector sink with compaction setting is enabled can't restore job from historical checkpoint (when MAX_RETAINED_CHECKPOINTS > 1 and restroing checkpoint is not last)


## Brief change log

Added check - if operator implements InternalCheckpointListener then call subsume on it, and CompactOperator can acquire subsume for remove old uncompacted files.


## Verifying this change

org.apache.flink.connector.file.table.stream.compact.CompactOperatorTest#testCompactOperator
org.apache.flink.connector.file.table.stream.compact.CompactOperatorTest#testCompactOperatorOnHistoricalCheckpoint

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: possible

## Documentation

  - Does this pull request introduce a new feature? no
