### PR TITLE
 [FLINK-34081][configuration] Refactor all callers of deprecated `getXxx(ConfigOption<Xxx>)`, `getXxx(ConfigOption<Xxx>, Xxx)` and `setXxx(ConfigOption<Integer>, Xxx)` methods of Configuration

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -88,7 +88,7 @@ public enum ClientUtils {
 
             LOG.info(
                     "Starting program (detached: {})",
-                    !configuration.getBoolean(DeploymentOptions.ATTACHED));
+                    !configuration.get(DeploymentOptions.ATTACHED));
 
             ContextEnvironment.setAsContext(
                     executorServiceLoader,

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/AbstractCustomCommandLine.java
@@ -56,11 +56,11 @@ public abstract class AbstractCustomCommandLine implements CustomCommandLine {
     @Override
     public Configuration toConfiguration(CommandLine commandLine) throws FlinkException {
         final Configuration resultingConfiguration = new Configuration();
-        resultingConfiguration.setString(DeploymentOptions.TARGET, RemoteExecutor.NAME);
+        resultingConfiguration.set(DeploymentOptions.TARGET, RemoteExecutor.NAME);
 
         if (commandLine.hasOption(zookeeperNamespaceOption.getOpt())) {
             String zkNamespace = commandLine.getOptionValue(zookeeperNamespaceOption.getOpt());
-            resultingConfiguration.setString(HighAvailabilityOptions.HA_CLUSTER_ID, zkNamespace);
+            resultingConfiguration.set(HighAvailabilityOptions.HA_CLUSTER_ID, zkNamespace);
         }
 
         return resultingConfiguration;

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -1413,10 +1413,10 @@ public class CliFrontend {
      * @param config The configuration to write to
      */
     static void setJobManagerAddressInConfig(Configuration config, InetSocketAddress address) {
-        config.setString(JobManagerOptions.ADDRESS, address.getHostString());
-        config.setInteger(JobManagerOptions.PORT, address.getPort());
-        config.setString(RestOptions.ADDRESS, address.getHostString());
-        config.setInteger(RestOptions.PORT, address.getPort());
+        config.set(JobManagerOptions.ADDRESS, address.getHostString());
+        config.set(JobManagerOptions.PORT, address.getPort());
+        config.set(RestOptions.ADDRESS, address.getHostString());
+        config.set(RestOptions.PORT, address.getPort());
     }
 
     public static List<CustomCommandLine> loadCustomCommandLines(

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/DefaultCLI.java
@@ -65,11 +65,10 @@ public class DefaultCLI extends AbstractCustomCommandLine {
             setJobManagerAddressInConfig(resultingConfiguration, jobManagerAddress);
 
             URL url = NetUtils.getCorrectHostnamePort(addressWithPort);
-            resultingConfiguration.setString(RestOptions.PATH, url.getPath());
-            resultingConfiguration.setBoolean(
-                    SecurityOptions.SSL_REST_ENABLED, isHttpsProtocol(url));
+            resultingConfiguration.set(RestOptions.PATH, url.getPath());
+            resultingConfiguration.set(SecurityOptions.SSL_REST_ENABLED, isHttpsProtocol(url));
         }
-        resultingConfiguration.setString(DeploymentOptions.TARGET, RemoteExecutor.NAME);
+        resultingConfiguration.set(DeploymentOptions.TARGET, RemoteExecutor.NAME);
 
         DynamicPropertiesUtil.encodeDynamicProperties(commandLine, resultingConfiguration);
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
@@ -83,11 +83,11 @@ public class ExecutionConfigAccessor {
     }
 
     public int getParallelism() {
-        return configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM);
+        return configuration.get(CoreOptions.DEFAULT_PARALLELISM);
     }
 
     public boolean getDetachedMode() {
-        return !configuration.getBoolean(DeploymentOptions.ATTACHED);
+        return !configuration.get(DeploymentOptions.ATTACHED);
     }
 
     public SavepointRestoreSettings getSavepointRestoreSettings() {
@@ -95,6 +95,6 @@ public class ExecutionConfigAccessor {
     }
 
     public boolean isShutdownOnAttachedExit() {
-        return configuration.getBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED);
+        return configuration.get(DeploymentOptions.SHUTDOWN_IF_ATTACHED);
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
@@ -114,12 +114,12 @@ public class GenericCLI implements CustomCommandLine {
 
         final String executorName = commandLine.getOptionValue(executorOption.getOpt());
         if (executorName != null) {
-            resultConfiguration.setString(DeploymentOptions.TARGET, executorName);
+            resultConfiguration.set(DeploymentOptions.TARGET, executorName);
         }
 
         final String targetName = commandLine.getOptionValue(targetOption.getOpt());
         if (targetName != null) {
-            resultConfiguration.setString(DeploymentOptions.TARGET, targetName);
+            resultConfiguration.set(DeploymentOptions.TARGET, targetName);
         }
 
         DynamicPropertiesUtil.encodeDynamicProperties(commandLine, resultConfiguration);

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -174,12 +174,11 @@ public class ProgramOptions extends CommandLineOptions {
 
     public void applyToConfiguration(Configuration configuration) {
         if (hasParallelismOpt) {
-            configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, getParallelism());
+            configuration.set(CoreOptions.DEFAULT_PARALLELISM, getParallelism());
         }
 
-        configuration.setBoolean(DeploymentOptions.ATTACHED, !getDetachedMode());
-        configuration.setBoolean(
-                DeploymentOptions.SHUTDOWN_IF_ATTACHED, isShutdownOnAttachedExit());
+        configuration.set(DeploymentOptions.ATTACHED, !getDetachedMode());
+        configuration.set(DeploymentOptions.SHUTDOWN_IF_ATTACHED, isShutdownOnAttachedExit());
         ConfigUtils.encodeCollectionToConfig(
                 configuration, PipelineOptions.CLASSPATHS, getClasspaths(), URL::toString);
         SavepointRestoreSettings.toConfiguration(getSavepointRestoreSettings(), configuration);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractContainerizedClusterClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractContainerizedClusterClientFactory.java
@@ -54,7 +54,7 @@ public abstract class AbstractContainerizedClusterClientFactory<ClusterID>
                         .getTotalProcessMemorySize()
                         .getMebiBytes();
 
-        int slotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
+        int slotsPerTaskManager = configuration.get(TaskManagerOptions.NUM_TASK_SLOTS);
 
         return new ClusterSpecification.ClusterSpecificationBuilder()
                 .setMasterMemoryMB(jobManagerMemoryMB)

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClientFactory.java
@@ -34,8 +34,7 @@ public class StandaloneClientFactory implements ClusterClientFactory<StandaloneC
     @Override
     public boolean isCompatibleWith(Configuration configuration) {
         checkNotNull(configuration);
-        return RemoteExecutor.NAME.equalsIgnoreCase(
-                configuration.getString(DeploymentOptions.TARGET));
+        return RemoteExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
     }
 
     @Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/StandaloneClusterDescriptor.java
@@ -38,8 +38,8 @@ public class StandaloneClusterDescriptor implements ClusterDescriptor<Standalone
 
     @Override
     public String getClusterDescription() {
-        String host = config.getString(JobManagerOptions.ADDRESS, "");
-        int port = config.getInteger(JobManagerOptions.PORT, -1);
+        String host = config.get(JobManagerOptions.ADDRESS, "");
+        int port = config.get(JobManagerOptions.PORT, -1);
         return "Standalone cluster at " + host + ":" + port;
     }
 

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrap.java
@@ -192,7 +192,7 @@ public class ApplicationDispatcherBootstrap implements DispatcherBootstrap {
     private CompletableFuture<Acknowledge> finish(
             DispatcherGateway dispatcherGateway, ApplicationStatus applicationStatus) {
         boolean shouldShutDownOnFinish =
-                configuration.getBoolean(DeploymentOptions.SHUTDOWN_ON_APPLICATION_FINISH);
+                configuration.get(DeploymentOptions.SHUTDOWN_ON_APPLICATION_FINISH);
         return shouldShutDownOnFinish
                 ? dispatcherGateway.shutDownCluster(applicationStatus)
                 : CompletableFuture.completedFuture(Acknowledge.get());
@@ -209,7 +209,7 @@ public class ApplicationDispatcherBootstrap implements DispatcherBootstrap {
         final Optional<String> configuredJobId =
                 configuration.getOptional(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID);
         final boolean submitFailedJobOnApplicationError =
-                configuration.getBoolean(DeploymentOptions.SUBMIT_FAILED_JOB_ON_APPLICATION_ERROR);
+                configuration.get(DeploymentOptions.SUBMIT_FAILED_JOB_ON_APPLICATION_ERROR);
         if (!HighAvailabilityMode.isHighAvailabilityModeActivated(configuration)
                 && !configuredJobId.isPresent()) {
             return runApplicationAsync(

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
@@ -76,7 +76,7 @@ public class LocalExecutor implements PipelineExecutor {
         effectiveConfig.addAll(configuration);
 
         // we only support attached execution with the local executor.
-        checkState(configuration.getBoolean(DeploymentOptions.ATTACHED));
+        checkState(configuration.get(DeploymentOptions.ATTACHED));
 
         final JobGraph jobGraph = getJobGraph(pipeline, effectiveConfig, userCodeClassloader);
 
@@ -93,7 +93,7 @@ public class LocalExecutor implements PipelineExecutor {
         if (pipeline instanceof Plan) {
             Plan plan = (Plan) pipeline;
             final int slotsPerTaskManager =
-                    configuration.getInteger(
+                    configuration.get(
                             TaskManagerOptions.NUM_TASK_SLOTS, plan.getMaximumParallelism());
             final int numTaskManagers =
                     configuration.get(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/PipelineExecutorUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/PipelineExecutorUtils.java
@@ -68,10 +68,10 @@ public class PipelineExecutorUtils {
                 .getOptional(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID)
                 .ifPresent(strJobID -> jobGraph.setJobID(JobID.fromHexString(strJobID)));
 
-        if (configuration.getBoolean(DeploymentOptions.ATTACHED)
-                && configuration.getBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
+        if (configuration.get(DeploymentOptions.ATTACHED)
+                && configuration.get(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
             jobGraph.setInitialClientHeartbeatTimeout(
-                    configuration.getLong(ClientOptions.CLIENT_HEARTBEAT_TIMEOUT));
+                    configuration.get(ClientOptions.CLIENT_HEARTBEAT_TIMEOUT));
         }
 
         jobGraph.addJars(executionConfigAccessor.getJars());

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -94,12 +94,12 @@ public class ContextEnvironment extends ExecutionEnvironment {
         checkNotNull(jobClient);
 
         JobExecutionResult jobExecutionResult;
-        if (getConfiguration().getBoolean(DeploymentOptions.ATTACHED)) {
+        if (getConfiguration().get(DeploymentOptions.ATTACHED)) {
             CompletableFuture<JobExecutionResult> jobExecutionResultFuture =
                     jobClient.getJobExecutionResult();
 
             ScheduledExecutorService clientHeartbeatService = null;
-            if (getConfiguration().getBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
+            if (getConfiguration().get(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
                 Thread shutdownHook =
                         ShutdownHookUtil.addShutdownHook(
                                 () -> {
@@ -119,8 +119,8 @@ public class ContextEnvironment extends ExecutionEnvironment {
                 clientHeartbeatService =
                         ClientUtils.reportHeartbeatPeriodically(
                                 jobClient,
-                                getConfiguration().getLong(ClientOptions.CLIENT_HEARTBEAT_INTERVAL),
-                                getConfiguration().getLong(ClientOptions.CLIENT_HEARTBEAT_TIMEOUT));
+                                getConfiguration().get(ClientOptions.CLIENT_HEARTBEAT_INTERVAL),
+                                getConfiguration().get(ClientOptions.CLIENT_HEARTBEAT_TIMEOUT));
             }
 
             jobExecutionResult = jobExecutionResultFuture.get();

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PerJobMiniClusterFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PerJobMiniClusterFactory.java
@@ -120,7 +120,7 @@ public final class PerJobMiniClusterFactory {
         Configuration configuration = new Configuration(this.configuration);
 
         if (!configuration.contains(RestOptions.BIND_PORT)) {
-            configuration.setString(RestOptions.BIND_PORT, "0");
+            configuration.set(RestOptions.BIND_PORT, "0");
         }
 
         int numTaskManagers = configuration.get(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS);

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
@@ -138,12 +138,12 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
         checkNotNull(jobClient);
 
         JobExecutionResult jobExecutionResult;
-        if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
+        if (configuration.get(DeploymentOptions.ATTACHED)) {
             CompletableFuture<JobExecutionResult> jobExecutionResultFuture =
                     jobClient.getJobExecutionResult();
 
             ScheduledExecutorService clientHeartbeatService = null;
-            if (configuration.getBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
+            if (configuration.get(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
                 Thread shutdownHook =
                         ShutdownHookUtil.addShutdownHook(
                                 () -> {
@@ -163,8 +163,8 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
                 clientHeartbeatService =
                         ClientUtils.reportHeartbeatPeriodically(
                                 jobClient,
-                                configuration.getLong(ClientOptions.CLIENT_HEARTBEAT_INTERVAL),
-                                configuration.getLong(ClientOptions.CLIENT_HEARTBEAT_TIMEOUT));
+                                configuration.get(ClientOptions.CLIENT_HEARTBEAT_INTERVAL),
+                                configuration.get(ClientOptions.CLIENT_HEARTBEAT_TIMEOUT));
             }
 
             jobExecutionResult = jobExecutionResultFuture.get();

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -253,9 +253,9 @@ public class RestClusterClient<T> implements ClusterClient<T> {
         jobmanagerUrl =
                 new URL(
                         SecurityOptions.isRestSSLEnabled(configuration) ? "https" : "http",
-                        configuration.getString(JobManagerOptions.ADDRESS),
-                        configuration.getInteger(JobManagerOptions.PORT),
-                        configuration.getString(RestOptions.PATH));
+                        configuration.get(JobManagerOptions.ADDRESS),
+                        configuration.get(JobManagerOptions.PORT),
+                        configuration.get(RestOptions.PATH));
 
         if (restClient != null) {
             this.restClient = restClient;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClientConfiguration.java
@@ -77,9 +77,9 @@ public final class RestClusterClientConfiguration {
         RestClientConfiguration restClientConfiguration =
                 RestClientConfiguration.fromConfiguration(config);
 
-        final long awaitLeaderTimeout = config.getLong(RestOptions.AWAIT_LEADER_TIMEOUT);
-        final int retryMaxAttempts = config.getInteger(RestOptions.RETRY_MAX_ATTEMPTS);
-        final long retryDelay = config.getLong(RestOptions.RETRY_DELAY);
+        final long awaitLeaderTimeout = config.get(RestOptions.AWAIT_LEADER_TIMEOUT);
+        final int retryMaxAttempts = config.get(RestOptions.RETRY_MAX_ATTEMPTS);
+        final long retryDelay = config.get(RestOptions.RETRY_DELAY);
 
         return new RestClusterClientConfiguration(
                 restClientConfiguration, awaitLeaderTimeout, retryMaxAttempts, retryDelay);

--- a/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
@@ -96,8 +96,8 @@ class ClientHeartbeatTest {
                 Dispatcher.CLIENT_ALIVENESS_CHECK_DURATION,
                 Duration.ofMillis(clientHeartbeatInterval));
         if (shutdownOnAttachedExit) {
-            configuration.setBoolean(DeploymentOptions.ATTACHED, true);
-            configuration.setBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED, true);
+            configuration.set(DeploymentOptions.ATTACHED, true);
+            configuration.set(DeploymentOptions.SHUTDOWN_IF_ATTACHED, true);
         }
         return configuration;
     }
@@ -115,8 +115,8 @@ class ClientHeartbeatTest {
         JobGraph cancellableJobGraph = getCancellableJobGraph();
         // Enable heartbeat only when both execution.attached and
         // execution.shutdown-on-attached-exit are true.
-        if (configuration.getBoolean(DeploymentOptions.ATTACHED)
-                && configuration.getBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
+        if (configuration.get(DeploymentOptions.ATTACHED)
+                && configuration.get(DeploymentOptions.SHUTDOWN_IF_ATTACHED)) {
             cancellableJobGraph.setInitialClientHeartbeatTimeout(clientHeartbeatTimeout);
         }
         return perJobMiniClusterFactory

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestUtils.java
@@ -86,8 +86,8 @@ public class CliFrontendTestUtils {
 
     public static void checkJobManagerAddress(
             Configuration config, String expectedAddress, int expectedPort) {
-        String jobManagerAddress = config.getString(JobManagerOptions.ADDRESS);
-        int jobManagerPort = config.getInteger(JobManagerOptions.PORT, -1);
+        String jobManagerAddress = config.get(JobManagerOptions.ADDRESS);
+        int jobManagerPort = config.get(JobManagerOptions.PORT, -1);
 
         assertThat(jobManagerAddress).isEqualTo(expectedAddress);
         assertThat(jobManagerPort).isEqualTo(expectedPort);

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/GenericCLITest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/GenericCLITest.java
@@ -69,8 +69,8 @@ class GenericCLITest {
     @Test
     void testWithPreexistingConfigurationInConstructor() throws CliArgsException {
         final Configuration loadedConfig = new Configuration();
-        loadedConfig.setInteger(CoreOptions.DEFAULT_PARALLELISM, 2);
-        loadedConfig.setBoolean(DeploymentOptions.ATTACHED, false);
+        loadedConfig.set(CoreOptions.DEFAULT_PARALLELISM, 2);
+        loadedConfig.set(DeploymentOptions.ATTACHED, false);
 
         final ConfigOption<List<Integer>> listOption =
                 key("test.list").intType().asList().noDefaultValue();
@@ -92,9 +92,9 @@ class GenericCLITest {
 
         final Configuration configuration = cliUnderTest.toConfiguration(commandLine);
 
-        assertThat(configuration.getString(DeploymentOptions.TARGET)).isEqualTo("test-executor");
-        assertThat(configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM)).isEqualTo(5);
-        assertThat(configuration.getBoolean(DeploymentOptions.ATTACHED)).isFalse();
+        assertThat(configuration.get(DeploymentOptions.TARGET)).isEqualTo("test-executor");
+        assertThat(configuration.get(CoreOptions.DEFAULT_PARALLELISM)).isEqualTo(5);
+        assertThat(configuration.get(DeploymentOptions.ATTACHED)).isFalse();
         assertThat(configuration.get(listOption)).isEqualTo(listValue);
     }
 
@@ -123,6 +123,6 @@ class GenericCLITest {
 
         final Configuration configuration = cliUnderTest.toConfiguration(commandLine);
         assertThat(configuration.get(DeploymentOptions.TARGET)).isEqualTo(expectedExecutorName);
-        assertThat(configuration.getInteger(configOption)).isEqualTo(expectedValue);
+        assertThat(configuration.get(configOption)).isEqualTo(expectedValue);
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterClientFactory.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterClientFactory.java
@@ -46,7 +46,7 @@ public class DummyClusterClientFactory<ClusterID> implements ClusterClientFactor
 
     @Override
     public boolean isCompatibleWith(Configuration configuration) {
-        return ID.equals(configuration.getString(DeploymentOptions.TARGET));
+        return ID.equals(configuration.get(DeploymentOptions.TARGET));
     }
 
     @Override

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyCustomCommandLine.java
@@ -51,7 +51,7 @@ public class DummyCustomCommandLine implements CustomCommandLine {
     @Override
     public Configuration toConfiguration(CommandLine commandLine) {
         final Configuration configuration = new Configuration();
-        configuration.setString(DeploymentOptions.TARGET, DummyClusterClientFactory.ID);
+        configuration.set(DeploymentOptions.TARGET, DummyClusterClientFactory.ID);
         return configuration;
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/ClusterClientServiceLoaderTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/ClusterClientServiceLoaderTest.java
@@ -49,7 +49,7 @@ public class ClusterClientServiceLoaderTest {
     @Test
     public void testStandaloneClusterClientFactoryDiscovery() {
         final Configuration config = new Configuration();
-        config.setString(DeploymentOptions.TARGET, RemoteExecutor.NAME);
+        config.set(DeploymentOptions.TARGET, RemoteExecutor.NAME);
 
         ClusterClientFactory<StandaloneClusterId> factory =
                 serviceLoaderUnderTest.getClusterClientFactory(config);
@@ -59,7 +59,7 @@ public class ClusterClientServiceLoaderTest {
     @Test
     public void testFactoryDiscovery() {
         final Configuration config = new Configuration();
-        config.setString(DeploymentOptions.TARGET, VALID_TARGET);
+        config.set(DeploymentOptions.TARGET, VALID_TARGET);
 
         final ClusterClientFactory<Integer> factory =
                 serviceLoaderUnderTest.getClusterClientFactory(config);
@@ -74,7 +74,7 @@ public class ClusterClientServiceLoaderTest {
         assertThatThrownBy(
                         () -> {
                             final Configuration config = new Configuration();
-                            config.setString(DeploymentOptions.TARGET, AMBIGUOUS_TARGET);
+                            config.set(DeploymentOptions.TARGET, AMBIGUOUS_TARGET);
 
                             serviceLoaderUnderTest.getClusterClientFactory(config);
                         })
@@ -86,7 +86,7 @@ public class ClusterClientServiceLoaderTest {
         assertThatThrownBy(
                         () -> {
                             final Configuration config = new Configuration();
-                            config.setString(DeploymentOptions.TARGET, NON_EXISTING_TARGET);
+                            config.set(DeploymentOptions.TARGET, NON_EXISTING_TARGET);
 
                             final ClusterClientFactory<Integer> factory =
                                     serviceLoaderUnderTest.getClusterClientFactory(config);
@@ -101,7 +101,7 @@ public class ClusterClientServiceLoaderTest {
 
         @Override
         public boolean isCompatibleWith(Configuration configuration) {
-            return configuration.getString(DeploymentOptions.TARGET).equals(VALID_TARGET);
+            return configuration.get(DeploymentOptions.TARGET).equals(VALID_TARGET);
         }
 
         @Nullable
@@ -118,7 +118,7 @@ public class ClusterClientServiceLoaderTest {
 
         @Override
         public boolean isCompatibleWith(Configuration configuration) {
-            return configuration.getString(DeploymentOptions.TARGET).equals(AMBIGUOUS_TARGET);
+            return configuration.get(DeploymentOptions.TARGET).equals(AMBIGUOUS_TARGET);
         }
     }
 
@@ -130,7 +130,7 @@ public class ClusterClientServiceLoaderTest {
 
         @Override
         public boolean isCompatibleWith(Configuration configuration) {
-            return configuration.getString(DeploymentOptions.TARGET).equals(AMBIGUOUS_TARGET);
+            return configuration.get(DeploymentOptions.TARGET).equals(AMBIGUOUS_TARGET);
         }
     }
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -99,7 +99,7 @@ class ClientTest {
         plan = env.createProgramPlan();
 
         config = new Configuration();
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
+        config.set(JobManagerOptions.ADDRESS, "localhost");
 
         config.set(
                 AkkaOptions.ASK_TIMEOUT_DURATION, AkkaOptions.ASK_TIMEOUT_DURATION.defaultValue());
@@ -108,7 +108,7 @@ class ClientTest {
     private Configuration fromPackagedProgram(
             final PackagedProgram program, final int parallelism, final boolean detached) {
         final Configuration configuration = new Configuration();
-        configuration.setString(DeploymentOptions.TARGET, TEST_EXECUTOR_NAME);
+        configuration.set(DeploymentOptions.TARGET, TEST_EXECUTOR_NAME);
         configuration.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
         configuration.set(DeploymentOptions.ATTACHED, !detached);
         ConfigUtils.encodeCollectionToConfig(
@@ -490,13 +490,13 @@ class ClientTest {
                 @Override
                 public boolean isCompatibleWith(@Nonnull Configuration configuration) {
                     return TEST_EXECUTOR_NAME.equalsIgnoreCase(
-                            configuration.getString(DeploymentOptions.TARGET));
+                            configuration.get(DeploymentOptions.TARGET));
                 }
 
                 @Override
                 public PipelineExecutor getExecutor(@Nonnull Configuration configuration) {
                     return (pipeline, config, classLoader) -> {
-                        final int parallelism = config.getInteger(CoreOptions.DEFAULT_PARALLELISM);
+                        final int parallelism = config.get(CoreOptions.DEFAULT_PARALLELISM);
                         final JobGraph jobGraph =
                                 FlinkPipelineTranslationUtil.getJobGraph(
                                         classLoader, plan, config, parallelism);

--- a/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverITCase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverITCase.java
@@ -187,7 +187,7 @@ class DefaultPackagedProgramRetrieverITCase {
         final JobID jobId = new JobID();
 
         final Configuration configuration = new Configuration();
-        configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+        configuration.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
         configuration.set(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, jobId.toHexString());
 
         final String expectedSuffix = "suffix";
@@ -259,7 +259,7 @@ class DefaultPackagedProgramRetrieverITCase {
                 SavepointRestoreSettings.forPath("foobar", true);
         final JobID jobId = new JobID();
 
-        configuration.setString(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, jobId.toHexString());
+        configuration.set(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, jobId.toHexString());
         SavepointRestoreSettings.toConfiguration(savepointRestoreSettings, configuration);
 
         final String expectedSuffix = "suffix";
@@ -525,7 +525,7 @@ class DefaultPackagedProgramRetrieverITCase {
             throws FlinkException, ProgramInvocationException, MalformedURLException {
         final PackagedProgram packagedProgram = retrieverUnderTest.getPackagedProgram();
 
-        final int defaultParallelism = configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM);
+        final int defaultParallelism = configuration.get(CoreOptions.DEFAULT_PARALLELISM);
         ConfigUtils.encodeCollectionToConfig(
                 configuration,
                 PipelineOptions.JARS,

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanCreationTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ExecutionPlanCreationTest.java
@@ -57,8 +57,8 @@ class ExecutionPlanCreationTest {
 
             Configuration config = new Configuration();
 
-            config.setString(JobManagerOptions.ADDRESS, mockJmAddress.getHostName());
-            config.setInteger(JobManagerOptions.PORT, mockJmAddress.getPort());
+            config.set(JobManagerOptions.ADDRESS, mockJmAddress.getHostName());
+            config.set(JobManagerOptions.PORT, mockJmAddress.getPort());
 
             Optimizer optimizer =
                     new Optimizer(new DataStatistics(), new DefaultCostEstimator(), config);

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientCheckpointTriggerTest.java
@@ -87,10 +87,10 @@ class RestClusterClientCheckpointTriggerTest {
 
     static {
         final Configuration config = new Configuration();
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
-        config.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 10);
-        config.setLong(RestOptions.RETRY_DELAY, 0);
-        config.setInteger(RestOptions.PORT, 0);
+        config.set(JobManagerOptions.ADDRESS, "localhost");
+        config.set(RestOptions.RETRY_MAX_ATTEMPTS, 10);
+        config.set(RestOptions.RETRY_DELAY, 0L);
+        config.set(RestOptions.PORT, 0);
 
         REST_CONFIG = new UnmodifiableConfiguration(config);
     }
@@ -217,7 +217,7 @@ class RestClusterClientCheckpointTriggerTest {
     private RestClusterClient<StandaloneClusterId> createRestClusterClient(final int port)
             throws Exception {
         final Configuration clientConfig = new Configuration(REST_CONFIG);
-        clientConfig.setInteger(RestOptions.PORT, port);
+        clientConfig.set(RestOptions.PORT, port);
         return new RestClusterClient<>(
                 clientConfig,
                 new RestClient(REST_CONFIG, executor),

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientConfigurationTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientConfigurationTest.java
@@ -34,9 +34,9 @@ class RestClusterClientConfigurationTest {
     @BeforeEach
     void setUp() throws Exception {
         final Configuration config = new Configuration();
-        config.setLong(RestOptions.AWAIT_LEADER_TIMEOUT, 1);
-        config.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 2);
-        config.setLong(RestOptions.RETRY_DELAY, 3);
+        config.set(RestOptions.AWAIT_LEADER_TIMEOUT, 1L);
+        config.set(RestOptions.RETRY_MAX_ATTEMPTS, 2);
+        config.set(RestOptions.RETRY_DELAY, 3L);
         restClusterClientConfiguration = RestClusterClientConfiguration.fromConfiguration(config);
     }
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientSavepointTriggerTest.java
@@ -91,10 +91,10 @@ class RestClusterClientSavepointTriggerTest {
 
     static {
         final Configuration config = new Configuration();
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
-        config.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 10);
-        config.setLong(RestOptions.RETRY_DELAY, 0);
-        config.setInteger(RestOptions.PORT, 0);
+        config.set(JobManagerOptions.ADDRESS, "localhost");
+        config.set(RestOptions.RETRY_MAX_ATTEMPTS, 10);
+        config.set(RestOptions.RETRY_DELAY, 0L);
+        config.set(RestOptions.PORT, 0);
 
         REST_CONFIG = new UnmodifiableConfiguration(config);
     }
@@ -346,7 +346,7 @@ class RestClusterClientSavepointTriggerTest {
     private RestClusterClient<StandaloneClusterId> createRestClusterClient(final int port)
             throws Exception {
         final Configuration clientConfig = new Configuration(REST_CONFIG);
-        clientConfig.setInteger(RestOptions.PORT, port);
+        clientConfig.set(RestOptions.PORT, port);
         return new RestClusterClient<>(
                 clientConfig,
                 new RestClient(REST_CONFIG, executor),

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -188,10 +188,10 @@ class RestClusterClientTest {
 
     static {
         final Configuration config = new Configuration();
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
-        config.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 10);
-        config.setLong(RestOptions.RETRY_DELAY, 0);
-        config.setInteger(RestOptions.PORT, 0);
+        config.set(JobManagerOptions.ADDRESS, "localhost");
+        config.set(RestOptions.RETRY_MAX_ATTEMPTS, 10);
+        config.set(RestOptions.RETRY_DELAY, 0L);
+        config.set(RestOptions.PORT, 0);
 
         restConfig = config;
     }
@@ -222,7 +222,7 @@ class RestClusterClientTest {
 
     private RestClusterClient<StandaloneClusterId> createRestClusterClient(
             int port, Configuration clientConfig) throws Exception {
-        clientConfig.setInteger(RestOptions.PORT, port);
+        clientConfig.set(RestOptions.PORT, port);
         return new RestClusterClient<>(
                 clientConfig,
                 createRestClient(),

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -76,7 +76,7 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
             SourceReaderContext context) {
         this(
                 new FutureCompletingBlockingQueue<>(
-                        config.getInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY)),
+                        config.get(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY)),
                 splitReaderSupplier,
                 recordEmitter,
                 config,

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderOptions.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderOptions.java
@@ -44,7 +44,7 @@ public class SourceReaderOptions {
     public final int elementQueueCapacity;
 
     public SourceReaderOptions(Configuration config) {
-        this.sourceReaderCloseTimeout = config.getLong(SOURCE_READER_CLOSE_TIMEOUT);
-        this.elementQueueCapacity = config.getInteger(ELEMENT_QUEUE_CAPACITY);
+        this.sourceReaderCloseTimeout = config.get(SOURCE_READER_CLOSE_TIMEOUT);
+        this.elementQueueCapacity = config.get(ELEMENT_QUEUE_CAPACITY);
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
@@ -342,8 +342,8 @@ public class HybridSourceReaderTest {
                     new FutureCompletingBlockingQueue<>();
 
             Configuration config = new Configuration();
-            config.setInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 2);
-            config.setLong(SourceReaderOptions.SOURCE_READER_CLOSE_TIMEOUT, 30000L);
+            config.set(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 2);
+            config.set(SourceReaderOptions.SOURCE_READER_CLOSE_TIMEOUT, 30000L);
             MockSplitReader.Builder builder =
                     MockSplitReader.newBuilder()
                             .setNumRecordsPerSplitPerFetch(2)

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceRescaleITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceRescaleITCase.java
@@ -110,13 +110,12 @@ public class CoordinatedSourceRescaleITCase extends TestLogger {
     private StreamExecutionEnvironment createEnv(
             File checkpointDir, @Nullable File restoreCheckpoint, int p) {
         Configuration conf = new Configuration();
-        conf.setString(
-                CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+        conf.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
         conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
         if (restoreCheckpoint != null) {
             conf.set(SavepointConfigOptions.SAVEPOINT_PATH, restoreCheckpoint.toURI().toString());
         }
-        conf.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, p);
+        conf.set(TaskManagerOptions.NUM_TASK_SLOTS, p);
 
         final StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.getExecutionEnvironment(conf);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -434,8 +434,8 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 
     private Configuration getConfig() {
         Configuration config = new Configuration();
-        config.setInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 1);
-        config.setLong(SourceReaderOptions.SOURCE_READER_CLOSE_TIMEOUT, 30000L);
+        config.set(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 1);
+        config.set(SourceReaderOptions.SOURCE_READER_CLOSE_TIMEOUT, 30000L);
         return config;
     }
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockBaseSource.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockBaseSource.java
@@ -70,8 +70,8 @@ public class MockBaseSource implements Source<Integer, MockSourceSplit, List<Moc
                 new FutureCompletingBlockingQueue<>();
 
         Configuration config = new Configuration();
-        config.setInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 1);
-        config.setLong(SourceReaderOptions.SOURCE_READER_CLOSE_TIMEOUT, 30000L);
+        config.set(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 1);
+        config.set(SourceReaderOptions.SOURCE_READER_CLOSE_TIMEOUT, 30000L);
         MockSplitReader.Builder builder =
                 MockSplitReader.newBuilder()
                         .setNumRecordsPerSplitPerFetch(2)

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
@@ -218,7 +218,7 @@ public class FileSystemTableSink extends AbstractFileSystemTable
         FileSystemFactory fsFactory = FileSystem::get;
         RowDataPartitionComputer computer = partitionComputer();
 
-        boolean autoCompaction = tableOptions.getBoolean(AUTO_COMPACTION);
+        boolean autoCompaction = tableOptions.get(AUTO_COMPACTION);
         Object writer = createWriter(sinkContext);
         boolean isEncoder = writer instanceof Encoder;
         TableBucketAssigner assigner = new TableBucketAssigner(computer);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionTimeCommitPredicate.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionTimeCommitPredicate.java
@@ -59,8 +59,7 @@ public class PartitionTimeCommitPredicate implements PartitionCommitPredicate {
                         conf.get(PARTITION_TIME_EXTRACTOR_CLASS),
                         conf.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN),
                         conf.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER));
-        this.watermarkTimeZone =
-                ZoneId.of(conf.getString(SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE));
+        this.watermarkTimeZone = ZoneId.of(conf.get(SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE));
     }
 
     @Override

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkSpeculativeITCase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileSinkSpeculativeITCase.java
@@ -140,8 +140,8 @@ class FileSinkSpeculativeITCase {
 
     private static Configuration configure() {
         Configuration configuration = new Configuration();
-        configuration.setString(RestOptions.BIND_PORT, "0");
-        configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
+        configuration.set(RestOptions.BIND_PORT, "0");
+        configuration.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
 
         // for speculative execution
         configuration.set(BatchExecutionOptions.SPECULATIVE_ENABLED, true);

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/StreamingFileWriterTest.java
@@ -381,7 +381,7 @@ class StreamingFileWriterTest {
 
     private Configuration getPartitionCommitTriggerConf(long commitDelay) {
         Configuration configuration = new Configuration();
-        configuration.setString(SINK_PARTITION_COMMIT_POLICY_KIND, "success-file");
+        configuration.set(SINK_PARTITION_COMMIT_POLICY_KIND, "success-file");
         configuration.setString(PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER.key(), "yyyy-MM-dd");
         configuration.setString(SINK_PARTITION_COMMIT_TRIGGER.key(), "partition-time");
         configuration.setLong(SINK_PARTITION_COMMIT_DELAY.key(), commitDelay);
@@ -391,7 +391,7 @@ class StreamingFileWriterTest {
 
     private Configuration getProcTimeCommitTriggerConf(long commitDelay) {
         Configuration configuration = new Configuration();
-        configuration.setString(SINK_PARTITION_COMMIT_POLICY_KIND, "success-file");
+        configuration.set(SINK_PARTITION_COMMIT_POLICY_KIND, "success-file");
         configuration.setString(SINK_PARTITION_COMMIT_TRIGGER.key(), "process-time");
         configuration.setLong(SINK_PARTITION_COMMIT_DELAY.key(), commitDelay);
         configuration.setString(SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE.key(), "UTC");

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -210,7 +210,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
             // the table's option "SINK_PARTITION_COMMIT_POLICY_KIND" should contain 'metastore'
             org.apache.flink.configuration.Configuration flinkConf =
                     org.apache.flink.configuration.Configuration.fromMap(catalogTable.getOptions());
-            String policyKind = flinkConf.getString(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND);
+            String policyKind = flinkConf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND);
             String[] policyStrings = policyKind.split(",");
             Arrays.stream(policyStrings)
                     .filter(policy -> policy.equalsIgnoreCase(PartitionCommitPolicy.METASTORE))
@@ -383,7 +383,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
         org.apache.flink.configuration.Configuration conf =
                 new org.apache.flink.configuration.Configuration();
         catalogTable.getOptions().forEach(conf::setString);
-        boolean autoCompaction = conf.getBoolean(FileSystemConnectorOptions.AUTO_COMPACTION);
+        boolean autoCompaction = conf.get(FileSystemConnectorOptions.AUTO_COMPACTION);
         if (autoCompaction) {
             Optional<Integer> compactParallelismOptional =
                     conf.getOptional(FileSystemConnectorOptions.COMPACTION_PARALLELISM);
@@ -638,7 +638,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
         catalogTable.getOptions().forEach(conf::setString);
 
         String commitPolicies =
-                conf.getString(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND);
+                conf.get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND);
         if (!getPartitionKeys().isEmpty() && StringUtils.isNullOrWhitespaceOnly(commitPolicies)) {
             throw new FlinkHiveException(
                     String.format(
@@ -648,7 +648,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                             FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND.key()));
         }
 
-        boolean autoCompaction = conf.getBoolean(FileSystemConnectorOptions.AUTO_COMPACTION);
+        boolean autoCompaction = conf.get(FileSystemConnectorOptions.AUTO_COMPACTION);
         if (autoCompaction) {
             fileNamingBuilder.withPartPrefix(
                     convertToUncompacted(fileNamingBuilder.build().getPartPrefix()));

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -429,7 +429,7 @@ public class HiveTableSource
                 case PARTITION_NAME:
                     if (configuration.contains(STREAMING_SOURCE_CONSUME_START_OFFSET)) {
                         String consumeOffsetStr =
-                                configuration.getString(STREAMING_SOURCE_CONSUME_START_OFFSET);
+                                configuration.get(STREAMING_SOURCE_CONSUME_START_OFFSET);
                         consumeStartOffset = (T) consumeOffsetStr;
                     } else {
                         consumeStartOffset = (T) DEFAULT_MIN_NAME_OFFSET;
@@ -440,12 +440,12 @@ public class HiveTableSource
                 case CREATE_TIME:
                     if (configuration.contains(STREAMING_SOURCE_CONSUME_START_OFFSET)) {
                         String consumeOffsetStr =
-                                configuration.getString(STREAMING_SOURCE_CONSUME_START_OFFSET);
+                                configuration.get(STREAMING_SOURCE_CONSUME_START_OFFSET);
 
                         LocalDateTime localDateTime =
                                 DefaultPartTimeExtractor.toLocalDateTime(
                                         consumeOffsetStr,
-                                        configuration.getString(
+                                        configuration.get(
                                                 PARTITION_TIME_EXTRACTOR_TIMESTAMP_FORMATTER));
 
                         consumeStartOffset =

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/security/token/HiveServer2DelegationTokenProviderITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/security/token/HiveServer2DelegationTokenProviderITCase.java
@@ -108,8 +108,8 @@ public class HiveServer2DelegationTokenProviderITCase {
                 new org.apache.flink.configuration.Configuration();
 
         final Path keyTab = Files.createFile(tmpDir.resolve("test.keytab"));
-        configuration.setString(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
-        configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, "test@EXAMPLE.COM");
+        configuration.set(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
+        configuration.set(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, "test@EXAMPLE.COM");
         provider.init(configuration);
         boolean result = provider.delegationTokensRequired();
         assertTrue(result);

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -304,7 +304,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
     @Internal
     public void enablePeriodicMaterialize(boolean enabled) {
-        configuration.setBoolean(StateChangelogOptions.PERIODIC_MATERIALIZATION_ENABLED, enabled);
+        configuration.set(StateChangelogOptions.PERIODIC_MATERIALIZATION_ENABLED, enabled);
     }
 
     @Internal

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/DelimitedInputFormat.java
@@ -89,8 +89,8 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT>
     }
 
     protected static void loadConfigParameters(Configuration parameters) {
-        int maxSamples = parameters.getInteger(OptimizerOptions.DELIMITED_FORMAT_MAX_LINE_SAMPLES);
-        int minSamples = parameters.getInteger(OptimizerOptions.DELIMITED_FORMAT_MIN_LINE_SAMPLES);
+        int maxSamples = parameters.get(OptimizerOptions.DELIMITED_FORMAT_MAX_LINE_SAMPLES);
+        int minSamples = parameters.get(OptimizerOptions.DELIMITED_FORMAT_MIN_LINE_SAMPLES);
 
         if (maxSamples < 0) {
             LOG.error(
@@ -124,7 +124,7 @@ public abstract class DelimitedInputFormat<OT> extends FileInputFormat<OT>
             DEFAULT_MIN_NUM_SAMPLES = minSamples;
         }
 
-        int maxLen = parameters.getInteger(OptimizerOptions.DELIMITED_FORMAT_MAX_SAMPLE_LEN);
+        int maxLen = parameters.get(OptimizerOptions.DELIMITED_FORMAT_MAX_SAMPLE_LEN);
         if (maxLen <= 0) {
             maxLen = OptimizerOptions.DELIMITED_FORMAT_MAX_SAMPLE_LEN.defaultValue();
             LOG.error(

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FileOutputFormat.java
@@ -75,12 +75,12 @@ public abstract class FileOutputFormat<IT> extends RichOutputFormat<IT>
      * @param configuration The configuration to load defaults from
      */
     public static void initDefaultsFromConfiguration(Configuration configuration) {
-        final boolean overwrite = configuration.getBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE);
+        final boolean overwrite = configuration.get(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE);
 
         DEFAULT_WRITE_MODE = overwrite ? WriteMode.OVERWRITE : WriteMode.NO_OVERWRITE;
 
         final boolean alwaysCreateDirectory =
-                configuration.getBoolean(CoreOptions.FILESYSTEM_OUTPUT_ALWAYS_CREATE_DIRECTORY);
+                configuration.get(CoreOptions.FILESYSTEM_OUTPUT_ALWAYS_CREATE_DIRECTORY);
 
         DEFAULT_OUTPUT_DIRECTORY_MODE =
                 alwaysCreateDirectory ? OutputDirectoryMode.ALWAYS : OutputDirectoryMode.PARONLY;

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -54,12 +54,11 @@ public class ConfigurationUtils {
      */
     public static Optional<Time> getSystemResourceMetricsProbingInterval(
             Configuration configuration) {
-        if (!configuration.getBoolean(SYSTEM_RESOURCE_METRICS)) {
+        if (!configuration.get(SYSTEM_RESOURCE_METRICS)) {
             return Optional.empty();
         } else {
             return Optional.of(
-                    Time.milliseconds(
-                            configuration.getLong(SYSTEM_RESOURCE_METRICS_PROBING_INTERVAL)));
+                    Time.milliseconds(configuration.get(SYSTEM_RESOURCE_METRICS_PROBING_INTERVAL)));
         }
     }
 
@@ -72,7 +71,7 @@ public class ConfigurationUtils {
      */
     @Nonnull
     public static String[] parseTempDirectories(Configuration configuration) {
-        return splitPaths(configuration.getString(CoreOptions.TMP_DIRS));
+        return splitPaths(configuration.get(CoreOptions.TMP_DIRS));
     }
 
     /**
@@ -106,7 +105,7 @@ public class ConfigurationUtils {
     @Nonnull
     public static String[] parseLocalStateDirectories(Configuration configuration) {
         String configValue =
-                configuration.getString(
+                configuration.get(
                         CheckpointingOptions.LOCAL_RECOVERY_TASK_MANAGER_STATE_ROOT_DIRS, "");
         return splitPaths(configValue);
     }
@@ -141,14 +140,11 @@ public class ConfigurationUtils {
     public static Time getStandaloneClusterStartupPeriodTime(Configuration configuration) {
         final Time timeout;
         long standaloneClusterStartupPeriodTime =
-                configuration.getLong(
-                        ResourceManagerOptions.STANDALONE_CLUSTER_STARTUP_PERIOD_TIME);
+                configuration.get(ResourceManagerOptions.STANDALONE_CLUSTER_STARTUP_PERIOD_TIME);
         if (standaloneClusterStartupPeriodTime >= 0) {
             timeout = Time.milliseconds(standaloneClusterStartupPeriodTime);
         } else {
-            timeout =
-                    Time.milliseconds(
-                            configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
+            timeout = Time.milliseconds(configuration.get(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
         }
         return timeout;
     }

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -76,12 +76,12 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public String getString(ConfigOption<String> configOption) {
-        return this.backingConfig.getString(prefixOption(configOption, prefix));
+        return this.backingConfig.get(prefixOption(configOption, prefix));
     }
 
     @Override
     public String getString(ConfigOption<String> configOption, String overrideDefault) {
-        return this.backingConfig.getString(prefixOption(configOption, prefix), overrideDefault);
+        return this.backingConfig.get(prefixOption(configOption, prefix), overrideDefault);
     }
 
     @Override
@@ -91,7 +91,7 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public void setString(ConfigOption<String> key, String value) {
-        this.backingConfig.setString(prefixOption(key, prefix), value);
+        this.backingConfig.set(prefixOption(key, prefix), value);
     }
 
     @Override
@@ -113,12 +113,12 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public int getInteger(ConfigOption<Integer> configOption) {
-        return this.backingConfig.getInteger(prefixOption(configOption, prefix));
+        return this.backingConfig.get(prefixOption(configOption, prefix));
     }
 
     @Override
     public int getInteger(ConfigOption<Integer> configOption, int overrideDefault) {
-        return this.backingConfig.getInteger(prefixOption(configOption, prefix), overrideDefault);
+        return this.backingConfig.get(prefixOption(configOption, prefix), overrideDefault);
     }
 
     @Override
@@ -128,7 +128,7 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public void setInteger(ConfigOption<Integer> key, int value) {
-        this.backingConfig.setInteger(prefixOption(key, prefix), value);
+        this.backingConfig.set(prefixOption(key, prefix), value);
     }
 
     @Override
@@ -138,12 +138,12 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public long getLong(ConfigOption<Long> configOption) {
-        return this.backingConfig.getLong(prefixOption(configOption, prefix));
+        return this.backingConfig.get(prefixOption(configOption, prefix));
     }
 
     @Override
     public long getLong(ConfigOption<Long> configOption, long overrideDefault) {
-        return this.backingConfig.getLong(prefixOption(configOption, prefix), overrideDefault);
+        return this.backingConfig.get(prefixOption(configOption, prefix), overrideDefault);
     }
 
     @Override
@@ -153,7 +153,7 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public void setLong(ConfigOption<Long> key, long value) {
-        this.backingConfig.setLong(prefixOption(key, prefix), value);
+        this.backingConfig.set(prefixOption(key, prefix), value);
     }
 
     @Override
@@ -163,7 +163,7 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public boolean getBoolean(ConfigOption<Boolean> configOption) {
-        return this.backingConfig.getBoolean(prefixOption(configOption, prefix));
+        return this.backingConfig.get(prefixOption(configOption, prefix));
     }
 
     @Override
@@ -173,12 +173,12 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public void setBoolean(ConfigOption<Boolean> key, boolean value) {
-        this.backingConfig.setBoolean(prefixOption(key, prefix), value);
+        this.backingConfig.set(prefixOption(key, prefix), value);
     }
 
     @Override
     public boolean getBoolean(ConfigOption<Boolean> configOption, boolean overrideDefault) {
-        return this.backingConfig.getBoolean(prefixOption(configOption, prefix), overrideDefault);
+        return this.backingConfig.get(prefixOption(configOption, prefix), overrideDefault);
     }
 
     @Override
@@ -188,12 +188,12 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public float getFloat(ConfigOption<Float> configOption) {
-        return this.backingConfig.getFloat(prefixOption(configOption, prefix));
+        return this.backingConfig.get(prefixOption(configOption, prefix));
     }
 
     @Override
     public float getFloat(ConfigOption<Float> configOption, float overrideDefault) {
-        return this.backingConfig.getFloat(prefixOption(configOption, prefix), overrideDefault);
+        return this.backingConfig.get(prefixOption(configOption, prefix), overrideDefault);
     }
 
     @Override
@@ -203,7 +203,7 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public void setFloat(ConfigOption<Float> key, float value) {
-        this.backingConfig.setFloat(prefixOption(key, prefix), value);
+        this.backingConfig.set(prefixOption(key, prefix), value);
     }
 
     @Override
@@ -213,12 +213,12 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public double getDouble(ConfigOption<Double> configOption) {
-        return this.backingConfig.getDouble(prefixOption(configOption, prefix));
+        return this.backingConfig.get(prefixOption(configOption, prefix));
     }
 
     @Override
     public double getDouble(ConfigOption<Double> configOption, double overrideDefault) {
-        return this.backingConfig.getDouble(prefixOption(configOption, prefix), overrideDefault);
+        return this.backingConfig.get(prefixOption(configOption, prefix), overrideDefault);
     }
 
     @Override
@@ -228,7 +228,7 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public void setDouble(ConfigOption<Double> key, double value) {
-        this.backingConfig.setDouble(prefixOption(key, prefix), value);
+        this.backingConfig.set(prefixOption(key, prefix), value);
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -630,20 +630,20 @@ public class SecurityOptions {
      */
     public static boolean isInternalSSLEnabled(Configuration sslConfig) {
         @SuppressWarnings("deprecation")
-        final boolean fallbackFlag = sslConfig.getBoolean(SSL_ENABLED);
-        return sslConfig.getBoolean(SSL_INTERNAL_ENABLED, fallbackFlag);
+        final boolean fallbackFlag = sslConfig.get(SSL_ENABLED);
+        return sslConfig.get(SSL_INTERNAL_ENABLED, fallbackFlag);
     }
 
     /** Checks whether SSL for the external REST endpoint is enabled. */
     public static boolean isRestSSLEnabled(Configuration sslConfig) {
         @SuppressWarnings("deprecation")
-        final boolean fallbackFlag = sslConfig.getBoolean(SSL_ENABLED);
-        return sslConfig.getBoolean(SSL_REST_ENABLED, fallbackFlag);
+        final boolean fallbackFlag = sslConfig.get(SSL_ENABLED);
+        return sslConfig.get(SSL_REST_ENABLED, fallbackFlag);
     }
 
     /** Checks whether mutual SSL authentication for the external REST endpoint is enabled. */
     public static boolean isRestSSLAuthenticationEnabled(Configuration sslConfig) {
         checkNotNull(sslConfig, "sslConfig");
-        return isRestSSLEnabled(sslConfig) && sslConfig.getBoolean(SSL_REST_AUTHENTICATION_ENABLED);
+        return isRestSSLEnabled(sslConfig) && sslConfig.get(SSL_REST_AUTHENTICATION_ENABLED);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -864,7 +864,7 @@ public class TaskManagerOptions {
                 return taskManagerLoadBalanceModeOptional.get();
             }
             boolean evenlySpreadOutSlots =
-                    configuration.getBoolean(ClusterOptions.EVENLY_SPREAD_OUT_SLOTS_STRATEGY);
+                    configuration.get(ClusterOptions.EVENLY_SPREAD_OUT_SLOTS_STRATEGY);
 
             return evenlySpreadOutSlots
                     ? TaskManagerLoadBalanceMode.SLOTS

--- a/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/FileSystem.java
@@ -353,8 +353,7 @@ public abstract class FileSystem {
             FALLBACK_FACTORY.configure(config);
 
             // also read the default file system scheme
-            final String stringifiedUri =
-                    config.getString(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, null);
+            final String stringifiedUri = config.get(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, null);
             if (stringifiedUri == null) {
                 defaultScheme = null;
             } else {
@@ -375,7 +374,7 @@ public abstract class FileSystem {
                     Splitter.on(';')
                             .omitEmptyStrings()
                             .trimResults()
-                            .split(config.getString(CoreOptions.ALLOWED_FALLBACK_FILESYSTEMS));
+                            .split(config.get(CoreOptions.ALLOWED_FALLBACK_FILESYSTEMS));
             allowedFallbackFilesystems.forEach(ALLOWED_FALLBACK_FILESYSTEMS::add);
         } finally {
             LOCK.unlock();

--- a/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/LimitedConnectionsFileSystem.java
@@ -1047,9 +1047,9 @@ public class LimitedConnectionsFileSystem extends FileSystem {
             final ConfigOption<Integer> limitOutOption =
                     CoreOptions.fileSystemConnectionLimitOut(fsScheme);
 
-            final int totalLimit = config.getInteger(totalLimitOption);
-            final int limitIn = config.getInteger(limitInOption);
-            final int limitOut = config.getInteger(limitOutOption);
+            final int totalLimit = config.get(totalLimitOption);
+            final int limitIn = config.get(limitInOption);
+            final int limitOut = config.get(limitOutOption);
 
             checkLimit(totalLimit, totalLimitOption);
             checkLimit(limitIn, limitInOption);
@@ -1065,8 +1065,8 @@ public class LimitedConnectionsFileSystem extends FileSystem {
                 final ConfigOption<Long> inactivityTimeoutOption =
                         CoreOptions.fileSystemConnectionLimitStreamInactivityTimeout(fsScheme);
 
-                final long openTimeout = config.getLong(openTimeoutOption);
-                final long inactivityTimeout = config.getLong(inactivityTimeoutOption);
+                final long openTimeout = config.get(openTimeoutOption);
+                final long inactivityTimeout = config.get(inactivityTimeoutOption);
 
                 checkTimeout(openTimeout, openTimeoutOption);
                 checkTimeout(inactivityTimeout, inactivityTimeoutOption);

--- a/flink-core/src/test/java/org/apache/flink/configuration/FilesystemSchemeConfigTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/FilesystemSchemeConfigTest.java
@@ -61,8 +61,7 @@ public class FilesystemSchemeConfigTest extends TestLogger {
     @Test
     public void testExplicitlySetToLocal() throws Exception {
         final Configuration conf = new Configuration();
-        conf.setString(
-                CoreOptions.DEFAULT_FILESYSTEM_SCHEME, LocalFileSystem.getLocalFsURI().toString());
+        conf.set(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, LocalFileSystem.getLocalFsURI().toString());
         FileSystem.initialize(conf);
 
         URI justPath = new URI(tempFolder.newFile().toURI().getPath());
@@ -75,7 +74,7 @@ public class FilesystemSchemeConfigTest extends TestLogger {
     @Test
     public void testExplicitlySetToOther() throws Exception {
         final Configuration conf = new Configuration();
-        conf.setString(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "otherFS://localhost:1234/");
+        conf.set(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "otherFS://localhost:1234/");
         FileSystem.initialize(conf);
 
         URI justPath = new URI(tempFolder.newFile().toURI().getPath());
@@ -92,7 +91,7 @@ public class FilesystemSchemeConfigTest extends TestLogger {
     @Test
     public void testExplicitlyPathTakesPrecedence() throws Exception {
         final Configuration conf = new Configuration();
-        conf.setString(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "otherFS://localhost:1234/");
+        conf.set(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "otherFS://localhost:1234/");
         FileSystem.initialize(conf);
 
         URI pathAndScheme = tempFolder.newFile().toURI();

--- a/flink-core/src/test/java/org/apache/flink/configuration/RestOptionsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/RestOptionsTest.java
@@ -35,7 +35,7 @@ public class RestOptionsTest extends TestLogger {
         final String expectedAddress = "foobar";
         configuration.setString("web.address", expectedAddress);
 
-        final String actualAddress = configuration.getString(RestOptions.BIND_ADDRESS);
+        final String actualAddress = configuration.get(RestOptions.BIND_ADDRESS);
 
         assertThat(actualAddress, is(equalTo(expectedAddress)));
     }
@@ -46,7 +46,7 @@ public class RestOptionsTest extends TestLogger {
         final String expectedAddress = "foobar";
         configuration.setString("jobmanager.web.address", expectedAddress);
 
-        final String actualAddress = configuration.getString(RestOptions.BIND_ADDRESS);
+        final String actualAddress = configuration.get(RestOptions.BIND_ADDRESS);
 
         assertThat(actualAddress, is(equalTo(expectedAddress)));
     }

--- a/flink-core/src/test/java/org/apache/flink/configuration/SecurityOptionsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/SecurityOptionsTest.java
@@ -33,22 +33,22 @@ public class SecurityOptionsTest extends TestLogger {
     public void checkEnableSSL() {
         // backwards compatibility
         Configuration oldConf = new Configuration();
-        oldConf.setBoolean(SecurityOptions.SSL_ENABLED, true);
+        oldConf.set(SecurityOptions.SSL_ENABLED, true);
         assertTrue(SecurityOptions.isInternalSSLEnabled(oldConf));
         assertTrue(SecurityOptions.isRestSSLEnabled(oldConf));
 
         // new options take precedence
         Configuration newOptions = new Configuration();
-        newOptions.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
-        newOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+        newOptions.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        newOptions.set(SecurityOptions.SSL_REST_ENABLED, false);
         assertTrue(SecurityOptions.isInternalSSLEnabled(newOptions));
         assertFalse(SecurityOptions.isRestSSLEnabled(newOptions));
 
         // new options take precedence
         Configuration precedence = new Configuration();
-        precedence.setBoolean(SecurityOptions.SSL_ENABLED, true);
-        precedence.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, false);
-        precedence.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+        precedence.set(SecurityOptions.SSL_ENABLED, true);
+        precedence.set(SecurityOptions.SSL_INTERNAL_ENABLED, false);
+        precedence.set(SecurityOptions.SSL_REST_ENABLED, false);
         assertFalse(SecurityOptions.isInternalSSLEnabled(precedence));
         assertFalse(SecurityOptions.isRestSSLEnabled(precedence));
     }
@@ -61,18 +61,18 @@ public class SecurityOptionsTest extends TestLogger {
     public void checkEnableRestSSLAuthentication() {
         // SSL has to be enabled
         Configuration noSSLOptions = new Configuration();
-        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
-        noSSLOptions.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+        noSSLOptions.set(SecurityOptions.SSL_REST_ENABLED, false);
+        noSSLOptions.set(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
         assertFalse(SecurityOptions.isRestSSLAuthenticationEnabled(noSSLOptions));
 
         // authentication is disabled by default
         Configuration defaultOptions = new Configuration();
-        defaultOptions.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        defaultOptions.set(SecurityOptions.SSL_REST_ENABLED, true);
         assertFalse(SecurityOptions.isRestSSLAuthenticationEnabled(defaultOptions));
 
         Configuration options = new Configuration();
-        options.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
-        options.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+        options.set(SecurityOptions.SSL_REST_ENABLED, true);
+        options.set(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
         assertTrue(SecurityOptions.isRestSSLAuthenticationEnabled(options));
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/LimitedConnectionsConfigurationTest.java
@@ -99,7 +99,7 @@ public class LimitedConnectionsConfigurationTest {
         // only total limit set
         {
             Configuration conf = new Configuration();
-            conf.setInteger(CoreOptions.fileSystemConnectionLimit(scheme), 10);
+            conf.set(CoreOptions.fileSystemConnectionLimit(scheme), 10);
 
             ConnectionLimitingSettings settings =
                     ConnectionLimitingSettings.fromConfig(conf, scheme);
@@ -112,7 +112,7 @@ public class LimitedConnectionsConfigurationTest {
         // only input limit set
         {
             Configuration conf = new Configuration();
-            conf.setInteger(CoreOptions.fileSystemConnectionLimitIn(scheme), 10);
+            conf.set(CoreOptions.fileSystemConnectionLimitIn(scheme), 10);
 
             ConnectionLimitingSettings settings =
                     ConnectionLimitingSettings.fromConfig(conf, scheme);
@@ -125,7 +125,7 @@ public class LimitedConnectionsConfigurationTest {
         // only output limit set
         {
             Configuration conf = new Configuration();
-            conf.setInteger(CoreOptions.fileSystemConnectionLimitOut(scheme), 10);
+            conf.set(CoreOptions.fileSystemConnectionLimitOut(scheme), 10);
 
             ConnectionLimitingSettings settings =
                     ConnectionLimitingSettings.fromConfig(conf, scheme);

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
@@ -67,8 +67,8 @@ public class FsStateChangelogStorageFactory implements StateChangelogStorageFact
             File newFolder,
             Duration uploadTimeout,
             int maxUploadAttempts) {
-        configuration.setString(STATE_CHANGE_LOG_STORAGE, IDENTIFIER);
-        configuration.setString(BASE_PATH, newFolder.getAbsolutePath());
+        configuration.set(STATE_CHANGE_LOG_STORAGE, IDENTIFIER);
+        configuration.set(BASE_PATH, newFolder.getAbsolutePath());
         configuration.set(UPLOAD_TIMEOUT, uploadTimeout);
         configuration.set(RETRY_MAX_ATTEMPTS, maxUploadAttempts);
     }

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/test/java/org/apache/flink/streaming/tests/AllroundMiniClusterTest.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/test/java/org/apache/flink/streaming/tests/AllroundMiniClusterTest.java
@@ -57,7 +57,7 @@ public class AllroundMiniClusterTest extends TestLogger {
 
     private static Configuration createConfiguration() {
         Configuration configuration = new Configuration();
-        configuration.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
         configuration.setString(EXECUTION_FAILOVER_STRATEGY.key(), "region");
         return configuration;
     }

--- a/flink-external-resources/flink-external-resource-gpu/src/main/java/org/apache/flink/externalresource/gpu/GPUDriver.java
+++ b/flink-external-resources/flink-external-resource-gpu/src/main/java/org/apache/flink/externalresource/gpu/GPUDriver.java
@@ -75,7 +75,7 @@ class GPUDriver implements ExternalResourceDriver {
     private final String args;
 
     GPUDriver(Configuration config) throws Exception {
-        final String discoveryScriptPathStr = config.getString(DISCOVERY_SCRIPT_PATH);
+        final String discoveryScriptPathStr = config.get(DISCOVERY_SCRIPT_PATH);
         if (StringUtils.isNullOrWhitespaceOnly(discoveryScriptPathStr)) {
             throw new IllegalConfigurationException(
                     String.format(
@@ -106,7 +106,7 @@ class GPUDriver implements ExternalResourceDriver {
                             discoveryScriptFile.getAbsolutePath()));
         }
 
-        args = config.getString(DISCOVERY_SCRIPT_ARG);
+        args = config.get(DISCOVERY_SCRIPT_ARG);
     }
 
     @Override

--- a/flink-external-resources/flink-external-resource-gpu/src/test/java/org/apache/flink/externalresource/gpu/GPUDriverTest.java
+++ b/flink-external-resources/flink-external-resource-gpu/src/test/java/org/apache/flink/externalresource/gpu/GPUDriverTest.java
@@ -46,7 +46,7 @@ class GPUDriverTest {
     void testGPUDriverWithTestScript() throws Exception {
         final int gpuAmount = 2;
         final Configuration config = new Configuration();
-        config.setString(GPUDriver.DISCOVERY_SCRIPT_PATH, TESTING_DISCOVERY_SCRIPT_PATH);
+        config.set(GPUDriver.DISCOVERY_SCRIPT_PATH, TESTING_DISCOVERY_SCRIPT_PATH);
 
         final GPUDriver gpuDriver = new GPUDriver(config);
         final Set<GPUInfo> gpuResource = gpuDriver.retrieveResourceInfo(gpuAmount);
@@ -58,7 +58,7 @@ class GPUDriverTest {
     void testGPUDriverWithInvalidAmount() throws Exception {
         final int gpuAmount = -1;
         final Configuration config = new Configuration();
-        config.setString(GPUDriver.DISCOVERY_SCRIPT_PATH, TESTING_DISCOVERY_SCRIPT_PATH);
+        config.set(GPUDriver.DISCOVERY_SCRIPT_PATH, TESTING_DISCOVERY_SCRIPT_PATH);
 
         final GPUDriver gpuDriver = new GPUDriver(config);
         assertThatThrownBy(() -> gpuDriver.retrieveResourceInfo(gpuAmount))
@@ -68,7 +68,7 @@ class GPUDriverTest {
     @Test
     void testGPUDriverWithIllegalConfigTestScript() {
         final Configuration config = new Configuration();
-        config.setString(GPUDriver.DISCOVERY_SCRIPT_PATH, " ");
+        config.set(GPUDriver.DISCOVERY_SCRIPT_PATH, " ");
 
         assertThatThrownBy(() -> new GPUDriver(config))
                 .isInstanceOf(IllegalConfigurationException.class);
@@ -77,7 +77,7 @@ class GPUDriverTest {
     @Test
     void testGPUDriverWithTestScriptDoNotExist() throws Exception {
         final Configuration config = new Configuration();
-        config.setString(GPUDriver.DISCOVERY_SCRIPT_PATH, "invalid/path");
+        config.set(GPUDriver.DISCOVERY_SCRIPT_PATH, "invalid/path");
         assertThatThrownBy(() -> new GPUDriver(config)).isInstanceOf(FileNotFoundException.class);
     }
 
@@ -89,7 +89,7 @@ class GPUDriverTest {
         final File inExecutableFile = tempFile.toFile();
         assertThat(inExecutableFile.setExecutable(false)).isTrue();
 
-        config.setString(GPUDriver.DISCOVERY_SCRIPT_PATH, inExecutableFile.getAbsolutePath());
+        config.set(GPUDriver.DISCOVERY_SCRIPT_PATH, inExecutableFile.getAbsolutePath());
 
         assertThatThrownBy(() -> new GPUDriver(config)).isInstanceOf(FlinkException.class);
     }
@@ -97,8 +97,8 @@ class GPUDriverTest {
     @Test
     void testGPUDriverWithTestScriptExitWithNonZero() throws Exception {
         final Configuration config = new Configuration();
-        config.setString(GPUDriver.DISCOVERY_SCRIPT_PATH, TESTING_DISCOVERY_SCRIPT_PATH);
-        config.setString(GPUDriver.DISCOVERY_SCRIPT_ARG, "--exit-non-zero");
+        config.set(GPUDriver.DISCOVERY_SCRIPT_PATH, TESTING_DISCOVERY_SCRIPT_PATH);
+        config.set(GPUDriver.DISCOVERY_SCRIPT_ARG, "--exit-non-zero");
 
         final GPUDriver gpuDriver = new GPUDriver(config);
         assertThatThrownBy(() -> gpuDriver.retrieveResourceInfo(1))

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/java/org/apache/flink/fs/osshadoop/OSSFileSystemFactory.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/java/org/apache/flink/fs/osshadoop/OSSFileSystemFactory.java
@@ -106,8 +106,8 @@ public class OSSFileSystemFactory implements FileSystemFactory {
         final String localTmpDirectory = localTmpDirectories[0];
         return new FlinkOSSFileSystem(
                 fs,
-                flinkConfig.getLong(PART_UPLOAD_MIN_SIZE),
-                flinkConfig.getInteger(MAX_CONCURRENT_UPLOADS),
+                flinkConfig.get(PART_UPLOAD_MIN_SIZE),
+                flinkConfig.get(MAX_CONCURRENT_UPLOADS),
                 localTmpDirectory,
                 new OSSAccessor(fs));
     }

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterExceptionITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterExceptionITCase.java
@@ -56,10 +56,10 @@ public class HadoopOSSRecoverableWriterExceptionITCase
         conf.setString("fs.oss.accessKeyId", OSSTestCredentials.getOSSAccessKey());
         conf.setString("fs.oss.accessKeySecret", OSSTestCredentials.getOSSSecretKey());
 
-        conf.setInteger(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
+        conf.set(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
 
         final String defaultTmpDir = TEMP_FOLDER.getRoot().getAbsolutePath() + "/oss_tmp_dir";
-        conf.setString(CoreOptions.TMP_DIRS, defaultTmpDir);
+        conf.set(CoreOptions.TMP_DIRS, defaultTmpDir);
 
         FileSystem.initialize(conf);
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterITCase.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/test/java/org/apache/flink/fs/osshadoop/HadoopOSSRecoverableWriterITCase.java
@@ -58,10 +58,10 @@ public class HadoopOSSRecoverableWriterITCase extends AbstractHadoopRecoverableW
         conf.setString("fs.oss.accessKeyId", OSSTestCredentials.getOSSAccessKey());
         conf.setString("fs.oss.accessKeySecret", OSSTestCredentials.getOSSSecretKey());
 
-        conf.setInteger(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
+        conf.set(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
 
         final String defaultTmpDir = TEMP_FOLDER.getRoot().getAbsolutePath() + "/oss_tmp_dir";
-        conf.setString(CoreOptions.TMP_DIRS, defaultTmpDir);
+        conf.set(CoreOptions.TMP_DIRS, defaultTmpDir);
 
         FileSystem.initialize(conf);
         bigDataChunk =

--- a/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-base/src/main/java/org/apache/flink/fs/s3/common/AbstractS3FileSystemFactory.java
@@ -129,7 +129,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
             fs.initialize(getInitURI(fsUri, hadoopConfig), hadoopConfig);
 
             // load the entropy injection settings
-            String entropyInjectionKey = flinkConfig.getString(ENTROPY_INJECT_KEY_OPTION);
+            String entropyInjectionKey = flinkConfig.get(ENTROPY_INJECT_KEY_OPTION);
             int numEntropyChars = -1;
             if (entropyInjectionKey != null) {
                 if (entropyInjectionKey.matches(INVALID_ENTROPY_KEY_CHARS)) {
@@ -139,7 +139,7 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
                                     + " : "
                                     + entropyInjectionKey);
                 }
-                numEntropyChars = flinkConfig.getInteger(ENTROPY_INJECT_LENGTH_OPTION);
+                numEntropyChars = flinkConfig.get(ENTROPY_INJECT_LENGTH_OPTION);
                 if (numEntropyChars <= 0) {
                     throw new IllegalConfigurationException(
                             ENTROPY_INJECT_LENGTH_OPTION.key() + " must configure a value > 0");
@@ -150,8 +150,8 @@ public abstract class AbstractS3FileSystemFactory implements FileSystemFactory {
                     ConfigurationUtils.parseTempDirectories(flinkConfig);
             Preconditions.checkArgument(localTmpDirectories.length > 0);
             final String localTmpDirectory = localTmpDirectories[0];
-            final long s3minPartSize = flinkConfig.getLong(PART_UPLOAD_MIN_SIZE);
-            final int maxConcurrentUploads = flinkConfig.getInteger(MAX_CONCURRENT_UPLOADS);
+            final long s3minPartSize = flinkConfig.get(PART_UPLOAD_MIN_SIZE);
+            final int maxConcurrentUploads = flinkConfig.get(MAX_CONCURRENT_UPLOADS);
             final S3AccessHelper s3AccessHelper = getS3AccessHelper(fs);
 
             return createFlinkFileSystem(

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3RecoverableWriterExceptionITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3RecoverableWriterExceptionITCase.java
@@ -58,11 +58,11 @@ public class HadoopS3RecoverableWriterExceptionITCase
         conf.setString("s3.access.key", S3TestCredentials.getS3AccessKey());
         conf.setString("s3.secret.key", S3TestCredentials.getS3SecretKey());
 
-        conf.setLong(PART_UPLOAD_MIN_SIZE, PART_UPLOAD_MIN_SIZE_VALUE);
-        conf.setInteger(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
+        conf.set(PART_UPLOAD_MIN_SIZE, PART_UPLOAD_MIN_SIZE_VALUE);
+        conf.set(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
 
         final String defaultTmpDir = TEMP_FOLDER.getRoot().getAbsolutePath() + "s3_tmp_dir";
-        conf.setString(CoreOptions.TMP_DIRS, defaultTmpDir);
+        conf.set(CoreOptions.TMP_DIRS, defaultTmpDir);
 
         FileSystem.initialize(conf);
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3RecoverableWriterITCase.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/test/java/org/apache/flink/fs/s3hadoop/HadoopS3RecoverableWriterITCase.java
@@ -59,11 +59,11 @@ public class HadoopS3RecoverableWriterITCase extends AbstractHadoopRecoverableWr
         conf.setString("s3.access.key", S3TestCredentials.getS3AccessKey());
         conf.setString("s3.secret.key", S3TestCredentials.getS3SecretKey());
 
-        conf.setLong(PART_UPLOAD_MIN_SIZE, PART_UPLOAD_MIN_SIZE_VALUE);
-        conf.setInteger(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
+        conf.set(PART_UPLOAD_MIN_SIZE, PART_UPLOAD_MIN_SIZE_VALUE);
+        conf.set(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
 
         final String defaultTmpDir = TEMP_FOLDER.getRoot().getAbsolutePath() + "s3_tmp_dir";
-        conf.setString(CoreOptions.TMP_DIRS, defaultTmpDir);
+        conf.set(CoreOptions.TMP_DIRS, defaultTmpDir);
 
         FileSystem.initialize(conf);
         bigDataChunk = createBigDataChunk(BIG_CHUNK_DATA_PATTERN, PART_UPLOAD_MIN_SIZE_VALUE);

--- a/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3RecoverableWriterTest.java
+++ b/flink-filesystems/flink-s3-fs-presto/src/test/java/org/apache/flink/fs/s3presto/PrestoS3RecoverableWriterTest.java
@@ -59,11 +59,11 @@ public class PrestoS3RecoverableWriterTest {
         conf.setString("s3.access.key", S3TestCredentials.getS3AccessKey());
         conf.setString("s3.secret.key", S3TestCredentials.getS3SecretKey());
 
-        conf.setLong(PART_UPLOAD_MIN_SIZE, PART_UPLOAD_MIN_SIZE_VALUE);
-        conf.setInteger(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
+        conf.set(PART_UPLOAD_MIN_SIZE, PART_UPLOAD_MIN_SIZE_VALUE);
+        conf.set(MAX_CONCURRENT_UPLOADS, MAX_CONCURRENT_UPLOADS_VALUE);
 
-        final String defaultTmpDir = conf.getString(CoreOptions.TMP_DIRS) + "s3_tmp_dir";
-        conf.setString(CoreOptions.TMP_DIRS, defaultTmpDir);
+        final String defaultTmpDir = conf.get(CoreOptions.TMP_DIRS) + "s3_tmp_dir";
+        conf.set(CoreOptions.TMP_DIRS, defaultTmpDir);
 
         FileSystem.initialize(conf);
     }

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/AbstractOrcFileInputFormat.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/AbstractOrcFileInputFormat.java
@@ -97,8 +97,7 @@ public abstract class AbstractOrcFileInputFormat<T, BatchT, SplitT extends FileS
     public OrcVectorizedReader<T, BatchT> createReader(
             final Configuration config, final SplitT split) throws IOException {
 
-        final int numBatchesToCirculate =
-                config.getInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
+        final int numBatchesToCirculate = config.get(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
         final Pool<OrcReaderBatch<T, BatchT>> poolOfBatches =
                 createPoolOfBatches(split, numBatchesToCirculate);
 

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
@@ -149,7 +149,7 @@ public abstract class ParquetVectorizedInputFormat<T, SplitT extends FileSourceS
     }
 
     protected int numBatchesToCirculate(Configuration config) {
-        return config.getInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
+        return config.get(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
     }
 
     @Override

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/HDFSTest.java
@@ -204,10 +204,10 @@ public class HDFSTest {
     public void testBlobServerRecovery() throws Exception {
         org.apache.flink.configuration.Configuration config =
                 new org.apache.flink.configuration.Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
-        config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
         BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
@@ -228,10 +228,10 @@ public class HDFSTest {
     public void testBlobServerCorruptedFile() throws Exception {
         org.apache.flink.configuration.Configuration config =
                 new org.apache.flink.configuration.Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
-        config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
         BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
@@ -252,10 +252,10 @@ public class HDFSTest {
     public void testBlobCacheRecovery() throws Exception {
         org.apache.flink.configuration.Configuration config =
                 new org.apache.flink.configuration.Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
-        config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
         BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 
@@ -276,10 +276,10 @@ public class HDFSTest {
     public void testBlobCacheCorruptedFile() throws Exception {
         org.apache.flink.configuration.Configuration config =
                 new org.apache.flink.configuration.Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
-        config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, hdfsURI);
 
         BlobStoreService blobStoreService = BlobUtils.createBlobStoreFromConfig(config);
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -964,7 +964,7 @@ public class ExecutionEnvironment {
         final JobClient jobClient = executeAsync(jobName);
 
         try {
-            if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
+            if (configuration.get(DeploymentOptions.ATTACHED)) {
                 lastJobExecutionResult = jobClient.getJobExecutionResult().get();
             } else {
                 lastJobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
@@ -1211,7 +1211,7 @@ public class ExecutionEnvironment {
      * @return A job name.
      */
     private String getJobName() {
-        return configuration.getString(
+        return configuration.get(
                 PipelineOptions.NAME, "Flink Java Job at " + Calendar.getInstance().getTime());
     }
 
@@ -1302,7 +1302,7 @@ public class ExecutionEnvironment {
 
         if (!conf.contains(RestOptions.PORT)) {
             // explicitly set this option so that it's not set to 0 later
-            conf.setInteger(RestOptions.PORT, RestOptions.PORT.defaultValue());
+            conf.set(RestOptions.PORT, RestOptions.PORT.defaultValue());
         }
 
         return createLocalEnvironment(conf, -1);

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironment.java
@@ -154,16 +154,16 @@ public class RemoteEnvironment extends ExecutionEnvironment {
 
         // these should be set in the end to overwrite any values from the client config provided in
         // the constructor.
-        effectiveConfiguration.setString(DeploymentOptions.TARGET, "remote");
-        effectiveConfiguration.setBoolean(DeploymentOptions.ATTACHED, true);
+        effectiveConfiguration.set(DeploymentOptions.TARGET, "remote");
+        effectiveConfiguration.set(DeploymentOptions.ATTACHED, true);
 
         return effectiveConfiguration;
     }
 
     @Override
     public String toString() {
-        final String host = getConfiguration().getString(JobManagerOptions.ADDRESS);
-        final int port = getConfiguration().getInteger(JobManagerOptions.PORT);
+        final String host = getConfiguration().get(JobManagerOptions.ADDRESS);
+        final int port = getConfiguration().get(JobManagerOptions.PORT);
         final String parallelism = (getParallelism() == -1 ? "default" : "" + getParallelism());
 
         return "Remote Environment ("

--- a/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironmentConfigUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/RemoteEnvironmentConfigUtils.java
@@ -61,10 +61,10 @@ public class RemoteEnvironmentConfigUtils {
     public static void setJobManagerAddressToConfig(
             final String host, final int port, final Configuration configuration) {
         final InetSocketAddress address = new InetSocketAddress(host, port);
-        configuration.setString(JobManagerOptions.ADDRESS, address.getHostString());
-        configuration.setInteger(JobManagerOptions.PORT, address.getPort());
-        configuration.setString(RestOptions.ADDRESS, address.getHostString());
-        configuration.setInteger(RestOptions.PORT, address.getPort());
+        configuration.set(JobManagerOptions.ADDRESS, address.getHostString());
+        configuration.set(JobManagerOptions.PORT, address.getPort());
+        configuration.set(RestOptions.ADDRESS, address.getHostString());
+        configuration.set(RestOptions.PORT, address.getPort());
     }
 
     public static void setJarURLsToConfig(final String[] jars, final Configuration configuration) {

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/AbstractParameterToolTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/AbstractParameterToolTest.java
@@ -578,11 +578,7 @@ public abstract class AbstractParameterToolTest {
         if (parameter instanceof ParameterTool) {
             ParameterTool parameterTool = (ParameterTool) parameter;
             final Configuration config = parameterTool.getConfiguration();
-            assertThat(
-                            config.getLong(
-                                    ConfigOptions.key("expectedCount")
-                                            .longType()
-                                            .defaultValue(-1L)))
+            assertThat(config.get(ConfigOptions.key("expectedCount").longType().defaultValue(-1L)))
                     .isEqualTo(15L);
 
             final Properties props = parameterTool.getProperties();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
@@ -45,7 +45,7 @@ public class KubernetesClusterClientFactory
     @Override
     public boolean isCompatibleWith(Configuration configuration) {
         checkNotNull(configuration);
-        final String deploymentTarget = configuration.getString(DeploymentOptions.TARGET);
+        final String deploymentTarget = configuration.get(DeploymentOptions.TARGET);
         return KubernetesDeploymentTarget.isValidKubernetesTarget(deploymentTarget);
     }
 
@@ -54,7 +54,7 @@ public class KubernetesClusterClientFactory
         checkNotNull(configuration);
         if (!configuration.contains(KubernetesConfigOptions.CLUSTER_ID)) {
             final String clusterId = generateClusterId();
-            configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
+            configuration.set(KubernetesConfigOptions.CLUSTER_ID, clusterId);
         }
         return new KubernetesClusterDescriptor(configuration, FlinkKubeClientFactory.getInstance());
     }
@@ -63,7 +63,7 @@ public class KubernetesClusterClientFactory
     @Override
     public String getClusterId(Configuration configuration) {
         checkNotNull(configuration);
-        return configuration.getString(KubernetesConfigOptions.CLUSTER_ID);
+        return configuration.get(KubernetesConfigOptions.CLUSTER_ID);
     }
 
     @Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -88,7 +88,7 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
         this.client = clientFactory.fromConfiguration(flinkConfig, "client");
         this.clusterId =
                 checkNotNull(
-                        flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID),
+                        flinkConfig.get(KubernetesConfigOptions.CLUSTER_ID),
                         "ClusterId must be specified!");
     }
 
@@ -108,8 +108,8 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
             }
 
             if (restEndpoint.isPresent()) {
-                configuration.setString(RestOptions.ADDRESS, restEndpoint.get().getAddress());
-                configuration.setInteger(RestOptions.PORT, restEndpoint.get().getPort());
+                configuration.set(RestOptions.ADDRESS, restEndpoint.get().getAddress());
+                configuration.set(RestOptions.PORT, restEndpoint.get().getPort());
             } else {
                 throw new RuntimeException(
                         new ClusterRetrieveException(
@@ -247,10 +247,10 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
                 detached
                         ? ClusterEntrypoint.ExecutionMode.DETACHED
                         : ClusterEntrypoint.ExecutionMode.NORMAL;
-        flinkConfig.setString(
+        flinkConfig.set(
                 ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE, executionMode.toString());
 
-        flinkConfig.setString(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS, entryPoint);
+        flinkConfig.set(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS, entryPoint);
 
         // Rpc, blob, rest, taskManagerRpc ports need to be exposed, so update them to fixed values.
         KubernetesUtils.checkAndUpdatePortConfigOption(
@@ -261,7 +261,7 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
                 flinkConfig, RestOptions.BIND_PORT, Constants.REST_PORT);
 
         if (HighAvailabilityMode.isHighAvailabilityModeActivated(flinkConfig)) {
-            flinkConfig.setString(HighAvailabilityOptions.HA_CLUSTER_ID, clusterId);
+            flinkConfig.set(HighAvailabilityOptions.HA_CLUSTER_ID, clusterId);
             KubernetesUtils.checkAndUpdatePortConfigOption(
                     flinkConfig,
                     HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -309,13 +309,13 @@ public class KubernetesResourceManagerDriver
                     .updateServiceTargetPort(
                             internalServiceName,
                             Constants.BLOB_SERVER_PORT_NAME,
-                            Integer.parseInt(flinkConfig.getString(BlobServerOptions.PORT)))
+                            Integer.parseInt(flinkConfig.get(BlobServerOptions.PORT)))
                     .get();
             flinkKubeClient
                     .updateServiceTargetPort(
                             internalServiceName,
                             Constants.JOB_MANAGER_RPC_PORT_NAME,
-                            flinkConfig.getInteger(JobManagerOptions.PORT))
+                            flinkConfig.get(JobManagerOptions.PORT))
                     .get();
         }
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesLeaderElectionConfiguration.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesLeaderElectionConfiguration.java
@@ -37,7 +37,7 @@ public class KubernetesLeaderElectionConfiguration {
 
     public KubernetesLeaderElectionConfiguration(
             String configMapName, String lockIdentity, Configuration config) {
-        this.clusterId = config.getString(KubernetesConfigOptions.CLUSTER_ID);
+        this.clusterId = config.get(KubernetesConfigOptions.CLUSTER_ID);
         this.configMapName = configMapName;
         this.lockIdentity = lockIdentity;
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesEntrypointUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesEntrypointUtils.java
@@ -55,11 +55,11 @@ class KubernetesEntrypointUtils {
                 GlobalConfiguration.loadConfiguration(configDir, dynamicParameters);
 
         if (KubernetesUtils.isHostNetwork(configuration)) {
-            configuration.setString(RestOptions.BIND_PORT, "0");
-            configuration.setInteger(JobManagerOptions.PORT, 0);
-            configuration.setString(BlobServerOptions.PORT, "0");
-            configuration.setString(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE, "0");
-            configuration.setString(TaskManagerOptions.RPC_PORT, "0");
+            configuration.set(RestOptions.BIND_PORT, "0");
+            configuration.set(JobManagerOptions.PORT, 0);
+            configuration.set(BlobServerOptions.PORT, "0");
+            configuration.set(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE, "0");
+            configuration.set(TaskManagerOptions.RPC_PORT, "0");
         }
 
         if (HighAvailabilityMode.isHighAvailabilityModeActivated(configuration)) {
@@ -68,8 +68,8 @@ class KubernetesEntrypointUtils {
                     ipAddress != null,
                     "JobManager ip address environment variable %s not set",
                     Constants.ENV_FLINK_POD_IP_ADDRESS);
-            configuration.setString(JobManagerOptions.ADDRESS, ipAddress);
-            configuration.setString(RestOptions.ADDRESS, ipAddress);
+            configuration.set(JobManagerOptions.ADDRESS, ipAddress);
+            configuration.set(RestOptions.ADDRESS, ipAddress);
         }
 
         return configuration;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
@@ -54,7 +54,7 @@ public class KubernetesResourceManagerFactory
         final KubernetesResourceManagerDriverConfiguration
                 kubernetesResourceManagerDriverConfiguration =
                         new KubernetesResourceManagerDriverConfiguration(
-                                configuration.getString(KubernetesConfigOptions.CLUSTER_ID),
+                                configuration.get(KubernetesConfigOptions.CLUSTER_ID),
                                 webInterfaceUrl);
 
         return new KubernetesResourceManagerDriver(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactory.java
@@ -41,7 +41,7 @@ public class KubernetesWorkerResourceSpecFactory extends WorkerResourceSpecFacto
 
     @VisibleForTesting
     static CPUResource getDefaultCpus(Configuration configuration) {
-        double fallback = configuration.getDouble(KubernetesConfigOptions.TASK_MANAGER_CPU);
+        double fallback = configuration.get(KubernetesConfigOptions.TASK_MANAGER_CPU);
         return TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -98,9 +98,9 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
                                                 String.format(
                                                         "Configuration option '%s' is not set.",
                                                         KubernetesConfigOptions.CLUSTER_ID.key())));
-        this.namespace = flinkConfig.getString(KubernetesConfigOptions.NAMESPACE);
+        this.namespace = flinkConfig.get(KubernetesConfigOptions.NAMESPACE);
         this.maxRetryAttempts =
-                flinkConfig.getInteger(
+                flinkConfig.get(
                         KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);
         this.nodePortAddressType =
                 flinkConfig.get(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
@@ -58,13 +58,12 @@ public class FlinkKubeClientFactory {
     public FlinkKubeClient fromConfiguration(Configuration flinkConfig, String useCase) {
         final Config config;
 
-        final String kubeContext = flinkConfig.getString(KubernetesConfigOptions.CONTEXT);
+        final String kubeContext = flinkConfig.get(KubernetesConfigOptions.CONTEXT);
         if (kubeContext != null) {
             LOG.info("Configuring kubernetes client to use context {}.", kubeContext);
         }
 
-        final String kubeConfigFile =
-                flinkConfig.getString(KubernetesConfigOptions.KUBE_CONFIG_FILE);
+        final String kubeConfigFile = flinkConfig.get(KubernetesConfigOptions.KUBE_CONFIG_FILE);
         if (kubeConfigFile != null) {
             LOG.debug("Trying to load kubernetes config from file: {}.", kubeConfigFile);
             try {
@@ -88,9 +87,9 @@ public class FlinkKubeClientFactory {
             config = Config.autoConfigure(kubeContext);
         }
 
-        final String namespace = flinkConfig.getString(KubernetesConfigOptions.NAMESPACE);
+        final String namespace = flinkConfig.get(KubernetesConfigOptions.NAMESPACE);
         final String userAgent =
-                flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_CLIENT_USER_AGENT);
+                flinkConfig.get(KubernetesConfigOptions.KUBERNETES_CLIENT_USER_AGENT);
         config.setNamespace(namespace);
         config.setUserAgent(userAgent);
         LOG.debug("Setting Kubernetes client namespace: {}, userAgent: {}", namespace, userAgent);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecorator.java
@@ -61,7 +61,7 @@ public class InternalServiceDecorator extends AbstractKubernetesStepDecorator {
         final String namespace = kubernetesJobManagerParameters.getNamespace();
         kubernetesJobManagerParameters
                 .getFlinkConfiguration()
-                .setString(
+                .set(
                         JobManagerOptions.ADDRESS,
                         getNamespacedInternalServiceName(serviceName, namespace));
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -77,10 +77,10 @@ public class KubernetesJobManagerFactory {
                                 new ExternalServiceDecorator(kubernetesJobManagerParameters)));
 
         Configuration configuration = kubernetesJobManagerParameters.getFlinkConfiguration();
-        if (configuration.getBoolean(KUBERNETES_HADOOP_CONF_MOUNT_DECORATOR_ENABLED)) {
+        if (configuration.get(KUBERNETES_HADOOP_CONF_MOUNT_DECORATOR_ENABLED)) {
             stepDecorators.add(new HadoopConfMountDecorator(kubernetesJobManagerParameters));
         }
-        if (configuration.getBoolean(KUBERNETES_KERBEROS_MOUNT_DECORATOR_ENABLED)) {
+        if (configuration.get(KUBERNETES_KERBEROS_MOUNT_DECORATOR_ENABLED)) {
             stepDecorators.add(new KerberosMountDecorator(kubernetesJobManagerParameters));
         }
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
@@ -58,10 +58,10 @@ public class KubernetesTaskManagerFactory {
                                 new CmdTaskManagerDecorator(kubernetesTaskManagerParameters)));
 
         Configuration configuration = kubernetesTaskManagerParameters.getFlinkConfiguration();
-        if (configuration.getBoolean(KUBERNETES_HADOOP_CONF_MOUNT_DECORATOR_ENABLED)) {
+        if (configuration.get(KUBERNETES_HADOOP_CONF_MOUNT_DECORATOR_ENABLED)) {
             stepDecorators.add(new HadoopConfMountDecorator(kubernetesTaskManagerParameters));
         }
-        if (configuration.getBoolean(KUBERNETES_KERBEROS_MOUNT_DECORATOR_ENABLED)) {
+        if (configuration.get(KUBERNETES_KERBEROS_MOUNT_DECORATOR_ENABLED)) {
             stepDecorators.add(new KerberosMountDecorator(kubernetesTaskManagerParameters));
         }
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -57,7 +57,7 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
         final String configDir =
                 flinkConfig
                         .getOptional(DeploymentOptionsInternal.CONF_DIR)
-                        .orElse(flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR));
+                        .orElse(flinkConfig.get(KubernetesConfigOptions.FLINK_CONF_DIR));
 
         checkNotNull(configDir);
         return configDir;
@@ -65,7 +65,7 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
 
     @Override
     public String getClusterId() {
-        final String clusterId = flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID);
+        final String clusterId = flinkConfig.get(KubernetesConfigOptions.CLUSTER_ID);
 
         if (StringUtils.isBlank(clusterId)) {
             throw new IllegalArgumentException(
@@ -83,7 +83,7 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
 
     @Override
     public String getNamespace() {
-        final String namespace = flinkConfig.getString(KubernetesConfigOptions.NAMESPACE);
+        final String namespace = flinkConfig.get(KubernetesConfigOptions.NAMESPACE);
         checkArgument(
                 !namespace.trim().isEmpty(), "Invalid " + KubernetesConfigOptions.NAMESPACE + ".");
 
@@ -92,8 +92,7 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
 
     @Override
     public String getImage() {
-        final String containerImage =
-                flinkConfig.getString(KubernetesConfigOptions.CONTAINER_IMAGE);
+        final String containerImage = flinkConfig.get(KubernetesConfigOptions.CONTAINER_IMAGE);
         checkArgument(
                 !containerImage.trim().isEmpty(),
                 "Invalid " + KubernetesConfigOptions.CONTAINER_IMAGE + ".");
@@ -127,17 +126,17 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
 
     @Override
     public String getFlinkConfDirInPod() {
-        return flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR);
+        return flinkConfig.get(KubernetesConfigOptions.FLINK_CONF_DIR);
     }
 
     @Override
     public Optional<String> getFlinkLogDirInPod() {
-        return Optional.ofNullable(flinkConfig.getString(KubernetesConfigOptions.FLINK_LOG_DIR));
+        return Optional.ofNullable(flinkConfig.get(KubernetesConfigOptions.FLINK_LOG_DIR));
     }
 
     @Override
     public String getContainerEntrypoint() {
-        return flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_ENTRY_PATH);
+        return flinkConfig.get(KubernetesConfigOptions.KUBERNETES_ENTRY_PATH);
     }
 
     @Override
@@ -157,7 +156,7 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
     @Override
     public Optional<String> getExistingHadoopConfigurationConfigMap() {
         final String existingHadoopConfigMap =
-                flinkConfig.getString(KubernetesConfigOptions.HADOOP_CONF_CONFIG_MAP);
+                flinkConfig.get(KubernetesConfigOptions.HADOOP_CONF_CONFIG_MAP);
         if (StringUtils.isBlank(existingHadoopConfigMap)) {
             return Optional.empty();
         } else {
@@ -204,6 +203,6 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
     }
 
     public boolean isHostNetworkEnabled() {
-        return flinkConfig.getBoolean(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED);
+        return flinkConfig.get(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -122,12 +122,12 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
     }
 
     public double getJobManagerCPU() {
-        return flinkConfig.getDouble(KubernetesConfigOptions.JOB_MANAGER_CPU);
+        return flinkConfig.get(KubernetesConfigOptions.JOB_MANAGER_CPU);
     }
 
     public double getJobManagerCPULimitFactor() {
         final double limitFactor =
-                flinkConfig.getDouble(KubernetesConfigOptions.JOB_MANAGER_CPU_LIMIT_FACTOR);
+                flinkConfig.get(KubernetesConfigOptions.JOB_MANAGER_CPU_LIMIT_FACTOR);
         checkArgument(
                 limitFactor >= 1,
                 "%s should be greater or equal to 1.",
@@ -137,7 +137,7 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
 
     public double getJobManagerMemoryLimitFactor() {
         final double limitFactor =
-                flinkConfig.getDouble(KubernetesConfigOptions.JOB_MANAGER_MEMORY_LIMIT_FACTOR);
+                flinkConfig.get(KubernetesConfigOptions.JOB_MANAGER_MEMORY_LIMIT_FACTOR);
         checkArgument(
                 limitFactor >= 1,
                 "%s should be greater or equal to 1.",
@@ -146,15 +146,15 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
     }
 
     public int getRestPort() {
-        return flinkConfig.getInteger(RestOptions.PORT);
+        return flinkConfig.get(RestOptions.PORT);
     }
 
     public int getRestBindPort() {
-        return Integer.valueOf(flinkConfig.getString(RestOptions.BIND_PORT));
+        return Integer.valueOf(flinkConfig.get(RestOptions.BIND_PORT));
     }
 
     public int getRPCPort() {
-        return flinkConfig.getInteger(JobManagerOptions.PORT);
+        return flinkConfig.get(JobManagerOptions.PORT);
     }
 
     public int getBlobServerPort() {
@@ -169,7 +169,7 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
 
     public String getEntrypointClass() {
         final String entrypointClass =
-                flinkConfig.getString(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS);
+                flinkConfig.get(KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS);
         checkNotNull(
                 entrypointClass,
                 KubernetesConfigOptionsInternal.ENTRY_POINT_CLASS + " must be specified!");
@@ -202,6 +202,6 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
     }
 
     public String getEntrypointArgs() {
-        return flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_JOBMANAGER_ENTRYPOINT_ARGS);
+        return flinkConfig.get(KubernetesConfigOptions.KUBERNETES_JOBMANAGER_ENTRYPOINT_ARGS);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -134,7 +134,7 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 
     public double getTaskManagerCPULimitFactor() {
         final double limitFactor =
-                flinkConfig.getDouble(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR);
+                flinkConfig.get(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR);
         checkArgument(
                 limitFactor >= 1,
                 "%s should be greater or equal to 1.",
@@ -144,7 +144,7 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 
     public double getTaskManagerMemoryLimitFactor() {
         final double limitFactor =
-                flinkConfig.getDouble(KubernetesConfigOptions.TASK_MANAGER_MEMORY_LIMIT_FACTOR);
+                flinkConfig.get(KubernetesConfigOptions.TASK_MANAGER_MEMORY_LIMIT_FACTOR);
         checkArgument(
                 limitFactor >= 1,
                 "%s should be greater or equal to 1.",
@@ -193,7 +193,6 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
     }
 
     public String getEntrypointArgs() {
-        return flinkConfig.getString(
-                KubernetesConfigOptions.KUBERNETES_TASKMANAGER_ENTRYPOINT_ARGS);
+        return flinkConfig.get(KubernetesConfigOptions.KUBERNETES_TASKMANAGER_ENTRYPOINT_ARGS);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
@@ -57,7 +57,7 @@ public class KubernetesTaskExecutorRunner {
                     "The environment variable %s is not set, "
                             + "which is used to identify the node where the task manager is located.",
                     Constants.ENV_FLINK_POD_NODE_ID);
-            configuration.setString(TaskManagerOptionsInternal.TASK_MANAGER_NODE_ID, nodeId);
+            configuration.set(TaskManagerOptionsInternal.TASK_MANAGER_NODE_ID, nodeId);
         } catch (FlinkParseException fpe) {
             LOG.error("Could not load the configuration.", fpe);
             System.exit(TaskManagerRunner.FAILURE_EXIT_CODE);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -115,7 +115,7 @@ public class KubernetesUtils {
     public static void checkAndUpdatePortConfigOption(
             Configuration flinkConfig, ConfigOption<String> port, int fallbackPort) {
         if (KubernetesUtils.parsePort(flinkConfig, port) == 0) {
-            flinkConfig.setString(port, String.valueOf(fallbackPort));
+            flinkConfig.set(port, String.valueOf(fallbackPort));
             LOG.info(
                     "Kubernetes deployment requires a fixed port. Configuration {} will be set to {}",
                     port.key(),
@@ -548,7 +548,7 @@ public class KubernetesUtils {
 
     /** Checks if hostNetwork is enabled. */
     public static boolean isHostNetwork(Configuration configuration) {
-        return configuration.getBoolean(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED);
+        return configuration.get(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED);
     }
 
     /**

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterClientFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterClientFactoryTest.java
@@ -39,7 +39,7 @@ class KubernetesClusterClientFactoryTest {
 
     private void testKubernetesClusterClientFactoryDiscoveryHelper(final String targetName) {
         final Configuration configuration = new Configuration();
-        configuration.setString(DeploymentOptions.TARGET, targetName);
+        configuration.set(DeploymentOptions.TARGET, targetName);
 
         final ClusterClientServiceLoader serviceLoader = new DefaultClusterClientServiceLoader();
         final ClusterClientFactory<String> factory =

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -101,8 +101,7 @@ class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
     @Test
     void testDeployHighAvailabilitySessionCluster() throws ClusterDeploymentException {
         flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.SESSION.getName());
-        flinkConfig.setString(
-                HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.toString());
+        flinkConfig.set(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.toString());
         final ClusterClient<String> clusterClient = deploySessionCluster().getClusterClient();
         checkClusterClient(clusterClient);
 
@@ -255,11 +254,11 @@ class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
 
     private void checkUpdatedConfigAndResourceSetting() {
         // Check updated flink config options
-        assertThat(flinkConfig.getString(BlobServerOptions.PORT))
+        assertThat(flinkConfig.get(BlobServerOptions.PORT))
                 .isEqualTo(String.valueOf(Constants.BLOB_SERVER_PORT));
-        assertThat(flinkConfig.getString(TaskManagerOptions.RPC_PORT))
+        assertThat(flinkConfig.get(TaskManagerOptions.RPC_PORT))
                 .isEqualTo(String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
-        assertThat(flinkConfig.getString(JobManagerOptions.ADDRESS))
+        assertThat(flinkConfig.get(JobManagerOptions.ADDRESS))
                 .isEqualTo(
                         InternalServiceDecorator.getNamespacedInternalServiceName(
                                 CLUSTER_ID, NAMESPACE));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesExtension.java
@@ -58,7 +58,7 @@ public class KubernetesExtension implements BeforeAllCallback, AfterAllCallback 
         checkEnv();
         configuration = new Configuration();
         configuration.set(KubernetesConfigOptions.KUBE_CONFIG_FILE, kubeConfigFile);
-        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
+        configuration.set(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
         configuration.set(
                 KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES,
                 KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -424,8 +424,8 @@ class KubernetesResourceManagerDriverTest
 
         @Override
         protected void prepareRunTest() {
-            flinkConfig.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
-            flinkConfig.setString(
+            flinkConfig.set(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
+            flinkConfig.set(
                     TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
 
             flinkKubeClient = flinkKubeClientBuilder.build();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
@@ -69,9 +69,9 @@ public class KubernetesTestBase {
     protected FlinkKubeClient flinkKubeClient;
 
     protected void setupFlinkConfig() {
-        flinkConfig.setString(KubernetesConfigOptions.NAMESPACE, NAMESPACE);
-        flinkConfig.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
-        flinkConfig.setString(KubernetesConfigOptions.CONTAINER_IMAGE, CONTAINER_IMAGE);
+        flinkConfig.set(KubernetesConfigOptions.NAMESPACE, NAMESPACE);
+        flinkConfig.set(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
+        flinkConfig.set(KubernetesConfigOptions.CONTAINER_IMAGE, CONTAINER_IMAGE);
         flinkConfig.set(
                 KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY, CONTAINER_IMAGE_PULL_POLICY);
         flinkConfig.set(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/cli/KubernetesSessionCliTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/cli/KubernetesSessionCliTest.java
@@ -143,7 +143,7 @@ class KubernetesSessionCliTest {
                 JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(jobManagerMemory));
         configuration.set(
                 TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(taskManagerMemory));
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
         final String[] args = {
             "-e",
@@ -179,7 +179,7 @@ class KubernetesSessionCliTest {
         configuration.set(
                 TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(taskManagerMemory));
         final int slotsPerTaskManager = 42;
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
         final String[] args = {"-e", KubernetesSessionClusterExecutor.NAME};
         final KubernetesSessionCli cli =
@@ -244,8 +244,8 @@ class KubernetesSessionCliTest {
     void testHeapMemoryPropertyWithOldConfigKey() throws Exception {
         Configuration configuration = new Configuration();
         configuration.set(DeploymentOptions.TARGET, KubernetesSessionClusterExecutor.NAME);
-        configuration.setInteger(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB, 2048);
-        configuration.setInteger(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB, 4096);
+        configuration.set(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY_MB, 2048);
+        configuration.set(TaskManagerOptions.TASK_MANAGER_HEAP_MEMORY_MB, 4096);
 
         final KubernetesSessionCli cli =
                 new KubernetesSessionCli(configuration, confDirPath.toAbsolutePath().toString());

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactoryTest.java
@@ -33,10 +33,10 @@ class KubernetesWorkerResourceSpecFactoryTest {
     @Test
     void testGetCpuCoresCommonOption() {
         final Configuration configuration = new Configuration();
-        configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
-        configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
-        configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR, 1.5);
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+        configuration.set(TaskManagerOptions.CPU_CORES, 1.0);
+        configuration.set(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+        configuration.set(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR, 1.5);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
         assertThat(KubernetesWorkerResourceSpecFactory.getDefaultCpus(configuration))
                 .isEqualTo(new CPUResource(1.0));
@@ -45,9 +45,9 @@ class KubernetesWorkerResourceSpecFactoryTest {
     @Test
     void testGetCpuCoresKubernetesOption() {
         final Configuration configuration = new Configuration();
-        configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
-        configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR, 1.5);
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+        configuration.set(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+        configuration.set(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR, 1.5);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
         assertThat(KubernetesWorkerResourceSpecFactory.getDefaultCpus(configuration))
                 .isEqualTo(new CPUResource(2.0));
@@ -56,7 +56,7 @@ class KubernetesWorkerResourceSpecFactoryTest {
     @Test
     void testGetCpuCoresNumSlots() {
         final Configuration configuration = new Configuration();
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
         assertThat(KubernetesWorkerResourceSpecFactory.getDefaultCpus(configuration))
                 .isEqualTo(new CPUResource(3.0));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionAndRetrievalITCase.java
@@ -71,7 +71,7 @@ class KubernetesLeaderElectionAndRetrievalITCase {
         final FlinkKubeClient flinkKubeClient = KUBERNETES_EXTENSION.getFlinkKubeClient();
         final Configuration configuration = KUBERNETES_EXTENSION.getConfiguration();
 
-        final String clusterId = configuration.getString(KubernetesConfigOptions.CLUSTER_ID);
+        final String clusterId = configuration.get(KubernetesConfigOptions.CLUSTER_ID);
 
         // This will make the leader election retrieval time out if we won't process already
         // existing leader information when starting it up.

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesTestFixture.java
@@ -69,7 +69,7 @@ class KubernetesTestFixture {
         this.leaderConfigmapName = leaderConfigmapName;
         this.lockIdentity = lockIdentity;
         configuration = new Configuration();
-        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
+        configuration.set(KubernetesConfigOptions.CLUSTER_ID, clusterId);
 
         flinkKubeClient = createFlinkKubeClient();
         configMapSharedWatcher = flinkKubeClient.createConfigMapSharedWatcher(leaderConfigmapName);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -572,7 +572,7 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
     @Test
     void testCheckAndUpdateConfigMapWhenGetConfigMapFailed() throws Exception {
         final int configuredRetries =
-                flinkConfig.getInteger(
+                flinkConfig.get(
                         KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);
         final KubernetesConfigMap configMap = buildTestingConfigMap();
         this.flinkKubeClient.createConfigMap(configMap).get();
@@ -609,7 +609,7 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
     @Test
     void testCheckAndUpdateConfigMapWhenReplaceConfigMapFailed() throws Exception {
         final int configuredRetries =
-                flinkConfig.getInteger(
+                flinkConfig.get(
                         KubernetesConfigOptions.KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES);
         final KubernetesConfigMap configMap = buildTestingConfigMap();
         this.flinkKubeClient.createConfigMap(configMap).get();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/DecoratorWithPodTemplateTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/DecoratorWithPodTemplateTestBase.java
@@ -89,7 +89,7 @@ public abstract class DecoratorWithPodTemplateTestBase extends KubernetesPodTest
         // Set fixed ports
         flinkConfig.set(RestOptions.PORT, Constants.REST_PORT);
         flinkConfig.set(BlobServerOptions.PORT, Integer.toString(Constants.BLOB_SERVER_PORT));
-        flinkConfig.setString(
+        flinkConfig.set(
                 TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
 
         // Set resources

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -285,8 +285,7 @@ class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
         assertThat(requirements)
                 .containsExactlyInAnyOrder(
                         new NodeSelectorRequirement(
-                                flinkConfig.getString(
-                                        KubernetesConfigOptions.KUBERNETES_NODE_NAME_LABEL),
+                                flinkConfig.get(KubernetesConfigOptions.KUBERNETES_NODE_NAME_LABEL),
                                 "NotIn",
                                 new ArrayList<>(BLOCKED_NODES)));
     }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InternalServiceDecoratorTest.java
@@ -57,7 +57,7 @@ class InternalServiceDecoratorTest extends KubernetesJobManagerTestBase {
         assertThat(resources).hasSize(1);
 
         assertThat(InternalServiceDecorator.getNamespacedInternalServiceName(CLUSTER_ID, NAMESPACE))
-                .isEqualTo(this.flinkConfig.getString(JobManagerOptions.ADDRESS));
+                .isEqualTo(this.flinkConfig.get(JobManagerOptions.ADDRESS));
 
         final Service internalService = (Service) resources.get(0);
 
@@ -90,7 +90,7 @@ class InternalServiceDecoratorTest extends KubernetesJobManagerTestBase {
 
     @Test
     void testDisableInternalService() throws IOException {
-        this.flinkConfig.setString(
+        this.flinkConfig.set(
                 HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.name());
 
         final List<HasMetadata> resources =

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesFactoryWithPodTemplateTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesFactoryWithPodTemplateTestBase.java
@@ -64,7 +64,7 @@ public abstract class KubernetesFactoryWithPodTemplateTestBase extends Kubernete
         // Set fixed ports
         flinkConfig.set(RestOptions.PORT, Constants.REST_PORT);
         flinkConfig.set(BlobServerOptions.PORT, Integer.toString(Constants.BLOB_SERVER_PORT));
-        flinkConfig.setString(
+        flinkConfig.set(
                 TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
 
         flinkConfig.set(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/utils/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/utils/KubernetesUtilsTest.java
@@ -220,7 +220,7 @@ class KubernetesUtilsTest extends KubernetesTestBase {
     private void testCheckAndUpdatePortConfigOption(
             String port, String fallbackPort, String expectedPort) {
         final Configuration cfg = new Configuration();
-        cfg.setString(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE, port);
+        cfg.set(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE, port);
         KubernetesUtils.checkAndUpdatePortConfigOption(
                 cfg,
                 HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE,

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -185,7 +185,7 @@ public class SavepointEnvironment implements Environment {
     public Configuration getJobConfiguration() {
         Configuration jobConfiguration = new Configuration(configuration);
         // This means leaving this stateBackend unwrapped.
-        jobConfiguration.setBoolean(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, false);
+        jobConfiguration.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, false);
         return jobConfiguration;
     }
 

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/runtime/jobmanager/JMXJobManagerMetricTest.java
@@ -75,7 +75,7 @@ class JMXJobManagerMetricTest {
 
         MetricOptions.forReporter(flinkConfiguration, "test")
                 .set(MetricOptions.REPORTER_FACTORY_CLASS, JMXReporterFactory.class.getName());
-        flinkConfiguration.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "jobmanager.<job_name>");
+        flinkConfiguration.set(MetricOptions.SCOPE_NAMING_JM_JOB, "jobmanager.<job_name>");
 
         return flinkConfiguration;
     }

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/Optimizer.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/Optimizer.java
@@ -354,7 +354,7 @@ public class Optimizer {
         this.costEstimator = estimator;
 
         // determine the default parallelism
-        this.defaultParallelism = config.getInteger(CoreOptions.DEFAULT_PARALLELISM);
+        this.defaultParallelism = config.get(CoreOptions.DEFAULT_PARALLELISM);
 
         if (defaultParallelism < 1) {
             this.defaultParallelism = CoreOptions.DEFAULT_PARALLELISM.defaultValue();

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plantranslate/JobGraphGenerator.java
@@ -174,9 +174,8 @@ public class JobGraphGenerator implements Visitor<PlanNode> {
     }
 
     public JobGraphGenerator(Configuration config) {
-        this.defaultMaxFan = config.getInteger(AlgorithmOptions.SPILLING_MAX_FAN);
-        this.defaultSortSpillingThreshold =
-                config.getFloat(AlgorithmOptions.SORT_SPILLING_THRESHOLD);
+        this.defaultMaxFan = config.get(AlgorithmOptions.SPILLING_MAX_FAN);
+        this.defaultSortSpillingThreshold = config.get(AlgorithmOptions.SORT_SPILLING_THRESHOLD);
         this.useLargeRecordHandler =
                 config.getBoolean(
                         ConfigConstants.USE_LARGE_RECORD_HANDLER_KEY,

--- a/flink-python/src/main/java/org/apache/flink/python/metric/process/FlinkMetricContainer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/metric/process/FlinkMetricContainer.java
@@ -60,7 +60,7 @@ public final class FlinkMetricContainer {
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
 
     private static final String METRIC_KEY_SEPARATOR =
-            GlobalConfiguration.loadConfiguration().getString(MetricOptions.SCOPE_DELIMITER);
+            GlobalConfiguration.loadConfiguration().get(MetricOptions.SCOPE_DELIMITER);
 
     private final MetricsContainerStepMap metricsContainers;
     private final MetricGroup baseMetricGroup;

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonEnvUtilsTest.java
@@ -206,7 +206,7 @@ class PythonEnvUtilsTest {
             CommonTestUtils.setEnv(systemEnv);
         }
 
-        config.setString(PYTHON_ARCHIVES, zipFile.getPath());
+        config.set(PYTHON_ARCHIVES, zipFile.getPath());
         systemEnv = new HashMap<>(System.getenv());
         systemEnv.put(PYFLINK_CLIENT_EXECUTABLE, "venv.zip/venv/bin/python");
         CommonTestUtils.setEnv(systemEnv);

--- a/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
@@ -32,72 +32,68 @@ class PythonOptionsTest {
     @Test
     void testBundleSize() {
         final Configuration configuration = new Configuration();
-        final int defaultBundleSize = configuration.getInteger(PythonOptions.MAX_BUNDLE_SIZE);
+        final int defaultBundleSize = configuration.get(PythonOptions.MAX_BUNDLE_SIZE);
         assertThat(defaultBundleSize).isEqualTo(PythonOptions.MAX_BUNDLE_SIZE.defaultValue());
 
         final int expectedBundleSize = 100;
-        configuration.setInteger(PythonOptions.MAX_BUNDLE_SIZE, expectedBundleSize);
+        configuration.set(PythonOptions.MAX_BUNDLE_SIZE, expectedBundleSize);
 
-        final int actualBundleSize = configuration.getInteger(PythonOptions.MAX_BUNDLE_SIZE);
+        final int actualBundleSize = configuration.get(PythonOptions.MAX_BUNDLE_SIZE);
         assertThat(actualBundleSize).isEqualTo(expectedBundleSize);
     }
 
     @Test
     void testBundleTime() {
         final Configuration configuration = new Configuration();
-        final long defaultBundleTime = configuration.getLong(PythonOptions.MAX_BUNDLE_TIME_MILLS);
+        final long defaultBundleTime = configuration.get(PythonOptions.MAX_BUNDLE_TIME_MILLS);
         assertThat(defaultBundleTime).isEqualTo(PythonOptions.MAX_BUNDLE_TIME_MILLS.defaultValue());
 
         final long expectedBundleTime = 100;
-        configuration.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, expectedBundleTime);
+        configuration.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, expectedBundleTime);
 
-        final long actualBundleSize = configuration.getLong(PythonOptions.MAX_BUNDLE_TIME_MILLS);
+        final long actualBundleSize = configuration.get(PythonOptions.MAX_BUNDLE_TIME_MILLS);
         assertThat(actualBundleSize).isEqualTo(expectedBundleTime);
     }
 
     @Test
     void testArrowBatchSize() {
         final Configuration configuration = new Configuration();
-        final int defaultArrowBatchSize =
-                configuration.getInteger(PythonOptions.MAX_ARROW_BATCH_SIZE);
+        final int defaultArrowBatchSize = configuration.get(PythonOptions.MAX_ARROW_BATCH_SIZE);
         assertThat(defaultArrowBatchSize)
                 .isEqualTo(PythonOptions.MAX_ARROW_BATCH_SIZE.defaultValue());
 
         final int expectedArrowBatchSize = 100;
-        configuration.setInteger(PythonOptions.MAX_ARROW_BATCH_SIZE, expectedArrowBatchSize);
+        configuration.set(PythonOptions.MAX_ARROW_BATCH_SIZE, expectedArrowBatchSize);
 
-        final int actualArrowBatchSize =
-                configuration.getInteger(PythonOptions.MAX_ARROW_BATCH_SIZE);
+        final int actualArrowBatchSize = configuration.get(PythonOptions.MAX_ARROW_BATCH_SIZE);
         assertThat(actualArrowBatchSize).isEqualTo(expectedArrowBatchSize);
     }
 
     @Test
     void testPythonMetricEnabled() {
         final Configuration configuration = new Configuration();
-        final boolean isMetricEnabled =
-                configuration.getBoolean(PythonOptions.PYTHON_METRIC_ENABLED);
+        final boolean isMetricEnabled = configuration.get(PythonOptions.PYTHON_METRIC_ENABLED);
         assertThat(isMetricEnabled).isEqualTo(PythonOptions.PYTHON_METRIC_ENABLED.defaultValue());
 
         final boolean expectedIsMetricEnabled = false;
-        configuration.setBoolean(PythonOptions.PYTHON_METRIC_ENABLED, false);
+        configuration.set(PythonOptions.PYTHON_METRIC_ENABLED, false);
 
         final boolean actualIsMetricEnabled =
-                configuration.getBoolean(PythonOptions.PYTHON_METRIC_ENABLED);
+                configuration.get(PythonOptions.PYTHON_METRIC_ENABLED);
         assertThat(actualIsMetricEnabled).isEqualTo(expectedIsMetricEnabled);
     }
 
     @Test
     void testPythonProfileEnabled() {
         final Configuration configuration = new Configuration();
-        final boolean isProfileEnabled =
-                configuration.getBoolean(PythonOptions.PYTHON_PROFILE_ENABLED);
+        final boolean isProfileEnabled = configuration.get(PythonOptions.PYTHON_PROFILE_ENABLED);
         assertThat(isProfileEnabled).isEqualTo(PythonOptions.PYTHON_PROFILE_ENABLED.defaultValue());
 
         final boolean expectedIsProfileEnabled = true;
-        configuration.setBoolean(PythonOptions.PYTHON_PROFILE_ENABLED, true);
+        configuration.set(PythonOptions.PYTHON_PROFILE_ENABLED, true);
 
         final boolean actualIsProfileEnabled =
-                configuration.getBoolean(PythonOptions.PYTHON_PROFILE_ENABLED);
+                configuration.get(PythonOptions.PYTHON_PROFILE_ENABLED);
         assertThat(actualIsProfileEnabled).isEqualTo(expectedIsProfileEnabled);
     }
 
@@ -177,15 +173,15 @@ class PythonOptionsTest {
     void testPythonSystemEnvEnabled() {
         final Configuration configuration = new Configuration();
         final boolean isSystemEnvEnabled =
-                configuration.getBoolean(PythonOptions.PYTHON_SYSTEMENV_ENABLED);
+                configuration.get(PythonOptions.PYTHON_SYSTEMENV_ENABLED);
         assertThat(isSystemEnvEnabled)
                 .isEqualTo(PythonOptions.PYTHON_SYSTEMENV_ENABLED.defaultValue());
 
         final boolean expectedIsSystemEnvEnabled = false;
-        configuration.setBoolean(PythonOptions.PYTHON_SYSTEMENV_ENABLED, false);
+        configuration.set(PythonOptions.PYTHON_SYSTEMENV_ENABLED, false);
 
         final boolean actualIsSystemEnvEnabled =
-                configuration.getBoolean(PythonOptions.PYTHON_SYSTEMENV_ENABLED);
+                configuration.get(PythonOptions.PYTHON_SYSTEMENV_ENABLED);
         assertThat(actualIsSystemEnvEnabled).isEqualTo(expectedIsSystemEnvEnabled);
     }
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupAggregateOperatorTest.java
@@ -68,7 +68,7 @@ class PythonStreamGroupAggregateOperatorTest extends AbstractPythonStreamAggrega
     @Test
     void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -94,7 +94,7 @@ class PythonStreamGroupAggregateOperatorTest extends AbstractPythonStreamAggrega
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 3);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 3);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -120,8 +120,8 @@ class PythonStreamGroupAggregateOperatorTest extends AbstractPythonStreamAggrega
     @Test
     void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-        conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -147,7 +147,7 @@ class PythonStreamGroupAggregateOperatorTest extends AbstractPythonStreamAggrega
     @Test
     void testWatermarkProcessedOnFinishBundle() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
         long initialTime = 0L;
         ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupTableAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupTableAggregateOperatorTest.java
@@ -71,7 +71,7 @@ class PythonStreamGroupTableAggregateOperatorTest
     @Test
     void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -100,7 +100,7 @@ class PythonStreamGroupTableAggregateOperatorTest
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 3);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 3);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -129,8 +129,8 @@ class PythonStreamGroupTableAggregateOperatorTest
     @Test
     void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-        conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -159,7 +159,7 @@ class PythonStreamGroupTableAggregateOperatorTest
     @Test
     void testWatermarkProcessedOnFinishBundle() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
         long initialTime = 0L;
         ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/PythonStreamGroupWindowAggregateOperatorTest.java
@@ -103,7 +103,7 @@ class PythonStreamGroupWindowAggregateOperatorTest
     @Test
     void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -149,7 +149,7 @@ class PythonStreamGroupWindowAggregateOperatorTest
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 4);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 4);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -193,8 +193,8 @@ class PythonStreamGroupWindowAggregateOperatorTest
     @Test
     void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-        conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupAggregateFunctionOperatorTest.java
@@ -80,7 +80,7 @@ class BatchArrowPythonGroupAggregateFunctionOperatorTest
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 2);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 2);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -111,8 +111,8 @@ class BatchArrowPythonGroupAggregateFunctionOperatorTest
     @Test
     void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-        conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonGroupWindowAggregateFunctionOperatorTest.java
@@ -131,7 +131,7 @@ class BatchArrowPythonGroupWindowAggregateFunctionOperatorTest
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 6);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 6);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -212,8 +212,8 @@ class BatchArrowPythonGroupWindowAggregateFunctionOperatorTest
     @Test
     void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-        conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/batch/BatchArrowPythonOverWindowAggregateFunctionOperatorTest.java
@@ -90,7 +90,7 @@ class BatchArrowPythonOverWindowAggregateFunctionOperatorTest
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 3);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 3);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -125,8 +125,8 @@ class BatchArrowPythonOverWindowAggregateFunctionOperatorTest
     @Test
     void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-        conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonGroupWindowAggregateFunctionOperatorTest.java
@@ -155,7 +155,7 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
     @Test
     void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -244,7 +244,7 @@ class StreamArrowPythonGroupWindowAggregateFunctionOperatorTest
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 4);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 4);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRangeOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRangeOperatorTest.java
@@ -95,7 +95,7 @@ class StreamArrowPythonRowTimeBoundedRangeOperatorTest
     @Test
     void testFinishBundleTriggeredOnWatermark() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -127,7 +127,7 @@ class StreamArrowPythonRowTimeBoundedRangeOperatorTest
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 4);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 4);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRowsOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/aggregate/arrow/stream/StreamArrowPythonRowTimeBoundedRowsOperatorTest.java
@@ -91,7 +91,7 @@ class StreamArrowPythonRowTimeBoundedRowsOperatorTest
     @Test
     void testFinishBundleTriggeredOnWatermark() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -123,7 +123,7 @@ class StreamArrowPythonRowTimeBoundedRowsOperatorTest
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 6);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 6);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
@@ -96,7 +96,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
     @Test
     public void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -120,7 +120,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
     @Test
     public void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 2);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 2);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -146,8 +146,8 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
     @Test
     public void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-        conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -170,7 +170,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
     @Test
     public void testFinishBundleTriggeredByClose() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
 
         long initialTime = 0L;
@@ -191,7 +191,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
     @Test
     public void testWatermarkProcessedOnFinishBundle() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness = getTestHarness(conf);
         long initialTime = 0L;
         ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTestBase.java
@@ -77,7 +77,7 @@ abstract class PythonTableFunctionOperatorTestBase<IN, OUT> {
     @Test
     void testFinishBundleTriggeredOnCheckpoint() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
                 getTestHarness(conf, FlinkJoinType.INNER);
 
@@ -102,7 +102,7 @@ abstract class PythonTableFunctionOperatorTestBase<IN, OUT> {
     @Test
     void testFinishBundleTriggeredByCount() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 2);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 2);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
                 getTestHarness(conf, FlinkJoinType.INNER);
 
@@ -129,8 +129,8 @@ abstract class PythonTableFunctionOperatorTestBase<IN, OUT> {
     @Test
     void testFinishBundleTriggeredByTime() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(PythonOptions.MAX_BUNDLE_SIZE, 10);
-        conf.setLong(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
+        conf.set(PythonOptions.MAX_BUNDLE_SIZE, 10);
+        conf.set(PythonOptions.MAX_BUNDLE_TIME_MILLS, 1000L);
         OneInputStreamOperatorTestHarness<IN, OUT> testHarness =
                 getTestHarness(conf, FlinkJoinType.INNER);
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
@@ -100,27 +100,27 @@ class HAQueryableStateFsBackendITCase extends AbstractQueryableStateTestBase {
     private static Configuration getConfig() {
 
         Configuration config = new Configuration();
-        config.setBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
+        config.set(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
         config.set(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS, NUM_TMS);
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
-        config.setInteger(QueryableStateOptions.CLIENT_NETWORK_THREADS, 2);
-        config.setInteger(QueryableStateOptions.PROXY_NETWORK_THREADS, 2);
-        config.setInteger(QueryableStateOptions.SERVER_NETWORK_THREADS, 2);
-        config.setString(
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
+        config.set(QueryableStateOptions.CLIENT_NETWORK_THREADS, 2);
+        config.set(QueryableStateOptions.PROXY_NETWORK_THREADS, 2);
+        config.set(QueryableStateOptions.SERVER_NETWORK_THREADS, 2);
+        config.set(
                 QueryableStateOptions.PROXY_PORT_RANGE,
                 QS_PROXY_PORT_RANGE_START + "-" + (QS_PROXY_PORT_RANGE_START + NUM_TMS));
-        config.setString(
+        config.set(
                 QueryableStateOptions.SERVER_PORT_RANGE,
                 QS_SERVER_PORT_RANGE_START + "-" + (QS_SERVER_PORT_RANGE_START + NUM_TMS));
-        config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
+        config.set(WebOptions.SUBMIT_ENABLE, false);
 
-        config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, tmpHaStoragePath.toString());
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, tmpHaStoragePath.toString());
 
-        config.setString(
+        config.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 ZK_RESOURCE.getCustomExtension().getConnectString());
-        config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        config.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
 
         return config;
     }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
@@ -98,27 +98,27 @@ class HAQueryableStateRocksDBBackendITCase extends AbstractQueryableStateTestBas
     private static Configuration getConfig() {
 
         Configuration config = new Configuration();
-        config.setBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
+        config.set(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
         config.set(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS, NUM_TMS);
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
-        config.setInteger(QueryableStateOptions.CLIENT_NETWORK_THREADS, 2);
-        config.setInteger(QueryableStateOptions.PROXY_NETWORK_THREADS, 2);
-        config.setInteger(QueryableStateOptions.SERVER_NETWORK_THREADS, 2);
-        config.setString(
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
+        config.set(QueryableStateOptions.CLIENT_NETWORK_THREADS, 2);
+        config.set(QueryableStateOptions.PROXY_NETWORK_THREADS, 2);
+        config.set(QueryableStateOptions.SERVER_NETWORK_THREADS, 2);
+        config.set(
                 QueryableStateOptions.PROXY_PORT_RANGE,
                 QS_PROXY_PORT_RANGE_START + "-" + (QS_PROXY_PORT_RANGE_START + NUM_TMS));
-        config.setString(
+        config.set(
                 QueryableStateOptions.SERVER_PORT_RANGE,
                 QS_SERVER_PORT_RANGE_START + "-" + (QS_SERVER_PORT_RANGE_START + NUM_TMS));
-        config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
+        config.set(WebOptions.SUBMIT_ENABLE, false);
 
-        config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, tmpHaStoragePath.toString());
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, tmpHaStoragePath.toString());
 
-        config.setString(
+        config.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 ZK_RESOURCE.getCustomExtension().getConnectString());
-        config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        config.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
 
         return config;
     }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateFsBackendITCase.java
@@ -82,20 +82,20 @@ public class NonHAQueryableStateFsBackendITCase extends AbstractQueryableStateTe
 
     private static Configuration getConfig() {
         Configuration config = new Configuration();
-        config.setBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
+        config.set(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
         config.set(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS, NUM_TMS);
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
-        config.setInteger(QueryableStateOptions.CLIENT_NETWORK_THREADS, 1);
-        config.setInteger(QueryableStateOptions.PROXY_NETWORK_THREADS, 1);
-        config.setInteger(QueryableStateOptions.SERVER_NETWORK_THREADS, 1);
-        config.setString(
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
+        config.set(QueryableStateOptions.CLIENT_NETWORK_THREADS, 1);
+        config.set(QueryableStateOptions.PROXY_NETWORK_THREADS, 1);
+        config.set(QueryableStateOptions.SERVER_NETWORK_THREADS, 1);
+        config.set(
                 QueryableStateOptions.PROXY_PORT_RANGE,
                 QS_PROXY_PORT_RANGE_START + "-" + (QS_PROXY_PORT_RANGE_START + NUM_PORT_COUNT));
-        config.setString(
+        config.set(
                 QueryableStateOptions.SERVER_PORT_RANGE,
                 QS_SERVER_PORT_RANGE_START + "-" + (QS_SERVER_PORT_RANGE_START + NUM_PORT_COUNT));
-        config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
+        config.set(WebOptions.SUBMIT_ENABLE, false);
         return config;
     }
 }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/NonHAQueryableStateRocksDBBackendITCase.java
@@ -81,20 +81,20 @@ public class NonHAQueryableStateRocksDBBackendITCase extends AbstractQueryableSt
 
     private static Configuration getConfig() {
         Configuration config = new Configuration();
-        config.setBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
+        config.set(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER, true);
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
         config.set(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS, NUM_TMS);
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
-        config.setInteger(QueryableStateOptions.CLIENT_NETWORK_THREADS, 1);
-        config.setInteger(QueryableStateOptions.PROXY_NETWORK_THREADS, 1);
-        config.setInteger(QueryableStateOptions.SERVER_NETWORK_THREADS, 1);
-        config.setString(
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
+        config.set(QueryableStateOptions.CLIENT_NETWORK_THREADS, 1);
+        config.set(QueryableStateOptions.PROXY_NETWORK_THREADS, 1);
+        config.set(QueryableStateOptions.SERVER_NETWORK_THREADS, 1);
+        config.set(
                 QueryableStateOptions.PROXY_PORT_RANGE,
                 QS_PROXY_PORT_RANGE_START + "-" + (QS_PROXY_PORT_RANGE_START + NUM_TMS));
-        config.setString(
+        config.set(
                 QueryableStateOptions.SERVER_PORT_RANGE,
                 QS_SERVER_PORT_RANGE_START + "-" + (QS_SERVER_PORT_RANGE_START + NUM_TMS));
-        config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
+        config.set(WebOptions.SUBMIT_ENABLE, false);
         return config;
     }
 }

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/ActorSystemBootstrapTools.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/ActorSystemBootstrapTools.java
@@ -264,11 +264,11 @@ public class ActorSystemBootstrapTools {
     public static RpcSystem.ForkJoinExecutorConfiguration getForkJoinExecutorConfiguration(
             final Configuration configuration) {
         final double parallelismFactor =
-                configuration.getDouble(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR);
+                configuration.get(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR);
         final int minParallelism =
-                configuration.getInteger(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MIN);
+                configuration.get(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MIN);
         final int maxParallelism =
-                configuration.getInteger(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MAX);
+                configuration.get(AkkaOptions.FORK_JOIN_EXECUTOR_PARALLELISM_MAX);
 
         return new RpcSystem.ForkJoinExecutorConfiguration(
                 parallelismFactor, minParallelism, maxParallelism);
@@ -277,11 +277,11 @@ public class ActorSystemBootstrapTools {
     public static RpcSystem.ForkJoinExecutorConfiguration getRemoteForkJoinExecutorConfiguration(
             final Configuration configuration) {
         final double parallelismFactor =
-                configuration.getDouble(AkkaOptions.REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR);
+                configuration.get(AkkaOptions.REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_FACTOR);
         final int minParallelism =
-                configuration.getInteger(AkkaOptions.REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_MIN);
+                configuration.get(AkkaOptions.REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_MIN);
         final int maxParallelism =
-                configuration.getInteger(AkkaOptions.REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_MAX);
+                configuration.get(AkkaOptions.REMOTE_FORK_JOIN_EXECUTOR_PARALLELISM_MAX);
 
         return new RpcSystem.ForkJoinExecutorConfiguration(
                 parallelismFactor, minParallelism, maxParallelism);

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcServiceUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcServiceUtils.java
@@ -130,8 +130,7 @@ public class PekkoRpcServiceUtils {
         checkNotNull(config, "config is null");
 
         final boolean sslEnabled =
-                config.getBoolean(AkkaOptions.SSL_ENABLED)
-                        && SecurityOptions.isInternalSSLEnabled(config);
+                config.get(AkkaOptions.SSL_ENABLED) && SecurityOptions.isInternalSSLEnabled(config);
 
         return getRpcUrl(
                 hostname,
@@ -233,7 +232,7 @@ public class PekkoRpcServiceUtils {
     // ------------------------------------------------------------------------
 
     public static long extractMaximumFramesize(Configuration configuration) {
-        String maxFrameSizeStr = configuration.getString(AkkaOptions.FRAMESIZE);
+        String maxFrameSizeStr = configuration.get(AkkaOptions.FRAMESIZE);
         String configStr = String.format(SIMPLE_CONFIG_TEMPLATE, maxFrameSizeStr);
         Config config = ConfigFactory.parseString(configStr);
         return config.getBytes(MAXIMUM_FRAME_SIZE_PATH);

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
@@ -70,11 +70,11 @@ class PekkoUtils {
      * @return Flink's basic Pekko config
      */
     private static Config getBasicConfig(Configuration configuration) {
-        final int throughput = configuration.getInteger(AkkaOptions.DISPATCHER_THROUGHPUT);
+        final int throughput = configuration.get(AkkaOptions.DISPATCHER_THROUGHPUT);
         final String jvmExitOnFatalError =
-                booleanToOnOrOff(configuration.getBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR));
+                booleanToOnOrOff(configuration.get(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR));
         final String logLifecycleEvents =
-                booleanToOnOrOff(configuration.getBoolean(AkkaOptions.LOG_LIFECYCLE_EVENTS));
+                booleanToOnOrOff(configuration.get(AkkaOptions.LOG_LIFECYCLE_EVENTS));
         final String supervisorStrategy = EscalatingSupervisorStrategy.class.getCanonicalName();
 
         return new ConfigBuilder()
@@ -211,16 +211,16 @@ class PekkoUtils {
         final String startupTimeout =
                 TimeUtils.getStringInMillis(
                         TimeUtils.parseDuration(
-                                configuration.getString(
+                                configuration.get(
                                         AkkaOptions.STARTUP_TIMEOUT,
                                         TimeUtils.getStringInMillis(
                                                 askTimeout.multipliedBy(10L)))));
 
         final String tcpTimeout =
                 TimeUtils.getStringInMillis(
-                        TimeUtils.parseDuration(configuration.getString(AkkaOptions.TCP_TIMEOUT)));
+                        TimeUtils.parseDuration(configuration.get(AkkaOptions.TCP_TIMEOUT)));
 
-        final String framesize = configuration.getString(AkkaOptions.FRAMESIZE);
+        final String framesize = configuration.get(AkkaOptions.FRAMESIZE);
 
         final int clientSocketWorkerPoolPoolSizeMin =
                 configuration.get(AkkaOptions.CLIENT_SOCKET_WORKER_POOL_SIZE_MIN);
@@ -236,9 +236,9 @@ class PekkoUtils {
                 configuration.get(AkkaOptions.SERVER_SOCKET_WORKER_POOL_SIZE_FACTOR);
 
         final String logLifecycleEvents =
-                booleanToOnOrOff(configuration.getBoolean(AkkaOptions.LOG_LIFECYCLE_EVENTS));
+                booleanToOnOrOff(configuration.get(AkkaOptions.LOG_LIFECYCLE_EVENTS));
 
-        final long retryGateClosedFor = configuration.getLong(AkkaOptions.RETRY_GATE_CLOSED_FOR);
+        final long retryGateClosedFor = configuration.get(AkkaOptions.RETRY_GATE_CLOSED_FOR);
 
         configBuilder
                 .add("pekko {")
@@ -312,38 +312,38 @@ class PekkoUtils {
             ConfigBuilder configBuilder, Configuration configuration) {
 
         final boolean enableSSLConfig =
-                configuration.getBoolean(AkkaOptions.SSL_ENABLED)
+                configuration.get(AkkaOptions.SSL_ENABLED)
                         && SecurityOptions.isInternalSSLEnabled(configuration);
 
         final String enableSSL = booleanToOnOrOff(enableSSLConfig);
 
         final String sslKeyStore =
-                configuration.getString(
+                configuration.get(
                         SecurityOptions.SSL_INTERNAL_KEYSTORE,
-                        configuration.getString(SecurityOptions.SSL_KEYSTORE));
+                        configuration.get(SecurityOptions.SSL_KEYSTORE));
 
         final String sslKeyStorePassword =
-                configuration.getString(
+                configuration.get(
                         SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD,
-                        configuration.getString(SecurityOptions.SSL_KEYSTORE_PASSWORD));
+                        configuration.get(SecurityOptions.SSL_KEYSTORE_PASSWORD));
 
         final String sslKeyPassword =
-                configuration.getString(
+                configuration.get(
                         SecurityOptions.SSL_INTERNAL_KEY_PASSWORD,
-                        configuration.getString(SecurityOptions.SSL_KEY_PASSWORD));
+                        configuration.get(SecurityOptions.SSL_KEY_PASSWORD));
 
         final String sslTrustStore =
-                configuration.getString(
+                configuration.get(
                         SecurityOptions.SSL_INTERNAL_TRUSTSTORE,
-                        configuration.getString(SecurityOptions.SSL_TRUSTSTORE));
+                        configuration.get(SecurityOptions.SSL_TRUSTSTORE));
 
         final String sslTrustStorePassword =
-                configuration.getString(
+                configuration.get(
                         SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD,
-                        configuration.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD));
+                        configuration.get(SecurityOptions.SSL_TRUSTSTORE_PASSWORD));
 
         final String sslCertFingerprintString =
-                configuration.getString(SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT);
+                configuration.get(SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT);
 
         final String sslCertFingerprints =
                 sslCertFingerprintString != null
@@ -351,9 +351,9 @@ class PekkoUtils {
                                 .collect(Collectors.joining("\",\"", "[\"", "\"]"))
                         : "[]";
 
-        final String sslProtocol = configuration.getString(SecurityOptions.SSL_PROTOCOL);
+        final String sslProtocol = configuration.get(SecurityOptions.SSL_PROTOCOL);
 
-        final String sslAlgorithmsString = configuration.getString(SecurityOptions.SSL_ALGORITHMS);
+        final String sslAlgorithmsString = configuration.get(SecurityOptions.SSL_ALGORITHMS);
         final String sslAlgorithms =
                 Arrays.stream(sslAlgorithmsString.split(","))
                         .collect(Collectors.joining(",", "[", "]"));

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/MessageSerializationTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/MessageSerializationTest.java
@@ -51,7 +51,7 @@ class MessageSerializationTest {
     @BeforeAll
     static void setup() throws Exception {
         Configuration configuration = new Configuration();
-        configuration.setString(AkkaOptions.FRAMESIZE, maxFrameSize + "b");
+        configuration.set(AkkaOptions.FRAMESIZE, maxFrameSize + "b");
 
         rpcService1 =
                 PekkoRpcServiceUtils.remoteServiceBuilder(configuration, "localhost", 0)

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcActorOversizedResponseMessageTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/PekkoRpcActorOversizedResponseMessageTest.java
@@ -58,7 +58,7 @@ class PekkoRpcActorOversizedResponseMessageTest {
         final Configuration configuration = new Configuration();
         // some tests explicitly test local communication where no serialization should occur
         configuration.set(AkkaOptions.FORCE_RPC_INVOCATION_SERIALIZATION, false);
-        configuration.setString(AkkaOptions.FRAMESIZE, FRAMESIZE + " b");
+        configuration.set(AkkaOptions.FRAMESIZE, FRAMESIZE + " b");
 
         rpcService1 =
                 PekkoRpcServiceUtils.remoteServiceBuilder(configuration, "localhost", 0)

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/PekkoUtilsTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/pekko/PekkoUtilsTest.java
@@ -236,7 +236,7 @@ class PekkoUtilsTest {
     @Test
     void getConfigSslEngineProviderWithoutCertFingerprint() {
         final Configuration configuration = new Configuration();
-        configuration.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        configuration.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
 
         final Config config =
                 PekkoUtils.getConfig(configuration, new HostAndPort("localhost", 31337));
@@ -250,10 +250,10 @@ class PekkoUtilsTest {
     @Test
     void getConfigSslEngineProviderWithCertFingerprint() {
         final Configuration configuration = new Configuration();
-        configuration.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        configuration.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
 
         final String fingerprint = "A8:98:5D:3A:65:E5:E5:C4:B2:D7:D6:6D:40:C6:DD:2F:B1:9C:54:36";
-        configuration.setString(SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT, fingerprint);
+        configuration.set(SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT, fingerprint);
 
         final Config config =
                 PekkoUtils.getConfig(configuration, new HostAndPort("localhost", 31337));

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -192,12 +192,12 @@ public class HistoryServer {
             this.serverSSLFactory = null;
         }
 
-        webAddress = config.getString(HistoryServerOptions.HISTORY_SERVER_WEB_ADDRESS);
-        webPort = config.getInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT);
+        webAddress = config.get(HistoryServerOptions.HISTORY_SERVER_WEB_ADDRESS);
+        webPort = config.get(HistoryServerOptions.HISTORY_SERVER_WEB_PORT);
         webRefreshIntervalMillis =
-                config.getLong(HistoryServerOptions.HISTORY_SERVER_WEB_REFRESH_INTERVAL);
+                config.get(HistoryServerOptions.HISTORY_SERVER_WEB_REFRESH_INTERVAL);
 
-        String webDirectory = config.getString(HistoryServerOptions.HISTORY_SERVER_WEB_DIR);
+        String webDirectory = config.get(HistoryServerOptions.HISTORY_SERVER_WEB_DIR);
         if (webDirectory == null) {
             webDirectory =
                     System.getProperty("java.io.tmpdir")
@@ -208,10 +208,9 @@ public class HistoryServer {
         webDir = new File(webDirectory);
 
         boolean cleanupExpiredArchives =
-                config.getBoolean(HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS);
+                config.get(HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS);
 
-        String refreshDirectories =
-                config.getString(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_DIRS);
+        String refreshDirectories = config.get(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_DIRS);
         if (refreshDirectories == null) {
             throw new FlinkException(
                     HistoryServerOptions.HISTORY_SERVER_ARCHIVE_DIRS + " was not configured.");
@@ -238,8 +237,8 @@ public class HistoryServer {
         }
 
         refreshIntervalMillis =
-                config.getLong(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL);
-        int maxHistorySize = config.getInteger(HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS);
+                config.get(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL);
+        int maxHistorySize = config.get(HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS);
         if (maxHistorySize == 0 || maxHistorySize < -1) {
             throw new IllegalConfigurationException(
                     "Cannot set %s to 0 or less than -1",

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/LogUrlUtil.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/LogUrlUtil.java
@@ -39,7 +39,7 @@ public class LogUrlUtil {
     /** Validate and normalize log url pattern. */
     public static Optional<String> getValidLogUrlPattern(
             final Configuration config, final ConfigOption<String> option) {
-        String pattern = config.getString(option);
+        String pattern = config.get(option);
         if (StringUtils.isNullOrWhitespaceOnly(pattern)) {
             return Optional.empty();
         }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrap.java
@@ -171,8 +171,7 @@ public class WebFrontendBootstrap {
 
         if (inetAddress.isAnyLocalAddress()) {
             address =
-                    config.getString(
-                            JobManagerOptions.ADDRESS, InetAddress.getLocalHost().getHostName());
+                    config.get(JobManagerOptions.ADDRESS, InetAddress.getLocalHost().getHostName());
         } else {
             address = inetAddress.getHostAddress();
         }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -106,7 +106,7 @@ class WebFrontendITCase {
             Files.createFile(logFile);
             Files.createFile(outFile);
 
-            config.setString(WebOptions.LOG_PATH, logFile.toAbsolutePath().toString());
+            config.set(WebOptions.LOG_PATH, logFile.toAbsolutePath().toString());
             config.set(
                     TaskManagerOptions.TASK_MANAGER_LOG_PATH, logFile.toAbsolutePath().toString());
         } catch (Exception e) {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebMonitorUtilsTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebMonitorUtilsTest.java
@@ -39,7 +39,7 @@ class WebMonitorUtilsTest {
     @Test
     void testLoadWebSubmissionExtension() throws Exception {
         final Configuration configuration = new Configuration();
-        configuration.setString(JobManagerOptions.ADDRESS, "localhost");
+        configuration.set(JobManagerOptions.ADDRESS, "localhost");
         final WebMonitorExtension webMonitorExtension =
                 WebMonitorUtils.loadWebSubmissionExtension(
                         CompletableFuture::new,

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -92,7 +92,7 @@ class HistoryServerTest {
         this.hsDirectory = hsDirectory;
 
         Configuration clusterConfig = new Configuration();
-        clusterConfig.setString(JobManagerOptions.ARCHIVE_DIR, jmDirectory.toURI().toString());
+        clusterConfig.set(JobManagerOptions.ARCHIVE_DIR, jmDirectory.toURI().toString());
 
         cluster =
                 new MiniClusterWithClientResource(
@@ -255,8 +255,7 @@ class HistoryServerTest {
         Configuration historyServerConfig =
                 createTestConfiguration(
                         HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS.defaultValue());
-        historyServerConfig.setInteger(
-                HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS, maxHistorySize);
+        historyServerConfig.set(HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS, maxHistorySize);
         new HistoryServer(historyServerConfig).start();
     }
 
@@ -385,17 +384,16 @@ class HistoryServerTest {
 
     private Configuration createTestConfiguration(boolean cleanupExpiredJobs) {
         Configuration historyServerConfig = new Configuration();
-        historyServerConfig.setString(
+        historyServerConfig.set(
                 HistoryServerOptions.HISTORY_SERVER_ARCHIVE_DIRS, jmDirectory.toURI().toString());
-        historyServerConfig.setString(
+        historyServerConfig.set(
                 HistoryServerOptions.HISTORY_SERVER_WEB_DIR, hsDirectory.getAbsolutePath());
-        historyServerConfig.setLong(
-                HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL, 100L);
+        historyServerConfig.set(HistoryServerOptions.HISTORY_SERVER_ARCHIVE_REFRESH_INTERVAL, 100L);
 
-        historyServerConfig.setBoolean(
+        historyServerConfig.set(
                 HistoryServerOptions.HISTORY_SERVER_CLEANUP_EXPIRED_JOBS, cleanupExpiredJobs);
 
-        historyServerConfig.setInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, 0);
+        historyServerConfig.set(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, 0);
         return historyServerConfig;
     }
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrapTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/utils/WebFrontendBootstrapTest.java
@@ -58,9 +58,8 @@ class WebFrontendBootstrapTest {
     void testHandlersMustBeLoaded() throws Exception {
         Path webDir = Files.createDirectories(tmp.resolve("webDir"));
         Configuration configuration = new Configuration();
-        configuration.setString(
-                Prio0InboundChannelHandlerFactory.REDIRECT_FROM_URL, "/nonExisting");
-        configuration.setString(Prio0InboundChannelHandlerFactory.REDIRECT_TO_URL, "/index.html");
+        configuration.set(Prio0InboundChannelHandlerFactory.REDIRECT_FROM_URL, "/nonExisting");
+        configuration.set(Prio0InboundChannelHandlerFactory.REDIRECT_TO_URL, "/index.html");
         Router<?> router =
                 new Router<>()
                         .addGet("/:*", new HistoryServerStaticFileServerHandler(webDir.toFile()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/AbstractBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/AbstractBlobCache.java
@@ -93,7 +93,7 @@ public abstract class AbstractBlobCache implements Closeable {
         log.info("Created BLOB cache storage directory " + storageDir);
 
         // configure the number of fetch retries
-        final int fetchRetries = blobClientConfig.getInteger(BlobServerOptions.FETCH_RETRIES);
+        final int fetchRetries = blobClientConfig.get(BlobServerOptions.FETCH_RETRIES);
         if (fetchRetries >= 0) {
             this.numFetchRetries = fetchRetries;
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobClient.java
@@ -83,7 +83,7 @@ public final class BlobClient implements Closeable {
         try {
             // create an SSL socket if configured
             if (SecurityOptions.isInternalSSLEnabled(clientConfig)
-                    && clientConfig.getBoolean(BlobServerOptions.SSL_ENABLED)) {
+                    && clientConfig.get(BlobServerOptions.SSL_ENABLED)) {
                 LOG.info("Using ssl connection to the blob server");
 
                 socket = SSLUtils.createSSLClientSocketFactory(clientConfig).createSocket();
@@ -96,8 +96,8 @@ public final class BlobClient implements Closeable {
             // InetSocketAddress can cache a failure in hostname resolution forever.
             socket.connect(
                     new InetSocketAddress(serverAddress.getHostName(), serverAddress.getPort()),
-                    clientConfig.getInteger(BlobServerOptions.CONNECT_TIMEOUT));
-            socket.setSoTimeout(clientConfig.getInteger(BlobServerOptions.SO_TIMEOUT));
+                    clientConfig.get(BlobServerOptions.CONNECT_TIMEOUT));
+            socket.setSoTimeout(clientConfig.get(BlobServerOptions.SO_TIMEOUT));
         } catch (Exception e) {
             BlobUtils.closeSilently(socket, LOG);
             throw new IOException("Could not connect to BlobServer at address " + serverAddress, e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -164,7 +164,7 @@ public class BlobServer extends Thread
         LOG.info("Created BLOB server storage directory {}", storageDir);
 
         // configure the maximum number of concurrent connections
-        final int maxConnections = config.getInteger(BlobServerOptions.FETCH_CONCURRENT);
+        final int maxConnections = config.get(BlobServerOptions.FETCH_CONCURRENT);
         if (maxConnections >= 1) {
             this.maxConnections = maxConnections;
         } else {
@@ -176,7 +176,7 @@ public class BlobServer extends Thread
         }
 
         // configure the backlog of connections
-        int backlog = config.getInteger(BlobServerOptions.FETCH_BACKLOG);
+        int backlog = config.get(BlobServerOptions.FETCH_BACKLOG);
         if (backlog < 1) {
             LOG.warn(
                     "Invalid value for BLOB connection backlog: {}. Using default value of {}",
@@ -188,7 +188,7 @@ public class BlobServer extends Thread
         // Initializing the clean up task
         this.cleanupTimer = new Timer(true);
 
-        this.cleanupInterval = config.getLong(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
+        this.cleanupInterval = config.get(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
         this.cleanupTimer.schedule(
                 new TransientBlobCleanupTask(blobExpiryTimes, this::deleteInternal, LOG),
                 cleanupInterval,
@@ -198,12 +198,12 @@ public class BlobServer extends Thread
 
         //  ----------------------- start the server -------------------
 
-        final String serverPortRange = config.getString(BlobServerOptions.PORT);
+        final String serverPortRange = config.get(BlobServerOptions.PORT);
         final Iterator<Integer> ports = NetUtils.getPortRangeFromString(serverPortRange);
 
         final ServerSocketFactory socketFactory;
         if (SecurityOptions.isInternalSSLEnabled(config)
-                && config.getBoolean(BlobServerOptions.SSL_ENABLED)) {
+                && config.get(BlobServerOptions.SSL_ENABLED)) {
             try {
                 socketFactory = SSLUtils.createSSLServerSocketFactory(config);
             } catch (Exception e) {
@@ -989,7 +989,7 @@ public class BlobServer extends Thread
      */
     @Override
     public final int getMinOffloadingSize() {
-        return blobServiceConfiguration.getInteger(BlobServerOptions.OFFLOAD_MINSIZE);
+        return blobServiceConfiguration.get(BlobServerOptions.OFFLOAD_MINSIZE);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobUtils.java
@@ -154,7 +154,7 @@ public class BlobUtils {
     static Reference<File> createBlobStorageDirectory(
             Configuration configuration, @Nullable Reference<File> fallbackStorageDirectory)
             throws IOException {
-        final String basePath = configuration.getString(BlobServerOptions.STORAGE_DIRECTORY);
+        final String basePath = configuration.get(BlobServerOptions.STORAGE_DIRECTORY);
 
         File baseDir = null;
         if (StringUtils.isNullOrWhitespaceOnly(basePath)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/PermanentBlobCache.java
@@ -153,7 +153,7 @@ public class PermanentBlobCache extends AbstractBlobCache implements JobPermanen
         // Initializing the clean up task
         this.cleanupTimer = new Timer(true);
 
-        this.cleanupInterval = blobClientConfig.getLong(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
+        this.cleanupInterval = blobClientConfig.get(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
         this.cleanupTimer.schedule(
                 new PermanentBlobCleanupTask(), cleanupInterval, cleanupInterval);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/TransientBlobCache.java
@@ -97,7 +97,7 @@ public class TransientBlobCache extends AbstractBlobCache implements TransientBl
         // Initializing the clean up task
         this.cleanupTimer = new Timer(true);
 
-        this.cleanupInterval = blobClientConfig.getLong(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
+        this.cleanupInterval = blobClientConfig.get(BlobServerOptions.CLEANUP_INTERVAL) * 1000;
         this.cleanupTimer.schedule(
                 new TransientBlobCleanupTask(blobExpiryTimes, this::deleteInternal, log),
                 cleanupInterval,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlocklistUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlocklistUtils.java
@@ -37,7 +37,7 @@ public class BlocklistUtils {
 
     public static boolean isBlocklistEnabled(Configuration configuration) {
         // Currently, only enable blocklist for speculative execution
-        return configuration.getBoolean(BatchExecutionOptions.SPECULATIVE_ENABLED);
+        return configuration.get(BatchExecutionOptions.SPECULATIVE_ENABLED);
     }
 
     /** Private default constructor to avoid being instantiated. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtils.java
@@ -60,7 +60,7 @@ public class DefaultCompletedCheckpointStoreUtils {
      */
     public static int getMaximumNumberOfRetainedCheckpoints(Configuration config, Logger logger) {
         final int maxNumberOfCheckpointsToRetain =
-                config.getInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS);
+                config.get(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS);
 
         if (maxNumberOfCheckpointsToRetain <= 0) {
             // warning and use 1 as the default value if the setting in

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -177,8 +177,8 @@ public class BootstrapTools {
                     configuration.getValue(CoreOptions.TMP_DIRS));
         } else if (defaultDirs != null) {
             LOG.info("Setting directories for temporary files to: {}", defaultDirs);
-            configuration.setString(CoreOptions.TMP_DIRS, defaultDirs);
-            configuration.setBoolean(USE_LOCAL_DEFAULT_TMP_DIRS, true);
+            configuration.set(CoreOptions.TMP_DIRS, defaultDirs);
+            configuration.set(USE_LOCAL_DEFAULT_TMP_DIRS, true);
         }
     }
 
@@ -191,7 +191,7 @@ public class BootstrapTools {
     public static Configuration cloneConfiguration(Configuration configuration) {
         final Configuration clonedConfiguration = new Configuration(configuration);
 
-        if (clonedConfiguration.getBoolean(USE_LOCAL_DEFAULT_TMP_DIRS)) {
+        if (clonedConfiguration.get(USE_LOCAL_DEFAULT_TMP_DIRS)) {
             clonedConfiguration.removeConfig(CoreOptions.TMP_DIRS);
             clonedConfiguration.removeConfig(USE_LOCAL_DEFAULT_TMP_DIRS);
         }
@@ -217,12 +217,12 @@ public class BootstrapTools {
                         .flatMap(
                                 (String key) -> {
                                     final String baseValue =
-                                            baseConfig.getString(
+                                            baseConfig.get(
                                                     ConfigOptions.key(key)
                                                             .stringType()
                                                             .noDefaultValue());
                                     final String targetValue =
-                                            targetConfig.getString(
+                                            targetConfig.get(
                                                     ConfigOptions.key(key)
                                                             .stringType()
                                                             .noDefaultValue());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpecBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpecBuilder.java
@@ -43,7 +43,7 @@ public class TaskExecutorProcessSpecBuilder {
     }
 
     public TaskExecutorProcessSpecBuilder withCpuCores(CPUResource cpuCores) {
-        configuration.setDouble(TaskManagerOptions.CPU_CORES, cpuCores.getValue().doubleValue());
+        configuration.set(TaskManagerOptions.CPU_CORES, cpuCores.getValue().doubleValue());
         return this;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -215,23 +215,23 @@ public class TaskExecutorProcessUtils {
     }
 
     private static int getNumSlots(final Configuration config) {
-        return config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
+        return config.get(TaskManagerOptions.NUM_TASK_SLOTS);
     }
 
     public static double getCpuCoresWithFallbackConfigOption(
             final Configuration config, ConfigOption<Double> fallbackOption) {
-        double fallbackValue = config.getDouble(fallbackOption);
+        double fallbackValue = config.get(fallbackOption);
         return getCpuCoresWithFallback(config, fallbackValue).getValue().doubleValue();
     }
 
     public static CPUResource getCpuCoresWithFallback(final Configuration config, double fallback) {
         final double cpuCores;
         if (config.contains(TaskManagerOptions.CPU_CORES)) {
-            cpuCores = config.getDouble(TaskManagerOptions.CPU_CORES);
+            cpuCores = config.get(TaskManagerOptions.CPU_CORES);
         } else if (fallback > 0.0) {
             cpuCores = fallback;
         } else {
-            cpuCores = config.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
+            cpuCores = config.get(TaskManagerOptions.NUM_TASK_SLOTS);
         }
 
         if (cpuCores <= 0) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -324,7 +324,7 @@ public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
         this.globalResourceCleaner =
                 resourceCleanerFactory.createGlobalResourceCleaner(this.getMainThreadExecutor());
 
-        this.webTimeout = Time.milliseconds(configuration.getLong(WebOptions.TIMEOUT));
+        this.webTimeout = Time.milliseconds(configuration.get(WebOptions.TIMEOUT));
 
         this.jobClientAlivenessCheckInterval =
                 configuration.get(CLIENT_ALIVENESS_CHECK_DURATION).toMillis();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/HistoryServerArchivist.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/HistoryServerArchivist.java
@@ -41,7 +41,7 @@ public interface HistoryServerArchivist {
 
     static HistoryServerArchivist createHistoryServerArchivist(
             Configuration configuration, JsonArchivist jsonArchivist, Executor ioExecutor) {
-        final String configuredArchivePath = configuration.getString(JobManagerOptions.ARCHIVE_DIR);
+        final String configuredArchivePath = configuration.get(JobManagerOptions.ARCHIVE_DIR);
 
         if (configuredArchivePath != null) {
             final Path archivePath = new Path(configuredArchivePath);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobDispatcherFactory.java
@@ -56,7 +56,7 @@ public enum JobDispatcherFactory implements DispatcherFactory {
 
         final Configuration configuration =
                 partialDispatcherServicesWithJobPersistenceComponents.getConfiguration();
-        final String executionModeValue = configuration.getString(INTERNAL_CLUSTER_EXECUTION_MODE);
+        final String executionModeValue = configuration.get(INTERNAL_CLUSTER_EXECUTION_MODE);
         final ClusterEntrypoint.ExecutionMode executionMode =
                 ClusterEntrypoint.ExecutionMode.valueOf(executionModeValue);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CheckpointResourcesCleanupRunner.java
@@ -91,8 +91,7 @@ public class CheckpointResourcesCleanupRunner implements JobManagerRunner {
 
         this.checkpointsCleaner =
                 new CheckpointsCleaner(
-                        jobManagerConfiguration.getBoolean(
-                                CheckpointingOptions.CLEANER_PARALLEL_MODE));
+                        jobManagerConfiguration.get(CheckpointingOptions.CLEANER_PARALLEL_MODE));
 
         this.resultFuture = new CompletableFuture<>();
         this.cleanupFuture = resultFuture.thenCompose(ignored -> runCleanupAsync());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRetryStrategyFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/CleanupRetryStrategyFactory.java
@@ -40,15 +40,14 @@ public enum CleanupRetryStrategyFactory {
 
     /** Creates the {@link RetryStrategy} instance based on the passed {@link Configuration}. */
     public RetryStrategy createRetryStrategy(Configuration configuration) {
-        final String configuredRetryStrategy =
-                configuration.getString(CleanupOptions.CLEANUP_STRATEGY);
+        final String configuredRetryStrategy = configuration.get(CleanupOptions.CLEANUP_STRATEGY);
         if (isRetryStrategy(
                 CleanupOptions.FIXED_DELAY_LABEL,
-                configuration.getString(CleanupOptions.CLEANUP_STRATEGY))) {
+                configuration.get(CleanupOptions.CLEANUP_STRATEGY))) {
             return createFixedRetryStrategy(configuration);
         } else if (isRetryStrategy(
                 CleanupOptions.EXPONENTIAL_DELAY_LABEL,
-                configuration.getString(CleanupOptions.CLEANUP_STRATEGY))) {
+                configuration.get(CleanupOptions.CLEANUP_STRATEGY))) {
             return createExponentialBackoffRetryStrategy(configuration);
         } else if (retryingDisabled(configuredRetryStrategy)) {
             return createNoRetryStrategy();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -288,8 +288,8 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             initializeServices(configuration, pluginManager);
 
             // write host information into configuration
-            configuration.setString(JobManagerOptions.ADDRESS, commonRpcService.getAddress());
-            configuration.setInteger(JobManagerOptions.PORT, commonRpcService.getPort());
+            configuration.set(JobManagerOptions.ADDRESS, commonRpcService.getAddress());
+            configuration.set(JobManagerOptions.PORT, commonRpcService.getPort());
 
             final DispatcherResourceManagerComponentFactory
                     dispatcherResourceManagerComponentFactory =
@@ -371,16 +371,16 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                     RpcUtils.createRemoteRpcService(
                             rpcSystem,
                             configuration,
-                            configuration.getString(JobManagerOptions.ADDRESS),
+                            configuration.get(JobManagerOptions.ADDRESS),
                             getRPCPortRange(configuration),
-                            configuration.getString(JobManagerOptions.BIND_HOST),
+                            configuration.get(JobManagerOptions.BIND_HOST),
                             configuration.getOptional(JobManagerOptions.RPC_BIND_PORT));
 
-            JMXService.startInstance(configuration.getString(JMXServerOptions.JMX_SERVER_PORT));
+            JMXService.startInstance(configuration.get(JMXServerOptions.JMX_SERVER_PORT));
 
             // update the configuration used to create the high availability services
-            configuration.setString(JobManagerOptions.ADDRESS, commonRpcService.getAddress());
-            configuration.setInteger(JobManagerOptions.PORT, commonRpcService.getPort());
+            configuration.set(JobManagerOptions.ADDRESS, commonRpcService.getAddress());
+            configuration.set(JobManagerOptions.PORT, commonRpcService.getPort());
 
             ioExecutor =
                     Executors.newFixedThreadPool(
@@ -402,7 +402,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                             Reference.borrowed(workingDirectory.unwrap().getBlobStorageDirectory()),
                             haServices.createBlobStore());
             blobServer.start();
-            configuration.setString(BlobServerOptions.PORT, String.valueOf(blobServer.getPort()));
+            configuration.set(BlobServerOptions.PORT, String.valueOf(blobServer.getPort()));
             heartbeatServices = createHeartbeatServices(configuration);
             failureEnrichers = FailureEnricherUtils.getFailureEnrichers(configuration);
             metricRegistry = createMetricRegistry(configuration, pluginManager, rpcSystem);
@@ -411,7 +411,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
                     MetricUtils.startRemoteMetricsRpcService(
                             configuration,
                             commonRpcService.getAddress(),
-                            configuration.getString(JobManagerOptions.BIND_HOST),
+                            configuration.get(JobManagerOptions.BIND_HOST),
                             rpcSystem);
             metricRegistry.startQueryService(metricQueryServiceRpcService, null);
 
@@ -438,9 +438,9 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
      */
     protected String getRPCPortRange(Configuration configuration) {
         if (ZooKeeperUtils.isZooKeeperRecoveryMode(configuration)) {
-            return configuration.getString(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE);
+            return configuration.get(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE);
         } else {
-            return String.valueOf(configuration.getInteger(JobManagerOptions.PORT));
+            return String.valueOf(configuration.get(JobManagerOptions.PORT));
         }
     }
 
@@ -484,7 +484,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
     protected CompletableFuture<Void> stopClusterServices(boolean cleanupHaData) {
         final long shutdownTimeout =
-                configuration.getLong(ClusterOptions.CLUSTER_SERVICES_SHUTDOWN_TIMEOUT);
+                configuration.get(ClusterOptions.CLUSTER_SERVICES_SHUTDOWN_TIMEOUT);
 
         synchronized (lock) {
             Throwable exception = null;
@@ -563,10 +563,10 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
         final Configuration resultConfiguration =
                 new Configuration(Preconditions.checkNotNull(configuration));
 
-        final String webTmpDir = configuration.getString(WebOptions.TMP_DIR);
+        final String webTmpDir = configuration.get(WebOptions.TMP_DIR);
         final File uniqueWebTmpDir = new File(webTmpDir, "flink-web-" + UUID.randomUUID());
 
-        resultConfiguration.setString(WebOptions.TMP_DIR, uniqueWebTmpDir.getAbsolutePath());
+        resultConfiguration.set(WebOptions.TMP_DIR, uniqueWebTmpDir.getAbsolutePath());
 
         return resultConfiguration;
     }
@@ -648,7 +648,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
     protected void cleanupDirectories(ShutdownBehaviour shutdownBehaviour) throws IOException {
         IOException ioException = null;
 
-        final String webTmpDir = configuration.getString(WebOptions.TMP_DIR);
+        final String webTmpDir = configuration.get(WebOptions.TMP_DIR);
 
         try {
             FileUtils.deleteDirectory(new File(webTmpDir));
@@ -711,7 +711,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             LOG.warn(
                     "The 'webui-port' parameter of 'jobmanager.sh' has been deprecated. Please use '-D {}=<port> instead.",
                     RestOptions.PORT);
-            configuration.setInteger(RestOptions.PORT, restPort);
+            configuration.set(RestOptions.PORT, restPort);
         }
 
         final String hostname = entrypointClusterConfiguration.getHostname();
@@ -720,7 +720,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             LOG.warn(
                     "The 'host' parameter of 'jobmanager.sh' has been deprecated. Please use '-D {}=<host> instead.",
                     JobManagerOptions.ADDRESS);
-            configuration.setString(JobManagerOptions.ADDRESS, hostname);
+            configuration.set(JobManagerOptions.ADDRESS, hostname);
         }
 
         return configuration;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypointUtils.java
@@ -113,7 +113,7 @@ public final class ClusterEntrypointUtils {
      */
     public static int getPoolSize(Configuration config) {
         final int poolSize =
-                config.getInteger(
+                config.get(
                         ClusterOptions.CLUSTER_IO_EXECUTOR_POOL_SIZE,
                         4 * Hardware.getNumberCPUCores());
         Preconditions.checkArgument(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/SessionClusterEntrypoint.java
@@ -45,9 +45,8 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
         final JobManagerOptions.JobStoreType jobStoreType =
                 configuration.get(JobManagerOptions.JOB_STORE_TYPE);
         final Time expirationTime =
-                Time.seconds(configuration.getLong(JobManagerOptions.JOB_STORE_EXPIRATION_TIME));
-        final int maximumCapacity =
-                configuration.getInteger(JobManagerOptions.JOB_STORE_MAX_CAPACITY);
+                Time.seconds(configuration.get(JobManagerOptions.JOB_STORE_EXPIRATION_TIME));
+        final int maximumCapacity = configuration.get(JobManagerOptions.JOB_STORE_MAX_CAPACITY);
 
         switch (jobStoreType) {
             case File:
@@ -55,7 +54,7 @@ public abstract class SessionClusterEntrypoint extends ClusterEntrypoint {
                     final File tmpDir =
                             new File(ConfigurationUtils.parseTempDirectories(configuration)[0]);
                     final long maximumCacheSizeBytes =
-                            configuration.getLong(JobManagerOptions.JOB_STORE_CACHE_SIZE);
+                            configuration.get(JobManagerOptions.JOB_STORE_CACHE_SIZE);
 
                     return new FileExecutionGraphInfoStore(
                             tmpDir,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DefaultDispatcherResourceManagerComponentFactory.java
@@ -149,12 +149,12 @@ public class DefaultDispatcherResourceManagerComponentFactory
 
             final ScheduledExecutorService executor =
                     WebMonitorEndpoint.createExecutorService(
-                            configuration.getInteger(RestOptions.SERVER_NUM_THREADS),
-                            configuration.getInteger(RestOptions.SERVER_THREAD_PRIORITY),
+                            configuration.get(RestOptions.SERVER_NUM_THREADS),
+                            configuration.get(RestOptions.SERVER_THREAD_PRIORITY),
                             "DispatcherRestEndpoint");
 
             final long updateInterval =
-                    configuration.getLong(MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL);
+                    configuration.get(MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL);
             final MetricFetcher metricFetcher =
                     updateInterval == 0
                             ? VoidMetricFetcher.INSTANCE

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/FileJobGraphRetriever.java
@@ -84,6 +84,6 @@ public class FileJobGraphRetriever extends AbstractUserClassPathJobGraphRetrieve
     public static FileJobGraphRetriever createFrom(
             Configuration configuration, @Nullable File usrLibDir) throws IOException {
         checkNotNull(configuration, "configuration");
-        return new FileJobGraphRetriever(configuration.getString(JOB_GRAPH_FILE_PATH), usrLibDir);
+        return new FileJobGraphRetriever(configuration.get(JOB_GRAPH_FILE_PATH), usrLibDir);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -114,7 +114,7 @@ public class DefaultExecutionGraphBuilder {
                         jobGraph.getClasspaths());
 
         final int executionHistorySizeLimit =
-                jobManagerConfig.getInteger(JobManagerOptions.MAX_ATTEMPTS_HISTORY_SIZE);
+                jobManagerConfig.get(JobManagerOptions.MAX_ATTEMPTS_HISTORY_SIZE);
 
         final PartitionGroupReleaseStrategy.Factory partitionGroupReleaseStrategyFactory =
                 PartitionGroupReleaseStrategyFactoryLoader.loadPartitionGroupReleaseStrategyFactory(
@@ -340,7 +340,7 @@ public class DefaultExecutionGraphBuilder {
                     rootStorage,
                     checkpointStatsTrackerFactory.get(),
                     checkpointsCleaner,
-                    jobManagerConfig.getString(STATE_CHANGE_LOG_STORAGE));
+                    jobManagerConfig.get(STATE_CHANGE_LOG_STORAGE));
         }
 
         return executionGraph;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyFactoryLoader.java
@@ -44,8 +44,7 @@ public final class FailoverStrategyFactoryLoader {
     public static FailoverStrategy.Factory loadFailoverStrategyFactory(final Configuration config) {
         checkNotNull(config);
 
-        final String strategyParam =
-                config.getString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY);
+        final String strategyParam = config.get(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY);
 
         switch (strategyParam.toLowerCase()) {
             case FULL_RESTART_STRATEGY_NAME:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailureRateRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FailureRateRestartBackoffTimeStrategy.java
@@ -111,7 +111,7 @@ public class FailureRateRestartBackoffTimeStrategy implements RestartBackoffTime
     public static FailureRateRestartBackoffTimeStrategyFactory createFactory(
             final Configuration configuration) {
         int maxFailuresPerInterval =
-                configuration.getInteger(
+                configuration.get(
                         RestartStrategyOptions
                                 .RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL);
         long failuresInterval =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FixedDelayRestartBackoffTimeStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/FixedDelayRestartBackoffTimeStrategy.java
@@ -84,8 +84,7 @@ public class FixedDelayRestartBackoffTimeStrategy implements RestartBackoffTimeS
     public static FixedDelayRestartBackoffTimeStrategyFactory createFactory(
             final Configuration configuration) {
         int maxAttempts =
-                configuration.getInteger(
-                        RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS);
+                configuration.get(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS);
         long delay =
                 configuration
                         .get(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/partitionrelease/PartitionGroupReleaseStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/partitionrelease/PartitionGroupReleaseStrategyFactoryLoader.java
@@ -28,7 +28,7 @@ public final class PartitionGroupReleaseStrategyFactoryLoader {
     public static PartitionGroupReleaseStrategy.Factory loadPartitionGroupReleaseStrategyFactory(
             final Configuration configuration) {
         final boolean partitionReleaseDuringJobExecution =
-                configuration.getBoolean(JobManagerOptions.PARTITION_RELEASE_DURING_JOB_EXECUTION);
+                configuration.get(JobManagerOptions.PARTITION_RELEASE_DURING_JOB_EXECUTION);
         if (partitionReleaseDuringJobExecution) {
             return new RegionPartitionGroupReleaseStrategy.Factory();
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/externalresource/ExternalResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/externalresource/ExternalResourceUtils.java
@@ -213,7 +213,7 @@ public class ExternalResourceUtils {
                                             resourceName))
                             .stringType()
                             .noDefaultValue();
-            final String driverFactoryClassName = config.getString(driverClassOption);
+            final String driverFactoryClassName = config.get(driverClassOption);
             if (StringUtils.isNullOrWhitespaceOnly(driverFactoryClassName)) {
                 LOG.warn(
                         "Could not find driver class name for {}. Please make sure {} is configured.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/failure/FailureEnricherUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/failure/FailureEnricherUtils.java
@@ -124,7 +124,7 @@ public class FailureEnricherUtils {
     @VisibleForTesting
     static Set<String> getIncludedFailureEnrichers(final Configuration configuration) {
         final String includedEnrichersString =
-                configuration.getString(JobManagerOptions.FAILURE_ENRICHERS_LIST, "");
+                configuration.get(JobManagerOptions.FAILURE_ENRICHERS_LIST, "");
         return enricherListPattern
                 .splitAsStream(includedEnrichersString)
                 .filter(r -> !r.isEmpty())

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/heartbeat/HeartbeatServices.java
@@ -75,9 +75,9 @@ public interface HeartbeatServices {
      * @return An HeartbeatServices instance created from the given configuration
      */
     static HeartbeatServices fromConfiguration(Configuration configuration) {
-        long heartbeatInterval = configuration.getLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL);
+        long heartbeatInterval = configuration.get(HeartbeatManagerOptions.HEARTBEAT_INTERVAL);
 
-        long heartbeatTimeout = configuration.getLong(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT);
+        long heartbeatTimeout = configuration.get(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT);
 
         int failedRpcRequestsUntilUnreachable =
                 configuration.get(HeartbeatManagerOptions.HEARTBEAT_RPC_FAILURE_THRESHOLD);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtils.java
@@ -181,8 +181,8 @@ public class HighAvailabilityServicesUtils {
     public static Tuple2<String, Integer> getJobManagerAddress(Configuration configuration)
             throws ConfigurationException {
 
-        final String hostname = configuration.getString(JobManagerOptions.ADDRESS);
-        final int port = configuration.getInteger(JobManagerOptions.PORT);
+        final String hostname = configuration.get(JobManagerOptions.ADDRESS);
+        final int port = configuration.get(JobManagerOptions.PORT);
 
         if (hostname == null) {
             throw new ConfigurationException(
@@ -215,7 +215,7 @@ public class HighAvailabilityServicesUtils {
             Configuration configuration, AddressResolution resolution) throws UnknownHostException {
         final String address =
                 checkNotNull(
-                        configuration.getString(RestOptions.ADDRESS),
+                        configuration.get(RestOptions.ADDRESS),
                         "%s must be set",
                         RestOptions.ADDRESS.key());
 
@@ -225,7 +225,7 @@ public class HighAvailabilityServicesUtils {
             InetAddress.getByName(address);
         }
 
-        final int port = configuration.getInteger(RestOptions.PORT);
+        final int port = configuration.get(RestOptions.PORT);
         final boolean enableSSL = SecurityOptions.isRestSSLEnabled(configuration);
         final String protocol = enableSSL ? "https://" : "http://";
 
@@ -279,7 +279,7 @@ public class HighAvailabilityServicesUtils {
     private static HighAvailabilityServices createCustomHAServices(
             Configuration config, Executor executor) throws FlinkException {
         return createCustomHAServices(
-                config.getString(HighAvailabilityOptions.HA_MODE), config, executor);
+                config.get(HighAvailabilityOptions.HA_MODE), config, executor);
     }
 
     private static HighAvailabilityServices createCustomHAServices(
@@ -311,8 +311,7 @@ public class HighAvailabilityServicesUtils {
 
     private static ClientHighAvailabilityServices createCustomClientHAServices(Configuration config)
             throws FlinkException {
-        return createCustomClientHAServices(
-                config.getString(HighAvailabilityOptions.HA_MODE), config);
+        return createCustomClientHAServices(config.get(HighAvailabilityOptions.HA_MODE), config);
     }
 
     private static ClientHighAvailabilityServices createCustomClientHAServices(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -102,43 +102,41 @@ public class NettyConfig {
     // ------------------------------------------------------------------------
 
     public int getServerConnectBacklog() {
-        return config.getInteger(NettyShuffleEnvironmentOptions.CONNECT_BACKLOG);
+        return config.get(NettyShuffleEnvironmentOptions.CONNECT_BACKLOG);
     }
 
     public int getNumberOfArenas() {
         // default: number of slots
-        final int configValue = config.getInteger(NettyShuffleEnvironmentOptions.NUM_ARENAS);
+        final int configValue = config.get(NettyShuffleEnvironmentOptions.NUM_ARENAS);
         return configValue == -1 ? numberOfSlots : configValue;
     }
 
     public int getServerNumThreads() {
         // default: number of task slots
-        final int configValue =
-                config.getInteger(NettyShuffleEnvironmentOptions.NUM_THREADS_SERVER);
+        final int configValue = config.get(NettyShuffleEnvironmentOptions.NUM_THREADS_SERVER);
         return configValue == -1 ? numberOfSlots : configValue;
     }
 
     public int getClientNumThreads() {
         // default: number of task slots
-        final int configValue =
-                config.getInteger(NettyShuffleEnvironmentOptions.NUM_THREADS_CLIENT);
+        final int configValue = config.get(NettyShuffleEnvironmentOptions.NUM_THREADS_CLIENT);
         return configValue == -1 ? numberOfSlots : configValue;
     }
 
     public int getClientConnectTimeoutSeconds() {
-        return config.getInteger(NettyShuffleEnvironmentOptions.CLIENT_CONNECT_TIMEOUT_SECONDS);
+        return config.get(NettyShuffleEnvironmentOptions.CLIENT_CONNECT_TIMEOUT_SECONDS);
     }
 
     public int getNetworkRetries() {
-        return config.getInteger(NettyShuffleEnvironmentOptions.NETWORK_RETRIES);
+        return config.get(NettyShuffleEnvironmentOptions.NETWORK_RETRIES);
     }
 
     public int getSendAndReceiveBufferSize() {
-        return config.getInteger(NettyShuffleEnvironmentOptions.SEND_RECEIVE_BUFFER_SIZE);
+        return config.get(NettyShuffleEnvironmentOptions.SEND_RECEIVE_BUFFER_SIZE);
     }
 
     public TransportType getTransportType() {
-        String transport = config.getString(NettyShuffleEnvironmentOptions.TRANSPORT_TYPE);
+        String transport = config.get(NettyShuffleEnvironmentOptions.TRANSPORT_TYPE);
 
         switch (transport) {
             case "nio":
@@ -173,7 +171,7 @@ public class NettyConfig {
     }
 
     public boolean getSSLEnabled() {
-        return config.getBoolean(NettyShuffleEnvironmentOptions.DATA_SSL_ENABLED)
+        return config.get(NettyShuffleEnvironmentOptions.DATA_SSL_ENABLED)
                 && SecurityOptions.isInternalSSLEnabled(config);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredInternalShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredInternalShuffleMaster.java
@@ -42,7 +42,7 @@ public class TieredInternalShuffleMaster {
     public TieredInternalShuffleMaster(Configuration conf) {
         TieredStorageConfiguration tieredStorageConfiguration =
                 TieredStorageConfiguration.builder(
-                                conf.getString(NETWORK_HYBRID_SHUFFLE_REMOTE_STORAGE_BASE_PATH))
+                                conf.get(NETWORK_HYBRID_SHUFFLE_REMOTE_STORAGE_BASE_PATH))
                         .build();
         TieredStorageResourceRegistry resourceRegistry = new TieredStorageResourceRegistry();
         List<TierMasterAgent> tierFactories =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -176,7 +176,7 @@ public class SavepointRestoreSettings implements Serializable {
                 SavepointConfigOptions.RESTORE_MODE, savepointRestoreSettings.getRestoreMode());
         final String savepointPath = savepointRestoreSettings.getRestorePath();
         if (savepointPath != null) {
-            configuration.setString(SavepointConfigOptions.SAVEPOINT_PATH, savepointPath);
+            configuration.set(SavepointConfigOptions.SAVEPOINT_PATH, savepointPath);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtils.java
@@ -108,8 +108,7 @@ public class JobManagerProcessUtils {
     public static String generateJvmParametersStr(
             JobManagerProcessSpec processSpec, Configuration configuration) {
         return ProcessMemoryUtils.generateJvmParametersStr(
-                processSpec,
-                configuration.getBoolean(JobManagerOptions.JVM_DIRECT_MEMORY_LIMIT_ENABLED));
+                processSpec, configuration.get(JobManagerOptions.JVM_DIRECT_MEMORY_LIMIT_ENABLED));
     }
 
     public static String generateDynamicConfigsStr(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
@@ -155,9 +155,9 @@ public final class DefaultSlotPoolServiceSchedulerFactory
         final Time rpcTimeout =
                 Time.fromDuration(configuration.get(AkkaOptions.ASK_TIMEOUT_DURATION));
         final Time slotIdleTimeout =
-                Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_IDLE_TIMEOUT));
+                Time.milliseconds(configuration.get(JobManagerOptions.SLOT_IDLE_TIMEOUT));
         final Time batchSlotTimeout =
-                Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
+                Time.milliseconds(configuration.get(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
 
         final SlotPoolServiceFactory slotPoolServiceFactory;
         final SchedulerNGFactory schedulerNGFactory;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServices.java
@@ -144,16 +144,14 @@ public class JobManagerSharedServices {
         checkNotNull(config);
         checkNotNull(blobServer);
 
-        final String classLoaderResolveOrder =
-                config.getString(CoreOptions.CLASSLOADER_RESOLVE_ORDER);
+        final String classLoaderResolveOrder = config.get(CoreOptions.CLASSLOADER_RESOLVE_ORDER);
 
         final String[] alwaysParentFirstLoaderPatterns =
                 CoreOptions.getParentFirstLoaderPatterns(config);
 
         final boolean failOnJvmMetaspaceOomError =
-                config.getBoolean(CoreOptions.FAIL_ON_USER_CLASS_LOADING_METASPACE_OOM);
-        final boolean checkClassLoaderLeak =
-                config.getBoolean(CoreOptions.CHECK_LEAKED_CLASSLOADER);
+                config.get(CoreOptions.FAIL_ON_USER_CLASS_LOADING_METASPACE_OOM);
+        final boolean checkClassLoaderLeak = config.get(CoreOptions.CHECK_LEAKED_CLASSLOADER);
         final BlobLibraryCacheManager libraryCacheManager =
                 new BlobLibraryCacheManager(
                         blobServer,
@@ -167,13 +165,13 @@ public class JobManagerSharedServices {
 
         final int numberCPUCores = Hardware.getNumberCPUCores();
         final int jobManagerFuturePoolSize =
-                config.getInteger(JobManagerOptions.JOB_MANAGER_FUTURE_POOL_SIZE, numberCPUCores);
+                config.get(JobManagerOptions.JOB_MANAGER_FUTURE_POOL_SIZE, numberCPUCores);
         final ScheduledExecutorService futureExecutor =
                 Executors.newScheduledThreadPool(
                         jobManagerFuturePoolSize, new ExecutorThreadFactory("jobmanager-future"));
 
         final int jobManagerIoPoolSize =
-                config.getInteger(JobManagerOptions.JOB_MANAGER_IO_POOL_SIZE, numberCPUCores);
+                config.get(JobManagerOptions.JOB_MANAGER_IO_POOL_SIZE, numberCPUCores);
         final ExecutorService ioExecutor =
                 Executors.newFixedThreadPool(
                         jobManagerIoPoolSize, new ExecutorThreadFactory("jobmanager-io"));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -311,7 +311,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
         this.retrieveTaskManagerHostName =
                 jobMasterConfiguration
                         .getConfiguration()
-                        .getBoolean(JobManagerOptions.RETRIEVE_TASK_MANAGER_HOSTNAME);
+                        .get(JobManagerOptions.RETRIEVE_TASK_MANAGER_HOSTNAME);
 
         final String jobName = jobGraph.getName();
         final JobID jid = jobGraph.getJobID();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterConfiguration.java
@@ -78,7 +78,7 @@ public class JobMasterConfiguration {
                 Time.fromDuration(configuration.get(AkkaOptions.ASK_TIMEOUT_DURATION));
 
         final Time slotRequestTimeout =
-                Time.milliseconds(configuration.getLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
+                Time.milliseconds(configuration.get(JobManagerOptions.SLOT_REQUEST_TIMEOUT));
 
         final String tmpDirectory = ConfigurationUtils.parseTempDirectories(configuration)[0];
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryConfiguration.java
@@ -86,7 +86,7 @@ public class MetricRegistryConfiguration {
 
         char delim;
         try {
-            delim = configuration.getString(MetricOptions.SCOPE_DELIMITER).charAt(0);
+            delim = configuration.get(MetricOptions.SCOPE_DELIMITER).charAt(0);
         } catch (Exception e) {
             LOG.warn("Failed to parse delimiter, using default delimiter.", e);
             delim = '.';

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -190,7 +190,7 @@ public final class ReporterSetup {
 
     public static List<ReporterSetup> fromConfiguration(
             final Configuration configuration, @Nullable final PluginManager pluginManager) {
-        String includedReportersString = configuration.getString(MetricOptions.REPORTERS_LIST, "");
+        String includedReportersString = configuration.get(MetricOptions.REPORTERS_LIST, "");
 
         Set<String> namedReporters =
                 findEnabledTraceReportersInConfiguration(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TraceReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TraceReporterSetup.java
@@ -136,8 +136,7 @@ public final class TraceReporterSetup {
 
     public static List<TraceReporterSetup> fromConfiguration(
             final Configuration configuration, @Nullable final PluginManager pluginManager) {
-        String includedReportersString =
-                configuration.getString(TraceOptions.TRACE_REPORTERS_LIST, "");
+        String includedReportersString = configuration.get(TraceOptions.TRACE_REPORTERS_LIST, "");
 
         Set<String> namedReporters =
                 ReporterSetup.findEnabledTraceReportersInConfiguration(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
@@ -97,13 +97,13 @@ public final class ScopeFormats {
      * @return The ScopeFormats parsed from the configuration
      */
     public static ScopeFormats fromConfig(Configuration config) {
-        String jmFormat = config.getString(MetricOptions.SCOPE_NAMING_JM);
-        String jmJobFormat = config.getString(MetricOptions.SCOPE_NAMING_JM_JOB);
-        String tmFormat = config.getString(MetricOptions.SCOPE_NAMING_TM);
-        String tmJobFormat = config.getString(MetricOptions.SCOPE_NAMING_TM_JOB);
-        String taskFormat = config.getString(MetricOptions.SCOPE_NAMING_TASK);
-        String operatorFormat = config.getString(MetricOptions.SCOPE_NAMING_OPERATOR);
-        String jmOperatorFormat = config.getString(MetricOptions.SCOPE_NAMING_JM_OPERATOR);
+        String jmFormat = config.get(MetricOptions.SCOPE_NAMING_JM);
+        String jmJobFormat = config.get(MetricOptions.SCOPE_NAMING_JM_JOB);
+        String tmFormat = config.get(MetricOptions.SCOPE_NAMING_TM);
+        String tmJobFormat = config.get(MetricOptions.SCOPE_NAMING_TM_JOB);
+        String taskFormat = config.get(MetricOptions.SCOPE_NAMING_TASK);
+        String operatorFormat = config.get(MetricOptions.SCOPE_NAMING_OPERATOR);
+        String jmOperatorFormat = config.get(MetricOptions.SCOPE_NAMING_JM_OPERATOR);
 
         return new ScopeFormats(
                 jmFormat,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -189,7 +189,7 @@ public class MetricUtils {
             @Nullable String bindAddress,
             RpcSystem rpcSystem)
             throws Exception {
-        final String portRange = configuration.getString(MetricOptions.QUERY_SERVICE_PORT);
+        final String portRange = configuration.get(MetricOptions.QUERY_SERVICE_PORT);
 
         final RpcSystem.RpcServiceBuilder rpcServiceBuilder =
                 rpcSystem.remoteServiceBuilder(configuration, externalAddress, portRange);
@@ -208,8 +208,7 @@ public class MetricUtils {
     private static RpcService startMetricRpcService(
             Configuration configuration, RpcSystem.RpcServiceBuilder rpcServiceBuilder)
             throws Exception {
-        final int threadPriority =
-                configuration.getInteger(MetricOptions.QUERY_SERVICE_THREAD_PRIORITY);
+        final int threadPriority = configuration.get(MetricOptions.QUERY_SERVICE_THREAD_PRIORITY);
 
         return rpcServiceBuilder
                 .withComponentName(METRICS_ACTOR_SYSTEM_NAME)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -666,7 +666,7 @@ public class MiniCluster implements AutoCloseableAsync {
                     final long shutdownTimeoutMillis =
                             miniClusterConfiguration
                                     .getConfiguration()
-                                    .getLong(ClusterOptions.CLUSTER_SERVICES_SHUTDOWN_TIMEOUT);
+                                    .get(ClusterOptions.CLUSTER_SERVICES_SHUTDOWN_TIMEOUT);
                     final int numComponents = 2 + miniClusterConfiguration.getNumTaskManagers();
                     final Collection<CompletableFuture<Void>> componentTerminationFutures =
                             new ArrayList<>(numComponents);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -117,33 +117,33 @@ public class MiniClusterConfiguration {
     public String getJobManagerExternalAddress() {
         return commonBindAddress != null
                 ? commonBindAddress
-                : configuration.getString(JobManagerOptions.ADDRESS, "localhost");
+                : configuration.get(JobManagerOptions.ADDRESS, "localhost");
     }
 
     public String getTaskManagerExternalAddress() {
         return commonBindAddress != null
                 ? commonBindAddress
-                : configuration.getString(TaskManagerOptions.HOST, "localhost");
+                : configuration.get(TaskManagerOptions.HOST, "localhost");
     }
 
     public String getJobManagerExternalPortRange() {
-        return String.valueOf(configuration.getInteger(JobManagerOptions.PORT, 0));
+        return String.valueOf(configuration.get(JobManagerOptions.PORT, 0));
     }
 
     public String getTaskManagerExternalPortRange() {
-        return configuration.getString(TaskManagerOptions.RPC_PORT);
+        return configuration.get(TaskManagerOptions.RPC_PORT);
     }
 
     public String getJobManagerBindAddress() {
         return commonBindAddress != null
                 ? commonBindAddress
-                : configuration.getString(JobManagerOptions.BIND_HOST, "localhost");
+                : configuration.get(JobManagerOptions.BIND_HOST, "localhost");
     }
 
     public String getTaskManagerBindAddress() {
         return commonBindAddress != null
                 ? commonBindAddress
-                : configuration.getString(TaskManagerOptions.BIND_HOST, "localhost");
+                : configuration.get(TaskManagerOptions.BIND_HOST, "localhost");
     }
 
     public UnmodifiableConfiguration getConfiguration() {
@@ -230,18 +230,17 @@ public class MiniClusterConfiguration {
 
         public MiniClusterConfiguration build() {
             final Configuration modifiedConfiguration = new Configuration(configuration);
-            modifiedConfiguration.setInteger(
-                    TaskManagerOptions.NUM_TASK_SLOTS, numSlotsPerTaskManager);
-            modifiedConfiguration.setString(
+            modifiedConfiguration.set(TaskManagerOptions.NUM_TASK_SLOTS, numSlotsPerTaskManager);
+            modifiedConfiguration.set(
                     RestOptions.ADDRESS,
-                    modifiedConfiguration.getString(RestOptions.ADDRESS, "localhost"));
+                    modifiedConfiguration.get(RestOptions.ADDRESS, "localhost"));
 
             if (useRandomPorts) {
                 if (!configuration.contains(JobManagerOptions.PORT)) {
                     modifiedConfiguration.set(JobManagerOptions.PORT, 0);
                 }
                 if (!configuration.contains(RestOptions.BIND_PORT)) {
-                    modifiedConfiguration.setString(RestOptions.BIND_PORT, "0");
+                    modifiedConfiguration.set(RestOptions.BIND_PORT, "0");
                 }
             }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SSLUtils.java
@@ -110,8 +110,8 @@ public class SSLUtils {
 
         return new SSLHandlerFactory(
                 sslContext,
-                config.getInteger(SecurityOptions.SSL_INTERNAL_HANDSHAKE_TIMEOUT),
-                config.getInteger(SecurityOptions.SSL_INTERNAL_CLOSE_NOTIFY_FLUSH_TIMEOUT));
+                config.get(SecurityOptions.SSL_INTERNAL_HANDSHAKE_TIMEOUT),
+                config.get(SecurityOptions.SSL_INTERNAL_CLOSE_NOTIFY_FLUSH_TIMEOUT));
     }
 
     /** Creates a SSLEngineFactory to be used by internal communication client endpoints. */
@@ -125,8 +125,8 @@ public class SSLUtils {
 
         return new SSLHandlerFactory(
                 sslContext,
-                config.getInteger(SecurityOptions.SSL_INTERNAL_HANDSHAKE_TIMEOUT),
-                config.getInteger(SecurityOptions.SSL_INTERNAL_CLOSE_NOTIFY_FLUSH_TIMEOUT));
+                config.get(SecurityOptions.SSL_INTERNAL_HANDSHAKE_TIMEOUT),
+                config.get(SecurityOptions.SSL_INTERNAL_CLOSE_NOTIFY_FLUSH_TIMEOUT));
     }
 
     /**
@@ -169,18 +169,18 @@ public class SSLUtils {
 
     private static String[] getEnabledProtocols(final Configuration config) {
         checkNotNull(config, "config must not be null");
-        return config.getString(SecurityOptions.SSL_PROTOCOL).split(",");
+        return config.get(SecurityOptions.SSL_PROTOCOL).split(",");
     }
 
     private static String[] getEnabledCipherSuites(final Configuration config) {
         checkNotNull(config, "config must not be null");
-        return config.getString(SecurityOptions.SSL_ALGORITHMS).split(",");
+        return config.get(SecurityOptions.SSL_ALGORITHMS).split(",");
     }
 
     @VisibleForTesting
     static SslProvider getSSLProvider(final Configuration config) {
         checkNotNull(config, "config must not be null");
-        String providerString = config.getString(SecurityOptions.SSL_PROVIDER);
+        String providerString = config.get(SecurityOptions.SSL_PROVIDER);
         if (providerString.equalsIgnoreCase("OPENSSL")) {
             if (OpenSsl.isAvailable()) {
                 return OPENSSL;
@@ -200,18 +200,18 @@ public class SSLUtils {
             throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException {
 
         String trustStoreFilePath =
-                config.getString(
+                config.get(
                         internal
                                 ? SecurityOptions.SSL_INTERNAL_TRUSTSTORE
                                 : SecurityOptions.SSL_REST_TRUSTSTORE,
-                        config.getString(SecurityOptions.SSL_TRUSTSTORE));
+                        config.get(SecurityOptions.SSL_TRUSTSTORE));
 
         String trustStorePassword =
-                config.getString(
+                config.get(
                         internal
                                 ? SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD
                                 : SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD,
-                        config.getString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD));
+                        config.get(SecurityOptions.SSL_TRUSTSTORE_PASSWORD));
 
         // Support for the REST client connecting to external HTTPS URLs to fall back to the
         // default trust store of the provider (JDK).
@@ -240,7 +240,7 @@ public class SSLUtils {
         }
 
         String certFingerprint =
-                config.getString(
+                config.get(
                         internal
                                 ? SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT
                                 : SecurityOptions.SSL_REST_CERT_FINGERPRINT);
@@ -338,8 +338,8 @@ public class SSLUtils {
 
         String[] sslProtocols = getEnabledProtocols(config);
         List<String> ciphers = Arrays.asList(getEnabledCipherSuites(config));
-        int sessionCacheSize = config.getInteger(SecurityOptions.SSL_INTERNAL_SESSION_CACHE_SIZE);
-        int sessionTimeoutMs = config.getInteger(SecurityOptions.SSL_INTERNAL_SESSION_TIMEOUT);
+        int sessionCacheSize = config.get(SecurityOptions.SSL_INTERNAL_SESSION_CACHE_SIZE);
+        int sessionTimeoutMs = config.get(SecurityOptions.SSL_INTERNAL_SESSION_TIMEOUT);
 
         KeyManagerFactory kmf = getKeyManagerFactory(config, true, provider);
         ClientAuth clientAuth = ClientAuth.REQUIRE;
@@ -441,7 +441,7 @@ public class SSLUtils {
             Configuration config,
             ConfigOption<String> primaryOption,
             ConfigOption<String> fallbackOption) {
-        String value = config.getString(primaryOption, config.getString(fallbackOption));
+        String value = config.get(primaryOption, config.get(fallbackOption));
         if (value != null) {
             return value;
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractCachedBuildSideJoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/AbstractCachedBuildSideJoinDriver.java
@@ -93,7 +93,7 @@ public abstract class AbstractCachedBuildSideJoinDriver<IT1, IT2, OT>
                 taskContext
                         .getTaskManagerInfo()
                         .getConfiguration()
-                        .getBoolean(AlgorithmOptions.HASH_JOIN_BLOOM_FILTERS);
+                        .get(AlgorithmOptions.HASH_JOIN_BLOOM_FILTERS);
 
         ExecutionConfig executionConfig = taskContext.getExecutionConfig();
         objectReuseEnabled = executionConfig.isObjectReuseEnabled();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/JoinDriver.java
@@ -139,7 +139,7 @@ public class JoinDriver<IT1, IT2, OT> implements Driver<FlatJoinFunction<IT1, IT
                 taskContext
                         .getTaskManagerInfo()
                         .getConfiguration()
-                        .getBoolean(AlgorithmOptions.HASH_JOIN_BLOOM_FILTERS);
+                        .get(AlgorithmOptions.HASH_JOIN_BLOOM_FILTERS);
 
         // create and return joining iterator according to provided local strategy.
         if (objectReuseEnabled) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistrationConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistrationConfiguration.java
@@ -74,11 +74,11 @@ public class RetryingRegistrationConfiguration {
     public static RetryingRegistrationConfiguration fromConfiguration(
             final Configuration configuration) {
         long initialRegistrationTimeoutMillis =
-                configuration.getLong(ClusterOptions.INITIAL_REGISTRATION_TIMEOUT);
+                configuration.get(ClusterOptions.INITIAL_REGISTRATION_TIMEOUT);
         long maxRegistrationTimeoutMillis =
-                configuration.getLong(ClusterOptions.MAX_REGISTRATION_TIMEOUT);
-        long errorDelayMillis = configuration.getLong(ClusterOptions.ERROR_REGISTRATION_DELAY);
-        long refusedDelayMillis = configuration.getLong(ClusterOptions.REFUSED_REGISTRATION_DELAY);
+                configuration.get(ClusterOptions.MAX_REGISTRATION_TIMEOUT);
+        long errorDelayMillis = configuration.get(ClusterOptions.ERROR_REGISTRATION_DELAY);
+        long refusedDelayMillis = configuration.get(ClusterOptions.REFUSED_REGISTRATION_DELAY);
 
         return new RetryingRegistrationConfiguration(
                 initialRegistrationTimeoutMillis,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServicesConfiguration.java
@@ -53,7 +53,7 @@ public class ResourceManagerRuntimeServicesConfiguration {
             Configuration configuration, WorkerResourceSpecFactory defaultWorkerResourceSpecFactory)
             throws ConfigurationException {
 
-        final String strJobTimeout = configuration.getString(ResourceManagerOptions.JOB_TIMEOUT);
+        final String strJobTimeout = configuration.get(ResourceManagerOptions.JOB_TIMEOUT);
         final Time jobTimeout;
 
         try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -136,7 +136,7 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
             throws Exception;
 
     public static ThresholdMeter createStartWorkerFailureRater(Configuration configuration) {
-        double rate = configuration.getDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE);
+        double rate = configuration.get(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE);
         if (rate <= 0) {
             throw new IllegalConfigurationException(
                     String.format(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -248,8 +248,7 @@ public class SlotManagerConfiguration {
                 Time.fromDuration(configuration.get(AkkaOptions.ASK_TIMEOUT_DURATION));
 
         final Time taskManagerTimeout =
-                Time.milliseconds(
-                        configuration.getLong(ResourceManagerOptions.TASK_MANAGER_TIMEOUT));
+                Time.milliseconds(configuration.get(ResourceManagerOptions.TASK_MANAGER_TIMEOUT));
 
         final Duration requirementCheckDelay =
                 configuration.get(ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY);
@@ -258,8 +257,7 @@ public class SlotManagerConfiguration {
                 configuration.get(ResourceManagerOptions.DECLARE_NEEDED_RESOURCE_DELAY);
 
         boolean waitResultConsumedBeforeRelease =
-                configuration.getBoolean(
-                        ResourceManagerOptions.TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED);
+                configuration.get(ResourceManagerOptions.TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED);
 
         TaskManagerLoadBalanceMode taskManagerLoadBalanceMode =
                 TaskManagerLoadBalanceMode.loadFromConfiguration(configuration);
@@ -268,13 +266,13 @@ public class SlotManagerConfiguration {
                         ? LeastUtilizationSlotMatchingStrategy.INSTANCE
                         : AnyMatchingSlotMatchingStrategy.INSTANCE;
 
-        int numSlotsPerWorker = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
+        int numSlotsPerWorker = configuration.get(TaskManagerOptions.NUM_TASK_SLOTS);
 
-        int minSlotNum = configuration.getInteger(ResourceManagerOptions.MIN_SLOT_NUM);
-        int maxSlotNum = configuration.getInteger(ResourceManagerOptions.MAX_SLOT_NUM);
+        int minSlotNum = configuration.get(ResourceManagerOptions.MIN_SLOT_NUM);
+        int maxSlotNum = configuration.get(ResourceManagerOptions.MAX_SLOT_NUM);
 
         int redundantTaskManagerNum =
-                configuration.getInteger(ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM);
+                configuration.get(ResourceManagerOptions.REDUNDANT_TASK_MANAGER_NUM);
 
         return new SlotManagerConfiguration(
                 rpcTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -154,7 +154,7 @@ public class RestClient implements AutoCloseableAsync {
         Preconditions.checkNotNull(rootUrl);
         if ("https".equals(rootUrl.getProtocol())) {
             configuration = configuration.clone();
-            configuration.setBoolean(SSL_REST_ENABLED, true);
+            configuration.set(SSL_REST_ENABLED, true);
         }
         return new RestClient(configuration, executor, rootUrl.getHost(), rootUrl.getPort());
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClientConfiguration.java
@@ -111,11 +111,11 @@ public final class RestClientConfiguration {
             sslHandlerFactory = null;
         }
 
-        final long connectionTimeout = config.getLong(RestOptions.CONNECTION_TIMEOUT);
+        final long connectionTimeout = config.get(RestOptions.CONNECTION_TIMEOUT);
 
-        final long idlenessTimeout = config.getLong(RestOptions.IDLENESS_TIMEOUT);
+        final long idlenessTimeout = config.get(RestOptions.IDLENESS_TIMEOUT);
 
-        int maxContentLength = config.getInteger(RestOptions.CLIENT_MAX_CONTENT_LENGTH);
+        int maxContentLength = config.get(RestOptions.CLIENT_MAX_CONTENT_LENGTH);
 
         return new RestClientConfiguration(
                 sslHandlerFactory, connectionTimeout, idlenessTimeout, maxContentLength);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestServerEndpointConfiguration.java
@@ -146,12 +146,12 @@ public final class RestServerEndpointConfiguration {
 
         final String restAddress =
                 Preconditions.checkNotNull(
-                        config.getString(RestOptions.ADDRESS),
+                        config.get(RestOptions.ADDRESS),
                         "%s must be set",
                         RestOptions.ADDRESS.key());
 
-        final String restBindAddress = config.getString(RestOptions.BIND_ADDRESS);
-        final String portRangeDefinition = config.getString(RestOptions.BIND_PORT);
+        final String restBindAddress = config.get(RestOptions.BIND_ADDRESS);
+        final String portRangeDefinition = config.get(RestOptions.BIND_PORT);
 
         final SSLHandlerFactory sslHandlerFactory;
         if (SecurityOptions.isRestSSLEnabled(config)) {
@@ -167,16 +167,15 @@ public final class RestServerEndpointConfiguration {
 
         final Path uploadDir =
                 Paths.get(
-                        config.getString(
-                                WebOptions.UPLOAD_DIR, config.getString(WebOptions.TMP_DIR)),
+                        config.get(WebOptions.UPLOAD_DIR, config.get(WebOptions.TMP_DIR)),
                         "flink-web-upload");
 
-        final int maxContentLength = config.getInteger(RestOptions.SERVER_MAX_CONTENT_LENGTH);
+        final int maxContentLength = config.get(RestOptions.SERVER_MAX_CONTENT_LENGTH);
 
         final Map<String, String> responseHeaders =
                 Collections.singletonMap(
                         HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(),
-                        config.getString(WebOptions.ACCESS_CONTROL_ALLOW_ORIGIN));
+                        config.get(WebOptions.ACCESS_CONTROL_ALLOW_ORIGIN));
 
         return new RestServerEndpointConfiguration(
                 restAddress,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/RestHandlerConfiguration.java
@@ -111,10 +111,9 @@ public class RestHandlerConfiguration {
     }
 
     public static RestHandlerConfiguration fromConfiguration(Configuration configuration) {
-        final long refreshInterval = configuration.getLong(WebOptions.REFRESH_INTERVAL);
+        final long refreshInterval = configuration.get(WebOptions.REFRESH_INTERVAL);
 
-        final int checkpointHistorySize =
-                configuration.getInteger(WebOptions.CHECKPOINTS_HISTORY_SIZE);
+        final int checkpointHistorySize = configuration.get(WebOptions.CHECKPOINTS_HISTORY_SIZE);
         final Duration checkpointStatsSnapshotCacheExpireAfterWrite =
                 configuration
                         .getOptional(RestOptions.CACHE_CHECKPOINT_STATISTICS_TIMEOUT)
@@ -122,18 +121,18 @@ public class RestHandlerConfiguration {
         final int checkpointStatsSnapshotCacheSize =
                 configuration.get(RestOptions.CACHE_CHECKPOINT_STATISTICS_SIZE);
 
-        final Time timeout = Time.milliseconds(configuration.getLong(WebOptions.TIMEOUT));
+        final Time timeout = Time.milliseconds(configuration.get(WebOptions.TIMEOUT));
 
         final String rootDir = "flink-web-ui";
-        final File webUiDir = new File(configuration.getString(WebOptions.TMP_DIR), rootDir);
+        final File webUiDir = new File(configuration.get(WebOptions.TMP_DIR), rootDir);
 
-        final boolean webSubmitEnabled = configuration.getBoolean(WebOptions.SUBMIT_ENABLE);
-        final boolean webCancelEnabled = configuration.getBoolean(WebOptions.CANCEL_ENABLE);
+        final boolean webSubmitEnabled = configuration.get(WebOptions.SUBMIT_ENABLE);
+        final boolean webCancelEnabled = configuration.get(WebOptions.CANCEL_ENABLE);
         final boolean webRescaleSupported =
                 ClusterOptions.isAdaptiveSchedulerEnabled(configuration)
                         && !ClusterOptions.isReactiveModeEnabled(configuration);
         final boolean webRescaleEnabled =
-                webRescaleSupported && configuration.getBoolean(WebOptions.RESCALE_ENABLE);
+                webRescaleSupported && configuration.get(WebOptions.RESCALE_ENABLE);
 
         return new RestHandlerConfiguration(
                 refreshInterval,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerProfilingFileHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/cluster/JobManagerProfilingFileHandler.java
@@ -47,7 +47,7 @@ public class JobManagerProfilingFileHandler
             Configuration configs) {
         super(leaderRetriever, timeout, responseHeaders, messageHeaders);
 
-        this.profilingResultDir = configs.getString(RestOptions.PROFILING_RESULT_DIR);
+        this.profilingResultDir = configs.get(RestOptions.PROFILING_RESULT_DIR);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherImpl.java
@@ -270,9 +270,8 @@ public class MetricFetcherImpl<T extends RestfulGateway> implements MetricFetche
             final MetricQueryServiceRetriever metricQueryServiceGatewayRetriever,
             final GatewayRetriever<T> dispatcherGatewayRetriever,
             final ExecutorService executor) {
-        final Time timeout = Time.milliseconds(configuration.getLong(WebOptions.TIMEOUT));
-        final long updateInterval =
-                configuration.getLong(MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL);
+        final Time timeout = Time.milliseconds(configuration.get(WebOptions.TIMEOUT));
+        final long updateInterval = configuration.get(MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL);
 
         return new MetricFetcherImpl<>(
                 dispatcherGatewayRetriever,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -128,8 +128,7 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
                 new CachingSupplier<>(
                         () ->
                                 new CheckpointStatsTracker(
-                                        configuration.getInteger(
-                                                WebOptions.CHECKPOINTS_HISTORY_SIZE),
+                                        configuration.get(WebOptions.CHECKPOINTS_HISTORY_SIZE),
                                         jobManagerJobMetricGroup));
         this.isDynamicGraph = isDynamicGraph;
         this.executionJobVertexFactory = checkNotNull(executionJobVertexFactory);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultSchedulerFactory.java
@@ -126,8 +126,7 @@ public class DefaultSchedulerFactory implements SchedulerNGFactory {
 
         final CheckpointsCleaner checkpointsCleaner =
                 new CheckpointsCleaner(
-                        jobMasterConfiguration.getBoolean(
-                                CheckpointingOptions.CLEANER_PARALLEL_MODE));
+                        jobMasterConfiguration.get(CheckpointingOptions.CLEANER_PARALLEL_MODE));
 
         return new DefaultScheduler(
                 log,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -244,7 +244,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
 
         this.exceptionHistory =
                 new BoundedFIFOQueue<>(
-                        jobMasterConfiguration.getInteger(WebOptions.MAX_EXCEPTION_HISTORY_SIZE));
+                        jobMasterConfiguration.get(WebOptions.MAX_EXCEPTION_HISTORY_SIZE));
 
         this.vertexEndOfDataListener = new VertexEndOfDataListener(executionGraph);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -334,8 +334,7 @@ public class AdaptiveScheduler
         jobStatusListeners = Collections.unmodifiableCollection(tmpJobStatusListeners);
         this.failureEnrichers = failureEnrichers;
         this.exceptionHistory =
-                new BoundedFIFOQueue<>(
-                        configuration.getInteger(WebOptions.MAX_EXCEPTION_HISTORY_SIZE));
+                new BoundedFIFOQueue<>(configuration.get(WebOptions.MAX_EXCEPTION_HISTORY_SIZE));
         this.jobManagerJobMetricGroup = jobManagerJobMetricGroup;
         this.slotIdleTimeout =
                 Duration.ofMillis(configuration.get(JobManagerOptions.SLOT_IDLE_TIMEOUT));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -132,7 +132,7 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
                                                 "The AdaptiveBatchScheduler requires a SlotPool."));
 
         final boolean enableSpeculativeExecution =
-                jobMasterConfiguration.getBoolean(BatchExecutionOptions.SPECULATIVE_ENABLED);
+                jobMasterConfiguration.get(BatchExecutionOptions.SPECULATIVE_ENABLED);
 
         final HybridPartitionDataConsumeConstraint hybridPartitionDataConsumeConstraint =
                 getOrDecideHybridPartitionDataConsumeConstraint(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDecider.java
@@ -541,8 +541,7 @@ public class DefaultVertexParallelismAndInputInfosDecider
             int maxParallelism, Configuration configuration) {
         return new DefaultVertexParallelismAndInputInfosDecider(
                 maxParallelism,
-                configuration.getInteger(
-                        BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MIN_PARALLELISM),
+                configuration.get(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MIN_PARALLELISM),
                 configuration.get(
                         BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_AVG_DATA_VOLUME_PER_TASK),
                 configuration.get(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
@@ -162,7 +162,7 @@ public class SpeculativeScheduler extends AdaptiveBatchScheduler
                 forwardGroupsByJobVertexId);
 
         this.maxConcurrentExecutions =
-                jobMasterConfiguration.getInteger(
+                jobMasterConfiguration.get(
                         BatchExecutionOptions.SPECULATIVE_MAX_CONCURRENT_EXECUTIONS);
 
         this.blockSlowNodeDuration =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/slowtaskdetector/ExecutionTimeBasedSlowTaskDetector.java
@@ -86,7 +86,7 @@ public class ExecutionTimeBasedSlowTaskDetector implements SlowTaskDetector {
                 this.baselineLowerBoundMillis);
 
         this.baselineRatio =
-                configuration.getDouble(SlowTaskDetectorOptions.EXECUTION_TIME_BASELINE_RATIO);
+                configuration.get(SlowTaskDetectorOptions.EXECUTION_TIME_BASELINE_RATIO);
         checkArgument(
                 baselineRatio >= 0 && this.baselineRatio < 1,
                 "The configuration {} should be in [0, 1), but is {}.",
@@ -94,7 +94,7 @@ public class ExecutionTimeBasedSlowTaskDetector implements SlowTaskDetector {
                 this.baselineRatio);
 
         this.baselineMultiplier =
-                configuration.getDouble(SlowTaskDetectorOptions.EXECUTION_TIME_BASELINE_MULTIPLIER);
+                configuration.get(SlowTaskDetectorOptions.EXECUTION_TIME_BASELINE_MULTIPLIER);
         checkArgument(
                 baselineMultiplier > 0,
                 "The configuration {} should be positive, but is {}.",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityConfiguration.java
@@ -90,16 +90,14 @@ public class SecurityConfiguration {
             List<String> securityContextFactory,
             List<String> securityModuleFactories) {
         this.flinkConfig = checkNotNull(flinkConf);
-        this.isZkSaslDisable = flinkConf.getBoolean(SecurityOptions.ZOOKEEPER_SASL_DISABLE);
-        this.keytab = flinkConf.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB);
-        this.principal = flinkConf.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL);
-        this.useTicketCache = flinkConf.getBoolean(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE);
+        this.isZkSaslDisable = flinkConf.get(SecurityOptions.ZOOKEEPER_SASL_DISABLE);
+        this.keytab = flinkConf.get(SecurityOptions.KERBEROS_LOGIN_KEYTAB);
+        this.principal = flinkConf.get(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL);
+        this.useTicketCache = flinkConf.get(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE);
         this.tgtRenewalPeriod = flinkConf.get(KERBEROS_RELOGIN_PERIOD);
-        this.loginContextNames =
-                parseList(flinkConf.getString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS));
-        this.zkServiceName = flinkConf.getString(SecurityOptions.ZOOKEEPER_SASL_SERVICE_NAME);
-        this.zkLoginContextName =
-                flinkConf.getString(SecurityOptions.ZOOKEEPER_SASL_LOGIN_CONTEXT_NAME);
+        this.loginContextNames = parseList(flinkConf.get(SecurityOptions.KERBEROS_LOGIN_CONTEXTS));
+        this.zkServiceName = flinkConf.get(SecurityOptions.ZOOKEEPER_SASL_SERVICE_NAME);
+        this.zkLoginContextName = flinkConf.get(SecurityOptions.ZOOKEEPER_SASL_LOGIN_CONTEXT_NAME);
         this.securityModuleFactories = Collections.unmodifiableList(securityModuleFactories);
         this.securityContextFactory = securityContextFactory;
         validate();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -78,7 +78,7 @@ public class HadoopModule implements SecurityModule {
                 if (HadoopUserUtils.isProxyUser((loginUser))
                         && securityConfig
                                 .getFlinkConfig()
-                                .getBoolean(SecurityOptions.DELEGATION_TOKENS_ENABLED)) {
+                                .get(SecurityOptions.DELEGATION_TOKENS_ENABLED)) {
                     throw new UnsupportedOperationException(
                             "Hadoop Proxy user is supported only when"
                                     + " delegation tokens fetch is managed outside of Flink!"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/JaasModule.java
@@ -76,7 +76,7 @@ public class JaasModule implements SecurityModule {
 
     public JaasModule(SecurityConfiguration securityConfig) {
         this.securityConfig = checkNotNull(securityConfig);
-        String[] dirs = splitPaths(securityConfig.getFlinkConfig().getString(CoreOptions.TMP_DIRS));
+        String[] dirs = splitPaths(securityConfig.getFlinkConfig().get(CoreOptions.TMP_DIRS));
         // should be at least one directory.
         checkState(dirs.length > 0);
         this.workingDir = dirs[0];

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java
@@ -169,7 +169,7 @@ public class DefaultDelegationTokenManager implements DelegationTokenManager {
 
     static boolean isProviderEnabled(Configuration configuration, String serviceName) {
         return SecurityOptions.forProvider(configuration, serviceName)
-                .getBoolean(DELEGATION_TOKEN_PROVIDER_ENABLED);
+                .get(DELEGATION_TOKEN_PROVIDER_ENABLED);
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerFactory.java
@@ -46,7 +46,7 @@ public class DefaultDelegationTokenManagerFactory {
             @Nullable ExecutorService ioExecutor)
             throws IOException {
 
-        if (configuration.getBoolean(SecurityOptions.DELEGATION_TOKENS_ENABLED)) {
+        if (configuration.get(SecurityOptions.DELEGATION_TOKENS_ENABLED)) {
             return new DefaultDelegationTokenManager(
                     configuration, pluginManager, scheduledExecutor, ioExecutor);
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenProvider.java
@@ -172,10 +172,7 @@ public class HadoopFSDelegationTokenProvider implements DelegationTokenProvider 
                         });
 
         // YARN staging dir
-        if (flinkConfiguration
-                .getString(DeploymentOptions.TARGET, "")
-                .toLowerCase()
-                .contains("yarn")) {
+        if (flinkConfiguration.get(DeploymentOptions.TARGET, "").toLowerCase().contains("yarn")) {
             LOG.debug("Running on YARN, trying to add staging directory to file systems to access");
             String yarnStagingDirectory =
                     flinkConfiguration.getString("yarn.staging-directory", "");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -61,17 +61,16 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
     public NettyShuffleMaster(Configuration conf) {
         checkNotNull(conf);
         buffersPerInputChannel =
-                conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL);
+                conf.get(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL);
         floatingBuffersPerGate =
-                conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE);
+                conf.get(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE);
         maxRequiredBuffersPerGate =
                 conf.getOptional(
                         NettyShuffleEnvironmentOptions.NETWORK_READ_MAX_REQUIRED_BUFFERS_PER_GATE);
         sortShuffleMinParallelism =
-                conf.getInteger(
-                        NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM);
+                conf.get(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM);
         sortShuffleMinBuffers =
-                conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS);
+                conf.get(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS);
         networkBufferSize = ConfigurationParserUtils.getPageSize(conf);
 
         if (isHybridShuffleNewModeEnabled(conf)) {
@@ -164,6 +163,6 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
     private boolean isHybridShuffleNewModeEnabled(Configuration conf) {
         return (conf.get(BATCH_SHUFFLE_MODE) == ALL_EXCHANGES_HYBRID_FULL
                         || conf.get(BATCH_SHUFFLE_MODE) == ALL_EXCHANGES_HYBRID_SELECTIVE)
-                && conf.getBoolean(NETWORK_HYBRID_SHUFFLE_ENABLE_NEW_MODE);
+                && conf.get(NETWORK_HYBRID_SHUFFLE_ENABLE_NEW_MODE);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoader.java
@@ -30,7 +30,7 @@ public enum ShuffleServiceLoader {
 
     public static ShuffleServiceFactory<?, ?, ?> loadShuffleServiceFactory(
             Configuration configuration) throws FlinkException {
-        String shuffleServiceClassName = configuration.getString(SHUFFLE_SERVICE_FACTORY_CLASS);
+        String shuffleServiceClassName = configuration.get(SHUFFLE_SERVICE_FACTORY_CLASS);
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         return InstantiationUtil.instantiate(
                 shuffleServiceClassName, ShuffleServiceFactory.class, classLoader);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
@@ -172,7 +172,7 @@ public class TaskExecutorLocalStateStoresManager {
                         jobConfiguration
                                 .getOptional(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)
                                 .orElse(
-                                        clusterConfiguration.getBoolean(
+                                        clusterConfiguration.get(
                                                 StateChangelogOptions.ENABLE_STATE_CHANGE_LOG));
 
                 if (localRecoveryConfig.isLocalRecoveryEnabled() && changelogEnabled) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageLoader.java
@@ -94,9 +94,7 @@ public class StateChangelogStorageLoader {
             LocalRecoveryConfig localRecoveryConfig)
             throws IOException {
         final String identifier =
-                configuration
-                        .getString(StateChangelogOptions.STATE_CHANGE_LOG_STORAGE)
-                        .toLowerCase();
+                configuration.get(StateChangelogOptions.STATE_CHANGE_LOG_STORAGE).toLowerCase();
 
         StateChangelogStorageFactory factory = STATE_CHANGELOG_STORAGE_FACTORIES.get(identifier);
         if (factory == null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/QueryableStateConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/QueryableStateConfiguration.java
@@ -152,26 +152,25 @@ public class QueryableStateConfiguration {
 
     /** Creates the {@link QueryableStateConfiguration} from the given Configuration. */
     public static QueryableStateConfiguration fromConfiguration(Configuration config) {
-        if (!config.getBoolean(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER)) {
+        if (!config.get(QueryableStateOptions.ENABLE_QUERYABLE_STATE_PROXY_SERVER)) {
             return null;
         }
 
         final Iterator<Integer> proxyPorts =
-                NetUtils.getPortRangeFromString(
-                        config.getString(QueryableStateOptions.PROXY_PORT_RANGE));
+                NetUtils.getPortRangeFromString(config.get(QueryableStateOptions.PROXY_PORT_RANGE));
         final Iterator<Integer> serverPorts =
                 NetUtils.getPortRangeFromString(
-                        config.getString(QueryableStateOptions.SERVER_PORT_RANGE));
+                        config.get(QueryableStateOptions.SERVER_PORT_RANGE));
 
         final int numProxyServerNetworkThreads =
-                config.getInteger(QueryableStateOptions.PROXY_NETWORK_THREADS);
+                config.get(QueryableStateOptions.PROXY_NETWORK_THREADS);
         final int numProxyServerQueryThreads =
-                config.getInteger(QueryableStateOptions.PROXY_ASYNC_QUERY_THREADS);
+                config.get(QueryableStateOptions.PROXY_ASYNC_QUERY_THREADS);
 
         final int numStateServerNetworkThreads =
-                config.getInteger(QueryableStateOptions.SERVER_NETWORK_THREADS);
+                config.get(QueryableStateOptions.SERVER_NETWORK_THREADS);
         final int numStateServerQueryThreads =
-                config.getInteger(QueryableStateOptions.SERVER_ASYNC_QUERY_THREADS);
+                config.get(QueryableStateOptions.SERVER_ASYNC_QUERY_THREADS);
 
         return new QueryableStateConfiguration(
                 proxyPorts,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
@@ -76,7 +76,7 @@ public class TaskExecutorResourceUtils {
             throw new IllegalConfigurationException("Failed to create TaskExecutorResourceSpec", e);
         }
         return new TaskExecutorResourceSpec(
-                new CPUResource(config.getDouble(TaskManagerOptions.CPU_CORES)),
+                new CPUResource(config.get(TaskManagerOptions.CPU_CORES)),
                 config.get(TaskManagerOptions.TASK_HEAP_MEMORY),
                 config.get(TaskManagerOptions.TASK_OFF_HEAP_MEMORY),
                 config.get(TaskManagerOptions.NETWORK_MEMORY_MIN),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -185,7 +185,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
             TaskExecutorResourceSpec taskExecutorResourceSpec,
             String externalAddress,
             File tmpWorkingDirectory) {
-        int numberSlots = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
+        int numberSlots = configuration.get(TaskManagerOptions.NUM_TASK_SLOTS, 1);
 
         if (numberSlots == -1) {
             numberSlots = 1;
@@ -209,8 +209,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
             finiteRegistrationDuration = null;
         }
 
-        final boolean exitOnOom =
-                configuration.getBoolean(TaskManagerOptions.KILL_ON_OUT_OF_MEMORY);
+        final boolean exitOnOom = configuration.get(TaskManagerOptions.KILL_ON_OUT_OF_MEMORY);
 
         final String taskManagerLogPath =
                 configuration.get(TaskManagerOptions.TASK_MANAGER_LOG_PATH);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -200,7 +200,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
                             rpcSystem,
                             this);
 
-            JMXService.startInstance(configuration.getString(JMXServerOptions.JMX_SERVER_PORT));
+            JMXService.startInstance(configuration.get(JMXServerOptions.JMX_SERVER_PORT));
 
             rpcService = createRpcService(configuration, highAvailabilityServices, rpcSystem);
 
@@ -229,7 +229,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
                     MetricUtils.startRemoteMetricsRpcService(
                             configuration,
                             rpcService.getAddress(),
-                            configuration.getString(TaskManagerOptions.BIND_HOST),
+                            configuration.get(TaskManagerOptions.BIND_HOST),
                             rpcSystem);
             metricRegistry.startQueryService(metricQueryServiceRpcService, resourceId.unwrap());
 
@@ -695,8 +695,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                 rpcSystem,
                 configuration,
                 determineTaskManagerBindAddress(configuration, haServices, rpcSystem),
-                configuration.getString(TaskManagerOptions.RPC_PORT),
-                configuration.getString(TaskManagerOptions.BIND_HOST),
+                configuration.get(TaskManagerOptions.RPC_PORT),
+                configuration.get(TaskManagerOptions.BIND_HOST),
                 configuration.getOptional(TaskManagerOptions.RPC_BIND_PORT));
     }
 
@@ -706,8 +706,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
             RpcSystemUtils rpcSystemUtils)
             throws Exception {
 
-        final String configuredTaskManagerHostname =
-                configuration.getString(TaskManagerOptions.HOST);
+        final String configuredTaskManagerHostname = configuration.get(TaskManagerOptions.HOST);
 
         if (configuredTaskManagerHostname != null) {
             LOG.info(
@@ -740,8 +739,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
                 taskManagerAddress.getHostAddress());
 
         HostBindPolicy bindPolicy =
-                HostBindPolicy.fromString(
-                        configuration.getString(TaskManagerOptions.HOST_BIND_POLICY));
+                HostBindPolicy.fromString(configuration.get(TaskManagerOptions.HOST_BIND_POLICY));
         return bindPolicy == HostBindPolicy.IP
                 ? taskManagerAddress.getHostAddress()
                 : taskManagerAddress.getHostName();
@@ -752,7 +750,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
             Configuration config, String rpcAddress, int rpcPort) {
 
         final String metadata =
-                config.getString(TaskManagerOptionsInternal.TASK_MANAGER_RESOURCE_ID_METADATA, "");
+                config.get(TaskManagerOptionsInternal.TASK_MANAGER_RESOURCE_ID_METADATA, "");
         return config.getOptional(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID)
                 .map(
                         value ->

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -404,11 +404,11 @@ public class TaskManagerServices {
         final boolean failOnJvmMetaspaceOomError =
                 taskManagerServicesConfiguration
                         .getConfiguration()
-                        .getBoolean(CoreOptions.FAIL_ON_USER_CLASS_LOADING_METASPACE_OOM);
+                        .get(CoreOptions.FAIL_ON_USER_CLASS_LOADING_METASPACE_OOM);
         final boolean checkClassLoaderLeak =
                 taskManagerServicesConfiguration
                         .getConfiguration()
-                        .getBoolean(CoreOptions.CHECK_LEAKED_CLASSLOADER);
+                        .get(CoreOptions.CHECK_LEAKED_CLASSLOADER);
         final LibraryCacheManager libraryCacheManager =
                 new BlobLibraryCacheManager(
                         permanentBlobService,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -283,7 +283,7 @@ public class TaskManagerServicesConfiguration {
             localStateDirs = Reference.owned(createdLocalStateDirs);
         }
 
-        boolean localRecoveryMode = configuration.getBoolean(CheckpointingOptions.LOCAL_RECOVERY);
+        boolean localRecoveryMode = configuration.get(CheckpointingOptions.LOCAL_RECOVERY);
 
         final QueryableStateConfiguration queryableStateConfig =
                 QueryableStateConfiguration.fromConfiguration(configuration);
@@ -294,16 +294,14 @@ public class TaskManagerServicesConfiguration {
         final RetryingRegistrationConfiguration retryingRegistrationConfiguration =
                 RetryingRegistrationConfiguration.fromConfiguration(configuration);
 
-        final int externalDataPort =
-                configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_PORT);
+        final int externalDataPort = configuration.get(NettyShuffleEnvironmentOptions.DATA_PORT);
 
         String bindAddr =
-                configuration.getString(
-                        TaskManagerOptions.BIND_HOST, NetUtils.getWildcardIPAddress());
+                configuration.get(TaskManagerOptions.BIND_HOST, NetUtils.getWildcardIPAddress());
         InetAddress bindAddress = InetAddress.getByName(bindAddr);
 
         final String classLoaderResolveOrder =
-                configuration.getString(CoreOptions.CLASSLOADER_RESOLVE_ORDER);
+                configuration.get(CoreOptions.CLASSLOADER_RESOLVE_ORDER);
 
         final String[] alwaysParentFirstLoaderPatterns =
                 CoreOptions.getParentFirstLoaderPatterns(configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MemoryLogger.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/MemoryLogger.java
@@ -66,16 +66,14 @@ public class MemoryLogger extends Thread {
             Logger logger,
             Configuration configuration,
             CompletableFuture<Void> taskManagerTerminationFuture) {
-        if (!logger.isInfoEnabled()
-                || !configuration.getBoolean(TaskManagerOptions.DEBUG_MEMORY_LOG)) {
+        if (!logger.isInfoEnabled() || !configuration.get(TaskManagerOptions.DEBUG_MEMORY_LOG)) {
             return;
         }
         logger.info("Starting periodic memory usage logger");
 
         new MemoryLogger(
                         logger,
-                        configuration.getLong(
-                                TaskManagerOptions.DEBUG_MEMORY_USAGE_LOG_INTERVAL_MS),
+                        configuration.get(TaskManagerOptions.DEBUG_MEMORY_USAGE_LOG_INTERVAL_MS),
                         taskManagerTerminationFuture)
                 .start();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -320,11 +320,9 @@ public class NettyShuffleEnvironmentConfiguration {
                 calculateNumberOfNetworkBuffers(configuration, networkMemorySize, pageSize);
 
         int initialRequestBackoff =
-                configuration.getInteger(
-                        NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL);
+                configuration.get(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL);
         int maxRequestBackoff =
-                configuration.getInteger(
-                        NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX);
+                configuration.get(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX);
         int listenerTimeout =
                 (int)
                         configuration
@@ -334,36 +332,32 @@ public class NettyShuffleEnvironmentConfiguration {
                                 .toMillis();
 
         int buffersPerChannel =
-                configuration.getInteger(
-                        NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL);
+                configuration.get(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL);
         int extraBuffersPerGate =
-                configuration.getInteger(
-                        NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE);
+                configuration.get(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE);
 
         Optional<Integer> maxRequiredBuffersPerGate =
                 configuration.getOptional(
                         NettyShuffleEnvironmentOptions.NETWORK_READ_MAX_REQUIRED_BUFFERS_PER_GATE);
 
         int maxBuffersPerChannel =
-                configuration.getInteger(
-                        NettyShuffleEnvironmentOptions.NETWORK_MAX_BUFFERS_PER_CHANNEL);
+                configuration.get(NettyShuffleEnvironmentOptions.NETWORK_MAX_BUFFERS_PER_CHANNEL);
 
         int maxOverdraftBuffersPerGate =
-                configuration.getInteger(
+                configuration.get(
                         NettyShuffleEnvironmentOptions.NETWORK_MAX_OVERDRAFT_BUFFERS_PER_GATE);
 
         long batchShuffleReadMemoryBytes =
                 configuration.get(TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY).getBytes();
 
         int sortShuffleMinBuffers =
-                configuration.getInteger(
-                        NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS);
+                configuration.get(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS);
         int sortShuffleMinParallelism =
-                configuration.getInteger(
+                configuration.get(
                         NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM);
 
         boolean isNetworkDetailedMetrics =
-                configuration.getBoolean(NettyShuffleEnvironmentOptions.NETWORK_DETAILED_METRICS);
+                configuration.get(NettyShuffleEnvironmentOptions.NETWORK_DETAILED_METRICS);
 
         String[] tempDirs = ConfigurationUtils.parseTempDirectories(configuration);
         // Shuffle the data directories to make it fairer for directory selection between different
@@ -373,7 +367,7 @@ public class NettyShuffleEnvironmentConfiguration {
 
         Duration requestSegmentsTimeout =
                 Duration.ofMillis(
-                        configuration.getLong(
+                        configuration.get(
                                 NettyShuffleEnvironmentOptions
                                         .NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS));
 
@@ -383,13 +377,12 @@ public class NettyShuffleEnvironmentConfiguration {
         boolean batchShuffleCompressionEnabled =
                 configuration.get(NettyShuffleEnvironmentOptions.BATCH_SHUFFLE_COMPRESSION_ENABLED);
         String compressionCodec =
-                configuration.getString(NettyShuffleEnvironmentOptions.SHUFFLE_COMPRESSION_CODEC);
+                configuration.get(NettyShuffleEnvironmentOptions.SHUFFLE_COMPRESSION_CODEC);
 
         int maxNumConnections =
                 Math.max(
                         1,
-                        configuration.getInteger(
-                                NettyShuffleEnvironmentOptions.MAX_NUM_TCP_CONNECTIONS));
+                        configuration.get(NettyShuffleEnvironmentOptions.MAX_NUM_TCP_CONNECTIONS));
 
         boolean connectionReuseEnabled =
                 configuration.get(
@@ -421,11 +414,11 @@ public class NettyShuffleEnvironmentConfiguration {
         TieredStorageConfiguration tieredStorageConfiguration = null;
         if ((configuration.get(BATCH_SHUFFLE_MODE) == ALL_EXCHANGES_HYBRID_FULL
                         || configuration.get(BATCH_SHUFFLE_MODE) == ALL_EXCHANGES_HYBRID_SELECTIVE)
-                && configuration.getBoolean(NETWORK_HYBRID_SHUFFLE_ENABLE_NEW_MODE)) {
+                && configuration.get(NETWORK_HYBRID_SHUFFLE_ENABLE_NEW_MODE)) {
             tieredStorageConfiguration =
                     TieredStorageConfiguration.builder(
                                     pageSize,
-                                    configuration.getString(
+                                    configuration.get(
                                             NETWORK_HYBRID_SHUFFLE_REMOTE_STORAGE_BASE_PATH))
                             .build();
         }
@@ -466,13 +459,12 @@ public class NettyShuffleEnvironmentConfiguration {
      */
     private static PortRange getDataBindPortRange(Configuration configuration) {
         if (configuration.contains(NettyShuffleEnvironmentOptions.DATA_BIND_PORT)) {
-            String dataBindPort =
-                    configuration.getString(NettyShuffleEnvironmentOptions.DATA_BIND_PORT);
+            String dataBindPort = configuration.get(NettyShuffleEnvironmentOptions.DATA_BIND_PORT);
 
             return new PortRange(dataBindPort);
         }
 
-        int dataBindPort = configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_PORT);
+        int dataBindPort = configuration.get(NettyShuffleEnvironmentOptions.DATA_PORT);
         ConfigurationParserUtils.checkConfigParameter(
                 dataBindPort >= 0,
                 dataBindPort,
@@ -555,8 +547,7 @@ public class NettyShuffleEnvironmentConfiguration {
 
     private static BoundedBlockingSubpartitionType getBlockingSubpartitionType(
             Configuration config) {
-        String transport =
-                config.getString(NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE);
+        String transport = config.get(NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE);
 
         switch (transport) {
             case "mmap":

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -362,10 +362,8 @@ public class Task
         this.serializedExecutionConfig = jobInformation.getSerializedExecutionConfig();
 
         Configuration tmConfig = taskManagerConfig.getConfiguration();
-        this.taskCancellationInterval =
-                tmConfig.getLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL);
-        this.taskCancellationTimeout =
-                tmConfig.getLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT);
+        this.taskCancellationInterval = tmConfig.get(TaskManagerOptions.TASK_CANCELLATION_INTERVAL);
+        this.taskCancellationTimeout = tmConfig.get(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT);
 
         this.memoryManager = Preconditions.checkNotNull(memManager);
         this.sharedResources = Preconditions.checkNotNull(sharedResources);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerRuntimeInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerRuntimeInfo.java
@@ -62,7 +62,7 @@ public interface TaskManagerRuntimeInfo {
      * @return The bind address of the TaskManager.
      */
     default String getTaskManagerBindAddress() {
-        return getConfiguration().getString(TaskManagerOptions.BIND_HOST);
+        return getConfiguration().get(TaskManagerOptions.BIND_HOST);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ConfigurationParserUtils.java
@@ -49,7 +49,7 @@ public class ConfigurationParserUtils {
      * @return the number of slots in task manager
      */
     public static int getSlot(Configuration configuration) {
-        int slots = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
+        int slots = configuration.get(TaskManagerOptions.NUM_TASK_SLOTS, 1);
         // we need this because many configs have been written with a "-1" entry
         if (slots == -1) {
             slots = 1;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/SlotSelectionStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/SlotSelectionStrategyUtils.java
@@ -50,7 +50,7 @@ public class SlotSelectionStrategyUtils {
                         : LocationPreferenceSlotSelectionStrategy.createDefault();
 
         final boolean isLocalRecoveryEnabled =
-                configuration.getBoolean(CheckpointingOptions.LOCAL_RECOVERY);
+                configuration.get(CheckpointingOptions.LOCAL_RECOVERY);
         if (isLocalRecoveryEnabled) {
             if (jobType == JobType.STREAMING) {
                 return PreviousAllocationSlotSelectionStrategy.create(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/ZooKeeperUtils.java
@@ -187,23 +187,21 @@ public class ZooKeeperUtils {
                             + "'.");
         }
 
-        int sessionTimeout =
-                configuration.getInteger(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT);
+        int sessionTimeout = configuration.get(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT);
 
         int connectionTimeout =
-                configuration.getInteger(HighAvailabilityOptions.ZOOKEEPER_CONNECTION_TIMEOUT);
+                configuration.get(HighAvailabilityOptions.ZOOKEEPER_CONNECTION_TIMEOUT);
 
-        int retryWait = configuration.getInteger(HighAvailabilityOptions.ZOOKEEPER_RETRY_WAIT);
+        int retryWait = configuration.get(HighAvailabilityOptions.ZOOKEEPER_RETRY_WAIT);
 
         int maxRetryAttempts =
-                configuration.getInteger(HighAvailabilityOptions.ZOOKEEPER_MAX_RETRY_ATTEMPTS);
+                configuration.get(HighAvailabilityOptions.ZOOKEEPER_MAX_RETRY_ATTEMPTS);
 
         String root = configuration.getValue(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT);
 
         String namespace = configuration.getValue(HighAvailabilityOptions.HA_CLUSTER_ID);
 
-        boolean disableSaslClient =
-                configuration.getBoolean(SecurityOptions.ZOOKEEPER_SASL_DISABLE);
+        boolean disableSaslClient = configuration.get(SecurityOptions.ZOOKEEPER_SASL_DISABLE);
 
         ACLProvider aclProvider;
 
@@ -234,7 +232,7 @@ public class ZooKeeperUtils {
         LOG.info("Using '{}' as Zookeeper namespace.", rootWithNamespace);
 
         boolean ensembleTracking =
-                configuration.getBoolean(HighAvailabilityOptions.ZOOKEEPER_ENSEMBLE_TRACKING);
+                configuration.get(HighAvailabilityOptions.ZOOKEEPER_ENSEMBLE_TRACKING);
 
         final CuratorFrameworkFactory.Builder curatorFrameworkBuilder =
                 CuratorFrameworkFactory.builder()
@@ -485,7 +483,7 @@ public class ZooKeeperUtils {
 
         // ZooKeeper submitted jobs root dir
         String zooKeeperJobsPath =
-                configuration.getString(HighAvailabilityOptions.HA_ZOOKEEPER_JOBGRAPHS_PATH);
+                configuration.get(HighAvailabilityOptions.HA_ZOOKEEPER_JOBGRAPHS_PATH);
 
         // Ensure that the job graphs path exists
         client.newNamespaceAwareEnsurePath(zooKeeperJobsPath).ensure(client.getZookeeperClient());
@@ -772,7 +770,7 @@ public class ZooKeeperUtils {
          *     HighAvailabilityOptions#ZOOKEEPER_CLIENT_ACL} if not configured.
          */
         public static ZkClientACLMode fromConfig(Configuration config) {
-            String aclMode = config.getString(HighAvailabilityOptions.ZOOKEEPER_CLIENT_ACL);
+            String aclMode = config.get(HighAvailabilityOptions.ZOOKEEPER_CLIENT_ACL);
             if (aclMode == null || aclMode.equalsIgnoreCase(OPEN.name())) {
                 return OPEN;
             } else if (aclMode.equalsIgnoreCase(CREATOR.name())) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/MemoryBackwardsCompatibilityUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/MemoryBackwardsCompatibilityUtils.java
@@ -87,8 +87,7 @@ public class MemoryBackwardsCompatibilityUtils {
         }
 
         if (configuration.contains(legacyMemoryOptions.getHeapMb())) {
-            final long legacyHeapMemoryMB =
-                    configuration.getInteger(legacyMemoryOptions.getHeapMb());
+            final long legacyHeapMemoryMB = configuration.get(legacyMemoryOptions.getHeapMb());
             if (legacyHeapMemoryMB < 0) {
                 throw new IllegalConfigurationException(
                         "Configured total process memory size ("

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtils.java
@@ -287,7 +287,7 @@ public class ProcessMemoryUtils<FM extends FlinkMemory> {
             MemorySize maxSize,
             ConfigOption<Float> fractionOption,
             Configuration config) {
-        double fraction = config.getFloat(fractionOption);
+        double fraction = config.get(fractionOption);
         try {
             return new RangeFraction(minSize, maxSize, fraction);
         } catch (IllegalArgumentException e) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/taskmanager/TaskExecutorFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/taskmanager/TaskExecutorFlinkMemoryUtils.java
@@ -252,8 +252,7 @@ public class TaskExecutorFlinkMemoryUtils implements FlinkMemoryUtils<TaskExecut
     private static MemorySize getNetworkMemorySizeWithLegacyConfig(final Configuration config) {
         checkArgument(isUsingLegacyNetworkConfigs(config));
         @SuppressWarnings("deprecation")
-        final long numOfBuffers =
-                config.getInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS);
+        final long numOfBuffers = config.get(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS);
         final long pageSize = ConfigurationParserUtils.getPageSize(config);
         return new MemorySize(numOfBuffers * pageSize);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/profiler/ProfilingService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/profiler/ProfilingService.java
@@ -64,13 +64,13 @@ public class ProfilingService implements Closeable {
 
     private ProfilingService(Configuration configs) {
         this.profilingMap = new HashMap<>();
-        this.historySizeLimit = configs.getInteger(RestOptions.MAX_PROFILING_HISTORY_SIZE);
+        this.historySizeLimit = configs.get(RestOptions.MAX_PROFILING_HISTORY_SIZE);
         Preconditions.checkArgument(
                 historySizeLimit > 0,
                 String.format(
                         "Configured %s must be positive.",
                         RestOptions.MAX_PROFILING_HISTORY_SIZE.key()));
-        this.profilingResultDir = configs.getString(RestOptions.PROFILING_RESULT_DIR);
+        this.profilingResultDir = configs.get(RestOptions.PROFILING_RESULT_DIR);
         this.scheduledExecutor =
                 Executors.newSingleThreadScheduledExecutor(
                         new ExecutorThreadFactory.Builder()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -278,12 +278,12 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                         resourceManagerRetriever, executor, restConfiguration.getTimeout())
                 .setCoordinator(threadInfoRequestCoordinator)
                 .setCleanUpInterval(flameGraphCleanUpInterval)
-                .setNumSamples(clusterConfiguration.getInteger(RestOptions.FLAMEGRAPH_NUM_SAMPLES))
+                .setNumSamples(clusterConfiguration.get(RestOptions.FLAMEGRAPH_NUM_SAMPLES))
                 .setStatsRefreshInterval(
                         clusterConfiguration.get(RestOptions.FLAMEGRAPH_REFRESH_INTERVAL))
                 .setDelayBetweenSamples(clusterConfiguration.get(RestOptions.FLAMEGRAPH_DELAY))
                 .setMaxThreadInfoDepth(
-                        clusterConfiguration.getInteger(RestOptions.FLAMEGRAPH_STACK_TRACE_DEPTH))
+                        clusterConfiguration.get(RestOptions.FLAMEGRAPH_STACK_TRACE_DEPTH))
                 .build();
     }
 
@@ -552,7 +552,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                 new JobExecutionResultHandler(leaderRetriever, timeout, responseHeaders);
 
         final String defaultSavepointDir =
-                clusterConfiguration.getString(CheckpointingOptions.SAVEPOINT_DIRECTORY);
+                clusterConfiguration.get(CheckpointingOptions.SAVEPOINT_DIRECTORY);
 
         final SavepointHandlers savepointHandlers = new SavepointHandlers(defaultSavepointDir);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorUtils.java
@@ -74,7 +74,7 @@ public final class WebMonitorUtils {
 
             if (logFilePath == null) {
                 LOG.warn("Log file environment variable '{}' is not set.", logEnv);
-                logFilePath = config.getString(WebOptions.LOG_PATH);
+                logFilePath = config.get(WebOptions.LOG_PATH);
             }
 
             // not configured, cannot serve log files

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerUtils.java
@@ -38,7 +38,7 @@ public enum HistoryServerUtils {
     private static final Logger LOG = LoggerFactory.getLogger(HistoryServerUtils.class);
 
     public static boolean isSSLEnabled(Configuration config) {
-        return config.getBoolean(HistoryServerOptions.HISTORY_SERVER_WEB_SSL_ENABLED)
+        return config.get(HistoryServerOptions.HISTORY_SERVER_WEB_SSL_ENABLED)
                 && SecurityOptions.isRestSSLEnabled(config);
     }
 
@@ -68,12 +68,12 @@ public enum HistoryServerUtils {
     }
 
     private static int getPort(Configuration configuration) {
-        return configuration.getInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT);
+        return configuration.get(HistoryServerOptions.HISTORY_SERVER_WEB_PORT);
     }
 
     @Nullable
     private static String getHostname(Configuration configuration) {
-        return configuration.getString(HistoryServerOptions.HISTORY_SERVER_WEB_ADDRESS);
+        return configuration.get(HistoryServerOptions.HISTORY_SERVER_WEB_ADDRESS);
     }
 
     private static String getProtocol(Configuration configuration) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCleanupTest.java
@@ -79,7 +79,7 @@ class BlobCacheCleanupTest {
 
         try {
             Configuration config = new Configuration();
-            config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+            config.set(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
             server = TestingBlobUtils.createServer(tempDir, config);
             server.start();
@@ -149,7 +149,7 @@ class BlobCacheCleanupTest {
         JobID jobId = new JobID();
 
         Configuration config = new Configuration();
-        config.setLong(
+        config.set(
                 BlobServerOptions.CLEANUP_INTERVAL,
                 3_600_000L); // 1 hour should effectively prevent races
 
@@ -176,7 +176,7 @@ class BlobCacheCleanupTest {
 
             // release a second time
             long cleanupLowerBound =
-                    System.currentTimeMillis() + config.getLong(BlobServerOptions.CLEANUP_INTERVAL);
+                    System.currentTimeMillis() + config.get(BlobServerOptions.CLEANUP_INTERVAL);
             cache.releaseJob(jobId);
             assertThat(cache.getJobRefCounters().get(jobId).references).isZero();
             assertThat(cache.getJobRefCounters().get(jobId).keepUntil)
@@ -189,7 +189,7 @@ class BlobCacheCleanupTest {
 
             // finally release the job
             cleanupLowerBound =
-                    System.currentTimeMillis() + config.getLong(BlobServerOptions.CLEANUP_INTERVAL);
+                    System.currentTimeMillis() + config.get(BlobServerOptions.CLEANUP_INTERVAL);
             cache.releaseJob(jobId);
             assertThat(cache.getJobRefCounters().get(jobId).references).isZero();
             assertThat(cache.getJobRefCounters().get(jobId).keepUntil)
@@ -218,7 +218,7 @@ class BlobCacheCleanupTest {
 
         try {
             Configuration config = new Configuration();
-            config.setLong(BlobServerOptions.CLEANUP_INTERVAL, cleanupInterval);
+            config.set(BlobServerOptions.CLEANUP_INTERVAL, cleanupInterval);
 
             server = new BlobServer(config, TempDirUtils.newFolder(tempDir), new VoidBlobStore());
             server.start();
@@ -327,7 +327,7 @@ class BlobCacheCleanupTest {
         byte[] data2 = Arrays.copyOfRange(data, 10, 54);
 
         Configuration config = new Configuration();
-        config.setLong(BlobServerOptions.CLEANUP_INTERVAL, cleanupInterval);
+        config.set(BlobServerOptions.CLEANUP_INTERVAL, cleanupInterval);
 
         long cleanupLowerBound;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCorruptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheCorruptionTest.java
@@ -76,8 +76,8 @@ class BlobCacheCorruptionTest {
             throws IOException {
 
         final Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStoreService = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRecoveryTest.java
@@ -38,8 +38,8 @@ public class BlobCacheRecoveryTest {
     @Test
     void testBlobCacheRecovery() throws Exception {
         Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStoreService = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheRetriesTest.java
@@ -68,8 +68,8 @@ class BlobCacheRetriesTest {
     @Test
     void testBlobFetchRetriesHa() throws IOException {
         final Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStoreService = null;
@@ -138,8 +138,8 @@ class BlobCacheRetriesTest {
     @Test
     void testBlobForJobFetchWithTooManyFailuresHa() throws IOException {
         final Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, tempDir.toString());
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, tempDir.toString());
 
         BlobStoreService blobStoreService = null;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCacheSuccessTest.java
@@ -51,7 +51,7 @@ class BlobCacheSuccessTest {
     @Test
     void testBlobNoJobCache() throws IOException {
         Configuration config = new Configuration();
-        config.setString(BlobServerOptions.STORAGE_DIRECTORY, tempDir.toString());
+        config.set(BlobServerOptions.STORAGE_DIRECTORY, tempDir.toString());
 
         uploadFileGetTest(config, null, false, false, TRANSIENT_BLOB);
     }
@@ -63,7 +63,7 @@ class BlobCacheSuccessTest {
     @Test
     void testBlobForJobCache() throws IOException {
         Configuration config = new Configuration();
-        config.setString(BlobServerOptions.STORAGE_DIRECTORY, tempDir.toString());
+        config.set(BlobServerOptions.STORAGE_DIRECTORY, tempDir.toString());
 
         uploadFileGetTest(config, new JobID(), false, false, TRANSIENT_BLOB);
     }
@@ -76,11 +76,11 @@ class BlobCacheSuccessTest {
     @Test
     void testBlobForJobCacheHa() throws IOException {
         Configuration config = new Configuration();
-        config.setString(
+        config.set(
                 BlobServerOptions.STORAGE_DIRECTORY,
                 TempDirUtils.newFolder(tempDir).getAbsolutePath());
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         uploadFileGetTest(config, new JobID(), true, true, PERMANENT_BLOB);
@@ -94,11 +94,11 @@ class BlobCacheSuccessTest {
     @Test
     void testBlobForJobCacheHa2() throws IOException {
         Configuration config = new Configuration();
-        config.setString(
+        config.set(
                 BlobServerOptions.STORAGE_DIRECTORY,
                 TempDirUtils.newFolder(tempDir).getAbsolutePath());
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
         uploadFileGetTest(config, new JobID(), false, true, PERMANENT_BLOB);
     }
@@ -110,11 +110,11 @@ class BlobCacheSuccessTest {
     @Test
     void testBlobForJobCacheHaFallback() throws IOException {
         Configuration config = new Configuration();
-        config.setString(
+        config.set(
                 BlobServerOptions.STORAGE_DIRECTORY,
                 TempDirUtils.newFolder(tempDir).getAbsolutePath());
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         uploadFileGetTest(config, new JobID(), false, false, PERMANENT_BLOB);
@@ -142,12 +142,12 @@ class BlobCacheSuccessTest {
             throws IOException {
 
         final Configuration cacheConfig = new Configuration(config);
-        cacheConfig.setString(
+        cacheConfig.set(
                 BlobServerOptions.STORAGE_DIRECTORY,
                 TempDirUtils.newFolder(tempDir).getAbsolutePath());
         if (!cacheHasAccessToFs) {
             // make sure the cache cannot access the HA store directly
-            cacheConfig.setString(
+            cacheConfig.set(
                     HighAvailabilityOptions.HA_STORAGE_PATH,
                     TempDirUtils.newFolder(tempDir).getPath() + "/does-not-exist");
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientSslTest.java
@@ -64,7 +64,7 @@ class BlobClientSslTest extends BlobClientTest {
         Configuration config =
                 SSLUtilsTest.createInternalSslConfigWithKeyAndTrustStores(
                         SecurityOptions.SSL_PROVIDER.defaultValue());
-        config.setBoolean(BlobServerOptions.SSL_ENABLED, false);
+        config.set(BlobServerOptions.SSL_ENABLED, false);
 
         blobNonSslServer = TestingBlobUtils.createServer(tempDir.resolve("non_ssl"), config);
         blobNonSslServer.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobClientTest.java
@@ -492,9 +492,9 @@ class BlobClientTest {
     @Test
     void testSocketTimeout() throws IOException {
         Configuration clientConfig = getBlobClientConfig();
-        int oldSoTimeout = clientConfig.getInteger(BlobServerOptions.SO_TIMEOUT);
+        int oldSoTimeout = clientConfig.get(BlobServerOptions.SO_TIMEOUT);
 
-        clientConfig.setInteger(BlobServerOptions.SO_TIMEOUT, 50);
+        clientConfig.set(BlobServerOptions.SO_TIMEOUT, 50);
 
         try (final TestBlobServer testBlobServer =
                 new TestBlobServer(
@@ -515,7 +515,7 @@ class BlobClientTest {
                         .isPresent();
             }
         } finally {
-            clientConfig.setInteger(BlobServerOptions.SO_TIMEOUT, oldSoTimeout);
+            clientConfig.set(BlobServerOptions.SO_TIMEOUT, oldSoTimeout);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
@@ -86,8 +86,8 @@ class BlobServerCleanupTest {
             String storageDirectoryPath, long cleanupInterval, BlobStore blobStore)
             throws IOException {
         final Configuration config = new Configuration();
-        config.setString(BlobServerOptions.STORAGE_DIRECTORY, storageDirectoryPath);
-        config.setLong(BlobServerOptions.CLEANUP_INTERVAL, cleanupInterval);
+        config.set(BlobServerOptions.STORAGE_DIRECTORY, storageDirectoryPath);
+        config.set(BlobServerOptions.CLEANUP_INTERVAL, cleanupInterval);
 
         return new BlobServer(config, new File(storageDirectoryPath), blobStore);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCorruptionTest.java
@@ -46,11 +46,11 @@ class BlobServerCorruptionTest {
     void testGetFailsFromCorruptFile() throws IOException {
 
         final Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 BlobServerOptions.STORAGE_DIRECTORY,
                 TempDirUtils.newFolder(tempDir).getAbsolutePath());
-        config.setString(
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStoreService = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerGetTest.java
@@ -154,8 +154,8 @@ class BlobServerGetTest {
         final JobID jobId = new JobID();
 
         final Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStore = null;
@@ -227,8 +227,8 @@ class BlobServerGetTest {
         final JobID jobId = new JobID();
 
         final Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStore = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRangeTest.java
@@ -41,7 +41,7 @@ class BlobServerRangeTest {
     @Test
     void testOnEphemeralPort() throws IOException {
         Configuration conf = new Configuration();
-        conf.setString(BlobServerOptions.PORT, "0");
+        conf.set(BlobServerOptions.PORT, "0");
 
         BlobServer server = TestingBlobUtils.createServer(tempDir, conf);
         server.start();
@@ -61,7 +61,7 @@ class BlobServerRangeTest {
         }
 
         Configuration conf = new Configuration();
-        conf.setString(BlobServerOptions.PORT, String.valueOf(socket.getLocalPort()));
+        conf.set(BlobServerOptions.PORT, String.valueOf(socket.getLocalPort()));
 
         // this thing is going to throw an exception
         try {
@@ -87,7 +87,7 @@ class BlobServerRangeTest {
             }
         }
         Configuration conf = new Configuration();
-        conf.setString(
+        conf.set(
                 BlobServerOptions.PORT,
                 sockets[0].getLocalPort() + "," + sockets[1].getLocalPort() + ",50000-50050");
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerRecoveryTest.java
@@ -38,8 +38,8 @@ class BlobServerRecoveryTest {
     @Test
     public void testBlobServerRecovery() throws Exception {
         Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH, TempDirUtils.newFolder(tempDir).getPath());
 
         BlobStoreService blobStoreService = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerSslTest.java
@@ -35,18 +35,18 @@ class BlobServerSslTest {
     void testFailedToInitWithTwoProtocolsSet() {
         final Configuration config = new Configuration();
 
-        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
-        config.setString(
+        config.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        config.set(
                 SecurityOptions.SSL_KEYSTORE,
                 getClass().getResource("/local127.keystore").getPath());
-        config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-        config.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
-        config.setString(
+        config.set(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
+        config.set(SecurityOptions.SSL_KEY_PASSWORD, "password");
+        config.set(
                 SecurityOptions.SSL_TRUSTSTORE,
                 getClass().getResource("/local127.truststore").getPath());
 
-        config.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
-        config.setString(SecurityOptions.SSL_ALGORITHMS, "TLSv1,TLSv1.1");
+        config.set(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
+        config.set(SecurityOptions.SSL_ALGORITHMS, "TLSv1,TLSv1.1");
 
         assertThatThrownBy(() -> new BlobServer(config, new File("foobar"), new VoidBlobStore()))
                 .isInstanceOf(IOException.class)
@@ -57,12 +57,12 @@ class BlobServerSslTest {
     void testFailedToInitWithInvalidSslKeystoreConfigured() {
         final Configuration config = new Configuration();
 
-        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
-        config.setString(SecurityOptions.SSL_KEYSTORE, "invalid.keystore");
-        config.setString(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
-        config.setString(SecurityOptions.SSL_KEY_PASSWORD, "password");
-        config.setString(SecurityOptions.SSL_TRUSTSTORE, "invalid.keystore");
-        config.setString(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
+        config.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        config.set(SecurityOptions.SSL_KEYSTORE, "invalid.keystore");
+        config.set(SecurityOptions.SSL_KEYSTORE_PASSWORD, "password");
+        config.set(SecurityOptions.SSL_KEY_PASSWORD, "password");
+        config.set(SecurityOptions.SSL_TRUSTSTORE, "invalid.keystore");
+        config.set(SecurityOptions.SSL_TRUSTSTORE_PASSWORD, "password");
 
         assertThatThrownBy(() -> new BlobServer(config, new File("foobar"), new VoidBlobStore()))
                 .isInstanceOf(IOException.class)
@@ -73,7 +73,7 @@ class BlobServerSslTest {
     void testFailedToInitWithMissingMandatorySslConfiguration() {
         final Configuration config = new Configuration();
 
-        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        config.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
 
         assertThatThrownBy(() -> new BlobServer(config, new File("foobar"), new VoidBlobStore()))
                 .isInstanceOf(IOException.class)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsNonWritableTest.java
@@ -57,8 +57,7 @@ class BlobUtilsNonWritableTest {
     @Test
     void testExceptionOnCreateStorageDirectoryFailure() {
         Configuration config = new Configuration();
-        config.setString(
-                BlobServerOptions.STORAGE_DIRECTORY, getStorageLocationFile().getAbsolutePath());
+        config.set(BlobServerOptions.STORAGE_DIRECTORY, getStorageLocationFile().getAbsolutePath());
 
         assertThatThrownBy(() -> BlobUtils.createBlobStorageDirectory(config, null))
                 .isInstanceOf(IOException.class);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobUtilsTest.java
@@ -60,8 +60,8 @@ class BlobUtilsTest {
     void testDefaultBlobStorageDirectory() throws IOException {
         Configuration config = new Configuration();
         String blobStorageDir = TempDirUtils.newFolder(tempDir).getAbsolutePath();
-        config.setString(BlobServerOptions.STORAGE_DIRECTORY, blobStorageDir);
-        config.setString(CoreOptions.TMP_DIRS, TempDirUtils.newFolder(tempDir).getAbsolutePath());
+        config.set(BlobServerOptions.STORAGE_DIRECTORY, blobStorageDir);
+        config.set(CoreOptions.TMP_DIRS, TempDirUtils.newFolder(tempDir).getAbsolutePath());
 
         File dir = BlobUtils.createBlobStorageDirectory(config, null).deref();
         assertThat(dir.getAbsolutePath()).startsWith(blobStorageDir);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobHelpers.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/TestingBlobHelpers.java
@@ -293,9 +293,8 @@ public final class TestingBlobHelpers {
     public static void testBlobServerRecovery(
             final Configuration config, final BlobStore blobStore, final File blobStorage)
             throws Exception {
-        final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
-        String storagePath =
-                config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
+        final String clusterId = config.get(HighAvailabilityOptions.HA_CLUSTER_ID);
+        String storagePath = config.get(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
         Random rand = new Random();
 
         try (BlobServer server0 =
@@ -378,9 +377,8 @@ public final class TestingBlobHelpers {
             final Configuration config, final BlobStore blobStore, final File blobStorage)
             throws IOException {
 
-        final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
-        String storagePath =
-                config.getString(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
+        final String clusterId = config.get(HighAvailabilityOptions.HA_CLUSTER_ID);
+        String storagePath = config.get(HighAvailabilityOptions.HA_STORAGE_PATH) + "/" + clusterId;
         Random rand = new Random();
 
         try (BlobServer server0 =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCompletedCheckpointStoreUtilsTest.java
@@ -145,7 +145,7 @@ class DefaultCompletedCheckpointStoreUtilsTest {
     @CsvSource({"10,10", "0,1", "-1,1"})
     void testGetMaximumNumberOfRetainedCheckpoints(int actualValue, int expectedValue) {
         final Configuration jobManagerConfig = new Configuration();
-        jobManagerConfig.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, actualValue);
+        jobManagerConfig.set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, actualValue);
 
         assertThat(
                         DefaultCompletedCheckpointStoreUtils.getMaximumNumberOfRetainedCheckpoints(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZKCheckpointIDCounterMultiServersTest.java
@@ -52,7 +52,7 @@ class ZKCheckpointIDCounterMultiServersTest {
     void testRecoveredAfterConnectionLoss() throws Exception {
 
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 zookeeperExtensionWrapper.getCustomExtension().getConnectString());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreTest.java
@@ -78,7 +78,7 @@ class ZooKeeperCompletedCheckpointStoreTest {
     @Test
     void testRecoverFailsIfDownloadFails() {
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 zooKeeperExtensionWrapper.getCustomExtension().getConnectString());
         final List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> checkpointsInZk =
@@ -125,7 +125,7 @@ class ZooKeeperCompletedCheckpointStoreTest {
     void testDiscardingSubsumedCheckpoints() throws Exception {
         final SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 zooKeeperExtensionWrapper.getCustomExtension().getConnectString());
 
@@ -164,7 +164,7 @@ class ZooKeeperCompletedCheckpointStoreTest {
     void testDiscardingCheckpointsAtShutDown() throws Exception {
         final SharedStateRegistry sharedStateRegistry = new SharedStateRegistryImpl();
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 zooKeeperExtensionWrapper.getCustomExtension().getConnectString());
 
@@ -240,7 +240,7 @@ class ZooKeeperCompletedCheckpointStoreTest {
 
         final int numCheckpointsToRetain = 1;
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 zooKeeperExtensionWrapper.getCustomExtension().getConnectString());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -133,24 +133,23 @@ class BootstrapToolsTest {
 
         // test that default value is taken
         BootstrapTools.updateTmpDirectoriesInConfiguration(config, "default/directory/path");
-        assertThat(config.getString(CoreOptions.TMP_DIRS)).isEqualTo("default/directory/path");
+        assertThat(config.get(CoreOptions.TMP_DIRS)).isEqualTo("default/directory/path");
 
         // test that we ignore default value is value is set before
         BootstrapTools.updateTmpDirectoriesInConfiguration(config, "not/default/directory/path");
-        assertThat(config.getString(CoreOptions.TMP_DIRS)).isEqualTo("default/directory/path");
+        assertThat(config.get(CoreOptions.TMP_DIRS)).isEqualTo("default/directory/path");
 
         // test that empty value is not a magic string
-        config.setString(CoreOptions.TMP_DIRS, "");
+        config.set(CoreOptions.TMP_DIRS, "");
         BootstrapTools.updateTmpDirectoriesInConfiguration(config, "some/new/path");
-        assertThat(config.getString(CoreOptions.TMP_DIRS)).isEmpty();
+        assertThat(config.get(CoreOptions.TMP_DIRS)).isEmpty();
     }
 
     @Test
     void testShouldNotUpdateTmpDirectoriesInConfigurationIfNoValueConfigured() {
         Configuration config = new Configuration();
         BootstrapTools.updateTmpDirectoriesInConfiguration(config, null);
-        assertThat(CoreOptions.TMP_DIRS.defaultValue())
-                .isEqualTo(config.getString(CoreOptions.TMP_DIRS));
+        assertThat(CoreOptions.TMP_DIRS.defaultValue()).isEqualTo(config.get(CoreOptions.TMP_DIRS));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
@@ -176,7 +176,7 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
         final double cpuCores = 1.0;
 
         Configuration conf = new Configuration();
-        conf.setDouble(TaskManagerOptions.CPU_CORES, cpuCores);
+        conf.set(TaskManagerOptions.CPU_CORES, cpuCores);
 
         validateInAllConfigurations(
                 conf,
@@ -188,7 +188,7 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
     @Test
     void testConfigNoCpuCores() {
         Configuration conf = new Configuration();
-        conf.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+        conf.set(TaskManagerOptions.NUM_TASK_SLOTS, 3);
         validateInAllConfigurations(
                 conf,
                 taskExecutorProcessSpec ->
@@ -199,7 +199,7 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
     @Test
     void testConfigNegativeCpuCores() {
         Configuration conf = new Configuration();
-        conf.setDouble(TaskManagerOptions.CPU_CORES, -0.1f);
+        conf.set(TaskManagerOptions.CPU_CORES, -0.1d);
         validateFailInAllConfigurations(conf);
     }
 
@@ -285,7 +285,7 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
         final Configuration configuration =
                 setupConfigWithFlinkAndTaskHeapToDeriveGivenNetworkMem(400);
         // set fraction to be extremely low to not match the derived network memory
-        configuration.setFloat(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 0.001f);
+        configuration.set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 0.001f);
         // internal validation should pass
         TaskExecutorProcessUtils.processSpecFromConfig(configuration);
     }
@@ -323,7 +323,7 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
                 setupConfigWithFlinkAndTaskHeapToDeriveGivenNetworkMem(networkMemorySizeMbToDerive);
         configuration.set(
                 TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.ofMebiBytes(pageSizeMb));
-        configuration.setInteger(
+        configuration.set(
                 NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, numberOfNetworkBuffers);
         // internal validation should fail
         assertThatExceptionOfType(IllegalConfigurationException.class)
@@ -390,7 +390,7 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
         Configuration conf = new Configuration();
         conf.set(TaskManagerOptions.NETWORK_MEMORY_MAX, networkMax);
         conf.set(TaskManagerOptions.NETWORK_MEMORY_MIN, networkMin);
-        conf.setFloat(TaskManagerOptions.NETWORK_MEMORY_FRACTION, fraction);
+        conf.set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, fraction);
 
         // validate in configurations without explicit total flink/process memory, otherwise
         // explicit configured
@@ -409,10 +409,10 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
     @Test
     void testConfigNetworkMemoryFractionFailure() {
         Configuration conf = new Configuration();
-        conf.setFloat(TaskManagerOptions.NETWORK_MEMORY_FRACTION, -0.1f);
+        conf.set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, -0.1f);
         validateFailInAllConfigurations(conf);
 
-        conf.setFloat(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 1.0f);
+        conf.set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 1.0f);
         validateFailInAllConfigurations(conf);
     }
 
@@ -434,8 +434,8 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
                 NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION;
 
         Configuration conf = new Configuration();
-        conf.setString(legacyOptionMin, networkMin.getMebiBytes() + "m");
-        conf.setString(legacyOptionMax, networkMax.getMebiBytes() + "m");
+        conf.set(legacyOptionMin, networkMin.getMebiBytes() + "m");
+        conf.set(legacyOptionMax, networkMax.getMebiBytes() + "m");
 
         validateInAllConfigurations(
                 conf,
@@ -446,9 +446,9 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
                             .isLessThanOrEqualTo(networkMax.getBytes());
                 });
 
-        conf.setString(legacyOptionMin, "0m");
-        conf.setString(legacyOptionMax, "1t");
-        conf.setFloat(legacyOptionFraction, fraction);
+        conf.set(legacyOptionMin, "0m");
+        conf.set(legacyOptionMax, "1t");
+        conf.set(legacyOptionFraction, fraction);
 
         validateInConfigWithExplicitTaskHeapAndManagedMem(
                 conf,
@@ -472,7 +472,7 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
 
         Configuration conf = new Configuration();
         conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, pageSize);
-        conf.setInteger(legacyOption, numOfBuffers);
+        conf.set(legacyOption, numOfBuffers);
 
         // validate in configurations without explicit total flink/process memory, otherwise
         // explicit configured
@@ -530,7 +530,7 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
         final float fraction = 0.5f;
 
         Configuration conf = new Configuration();
-        conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, fraction);
+        conf.set(TaskManagerOptions.MANAGED_MEMORY_FRACTION, fraction);
 
         // managed memory fraction is only used when managed memory size is not explicitly
         // configured
@@ -547,10 +547,10 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
     @Test
     void testConfigManagedMemoryFractionFailure() {
         final Configuration conf = new Configuration();
-        conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, -0.1f);
+        conf.set(TaskManagerOptions.MANAGED_MEMORY_FRACTION, -0.1f);
         validateFailInConfigurationsWithoutExplicitManagedMem(conf);
 
-        conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 1.0f);
+        conf.set(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 1.0f);
         validateFailInConfigurationsWithoutExplicitManagedMem(conf);
     }
 
@@ -581,8 +581,8 @@ class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<TaskExecut
         final float managedFraction = 0.6f;
 
         Configuration conf = new Configuration();
-        conf.setFloat(TaskManagerOptions.NETWORK_MEMORY_FRACTION, networkFraction);
-        conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, managedFraction);
+        conf.set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, networkFraction);
+        conf.set(TaskManagerOptions.MANAGED_MEMORY_FRACTION, managedFraction);
 
         // if managed memory size is explicitly configured, then managed memory fraction will be
         // ignored

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -217,7 +217,7 @@ class TaskDeploymentDescriptorTest {
 
         Configuration config = new Configuration();
         // always offload the serialized job and task information
-        config.setInteger(BlobServerOptions.OFFLOAD_MINSIZE, 0);
+        config.set(BlobServerOptions.OFFLOAD_MINSIZE, 0);
         BlobServer blobServer =
                 new BlobServer(
                         config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/ZooKeeperDefaultDispatcherRunnerTest.java
@@ -116,11 +116,11 @@ class ZooKeeperDefaultDispatcherRunnerTest {
     void setup() throws IOException {
         fatalErrorHandler = new TestingFatalErrorHandler();
         configuration = new Configuration();
-        configuration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
-        configuration.setString(
+        configuration.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        configuration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 zooKeeperExtensionWrapper.getCustomExtension().getConnectString());
-        configuration.setString(
+        configuration.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH,
                 TempDirUtils.newFolder(temporaryFolder).getAbsolutePath());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -94,7 +94,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 
         try {
             Configuration config = new Configuration();
-            config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+            config.set(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
             server = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
             server.start();
@@ -227,7 +227,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 
         try {
             Configuration config = new Configuration();
-            config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+            config.set(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
             server = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
             server.start();
@@ -337,7 +337,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
         try {
             // create the blob transfer services
             Configuration config = new Configuration();
-            config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1_000_000L);
+            config.set(BlobServerOptions.CLEANUP_INTERVAL, 1_000_000L);
 
             server = new BlobServer(config, temporaryFolder.newFolder(), new VoidBlobStore());
             server.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheRecoveryITCase.java
@@ -80,11 +80,11 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
         BlobStoreService blobStoreService = null;
 
         Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH,
                 temporaryFolder.newFolder().getAbsolutePath());
-        config.setLong(BlobServerOptions.CLEANUP_INTERVAL, 3_600L);
+        config.set(BlobServerOptions.CLEANUP_INTERVAL, 3_600L);
 
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         try {
@@ -182,8 +182,8 @@ public class BlobLibraryCacheRecoveryITCase extends TestLogger {
             server[1].globalCleanupAsync(jobId, executorService).join();
 
             // Verify everything is clean below recoveryDir/<cluster_id>
-            final String clusterId = config.getString(HighAvailabilityOptions.HA_CLUSTER_ID);
-            String haBlobStorePath = config.getString(HighAvailabilityOptions.HA_STORAGE_PATH);
+            final String clusterId = config.get(HighAvailabilityOptions.HA_CLUSTER_ID);
+            String haBlobStorePath = config.get(HighAvailabilityOptions.HA_STORAGE_PATH);
             File haBlobStoreDir = new File(haBlobStorePath, clusterId);
             File[] recoveryFiles = haBlobStoreDir.listFiles();
             assertNotNull("HA storage directory does not exist", recoveryFiles);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
@@ -540,7 +540,7 @@ class DefaultExecutionGraphDeploymentTest {
         final int negativeMaxNumberOfCheckpointsToRetain = -10;
 
         final Configuration jobManagerConfig = new Configuration();
-        jobManagerConfig.setInteger(
+        jobManagerConfig.set(
                 CheckpointingOptions.MAX_RETAINED_CHECKPOINTS,
                 negativeMaxNumberOfCheckpointsToRetain);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobCacheTest.java
@@ -43,7 +43,7 @@ class DefaultExecutionGraphDeploymentWithBlobCacheTest
     public void setupBlobServer() throws IOException {
         Configuration config = new Configuration();
         // always offload the serialized job and task information
-        config.setInteger(BlobServerOptions.OFFLOAD_MINSIZE, 0);
+        config.set(BlobServerOptions.OFFLOAD_MINSIZE, 0);
         blobServer =
                 new BlobServer(
                         config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobServerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobServerTest.java
@@ -63,7 +63,7 @@ class DefaultExecutionGraphDeploymentWithBlobServerTest
     void setupBlobServer() throws IOException {
         Configuration config = new Configuration();
         // always offload the serialized job and task information
-        config.setInteger(BlobServerOptions.OFFLOAD_MINSIZE, 0);
+        config.set(BlobServerOptions.OFFLOAD_MINSIZE, 0);
         blobServer =
                 new AssertBlobServer(
                         config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
@@ -75,7 +75,7 @@ class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
         Configuration config = new Configuration();
         // Always offload the serialized JobInformation, TaskInformation and cached
         // ShuffleDescriptors
-        config.setInteger(BlobServerOptions.OFFLOAD_MINSIZE, 0);
+        config.set(BlobServerOptions.OFFLOAD_MINSIZE, 0);
         blobServer =
                 new BlobServer(
                         config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyFactoryLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/FailoverStrategyFactoryLoaderTest.java
@@ -33,7 +33,7 @@ class FailoverStrategyFactoryLoaderTest {
     @Test
     void testLoadRestartAllStrategyFactory() {
         final Configuration config = new Configuration();
-        config.setString(
+        config.set(
                 JobManagerOptions.EXECUTION_FAILOVER_STRATEGY,
                 FailoverStrategyFactoryLoader.FULL_RESTART_STRATEGY_NAME);
         assertThat(FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config))
@@ -43,7 +43,7 @@ class FailoverStrategyFactoryLoaderTest {
     @Test
     void testLoadRestartPipelinedRegionStrategyFactory() {
         final Configuration config = new Configuration();
-        config.setString(
+        config.set(
                 JobManagerOptions.EXECUTION_FAILOVER_STRATEGY,
                 FailoverStrategyFactoryLoader.PIPELINED_REGION_RESTART_STRATEGY_NAME);
         assertThat(FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config))
@@ -60,7 +60,7 @@ class FailoverStrategyFactoryLoaderTest {
     @Test
     void testLoadFromInvalidConfiguration() {
         final Configuration config = new Configuration();
-        config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "invalidStrategy");
+        config.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "invalidStrategy");
         assertThatThrownBy(() -> FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config))
                 .isInstanceOf(IllegalConfigurationException.class);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/RestartBackoffTimeStrategyFactoryLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/RestartBackoffTimeStrategyFactoryLoaderTest.java
@@ -39,7 +39,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testNoRestartStrategySpecifiedInExecutionConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -52,7 +52,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testFixedDelayRestartStrategySpecifiedInExecutionConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -70,7 +70,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testExponentialDelayRestartStrategySpecifiedInExecutionConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -93,7 +93,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testFailureRateRestartStrategySpecifiedInExecutionConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -112,9 +112,9 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testNoRestartStrategySpecifiedInJobConfig() {
         final Configuration jobConf = new Configuration();
-        jobConf.setString(RestartStrategyOptions.RESTART_STRATEGY, "none");
+        jobConf.set(RestartStrategyOptions.RESTART_STRATEGY, "none");
         final Configuration clusterConf = new Configuration();
-        clusterConf.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+        clusterConf.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -127,9 +127,9 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testFixedDelayStrategySpecifiedInJobConfig() {
         final Configuration jobConf = new Configuration();
-        jobConf.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+        jobConf.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
         final Configuration clusterConf = new Configuration();
-        clusterConf.setString(RestartStrategyOptions.RESTART_STRATEGY, "exponential-delay");
+        clusterConf.set(RestartStrategyOptions.RESTART_STRATEGY, "exponential-delay");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -144,9 +144,9 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testExponentialDelayStrategySpecifiedInJobConfig() {
         final Configuration jobConf = new Configuration();
-        jobConf.setString(RestartStrategyOptions.RESTART_STRATEGY, "exponential-delay");
+        jobConf.set(RestartStrategyOptions.RESTART_STRATEGY, "exponential-delay");
         final Configuration clusterConf = new Configuration();
-        clusterConf.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
+        clusterConf.set(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -161,9 +161,9 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testFailureRateStrategySpecifiedInJobConfig() {
         final Configuration jobConf = new Configuration();
-        jobConf.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
+        jobConf.set(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
         final Configuration clusterConf = new Configuration();
-        clusterConf.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+        clusterConf.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -178,7 +178,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testInvalidStrategySpecifiedInJobConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "invalid-strategy");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "invalid-strategy");
 
         assertThatThrownBy(
                         () ->
@@ -194,7 +194,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testNoRestartStrategySpecifiedInClusterConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "none");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "none");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -207,7 +207,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testFixedDelayStrategySpecifiedInClusterConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -222,7 +222,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testExponentialDelayStrategySpecifiedInClusterConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "exponential-delay");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "exponential-delay");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -237,7 +237,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testFailureRateStrategySpecifiedInClusterConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
 
         final RestartBackoffTimeStrategy.Factory factory =
                 RestartBackoffTimeStrategyFactoryLoader.createRestartBackoffTimeStrategyFactory(
@@ -252,7 +252,7 @@ class RestartBackoffTimeStrategyFactoryLoaderTest {
     @Test
     void testInvalidStrategySpecifiedInClusterConfig() {
         final Configuration conf = new Configuration();
-        conf.setString(RestartStrategyOptions.RESTART_STRATEGY, "invalid-strategy");
+        conf.set(RestartStrategyOptions.RESTART_STRATEGY, "invalid-strategy");
 
         assertThatThrownBy(
                         () ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/partitionrelease/PartitionGroupReleaseStrategyFactoryLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/partitionrelease/PartitionGroupReleaseStrategyFactoryLoaderTest.java
@@ -42,8 +42,7 @@ class PartitionGroupReleaseStrategyFactoryLoaderTest {
     @Test
     public void featureCanBeDisabled() {
         final Configuration emptyConfiguration = new Configuration();
-        emptyConfiguration.setBoolean(
-                JobManagerOptions.PARTITION_RELEASE_DURING_JOB_EXECUTION, false);
+        emptyConfiguration.set(JobManagerOptions.PARTITION_RELEASE_DURING_JOB_EXECUTION, false);
 
         final PartitionGroupReleaseStrategy.Factory factory =
                 PartitionGroupReleaseStrategyFactoryLoader.loadPartitionGroupReleaseStrategyFactory(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/failure/FailureEnricherUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/failure/FailureEnricherUtilsTest.java
@@ -55,31 +55,30 @@ class FailureEnricherUtilsTest {
         Configuration conf = new Configuration();
 
         // Disabled feature
-        conf.setString(JobManagerOptions.FAILURE_ENRICHERS_LIST, "");
+        conf.set(JobManagerOptions.FAILURE_ENRICHERS_LIST, "");
         Set<String> result = FailureEnricherUtils.getIncludedFailureEnrichers(conf);
         assertThat(result).hasSize(0);
 
         // Single enricher
-        conf.setString(JobManagerOptions.FAILURE_ENRICHERS_LIST, "enricher1");
+        conf.set(JobManagerOptions.FAILURE_ENRICHERS_LIST, "enricher1");
         result = FailureEnricherUtils.getIncludedFailureEnrichers(conf);
         assertThat(result).hasSize(1);
         assertThat(result).contains("enricher1");
 
         // Multiple enrichers with spaces
-        conf.setString(JobManagerOptions.FAILURE_ENRICHERS_LIST, "enricher1, enricher2, enricher3");
+        conf.set(JobManagerOptions.FAILURE_ENRICHERS_LIST, "enricher1, enricher2, enricher3");
         result = FailureEnricherUtils.getIncludedFailureEnrichers(conf);
         assertThat(result).hasSize(3);
         assertThat(result).contains("enricher1", "enricher2", "enricher3");
 
         // Bad delimiter
-        conf.setString(JobManagerOptions.FAILURE_ENRICHERS_LIST, "enricher1. enricher2. enricher3");
+        conf.set(JobManagerOptions.FAILURE_ENRICHERS_LIST, "enricher1. enricher2. enricher3");
         result = FailureEnricherUtils.getIncludedFailureEnrichers(conf);
         assertThat(result).hasSize(1);
         assertThat(result).contains("enricher1. enricher2. enricher3");
 
         // Multiple enrichers with spaces and empty values
-        conf.setString(
-                JobManagerOptions.FAILURE_ENRICHERS_LIST, "enricher1, ,enricher2,   enricher3");
+        conf.set(JobManagerOptions.FAILURE_ENRICHERS_LIST, "enricher1, ,enricher2,   enricher3");
         result = FailureEnricherUtils.getIncludedFailureEnrichers(conf);
         assertThat(result).hasSize(3);
         assertThat(result).contains("enricher1", "enricher2", "enricher3");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/HighAvailabilityServicesUtilsTest.java
@@ -54,7 +54,7 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
 
         Executor executor = Executors.directExecutor();
 
-        config.setString(HighAvailabilityOptions.HA_MODE, TestHAFactory.class.getName());
+        config.set(HighAvailabilityOptions.HA_MODE, TestHAFactory.class.getName());
 
         // when
         HighAvailabilityServices actualHaServices =
@@ -85,7 +85,7 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
                 TestingClientHAServices.createClientHAServices();
         TestHAFactory.clientHAServices = clientHAServices;
 
-        config.setString(HighAvailabilityOptions.HA_MODE, TestHAFactory.class.getName());
+        config.set(HighAvailabilityOptions.HA_MODE, TestHAFactory.class.getName());
 
         // when
         ClientHighAvailabilityServices actualClientHAServices =
@@ -102,7 +102,7 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
 
         Executor executor = Executors.directExecutor();
 
-        config.setString(
+        config.set(
                 HighAvailabilityOptions.HA_MODE,
                 HighAvailabilityMode.FACTORY_CLASS.name().toLowerCase());
 
@@ -117,8 +117,8 @@ public class HighAvailabilityServicesUtilsTest extends TestLogger {
         final String clusterId = UUID.randomUUID().toString();
         final Configuration configuration = new Configuration();
 
-        configuration.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haStorageRootDirectory);
-        configuration.setString(HighAvailabilityOptions.HA_CLUSTER_ID, clusterId);
+        configuration.set(HighAvailabilityOptions.HA_STORAGE_PATH, haStorageRootDirectory);
+        configuration.set(HighAvailabilityOptions.HA_CLUSTER_ID, clusterId);
 
         final Path clusterHighAvailableStoragePath =
                 HighAvailabilityServicesUtils.getClusterHighAvailableStoragePath(configuration);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -73,14 +73,14 @@ class NettyClientServerSslTest {
     @TestTemplate
     void testValidSslConnectionAdvanced() throws Exception {
         Configuration sslConfig = createSslConfig();
-        sslConfig.setInteger(SSL_INTERNAL_SESSION_CACHE_SIZE, 1);
+        sslConfig.set(SSL_INTERNAL_SESSION_CACHE_SIZE, 1);
 
         // using different timeouts for each of the configuration parameters ensures that the right
         // config value is used in the right place
         final int timeoutInMillisBase = (int) Duration.ofHours(1).toMillis();
-        sslConfig.setInteger(SSL_INTERNAL_SESSION_TIMEOUT, timeoutInMillisBase + 1);
-        sslConfig.setInteger(SSL_INTERNAL_HANDSHAKE_TIMEOUT, timeoutInMillisBase + 2);
-        sslConfig.setInteger(SSL_INTERNAL_CLOSE_NOTIFY_FLUSH_TIMEOUT, timeoutInMillisBase + 3);
+        sslConfig.set(SSL_INTERNAL_SESSION_TIMEOUT, timeoutInMillisBase + 1);
+        sslConfig.set(SSL_INTERNAL_HANDSHAKE_TIMEOUT, timeoutInMillisBase + 2);
+        sslConfig.set(SSL_INTERNAL_CLOSE_NOTIFY_FLUSH_TIMEOUT, timeoutInMillisBase + 3);
 
         testValidSslConnection(sslConfig);
     }
@@ -152,7 +152,7 @@ class NettyClientServerSslTest {
         // our own channel initializer)
         assertEqualsOrDefault(
                 sslConfig, SSL_INTERNAL_SESSION_CACHE_SIZE, sessionContext.getSessionCacheSize());
-        int sessionTimeout = sslConfig.getInteger(SSL_INTERNAL_SESSION_TIMEOUT);
+        int sessionTimeout = sslConfig.get(SSL_INTERNAL_SESSION_TIMEOUT);
         if (sessionTimeout != -1) {
             // session timeout config is in milliseconds but the context returns it in seconds
             assertThat(sessionContext.getSessionTimeout()).isEqualTo(sessionTimeout / 1000);
@@ -167,7 +167,7 @@ class NettyClientServerSslTest {
 
     private static void assertEqualsOrDefault(
             Configuration sslConfig, ConfigOption<Integer> option, long actual) {
-        long expected = sslConfig.getInteger(option);
+        long expected = sslConfig.get(option);
         if (expected != option.defaultValue()) {
             assertThat(actual).isEqualTo(expected);
         } else {
@@ -185,7 +185,7 @@ class NettyClientServerSslTest {
 
         Configuration config = createSslConfig();
         // Modify the keystore password to an incorrect one
-        config.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "invalidpassword");
+        config.set(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "invalidpassword");
 
         try (NetUtils.Port port = NetUtils.getAvailablePort()) {
             NettyConfig nettyConfig = createNettyConfig(config, port);
@@ -204,8 +204,7 @@ class NettyClientServerSslTest {
         Configuration config = createSslConfig();
 
         // Use a server certificate which is not present in the truststore
-        config.setString(
-                SecurityOptions.SSL_INTERNAL_KEYSTORE, "src/test/resources/untrusted.keystore");
+        config.set(SecurityOptions.SSL_INTERNAL_KEYSTORE, "src/test/resources/untrusted.keystore");
 
         NettyTestUtil.NettyServerAndClient serverAndClient;
         try (NetUtils.Port port = NetUtils.getAvailablePort()) {
@@ -231,7 +230,7 @@ class NettyClientServerSslTest {
         final Configuration clientConfig = createSslConfig();
 
         // give the client a different keystore / certificate
-        clientConfig.setString(
+        clientConfig.set(
                 SecurityOptions.SSL_INTERNAL_KEYSTORE, "src/test/resources/untrusted.keystore");
 
         NettyServerAndClient serverAndClient;
@@ -269,7 +268,7 @@ class NettyClientServerSslTest {
         Configuration config = createSslConfig();
 
         // pin the certificate based on internal cert
-        config.setString(
+        config.set(
                 SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT,
                 SSLUtilsTest.getCertificateFingerprint(config, "flink.test"));
         NettyTestUtil.NettyServerAndClient serverAndClient;
@@ -297,7 +296,7 @@ class NettyClientServerSslTest {
         Configuration config = createSslConfig();
 
         // pin the certificate based on internal cert
-        config.setString(
+        config.set(
                 SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT,
                 SSLUtilsTest.getCertificateFingerprint(config, "flink.test")
                         .replaceAll("[0-9A-Z]", "0"));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManagerTest.java
@@ -111,9 +111,9 @@ class NettyConnectionManagerTest {
 
         // Expected number of threads
         Configuration flinkConfig = new Configuration();
-        flinkConfig.setInteger(NettyShuffleEnvironmentOptions.NUM_ARENAS, numberOfArenas);
-        flinkConfig.setInteger(NettyShuffleEnvironmentOptions.NUM_THREADS_CLIENT, 3);
-        flinkConfig.setInteger(NettyShuffleEnvironmentOptions.NUM_THREADS_SERVER, 4);
+        flinkConfig.set(NettyShuffleEnvironmentOptions.NUM_ARENAS, numberOfArenas);
+        flinkConfig.set(NettyShuffleEnvironmentOptions.NUM_THREADS_CLIENT, 3);
+        flinkConfig.set(NettyShuffleEnvironmentOptions.NUM_THREADS_SERVER, 4);
 
         NettyConnectionManager connectionManager;
         {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/Prio0InboundChannelHandlerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/Prio0InboundChannelHandlerFactory.java
@@ -48,8 +48,8 @@ public class Prio0InboundChannelHandlerFactory implements InboundChannelHandlerF
     public Optional<ChannelHandler> createHandler(
             Configuration configuration, Map<String, String> responseHeaders)
             throws ConfigurationException {
-        String redirectFromUrl = configuration.getString(REDIRECT_FROM_URL);
-        String redirectToUrl = configuration.getString(REDIRECT_TO_URL);
+        String redirectFromUrl = configuration.get(REDIRECT_FROM_URL);
+        String redirectToUrl = configuration.get(REDIRECT_TO_URL);
         if (!redirectFromUrl.isEmpty() && !redirectToUrl.isEmpty()) {
             return Optional.of(
                     new ChannelInboundHandlerAdapter() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileBufferReaderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileBufferReaderITCase.java
@@ -109,9 +109,8 @@ class FileBufferReaderITCase {
         // Increases the handshake timeout to avoid connection reset/close issues
         // if the netty server thread could not response in time, like when it is
         // busy reading the files.
-        configuration.setInteger(SecurityOptions.SSL_INTERNAL_HANDSHAKE_TIMEOUT, 100000);
-        configuration.setString(
-                NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE, "file");
+        configuration.set(SecurityOptions.SSL_INTERNAL_HANDSHAKE_TIMEOUT, 100000);
+        configuration.set(NettyShuffleEnvironmentOptions.NETWORK_BLOCKING_SHUFFLE_TYPE, "file");
         configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
         configuration.set(
                 TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse(bufferSize + "b"));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -63,8 +63,7 @@ class PartialConsumePipelinedResultTest {
     private static Configuration getFlinkConfiguration() {
         final Configuration config = new Configuration();
         config.set(AkkaOptions.ASK_TIMEOUT_DURATION, TestingUtils.DEFAULT_ASK_TIMEOUT);
-        config.setInteger(
-                NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, NUMBER_OF_NETWORK_BUFFERS);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, NUMBER_OF_NETWORK_BUFFERS);
 
         return config;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/BlobsCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/BlobsCleanupITCase.java
@@ -88,12 +88,12 @@ public class BlobsCleanupITCase extends TestLogger {
         blobBaseDir = TEMPORARY_FOLDER.newFolder();
 
         Configuration cfg = new Configuration();
-        cfg.setString(BlobServerOptions.STORAGE_DIRECTORY, blobBaseDir.getAbsolutePath());
-        cfg.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixeddelay");
-        cfg.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+        cfg.set(BlobServerOptions.STORAGE_DIRECTORY, blobBaseDir.getAbsolutePath());
+        cfg.set(RestartStrategyOptions.RESTART_STRATEGY, "fixeddelay");
+        cfg.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
         // BLOBs are deleted from BlobCache between 1s and 2s after last reference
         // -> the BlobCache may still have the BLOB or not (let's test both cases randomly)
-        cfg.setLong(BlobServerOptions.CLEANUP_INTERVAL, 1L);
+        cfg.set(BlobServerOptions.CLEANUP_INTERVAL, 1L);
 
         configuration = new UnmodifiableConfiguration(cfg);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/HighAvailabilityModeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/HighAvailabilityModeTest.java
@@ -44,13 +44,13 @@ public class HighAvailabilityModeTest extends TestLogger {
         assertEquals(DEFAULT_HA_MODE, HighAvailabilityMode.fromConfig(config));
 
         // Check not equals default
-        config.setString(
+        config.set(
                 HighAvailabilityOptions.HA_MODE,
                 HighAvailabilityMode.ZOOKEEPER.name().toLowerCase());
         assertEquals(HighAvailabilityMode.ZOOKEEPER, HighAvailabilityMode.fromConfig(config));
 
         // Check factory class
-        config.setString(HighAvailabilityOptions.HA_MODE, "factory.class.FQN");
+        config.set(HighAvailabilityOptions.HA_MODE, "factory.class.FQN");
         assertEquals(HighAvailabilityMode.FACTORY_CLASS, HighAvailabilityMode.fromConfig(config));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerSharedServicesTest.java
@@ -70,7 +70,7 @@ public class JobManagerSharedServicesTest extends TestLogger {
     public void testFutureExecutorConfiguration() throws Exception {
         final int futurePoolSize = 8;
         final Configuration config = new Configuration();
-        config.setInteger(JobManagerOptions.JOB_MANAGER_FUTURE_POOL_SIZE, futurePoolSize);
+        config.set(JobManagerOptions.JOB_MANAGER_FUTURE_POOL_SIZE, futurePoolSize);
 
         final JobManagerSharedServices jobManagerSharedServices =
                 buildJobManagerSharedServices(config);
@@ -98,7 +98,7 @@ public class JobManagerSharedServicesTest extends TestLogger {
     public void testIoExecutorConfiguration() throws Exception {
         final int ioPoolSize = 5;
         final Configuration config = new Configuration();
-        config.setInteger(JobManagerOptions.JOB_MANAGER_IO_POOL_SIZE, ioPoolSize);
+        config.set(JobManagerOptions.JOB_MANAGER_IO_POOL_SIZE, ioPoolSize);
 
         final JobManagerSharedServices jobManagerSharedServices =
                 buildJobManagerSharedServices(config);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
@@ -242,7 +242,7 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
                     clusterPartitionsForPromote::complete);
 
             Configuration configuration = new Configuration();
-            configuration.setString(
+            configuration.set(
                     BlobServerOptions.STORAGE_DIRECTORY,
                     temporaryFolder.newFolder().getAbsolutePath());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -233,7 +233,7 @@ class JobMasterTest {
         rmLeaderRetrievalService = new SettableLeaderRetrievalService(null, null);
         haServices.setResourceManagerLeaderRetriever(rmLeaderRetrievalService);
 
-        configuration.setString(
+        configuration.set(
                 BlobServerOptions.STORAGE_DIRECTORY,
                 Files.createTempDirectory(temporaryFolder, UUID.randomUUID().toString())
                         .toString());
@@ -1021,7 +1021,7 @@ class JobMasterTest {
     @Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler") // FLINK-21450
     void testRequestNextInputSplitWithLocalFailover() throws Exception {
 
-        configuration.setString(
+        configuration.set(
                 JobManagerOptions.EXECUTION_FAILOVER_STRATEGY,
                 FailoverStrategyFactoryLoader.PIPELINED_REGION_RESTART_STRATEGY_NAME);
 
@@ -1033,10 +1033,10 @@ class JobMasterTest {
 
     @Test
     void testRequestNextInputSplitWithGlobalFailover() throws Exception {
-        configuration.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
+        configuration.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
         configuration.set(
                 RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, Duration.ofSeconds(0));
-        configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
+        configuration.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
 
         final Function<List<List<InputSplit>>, Collection<InputSplit>>
                 expectAllRemainingInputSplits = this::flattenCollection;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -168,9 +168,9 @@ public class LeaderElectionTest {
 
             final Configuration configuration = new Configuration();
 
-            configuration.setString(
+            configuration.set(
                     HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
-            configuration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+            configuration.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
 
             curatorFrameworkWrapper =
                     ZooKeeperUtils.startCuratorFramework(configuration, fatalErrorHandler);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -106,10 +106,10 @@ class ZooKeeperLeaderElectionTest {
     void before() {
         configuration = new Configuration();
 
-        configuration.setString(
+        configuration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 zooKeeperResource.getCustomExtension().getConnectString());
-        configuration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        configuration.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
     }
 
     /** Tests that the ZooKeeperLeaderElection/RetrievalService return both the correct URL. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -83,8 +83,8 @@ class ZooKeeperLeaderRetrievalTest {
     @BeforeEach
     void before() throws Exception {
         config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        config.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperExtension.getConnectString());
 
         highAvailabilityServices =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
@@ -287,10 +287,10 @@ class MetricRegistryImplTest {
     void testScopeConfig() {
         Configuration config = new Configuration();
 
-        config.setString(MetricOptions.SCOPE_NAMING_TM, "A");
-        config.setString(MetricOptions.SCOPE_NAMING_TM_JOB, "B");
-        config.setString(MetricOptions.SCOPE_NAMING_TASK, "C");
-        config.setString(MetricOptions.SCOPE_NAMING_OPERATOR, "D");
+        config.set(MetricOptions.SCOPE_NAMING_TM, "A");
+        config.set(MetricOptions.SCOPE_NAMING_TM_JOB, "B");
+        config.set(MetricOptions.SCOPE_NAMING_TASK, "C");
+        config.set(MetricOptions.SCOPE_NAMING_OPERATOR, "D");
 
         ScopeFormats scopeConfig = ScopeFormats.fromConfig(config);
 
@@ -303,8 +303,8 @@ class MetricRegistryImplTest {
     @Test
     void testConfigurableDelimiter() throws Exception {
         Configuration config = new Configuration();
-        config.setString(MetricOptions.SCOPE_DELIMITER, "_");
-        config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D.E");
+        config.set(MetricOptions.SCOPE_DELIMITER, "_");
+        config.set(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D.E");
 
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(
@@ -361,7 +361,7 @@ class MetricRegistryImplTest {
         config3.setProperty(MetricOptions.REPORTER_SCOPE_DELIMITER.key(), "AA");
 
         Configuration config = new Configuration();
-        config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B");
+        config.set(MetricOptions.SCOPE_NAMING_TM, "A.B");
 
         List<ReporterSetup> reporterConfigurations =
                 Arrays.asList(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
@@ -114,7 +114,7 @@ class ReporterSetupTest {
         configureReporter1(config);
         configureReporter2(config);
 
-        config.setString(MetricOptions.REPORTERS_LIST, "reporter2");
+        config.set(MetricOptions.REPORTERS_LIST, "reporter2");
 
         final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -136,7 +136,7 @@ class AbstractMetricGroupTest {
     void testScopeCachingForMultipleReporters() throws Exception {
         String counterName = "1";
         Configuration config = new Configuration();
-        config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D");
+        config.set(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D");
 
         MetricConfig metricConfig1 = new MetricConfig();
         metricConfig1.setProperty(MetricOptions.REPORTER_SCOPE_DELIMITER.key(), "-");
@@ -269,7 +269,7 @@ class AbstractMetricGroupTest {
     @Test
     void testScopeGenerationWithoutReporters() throws Exception {
         Configuration config = new Configuration();
-        config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D");
+        config.set(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D");
         MetricRegistryImpl testRegistry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(config));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalOperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalOperatorGroupTest.java
@@ -82,7 +82,7 @@ class InternalOperatorGroupTest {
     @Test
     void testGenerateScopeCustom() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(
+        cfg.set(
                 MetricOptions.SCOPE_NAMING_OPERATOR,
                 "<tm_id>.<job_id>.<task_id>.<operator_name>.<operator_id>");
         MetricRegistryImpl registry =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerGroupTest.java
@@ -119,7 +119,7 @@ class JobManagerGroupTest {
     @Test
     void testGenerateScopeCustom() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_JM, "constant.<host>.foo.<host>");
+        cfg.set(MetricOptions.SCOPE_NAMING_JM, "constant.<host>.foo.<host>");
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerJobGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerJobGroupTest.java
@@ -55,8 +55,8 @@ class JobManagerJobGroupTest {
     @Test
     void testGenerateScopeCustom() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_JM, "abc");
-        cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "some-constant.<job_name>");
+        cfg.set(MetricOptions.SCOPE_NAMING_JM, "abc");
+        cfg.set(MetricOptions.SCOPE_NAMING_JM_JOB, "some-constant.<job_name>");
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
@@ -74,8 +74,8 @@ class JobManagerJobGroupTest {
     @Test
     void testGenerateScopeCustomWildcard() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_JM, "peter");
-        cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "*.some-constant.<job_id>");
+        cfg.set(MetricOptions.SCOPE_NAMING_JM, "peter");
+        cfg.set(MetricOptions.SCOPE_NAMING_JM_JOB, "*.some-constant.<job_id>");
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerOperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerOperatorGroupTest.java
@@ -122,7 +122,7 @@ class JobManagerOperatorGroupTest {
     @Test
     void testGenerateScopeCustom() {
         Configuration cfg = new Configuration();
-        cfg.setString(
+        cfg.set(
                 MetricOptions.SCOPE_NAMING_JM_OPERATOR,
                 "constant.<host>.foo.<host>.<job_id>.<job_name>.<task_id>.<task_name>.<operator_id>.<operator_name>");
         MetricRegistry registry =
@@ -160,9 +160,9 @@ class JobManagerOperatorGroupTest {
     @Test
     void testGenerateScopeCustomWildcard() {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_JM, "peter");
-        cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "*.some-constant.<job_id>");
-        cfg.setString(MetricOptions.SCOPE_NAMING_JM_OPERATOR, "*.other-constant.<operator_id>");
+        cfg.set(MetricOptions.SCOPE_NAMING_JM, "peter");
+        cfg.set(MetricOptions.SCOPE_NAMING_JM_JOB, "*.some-constant.<job_id>");
+        cfg.set(MetricOptions.SCOPE_NAMING_JM_OPERATOR, "*.other-constant.<operator_id>");
         MetricRegistry registry =
                 TestingMetricRegistry.builder()
                         .setScopeFormats(ScopeFormats.fromConfig(cfg))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerGroupTest.java
@@ -166,7 +166,7 @@ class TaskManagerGroupTest {
     @Test
     void testGenerateScopeCustom() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_TM, "constant.<host>.foo.<host>");
+        cfg.set(MetricOptions.SCOPE_NAMING_TM, "constant.<host>.foo.<host>");
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
         TaskManagerMetricGroup group =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobGroupTest.java
@@ -70,8 +70,8 @@ class TaskManagerJobGroupTest {
     @Test
     void testGenerateScopeCustom() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_TM, "abc");
-        cfg.setString(MetricOptions.SCOPE_NAMING_TM_JOB, "some-constant.<job_name>");
+        cfg.set(MetricOptions.SCOPE_NAMING_TM, "abc");
+        cfg.set(MetricOptions.SCOPE_NAMING_TM_JOB, "some-constant.<job_name>");
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
@@ -91,8 +91,8 @@ class TaskManagerJobGroupTest {
     @Test
     void testGenerateScopeCustomWildcard() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_TM, "peter.<tm_id>");
-        cfg.setString(MetricOptions.SCOPE_NAMING_TM_JOB, "*.some-constant.<job_id>");
+        cfg.set(MetricOptions.SCOPE_NAMING_TM, "peter.<tm_id>");
+        cfg.set(MetricOptions.SCOPE_NAMING_TM_JOB, "*.some-constant.<job_id>");
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroupTest.java
@@ -82,10 +82,9 @@ class TaskMetricGroupTest {
     @Test
     void testGenerateScopeCustom() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_TM, "abc");
-        cfg.setString(MetricOptions.SCOPE_NAMING_TM_JOB, "def");
-        cfg.setString(
-                MetricOptions.SCOPE_NAMING_TASK, "<tm_id>.<job_id>.<task_id>.<task_attempt_id>");
+        cfg.set(MetricOptions.SCOPE_NAMING_TM, "abc");
+        cfg.set(MetricOptions.SCOPE_NAMING_TM_JOB, "def");
+        cfg.set(MetricOptions.SCOPE_NAMING_TASK, "<tm_id>.<job_id>.<task_id>.<task_attempt_id>");
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
@@ -112,7 +111,7 @@ class TaskMetricGroupTest {
     @Test
     void testGenerateScopeWilcard() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_TASK, "*.<task_attempt_id>.<subtask_index>");
+        cfg.set(MetricOptions.SCOPE_NAMING_TASK, "*.<task_attempt_id>.<subtask_index>");
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
 
@@ -186,7 +185,7 @@ class TaskMetricGroupTest {
     @Test
     void testOperatorNameTruncation() throws Exception {
         Configuration cfg = new Configuration();
-        cfg.setString(MetricOptions.SCOPE_NAMING_OPERATOR, ScopeFormat.SCOPE_OPERATOR_NAME);
+        cfg.set(MetricOptions.SCOPE_NAMING_OPERATOR, ScopeFormat.SCOPE_OPERATOR_NAME);
         MetricRegistryImpl registry =
                 new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
         TaskManagerMetricGroup tm =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
@@ -79,8 +79,7 @@ class MetricUtilsTest {
     void testStartMetricActorSystemRespectsThreadPriority() throws Exception {
         final Configuration configuration = new Configuration();
         final int expectedThreadPriority = 3;
-        configuration.setInteger(
-                MetricOptions.QUERY_SERVICE_THREAD_PRIORITY, expectedThreadPriority);
+        configuration.set(MetricOptions.QUERY_SERVICE_THREAD_PRIORITY, expectedThreadPriority);
 
         final RpcService rpcService =
                 MetricUtils.startRemoteMetricsRpcService(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -109,7 +109,7 @@ class MiniClusterITCase {
         final Duration slotRequestTimeout = Duration.ofMillis(100);
 
         // this triggers the failure for the default scheduler
-        config.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, slotRequestTimeout.toMillis());
+        config.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, slotRequestTimeout.toMillis());
         // this triggers the failure for the adaptive scheduler
         config.set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, slotRequestTimeout);
 
@@ -132,7 +132,7 @@ class MiniClusterITCase {
         final Duration slotRequestTimeout = Duration.ofNanos(Long.MAX_VALUE);
 
         // this triggers the failure for the default scheduler
-        config.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, slotRequestTimeout.toMillis());
+        config.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, slotRequestTimeout.toMillis());
         // this triggers the failure for the adaptive scheduler
         config.set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, slotRequestTimeout);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniClusterConfiguration.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniClusterConfiguration.java
@@ -123,13 +123,12 @@ public class TestingMiniClusterConfiguration extends MiniClusterConfiguration {
 
         public TestingMiniClusterConfiguration build() {
             final Configuration modifiedConfiguration = new Configuration(configuration);
-            modifiedConfiguration.setInteger(
-                    TaskManagerOptions.NUM_TASK_SLOTS, numSlotsPerTaskManager);
-            modifiedConfiguration.setString(
+            modifiedConfiguration.set(TaskManagerOptions.NUM_TASK_SLOTS, numSlotsPerTaskManager);
+            modifiedConfiguration.set(
                     RestOptions.ADDRESS,
-                    modifiedConfiguration.getString(RestOptions.ADDRESS, "localhost"));
-            modifiedConfiguration.setInteger(
-                    RestOptions.PORT, modifiedConfiguration.getInteger(RestOptions.PORT, 0));
+                    modifiedConfiguration.get(RestOptions.ADDRESS, "localhost"));
+            modifiedConfiguration.set(
+                    RestOptions.PORT, modifiedConfiguration.get(RestOptions.PORT, 0));
 
             return new TestingMiniClusterConfiguration(
                     modifiedConfiguration,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/net/SSLUtilsTest.java
@@ -109,7 +109,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testRESTClientSSLDisabled(String sslProvider) {
         Configuration clientConfig = createRestSslConfigWithTrustStore(sslProvider);
-        clientConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+        clientConfig.set(SecurityOptions.SSL_REST_ENABLED, false);
 
         assertThatThrownBy(() -> SSLUtils.createRestClientSSLEngineFactory(clientConfig))
                 .isInstanceOf(IllegalConfigurationException.class);
@@ -119,8 +119,8 @@ public class SSLUtilsTest {
     @Test
     void testRESTClientSSLMissingTrustStore() {
         Configuration config = new Configuration();
-        config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
-        config.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "some password");
+        config.set(SecurityOptions.SSL_REST_ENABLED, true);
+        config.set(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "some password");
 
         assertThatThrownBy(() -> SSLUtils.createRestClientSSLEngineFactory(config))
                 .isInstanceOf(IllegalConfigurationException.class);
@@ -130,8 +130,8 @@ public class SSLUtilsTest {
     @Test
     void testRESTClientSSLMissingPassword() {
         Configuration config = new Configuration();
-        config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
-        config.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_PATH);
+        config.set(SecurityOptions.SSL_REST_ENABLED, true);
+        config.set(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_PATH);
 
         assertThatThrownBy(() -> SSLUtils.createRestClientSSLEngineFactory(config))
                 .isInstanceOf(IllegalConfigurationException.class);
@@ -142,7 +142,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testRESTClientSSLWrongPassword(String sslProvider) {
         Configuration clientConfig = createRestSslConfigWithTrustStore(sslProvider);
-        clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "badpassword");
+        clientConfig.set(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "badpassword");
 
         assertThatThrownBy(() -> SSLUtils.createRestClientSSLEngineFactory(clientConfig))
                 .isInstanceOf(Exception.class);
@@ -153,7 +153,7 @@ public class SSLUtilsTest {
     void testRESTSSLConfigCipherAlgorithms(String sslProvider) throws Exception {
         String testSSLAlgorithms = "test_algorithm1,test_algorithm2";
         Configuration config = createRestSslConfigWithTrustStore(sslProvider);
-        config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        config.set(SecurityOptions.SSL_REST_ENABLED, true);
         config.setString(SecurityOptions.SSL_ALGORITHMS.key(), testSSLAlgorithms);
         JdkSslContext nettySSLContext =
                 (JdkSslContext)
@@ -180,7 +180,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testRESTServerSSLDisabled(String sslProvider) {
         Configuration serverConfig = createRestSslConfigWithKeyStore(sslProvider);
-        serverConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, false);
+        serverConfig.set(SecurityOptions.SSL_REST_ENABLED, false);
 
         assertThatThrownBy(() -> SSLUtils.createRestServerSSLEngineFactory(serverConfig))
                 .isInstanceOf(IllegalConfigurationException.class);
@@ -191,7 +191,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testRESTServerSSLBadKeystorePassword(String sslProvider) {
         Configuration serverConfig = createRestSslConfigWithKeyStore(sslProvider);
-        serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "badpassword");
+        serverConfig.set(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "badpassword");
 
         assertThatThrownBy(() -> SSLUtils.createRestServerSSLEngineFactory(serverConfig))
                 .isInstanceOf(Exception.class);
@@ -202,7 +202,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testRESTServerSSLBadKeyPassword(String sslProvider) {
         Configuration serverConfig = createRestSslConfigWithKeyStore(sslProvider);
-        serverConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "badpassword");
+        serverConfig.set(SecurityOptions.SSL_REST_KEY_PASSWORD, "badpassword");
 
         assertThatThrownBy(() -> SSLUtils.createRestServerSSLEngineFactory(serverConfig))
                 .isInstanceOf(Exception.class);
@@ -222,7 +222,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testInternalSSLWithSSLPinning(String sslProvider) throws Exception {
         final Configuration config = createInternalSslConfigWithKeyAndTrustStores(sslProvider);
-        config.setString(
+        config.set(
                 SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT,
                 getCertificateFingerprint(config, "flink.test"));
 
@@ -234,7 +234,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testInternalSSLDisables(String sslProvider) {
         final Configuration config = createInternalSslConfigWithKeyAndTrustStores(sslProvider);
-        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, false);
+        config.set(SecurityOptions.SSL_INTERNAL_ENABLED, false);
 
         assertThatThrownBy(() -> SSLUtils.createInternalServerSSLEngineFactory(config))
                 .isInstanceOf(Exception.class);
@@ -271,7 +271,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testInternalSSLWrongKeystorePassword(String sslProvider) {
         final Configuration config = createInternalSslConfigWithKeyAndTrustStores(sslProvider);
-        config.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "badpw");
+        config.set(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "badpw");
 
         assertThatThrownBy(() -> SSLUtils.createInternalServerSSLEngineFactory(config))
                 .isInstanceOf(Exception.class);
@@ -284,7 +284,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testInternalSSLWrongTruststorePassword(String sslProvider) {
         final Configuration config = createInternalSslConfigWithKeyAndTrustStores(sslProvider);
-        config.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "badpw");
+        config.set(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "badpw");
 
         assertThatThrownBy(() -> SSLUtils.createInternalServerSSLEngineFactory(config))
                 .isInstanceOf(Exception.class);
@@ -297,7 +297,7 @@ public class SSLUtilsTest {
     @MethodSource("parameters")
     void testInternalSSLWrongKeyPassword(String sslProvider) {
         final Configuration config = createInternalSslConfigWithKeyAndTrustStores(sslProvider);
-        config.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "badpw");
+        config.set(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "badpw");
 
         assertThatThrownBy(() -> SSLUtils.createInternalServerSSLEngineFactory(config))
                 .isInstanceOf(Exception.class);
@@ -315,8 +315,8 @@ public class SSLUtilsTest {
         Configuration serverConfig = createInternalSslConfigWithKeyAndTrustStores(sslProvider);
 
         // set custom protocol and cipher suites
-        serverConfig.setString(SecurityOptions.SSL_PROTOCOL, "TLSv1.1");
-        serverConfig.setString(
+        serverConfig.set(SecurityOptions.SSL_PROTOCOL, "TLSv1.1");
+        serverConfig.set(
                 SecurityOptions.SSL_ALGORITHMS,
                 "TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA256");
 
@@ -359,8 +359,8 @@ public class SSLUtilsTest {
         }
 
         // set custom protocol and cipher suites
-        serverConfig.setString(SecurityOptions.SSL_PROTOCOL, "TLSv1");
-        serverConfig.setString(SecurityOptions.SSL_ALGORITHMS, String.join(",", sslAlgorithms));
+        serverConfig.set(SecurityOptions.SSL_PROTOCOL, "TLSv1");
+        serverConfig.set(SecurityOptions.SSL_ALGORITHMS, String.join(",", sslAlgorithms));
 
         final SSLHandlerFactory serverSSLHandlerFactory =
                 SSLUtils.createInternalServerSSLEngineFactory(serverConfig);
@@ -380,7 +380,7 @@ public class SSLUtilsTest {
         final Configuration config = createInternalSslConfigWithKeyAndTrustStores(sslProvider);
         final String fingerprint = getCertificateFingerprint(config, "flink.test");
 
-        config.setString(
+        config.set(
                 SecurityOptions.SSL_INTERNAL_CERT_FINGERPRINT,
                 fingerprint.substring(0, fingerprint.length() - 3));
 
@@ -392,7 +392,7 @@ public class SSLUtilsTest {
 
     private Configuration createRestSslConfigWithKeyStore(String sslProvider) {
         final Configuration config = new Configuration();
-        config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        config.set(SecurityOptions.SSL_REST_ENABLED, true);
         addSslProviderConfig(config, sslProvider);
         addRestKeyStoreConfig(config);
         return config;
@@ -400,7 +400,7 @@ public class SSLUtilsTest {
 
     private Configuration createRestSslConfigWithTrustStore(String sslProvider) {
         final Configuration config = new Configuration();
-        config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        config.set(SecurityOptions.SSL_REST_ENABLED, true);
         addSslProviderConfig(config, sslProvider);
         addRestTrustStoreConfig(config);
         return config;
@@ -408,7 +408,7 @@ public class SSLUtilsTest {
 
     public static Configuration createRestSslConfigWithKeyAndTrustStores(String sslProvider) {
         final Configuration config = new Configuration();
-        config.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        config.set(SecurityOptions.SSL_REST_ENABLED, true);
         addSslProviderConfig(config, sslProvider);
         addRestKeyStoreConfig(config);
         addRestTrustStoreConfig(config);
@@ -417,7 +417,7 @@ public class SSLUtilsTest {
 
     private Configuration createInternalSslConfigWithKeyStore(String sslProvider) {
         final Configuration config = new Configuration();
-        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        config.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
         addSslProviderConfig(config, sslProvider);
         addInternalKeyStoreConfig(config);
         return config;
@@ -425,7 +425,7 @@ public class SSLUtilsTest {
 
     private Configuration createInternalSslConfigWithTrustStore(String sslProvider) {
         final Configuration config = new Configuration();
-        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        config.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
         addSslProviderConfig(config, sslProvider);
         addInternalTrustStoreConfig(config);
         return config;
@@ -433,7 +433,7 @@ public class SSLUtilsTest {
 
     public static Configuration createInternalSslConfigWithKeyAndTrustStores(String sslProvider) {
         final Configuration config = new Configuration();
-        config.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        config.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
         addSslProviderConfig(config, sslProvider);
         addInternalKeyStoreConfig(config);
         addInternalTrustStoreConfig(config);
@@ -445,11 +445,10 @@ public class SSLUtilsTest {
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         try (InputStream keyStoreFile =
                 Files.newInputStream(
-                        new File(config.getString(SecurityOptions.SSL_INTERNAL_KEYSTORE))
-                                .toPath())) {
+                        new File(config.get(SecurityOptions.SSL_INTERNAL_KEYSTORE)).toPath())) {
             keyStore.load(
                     keyStoreFile,
-                    config.getString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD).toCharArray());
+                    config.get(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD).toCharArray());
         }
         return getSha1Fingerprint(keyStore.getCertificate(certificateAlias));
     }
@@ -459,10 +458,10 @@ public class SSLUtilsTest {
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         try (InputStream keyStoreFile =
                 Files.newInputStream(
-                        new File(config.getString(SecurityOptions.SSL_REST_KEYSTORE)).toPath())) {
+                        new File(config.get(SecurityOptions.SSL_REST_KEYSTORE)).toPath())) {
             keyStore.load(
                     keyStoreFile,
-                    config.getString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD).toCharArray());
+                    config.get(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD).toCharArray());
         }
         return getSha1Fingerprint(keyStore.getCertificate(certificateAlias));
     }
@@ -472,33 +471,33 @@ public class SSLUtilsTest {
             OpenSsl.ensureAvailability();
 
             // Flink's default algorithm set is not available for openSSL - choose a different one:
-            config.setString(
+            config.set(
                     SecurityOptions.SSL_ALGORITHMS,
                     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
         }
-        config.setString(SecurityOptions.SSL_PROVIDER, sslProvider);
+        config.set(SecurityOptions.SSL_PROVIDER, sslProvider);
     }
 
     private static void addRestKeyStoreConfig(Configuration config) {
-        config.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_PATH);
-        config.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, KEY_STORE_PASSWORD);
-        config.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, KEY_PASSWORD);
+        config.set(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_PATH);
+        config.set(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, KEY_STORE_PASSWORD);
+        config.set(SecurityOptions.SSL_REST_KEY_PASSWORD, KEY_PASSWORD);
     }
 
     private static void addRestTrustStoreConfig(Configuration config) {
-        config.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_PATH);
-        config.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, TRUST_STORE_PASSWORD);
+        config.set(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_PATH);
+        config.set(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, TRUST_STORE_PASSWORD);
     }
 
     private static void addInternalKeyStoreConfig(Configuration config) {
-        config.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, KEY_STORE_PATH);
-        config.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, KEY_STORE_PASSWORD);
-        config.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, KEY_PASSWORD);
+        config.set(SecurityOptions.SSL_INTERNAL_KEYSTORE, KEY_STORE_PATH);
+        config.set(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, KEY_STORE_PASSWORD);
+        config.set(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, KEY_PASSWORD);
     }
 
     private static void addInternalTrustStoreConfig(Configuration config) {
-        config.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_PATH);
-        config.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, TRUST_STORE_PASSWORD);
+        config.set(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_PATH);
+        config.set(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, TRUST_STORE_PASSWORD);
     }
 
     private static String getSha1Fingerprint(Certificate cert) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
@@ -186,7 +186,7 @@ public class CoordinatorEventsExactlyOnceITCase {
 
         vertex.setParallelism(1);
         vertex.setInvokableClass(EventCollectingTask.class);
-        vertex.getConfiguration().setString(ACC_NAME, name);
+        vertex.getConfiguration().set(ACC_NAME, name);
 
         final OperatorCoordinator.Provider provider =
                 new OperatorCoordinator.Provider() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationConfigurationTest.java
@@ -40,11 +40,10 @@ class RetryingRegistrationConfigurationTest {
         final long refusedRegistrationDelay = 3L;
         final long errorRegistrationDelay = 4L;
 
-        configuration.setLong(
-                ClusterOptions.INITIAL_REGISTRATION_TIMEOUT, initialRegistrationTimeout);
-        configuration.setLong(ClusterOptions.MAX_REGISTRATION_TIMEOUT, maxRegistrationTimeout);
-        configuration.setLong(ClusterOptions.REFUSED_REGISTRATION_DELAY, refusedRegistrationDelay);
-        configuration.setLong(ClusterOptions.ERROR_REGISTRATION_DELAY, errorRegistrationDelay);
+        configuration.set(ClusterOptions.INITIAL_REGISTRATION_TIMEOUT, initialRegistrationTimeout);
+        configuration.set(ClusterOptions.MAX_REGISTRATION_TIMEOUT, maxRegistrationTimeout);
+        configuration.set(ClusterOptions.REFUSED_REGISTRATION_DELAY, refusedRegistrationDelay);
+        configuration.set(ClusterOptions.ERROR_REGISTRATION_DELAY, errorRegistrationDelay);
 
         final RetryingRegistrationConfiguration retryingRegistrationConfiguration =
                 RetryingRegistrationConfiguration.fromConfiguration(configuration);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -689,7 +689,7 @@ class ActiveResourceManagerTest {
     void testStartWorkerIntervalOnWorkerTerminationExceedFailureRate() throws Exception {
         new Context() {
             {
-                flinkConfig.setDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE, 1);
+                flinkConfig.set(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE, 1d);
                 flinkConfig.set(
                         ResourceManagerOptions.START_WORKER_RETRY_INTERVAL,
                         Duration.ofMillis(TESTING_START_WORKER_INTERVAL.toMilliseconds()));
@@ -769,7 +769,7 @@ class ActiveResourceManagerTest {
     void testStartWorkerIntervalOnRequestWorkerFailure() throws Exception {
         new Context() {
             {
-                flinkConfig.setDouble(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE, 1);
+                flinkConfig.set(ResourceManagerOptions.START_WORKER_MAX_FAILURE_RATE, 1d);
                 flinkConfig.set(
                         ResourceManagerOptions.START_WORKER_RETRY_INTERVAL,
                         Duration.ofMillis(TESTING_START_WORKER_INTERVAL.toMilliseconds()));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/MultipartUploadExtension.java
@@ -99,13 +99,13 @@ public class MultipartUploadExtension implements CustomExtension {
     public void before(ExtensionContext context) throws Exception {
         Path tmpDirectory = tmpDirectorySupplier.get();
         Configuration config = new Configuration();
-        config.setString(RestOptions.BIND_PORT, "0");
-        config.setString(RestOptions.ADDRESS, "localhost");
+        config.set(RestOptions.BIND_PORT, "0");
+        config.set(RestOptions.ADDRESS, "localhost");
         // set this to a lower value on purpose to test that files larger than the content limit are
         // still accepted
-        config.setInteger(RestOptions.SERVER_MAX_CONTENT_LENGTH, 1024 * 1024);
+        config.set(RestOptions.SERVER_MAX_CONTENT_LENGTH, 1024 * 1024);
         configuredUploadDir = TempDirUtils.newFolder(tmpDirectory).toPath();
-        config.setString(WebOptions.UPLOAD_DIR, configuredUploadDir.toString());
+        config.set(WebOptions.UPLOAD_DIR, configuredUploadDir.toString());
 
         RestfulGateway mockRestfulGateway = new TestingRestfulGateway();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/Prio0OutboundChannelHandlerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/Prio0OutboundChannelHandlerFactory.java
@@ -45,7 +45,7 @@ public class Prio0OutboundChannelHandlerFactory implements OutboundChannelHandle
     @Override
     public Optional<ChannelHandler> createHandler(Configuration configuration)
             throws ConfigurationException {
-        String redirectToUrl = configuration.getString(REDIRECT_TO_URL);
+        String redirectToUrl = configuration.get(REDIRECT_TO_URL);
         if (!redirectToUrl.isEmpty()) {
             return Optional.of(
                     new ChannelDuplexHandler() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -96,7 +96,7 @@ class RestClientTest {
     @Test
     void testConnectionTimeout() throws Exception {
         final Configuration config = new Configuration();
-        config.setLong(RestOptions.CONNECTION_TIMEOUT, 1);
+        config.set(RestOptions.CONNECTION_TIMEOUT, 1L);
         try (final RestClient restClient = new RestClient(config, Executors.directExecutor())) {
             CompletableFuture<?> future =
                     restClient.sendRequest(
@@ -137,7 +137,7 @@ class RestClientTest {
     @Test
     void testConnectionClosedHandling() throws Exception {
         final Configuration config = new Configuration();
-        config.setLong(RestOptions.IDLENESS_TIMEOUT, 5000L);
+        config.set(RestOptions.IDLENESS_TIMEOUT, 5000L);
         try (final ServerSocket serverSocket = new ServerSocket(0);
                 final RestClient restClient =
                         new RestClient(config, EXECUTOR_EXTENSION.getExecutor())) {
@@ -184,7 +184,7 @@ class RestClientTest {
     @Test
     void testRestClientClosedHandling() throws Exception {
         final Configuration config = new Configuration();
-        config.setLong(RestOptions.IDLENESS_TIMEOUT, 5000L);
+        config.set(RestOptions.IDLENESS_TIMEOUT, 5000L);
 
         Socket connectionSocket = null;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestExternalHandlersITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestExternalHandlersITCase.java
@@ -92,12 +92,12 @@ class RestExternalHandlersITCase {
         final String loopbackAddress = InetAddress.getLoopbackAddress().getHostAddress();
 
         final Configuration config = new Configuration();
-        config.setString(RestOptions.BIND_PORT, "0");
-        config.setString(RestOptions.BIND_ADDRESS, loopbackAddress);
-        config.setString(RestOptions.ADDRESS, loopbackAddress);
-        config.setString(Prio0OutboundChannelHandlerFactory.REDIRECT_TO_URL, REDIRECT1_URL);
-        config.setString(Prio0InboundChannelHandlerFactory.REDIRECT_FROM_URL, REDIRECT1_URL);
-        config.setString(Prio0InboundChannelHandlerFactory.REDIRECT_TO_URL, REDIRECT2_URL);
+        config.set(RestOptions.BIND_PORT, "0");
+        config.set(RestOptions.BIND_ADDRESS, loopbackAddress);
+        config.set(RestOptions.ADDRESS, loopbackAddress);
+        config.set(Prio0OutboundChannelHandlerFactory.REDIRECT_TO_URL, REDIRECT1_URL);
+        config.set(Prio0InboundChannelHandlerFactory.REDIRECT_FROM_URL, REDIRECT1_URL);
+        config.set(Prio0InboundChannelHandlerFactory.REDIRECT_TO_URL, REDIRECT2_URL);
         return config;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointConfigurationTest.java
@@ -41,11 +41,11 @@ class RestServerEndpointConfigurationTest {
     @Test
     void testBasicMapping(@TempDir File file) throws ConfigurationException {
         Configuration originalConfig = new Configuration();
-        originalConfig.setString(RestOptions.ADDRESS, ADDRESS);
-        originalConfig.setString(RestOptions.BIND_ADDRESS, BIND_ADDRESS);
-        originalConfig.setString(RestOptions.BIND_PORT, BIND_PORT);
-        originalConfig.setInteger(RestOptions.SERVER_MAX_CONTENT_LENGTH, CONTENT_LENGTH);
-        originalConfig.setString(WebOptions.TMP_DIR, file.getAbsolutePath());
+        originalConfig.set(RestOptions.ADDRESS, ADDRESS);
+        originalConfig.set(RestOptions.BIND_ADDRESS, BIND_ADDRESS);
+        originalConfig.set(RestOptions.BIND_PORT, BIND_PORT);
+        originalConfig.set(RestOptions.SERVER_MAX_CONTENT_LENGTH, CONTENT_LENGTH);
+        originalConfig.set(WebOptions.TMP_DIR, file.getAbsolutePath());
 
         final RestServerEndpointConfiguration result =
                 RestServerEndpointConfiguration.fromConfiguration(originalConfig);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -153,18 +153,18 @@ public class RestServerEndpointITCase {
         final String keystorePath = getTestResource("local127.keystore").getAbsolutePath();
 
         final Configuration sslConfig = new Configuration(config);
-        sslConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
-        sslConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, truststorePath);
-        sslConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
-        sslConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, keystorePath);
-        sslConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
-        sslConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
+        sslConfig.set(SecurityOptions.SSL_REST_ENABLED, true);
+        sslConfig.set(SecurityOptions.SSL_REST_TRUSTSTORE, truststorePath);
+        sslConfig.set(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
+        sslConfig.set(SecurityOptions.SSL_REST_KEYSTORE, keystorePath);
+        sslConfig.set(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
+        sslConfig.set(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
 
         final Configuration sslRestAuthConfig = new Configuration(sslConfig);
-        sslRestAuthConfig.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+        sslRestAuthConfig.set(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
 
         final Configuration sslPinningRestAuthConfig = new Configuration(sslRestAuthConfig);
-        sslPinningRestAuthConfig.setString(
+        sslPinningRestAuthConfig.set(
                 SecurityOptions.SSL_REST_CERT_FINGERPRINT,
                 SSLUtilsTest.getRestCertificateFingerprint(sslPinningRestAuthConfig, "flink.test"));
 
@@ -178,17 +178,17 @@ public class RestServerEndpointITCase {
         final String loopbackAddress = InetAddress.getLoopbackAddress().getHostAddress();
 
         final Configuration config = new Configuration();
-        config.setString(RestOptions.BIND_PORT, "0");
-        config.setString(RestOptions.BIND_ADDRESS, loopbackAddress);
-        config.setString(RestOptions.ADDRESS, loopbackAddress);
-        config.setInteger(RestOptions.SERVER_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
-        config.setInteger(RestOptions.CLIENT_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
+        config.set(RestOptions.BIND_PORT, "0");
+        config.set(RestOptions.BIND_ADDRESS, loopbackAddress);
+        config.set(RestOptions.ADDRESS, loopbackAddress);
+        config.set(RestOptions.SERVER_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
+        config.set(RestOptions.CLIENT_MAX_CONTENT_LENGTH, TEST_REST_MAX_CONTENT_LENGTH);
         return config;
     }
 
     @BeforeEach
     void setup() throws Exception {
-        config.setString(WebOptions.UPLOAD_DIR, tempFolder.toUri().getPath());
+        config.set(WebOptions.UPLOAD_DIR, tempFolder.toUri().getPath());
 
         defaultSSLContext = SSLContext.getDefault();
         defaultSSLSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
@@ -514,7 +514,7 @@ public class RestServerEndpointITCase {
 
     @TestTemplate
     void testDefaultVersionRouting() throws Exception {
-        assumeThat(config.getBoolean(SecurityOptions.SSL_REST_ENABLED))
+        assumeThat(config.get(SecurityOptions.SSL_REST_ENABLED))
                 .as("Ignoring SSL-enabled test to keep OkHttp usage simple.")
                 .isFalse();
 
@@ -535,7 +535,7 @@ public class RestServerEndpointITCase {
 
     @TestTemplate
     void testNonSslRedirectForEnabledSsl() throws Exception {
-        assumeThat(config.getBoolean(SecurityOptions.SSL_REST_ENABLED)).isTrue();
+        assumeThat(config.get(SecurityOptions.SSL_REST_ENABLED)).isTrue();
 
         OkHttpClient client = new OkHttpClient.Builder().followRedirects(false).build();
         String httpsUrl = serverEndpoint.getRestBaseUrl() + "/path";
@@ -631,8 +631,8 @@ public class RestServerEndpointITCase {
         final int portRangeStart = 52300;
         final int portRangeEnd = 52400;
         final Configuration config = new Configuration();
-        config.setString(RestOptions.ADDRESS, "localhost");
-        config.setString(RestOptions.BIND_PORT, portRangeStart + "-" + portRangeEnd);
+        config.set(RestOptions.ADDRESS, "localhost");
+        config.set(RestOptions.BIND_PORT, portRangeStart + "-" + portRangeEnd);
 
         try (RestServerEndpoint serverEndpoint1 = TestRestServerEndpoint.builder(config).build();
                 RestServerEndpoint serverEndpoint2 =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerSSLAuthITCase.java
@@ -79,15 +79,15 @@ public class RestServerSSLAuthITCase {
         Tuple2<Configuration, Configuration> untrusted = getClientServerConfiguration();
 
         Configuration serverConfig = new Configuration(untrusted.f1);
-        serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
+        serverConfig.set(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
         // expect fingerprint which client does not have
-        serverConfig.setString(
+        serverConfig.set(
                 SecurityOptions.SSL_REST_CERT_FINGERPRINT,
                 SSLUtilsTest.getRestCertificateFingerprint(serverConfig, "flink.test")
                         .replaceAll("[0-9A-Z]", "0"));
 
         Configuration clientConfig = new Configuration(untrusted.f0);
-        clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
+        clientConfig.set(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
 
         // client and server uses same trust store, however server configured with mismatching
         // fingerprint
@@ -139,25 +139,25 @@ public class RestServerSSLAuthITCase {
 
     private static Tuple2<Configuration, Configuration> getClientServerConfiguration() {
         final Configuration baseConfig = new Configuration();
-        baseConfig.setString(RestOptions.BIND_PORT, "0");
-        baseConfig.setString(RestOptions.ADDRESS, "localhost");
-        baseConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
-        baseConfig.setBoolean(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
-        baseConfig.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
+        baseConfig.set(RestOptions.BIND_PORT, "0");
+        baseConfig.set(RestOptions.ADDRESS, "localhost");
+        baseConfig.set(SecurityOptions.SSL_REST_ENABLED, true);
+        baseConfig.set(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
+        baseConfig.set(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
 
         Configuration serverConfig = new Configuration(baseConfig);
-        serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
-        serverConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
-        serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
-        serverConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
-        serverConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
+        serverConfig.set(SecurityOptions.SSL_REST_TRUSTSTORE, TRUST_STORE_FILE);
+        serverConfig.set(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
+        serverConfig.set(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
+        serverConfig.set(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
+        serverConfig.set(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
 
         Configuration clientConfig = new Configuration(baseConfig);
-        clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, UNTRUSTED_KEY_STORE_FILE);
-        clientConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
-        clientConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
-        clientConfig.setString(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
-        clientConfig.setString(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
+        clientConfig.set(SecurityOptions.SSL_REST_TRUSTSTORE, UNTRUSTED_KEY_STORE_FILE);
+        clientConfig.set(SecurityOptions.SSL_REST_TRUSTSTORE_PASSWORD, "password");
+        clientConfig.set(SecurityOptions.SSL_REST_KEYSTORE, KEY_STORE_FILE);
+        clientConfig.set(SecurityOptions.SSL_REST_KEYSTORE_PASSWORD, "password");
+        clientConfig.set(SecurityOptions.SSL_REST_KEY_PASSWORD, "password");
         return Tuple2.of(clientConfig, serverConfig);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
@@ -87,16 +87,16 @@ class AbstractHandlerTest {
         final String loopbackAddress = InetAddress.getLoopbackAddress().getHostAddress();
 
         final Configuration config = new Configuration();
-        config.setString(RestOptions.BIND_PORT, "0");
-        config.setString(RestOptions.BIND_ADDRESS, loopbackAddress);
-        config.setString(RestOptions.ADDRESS, loopbackAddress);
+        config.set(RestOptions.BIND_PORT, "0");
+        config.set(RestOptions.BIND_ADDRESS, loopbackAddress);
+        config.set(RestOptions.ADDRESS, loopbackAddress);
 
         REST_BASE_CONFIG = config;
     }
 
     private RestClient createRestClient(int serverPort) throws ConfigurationException {
         Configuration config = new Configuration(REST_BASE_CONFIG);
-        config.setInteger(RestOptions.PORT, serverPort);
+        config.set(RestOptions.PORT, serverPort);
 
         return new RestClient(config, Executors.directExecutor());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/RestHandlerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/RestHandlerConfigurationTest.java
@@ -72,7 +72,7 @@ class RestHandlerConfigurationTest {
             boolean reactiveMode,
             boolean expectedResult) {
         final Configuration config = new Configuration();
-        config.setBoolean(WebOptions.RESCALE_ENABLE, webRescaleEnabled);
+        config.set(WebOptions.RESCALE_ENABLE, webRescaleEnabled);
         if (adaptiveScheduler) {
             config.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);
         } else {
@@ -88,7 +88,7 @@ class RestHandlerConfigurationTest {
 
     private static void testWebSubmitFeatureFlag(boolean webSubmitEnabled) {
         final Configuration config = new Configuration();
-        config.setBoolean(WebOptions.SUBMIT_ENABLE, webSubmitEnabled);
+        config.set(WebOptions.SUBMIT_ENABLE, webSubmitEnabled);
 
         RestHandlerConfiguration restHandlerConfiguration =
                 RestHandlerConfiguration.fromConfiguration(config);
@@ -97,7 +97,7 @@ class RestHandlerConfigurationTest {
 
     private static void testWebCancelFeatureFlag(boolean webCancelEnabled) {
         final Configuration config = new Configuration();
-        config.setBoolean(WebOptions.CANCEL_ENABLE, webCancelEnabled);
+        config.set(WebOptions.CANCEL_ENABLE, webCancelEnabled);
 
         RestHandlerConfiguration restHandlerConfiguration =
                 RestHandlerConfiguration.fromConfiguration(config);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
@@ -57,9 +57,9 @@ public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint
 
     static {
         config = new Configuration();
-        config.setString(RestOptions.ADDRESS, "localhost");
+        config.set(RestOptions.ADDRESS, "localhost");
         // necessary for loading the web-submission extension
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
+        config.set(JobManagerOptions.ADDRESS, "localhost");
         handlerConfig = RestHandlerConfiguration.fromConfiguration(config);
 
         dispatcherGatewayRetriever = () -> null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/RpcSSLAuthITCase.java
@@ -50,32 +50,32 @@ class RpcSSLAuthITCase {
     @Test
     void testConnectFailure() throws Exception {
         final Configuration baseConfig = new Configuration();
-        baseConfig.setString(AkkaOptions.TCP_TIMEOUT, "1 s");
+        baseConfig.set(AkkaOptions.TCP_TIMEOUT, "1 s");
         // we start the RPC service with a very long timeout to ensure that the test
         // can only pass if the connection problem is not recognized merely via a timeout
         baseConfig.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofSeconds(10000000));
 
         // !!! This config has KEY_STORE_FILE / TRUST_STORE_FILE !!!
         Configuration sslConfig1 = new Configuration(baseConfig);
-        sslConfig1.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
-        sslConfig1.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, KEY_STORE_FILE);
-        sslConfig1.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_FILE);
-        sslConfig1.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "password");
-        sslConfig1.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "password");
-        sslConfig1.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "password");
-        sslConfig1.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
+        sslConfig1.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        sslConfig1.set(SecurityOptions.SSL_INTERNAL_KEYSTORE, KEY_STORE_FILE);
+        sslConfig1.set(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_FILE);
+        sslConfig1.set(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "password");
+        sslConfig1.set(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "password");
+        sslConfig1.set(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "password");
+        sslConfig1.set(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
 
         // !!! This config has KEY_STORE_FILE / UNTRUSTED_KEY_STORE_FILE !!!
         // If this is presented by a client, it will trust the server, but the server will
         // not trust this client in case client auth is enabled.
         Configuration sslConfig2 = new Configuration(baseConfig);
-        sslConfig2.setBoolean(SecurityOptions.SSL_INTERNAL_ENABLED, true);
-        sslConfig2.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE, UNTRUSTED_KEY_STORE_FILE);
-        sslConfig2.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_FILE);
-        sslConfig2.setString(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "password");
-        sslConfig2.setString(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "password");
-        sslConfig2.setString(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "password");
-        sslConfig2.setString(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
+        sslConfig2.set(SecurityOptions.SSL_INTERNAL_ENABLED, true);
+        sslConfig2.set(SecurityOptions.SSL_INTERNAL_KEYSTORE, UNTRUSTED_KEY_STORE_FILE);
+        sslConfig2.set(SecurityOptions.SSL_INTERNAL_TRUSTSTORE, TRUST_STORE_FILE);
+        sslConfig2.set(SecurityOptions.SSL_INTERNAL_KEYSTORE_PASSWORD, "password");
+        sslConfig2.set(SecurityOptions.SSL_INTERNAL_KEY_PASSWORD, "password");
+        sslConfig2.set(SecurityOptions.SSL_INTERNAL_TRUSTSTORE_PASSWORD, "password");
+        sslConfig2.set(SecurityOptions.SSL_ALGORITHMS, "TLS_RSA_WITH_AES_128_CBC_SHA");
 
         RpcService rpcService1 = null;
         RpcService rpcService2 = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
@@ -68,7 +68,7 @@ public class SchedulerUtilsTest extends TestLogger {
 
         final int maxNumberOfCheckpointsToRetain = 10;
         final Configuration jobManagerConfig = new Configuration();
-        jobManagerConfig.setInteger(
+        jobManagerConfig.set(
                 CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, maxNumberOfCheckpointsToRetain);
 
         final CompletedCheckpointStore completedCheckpointStore =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
@@ -395,12 +395,12 @@ class DefaultVertexParallelismAndInputInfosDeciderTest {
             int defaultSourceParallelism) {
         Configuration configuration = new Configuration();
 
-        configuration.setInteger(
+        configuration.set(
                 BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MIN_PARALLELISM, minParallelism);
         configuration.set(
                 BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_AVG_DATA_VOLUME_PER_TASK,
                 new MemorySize(dataVolumePerTask));
-        configuration.setInteger(
+        configuration.set(
                 BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_DEFAULT_SOURCE_PARALLELISM,
                 defaultSourceParallelism);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
@@ -223,7 +223,7 @@ public class SecurityUtilsTest {
         // ------- no whitespaces
 
         testFlinkConf = new Configuration();
-        testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar,Client");
+        testFlinkConf.set(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar,Client");
         testSecurityConf =
                 new SecurityConfiguration(
                         testFlinkConf,
@@ -236,7 +236,7 @@ public class SecurityUtilsTest {
         // ------- with whitespaces surrounding comma
 
         testFlinkConf = new Configuration();
-        testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar , Client");
+        testFlinkConf.set(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar , Client");
         testSecurityConf =
                 new SecurityConfiguration(
                         testFlinkConf,
@@ -249,7 +249,7 @@ public class SecurityUtilsTest {
         // ------- leading / trailing whitespaces at start and end of list
 
         testFlinkConf = new Configuration();
-        testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, " Foo bar , Client ");
+        testFlinkConf.set(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, " Foo bar , Client ");
         testSecurityConf =
                 new SecurityConfiguration(
                         testFlinkConf,
@@ -262,7 +262,7 @@ public class SecurityUtilsTest {
         // ------- empty entries
 
         testFlinkConf = new Configuration();
-        testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar,,Client");
+        testFlinkConf.set(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar,,Client");
         testSecurityConf =
                 new SecurityConfiguration(
                         testFlinkConf,
@@ -275,7 +275,7 @@ public class SecurityUtilsTest {
         // ------- empty trailing String entries with whitespaces
 
         testFlinkConf = new Configuration();
-        testFlinkConf.setString(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar, ,, Client,");
+        testFlinkConf.set(SecurityOptions.KERBEROS_LOGIN_CONTEXTS, "Foo bar, ,, Client,");
         testSecurityConf =
                 new SecurityConfiguration(
                         testFlinkConf,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/modules/JaasModuleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/modules/JaasModuleTest.java
@@ -88,7 +88,7 @@ public class JaasModuleTest {
     private void testJaasModuleFilePath(String workingDir) throws IOException {
         Configuration configuration = new Configuration();
         // set the string for CoreOptions.TMP_DIRS to mock the working directory.
-        configuration.setString(CoreOptions.TMP_DIRS, workingDir);
+        configuration.set(CoreOptions.TMP_DIRS, workingDir);
         SecurityConfiguration sc = new SecurityConfiguration(configuration);
         JaasModule module = new JaasModule(sc);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
@@ -56,9 +56,9 @@ public class KerberosLoginProviderITCase {
     public void isLoginPossibleMustNotDoAccidentalLoginWithKeytab(
             boolean supportProxyUser, @TempDir Path tmpDir) throws IOException {
         Configuration configuration = new Configuration();
-        configuration.setString(KERBEROS_LOGIN_PRINCIPAL, "principal");
+        configuration.set(KERBEROS_LOGIN_PRINCIPAL, "principal");
         final Path keyTab = Files.createFile(tmpDir.resolve("test.keytab"));
-        configuration.setString(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
+        configuration.set(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
 
         try (MockedStatic<UserGroupInformation> ugi = mockStatic(UserGroupInformation.class)) {
@@ -107,9 +107,9 @@ public class KerberosLoginProviderITCase {
     public void isLoginPossibleMustReturnTrueWithKeytab(
             boolean supportProxyUser, @TempDir Path tmpDir) throws IOException {
         Configuration configuration = new Configuration();
-        configuration.setString(KERBEROS_LOGIN_PRINCIPAL, "principal");
+        configuration.set(KERBEROS_LOGIN_PRINCIPAL, "principal");
         final Path keyTab = Files.createFile(tmpDir.resolve("test.keytab"));
-        configuration.setString(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
+        configuration.set(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
 
         try (MockedStatic<UserGroupInformation> ugi = mockStatic(UserGroupInformation.class)) {
@@ -125,7 +125,7 @@ public class KerberosLoginProviderITCase {
     @ValueSource(booleans = {true, false})
     public void isLoginPossibleMustReturnTrueWithTGT(boolean supportProxyUser) throws IOException {
         Configuration configuration = new Configuration();
-        configuration.setBoolean(KERBEROS_LOGIN_USETICKETCACHE, true);
+        configuration.set(KERBEROS_LOGIN_USETICKETCACHE, true);
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
 
         try (MockedStatic<UserGroupInformation> ugi = mockStatic(UserGroupInformation.class)) {
@@ -177,9 +177,9 @@ public class KerberosLoginProviderITCase {
     public void doLoginMustLoginWithKeytab(boolean supportProxyUser, @TempDir Path tmpDir)
             throws IOException {
         Configuration configuration = new Configuration();
-        configuration.setString(KERBEROS_LOGIN_PRINCIPAL, "principal");
+        configuration.set(KERBEROS_LOGIN_PRINCIPAL, "principal");
         final Path keyTab = Files.createFile(tmpDir.resolve("test.keytab"));
-        configuration.setString(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
+        configuration.set(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
 
         try (MockedStatic<UserGroupInformation> ugi = mockStatic(UserGroupInformation.class)) {
@@ -195,7 +195,7 @@ public class KerberosLoginProviderITCase {
     @ValueSource(booleans = {true, false})
     public void doLoginMustLoginWithTGT(boolean supportProxyUser) throws IOException {
         Configuration configuration = new Configuration();
-        configuration.setBoolean(KERBEROS_LOGIN_USETICKETCACHE, true);
+        configuration.set(KERBEROS_LOGIN_USETICKETCACHE, true);
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
 
         try (MockedStatic<UserGroupInformation> ugi = mockStatic(UserGroupInformation.class)) {
@@ -244,9 +244,9 @@ public class KerberosLoginProviderITCase {
     @Test
     public void doLoginAndReturnUGIMustLoginWithKeytab(@TempDir Path tmpDir) throws IOException {
         Configuration configuration = new Configuration();
-        configuration.setString(KERBEROS_LOGIN_PRINCIPAL, "principal");
+        configuration.set(KERBEROS_LOGIN_PRINCIPAL, "principal");
         final Path keyTab = Files.createFile(tmpDir.resolve("test.keytab"));
-        configuration.setString(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
+        configuration.set(KERBEROS_LOGIN_KEYTAB, keyTab.toAbsolutePath().toString());
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
 
         try (MockedStatic<UserGroupInformation> ugi = mockStatic(UserGroupInformation.class)) {
@@ -264,7 +264,7 @@ public class KerberosLoginProviderITCase {
     @Test
     public void doLoginAndReturnUGIMustLoginWithTGT() throws IOException {
         Configuration configuration = new Configuration();
-        configuration.setBoolean(KERBEROS_LOGIN_USETICKETCACHE, true);
+        configuration.set(KERBEROS_LOGIN_USETICKETCACHE, true);
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
 
         try (MockedStatic<UserGroupInformation> ugi = mockStatic(UserGroupInformation.class)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleMasterTest.java
@@ -94,7 +94,7 @@ class ShuffleMasterTest {
 
     private MiniClusterConfiguration createClusterConfiguration(boolean stopTrackingPartition) {
         Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 ShuffleServiceOptions.SHUFFLE_SERVICE_FACTORY_CLASS,
                 TestShuffleServiceFactory.class.getName());
         configuration.setBoolean(STOP_TRACKING_PARTITION_KEY, stopTrackingPartition);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/ShuffleServiceLoaderTest.java
@@ -47,7 +47,7 @@ class ShuffleServiceLoaderTest {
     @Test
     void testLoadCustomShuffleServiceFactory() throws FlinkException {
         Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 SHUFFLE_SERVICE_FACTORY_CLASS,
                 "org.apache.flink.runtime.shuffle.ShuffleServiceLoaderTest$CustomShuffleServiceFactory");
         ShuffleServiceFactory<?, ?, ?> shuffleServiceFactory =
@@ -61,7 +61,7 @@ class ShuffleServiceLoaderTest {
     @Test
     public void testLoadShuffleServiceFactoryFailure() {
         Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 SHUFFLE_SERVICE_FACTORY_CLASS,
                 "org.apache.flink.runtime.shuffle.UnavailableShuffleServiceFactory");
         assertThatThrownBy(() -> ShuffleServiceLoader.loadShuffleServiceFactory(configuration))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStorageLoaderTest.java
@@ -320,7 +320,7 @@ class CheckpointStorageLoaderTest {
         config1.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
         config1.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
         config1.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, threshold);
-        config1.setInteger(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, minWriteBufferSize);
+        config1.set(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, minWriteBufferSize);
 
         CheckpointStorage storage1 = CheckpointStorageLoader.fromConfig(config1, cl, null).get();
 
@@ -365,7 +365,7 @@ class CheckpointStorageLoaderTest {
         config.set(
                 CheckpointingOptions.FS_SMALL_FILE_THRESHOLD,
                 MemorySize.parse("20")); // this should not be picked up
-        config.setInteger(
+        config.set(
                 CheckpointingOptions.FS_WRITE_BUFFER_SIZE, 3000000); // this should not be picked up
 
         final CheckpointStorage loadedStorage1 =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendLoadingTest.java
@@ -127,13 +127,13 @@ class StateBackendLoadingTest {
 
         final Configuration config1 = new Configuration();
         config1.setString(backendKey, "jobmanager");
-        config1.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
-        config1.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+        config1.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+        config1.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
 
         final Configuration config2 = new Configuration();
         config2.setString(backendKey, MemoryStateBackendFactory.class.getName());
-        config2.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
-        config2.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+        config2.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+        config2.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
 
         MemoryStateBackend backend1 =
                 (MemoryStateBackend)
@@ -168,8 +168,8 @@ class StateBackendLoadingTest {
 
         final Configuration config = new Configuration();
         config.setString(backendKey, "filesystem"); // check that this is not accidentally picked up
-        config.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+        config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
 
         StateBackend loadedBackendFromClusterConfig =
                 StateBackendLoader.fromApplicationOrConfigOrDefault(
@@ -210,10 +210,10 @@ class StateBackendLoadingTest {
 
         final Configuration config = new Configuration();
         config.setString(backendKey, "filesystem"); // check that this is not accidentally picked up
-        config.setString(
+        config.set(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY,
                 checkpointDir); // this parameter should not be picked up
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
 
         // add parameters from cluster config
         StateBackend loadedBackendFromJobConfig =
@@ -258,17 +258,17 @@ class StateBackendLoadingTest {
         // to guard against config-breaking changes of the name
         final Configuration config1 = new Configuration();
         config1.setString(backendKey, "filesystem");
-        config1.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
-        config1.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+        config1.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+        config1.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
         config1.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, threshold);
-        config1.setInteger(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, minWriteBufferSize);
+        config1.set(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, minWriteBufferSize);
 
         final Configuration config2 = new Configuration();
         config2.setString(backendKey, FsStateBackendFactory.class.getName());
-        config2.setString(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
-        config2.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+        config2.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir);
+        config2.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
         config2.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, threshold);
-        config1.setInteger(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, minWriteBufferSize);
+        config1.set(CheckpointingOptions.FS_WRITE_BUFFER_SIZE, minWriteBufferSize);
 
         StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
         StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
@@ -313,14 +313,14 @@ class StateBackendLoadingTest {
 
         final Configuration config = new Configuration();
         config.setString(backendKey, "jobmanager"); // this should not be picked up
-        config.setString(
+        config.set(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY,
                 checkpointDir); // this should not be picked up
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
         config.set(
                 CheckpointingOptions.FS_SMALL_FILE_THRESHOLD,
                 MemorySize.parse("20")); // this should not be picked up
-        config.setInteger(
+        config.set(
                 CheckpointingOptions.FS_WRITE_BUFFER_SIZE, 3000000); // this should not be picked up
 
         final StateBackend loadedBackend =
@@ -405,20 +405,20 @@ class StateBackendLoadingTest {
     private void testMemoryBackendHighAvailabilityDefault(
             String haPersistenceDir, Path checkpointPath) throws Exception {
         final Configuration config1 = new Configuration();
-        config1.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
-        config1.setString(HighAvailabilityOptions.HA_CLUSTER_ID, "myCluster");
-        config1.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haPersistenceDir);
+        config1.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        config1.set(HighAvailabilityOptions.HA_CLUSTER_ID, "myCluster");
+        config1.set(HighAvailabilityOptions.HA_STORAGE_PATH, haPersistenceDir);
 
         final Configuration config2 = new Configuration();
         config2.setString(backendKey, "jobmanager");
-        config2.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
-        config2.setString(HighAvailabilityOptions.HA_CLUSTER_ID, "myCluster");
-        config2.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haPersistenceDir);
+        config2.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        config2.set(HighAvailabilityOptions.HA_CLUSTER_ID, "myCluster");
+        config2.set(HighAvailabilityOptions.HA_STORAGE_PATH, haPersistenceDir);
 
         if (checkpointPath != null) {
-            config1.setString(
+            config1.set(
                     CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointPath.toUri().toString());
-            config2.setString(
+            config2.set(
                     CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointPath.toUri().toString());
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -264,7 +264,7 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> {
     void testEnableStateLatencyTracking() throws Exception {
         ConfigurableStateBackend stateBackend = getStateBackend();
         Configuration config = new Configuration();
-        config.setBoolean(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        config.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
         StateBackend configuredBackend =
                 stateBackend.configure(config, Thread.currentThread().getContextClassLoader());
         KeyGroupRange groupRange = new KeyGroupRange(0, 1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -78,11 +78,10 @@ class TaskExecutorLocalStateStoresManagerTest {
                 "__localStateRoot1,__localStateRoot2,__localStateRoot3".replaceAll("__", tmpDir);
 
         // test configuration of the local state directories
-        config.setString(
-                CheckpointingOptions.LOCAL_RECOVERY_TASK_MANAGER_STATE_ROOT_DIRS, rootDirString);
+        config.set(CheckpointingOptions.LOCAL_RECOVERY_TASK_MANAGER_STATE_ROOT_DIRS, rootDirString);
 
         // test configuration of the local state mode
-        config.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, true);
+        config.set(CheckpointingOptions.LOCAL_RECOVERY, true);
 
         final WorkingDirectory workingDirectory =
                 WORKING_DIRECTORY_EXTENSION_WRAPPER

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfigTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateConfigTest.java
@@ -72,9 +72,9 @@ class LatencyTrackingStateConfigTest {
     void testConfigureFromReadableConfig() {
         LatencyTrackingStateConfig.Builder builder = LatencyTrackingStateConfig.newBuilder();
         Configuration configuration = new Configuration();
-        configuration.setBoolean(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
-        configuration.setInteger(StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL, 10);
-        configuration.setInteger(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE, 500);
+        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.set(StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL, 10);
+        configuration.set(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE, 500);
         LatencyTrackingStateConfig latencyTrackingStateConfig =
                 builder.configure(configuration)
                         .setMetricGroup(new UnregisteredMetricsGroup())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metrics/LatencyTrackingStateTestBase.java
@@ -58,12 +58,11 @@ abstract class LatencyTrackingStateTestBase<K> {
         KeyGroupRange keyGroupRange = new KeyGroupRange(0, 127);
         int numberOfKeyGroups = keyGroupRange.getNumberOfKeyGroups();
         Configuration configuration = new Configuration();
-        configuration.setBoolean(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
-        configuration.setInteger(
-                StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL, SAMPLE_INTERVAL);
+        configuration.set(StateBackendOptions.LATENCY_TRACK_ENABLED, true);
+        configuration.set(StateBackendOptions.LATENCY_TRACK_SAMPLE_INTERVAL, SAMPLE_INTERVAL);
         // use a very large value to not let metrics data overridden.
         int historySize = 1000_000;
-        configuration.setInteger(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE, historySize);
+        configuration.set(StateBackendOptions.LATENCY_TRACK_HISTORY_SIZE, historySize);
         HashMapStateBackend stateBackend =
                 new HashMapStateBackend()
                         .configure(configuration, Thread.currentThread().getContextClassLoader());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/NettyShuffleEnvironmentConfigurationTest.java
@@ -62,10 +62,10 @@ class NettyShuffleEnvironmentConfigurationTest {
 
         // set some non-default values
         final Configuration config = new Configuration();
-        config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
-        config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
-        config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, 10);
-        config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE, 100);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, 10);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE, 100);
 
         final NettyShuffleEnvironmentConfiguration networkConfig =
                 NettyShuffleEnvironmentConfiguration.fromConfiguration(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
@@ -417,9 +417,9 @@ class TaskExecutorSubmissionTest {
             final int dataPort = port.getPort();
 
             Configuration config = new Configuration();
-            config.setInteger(NettyShuffleEnvironmentOptions.DATA_PORT, dataPort);
-            config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
-            config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
+            config.set(NettyShuffleEnvironmentOptions.DATA_PORT, dataPort);
+            config.set(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
+            config.set(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
 
             // Remote location (on the same TM though) for the partition
             NettyShuffleDescriptor sdd =
@@ -518,8 +518,8 @@ class TaskExecutorSubmissionTest {
         ExecutionAttemptID eid = tdd.getExecutionAttemptId();
 
         Configuration config = new Configuration();
-        config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
-        config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
 
         final CompletableFuture<Void> taskRunningFuture = new CompletableFuture<>();
         final CompletableFuture<Void> taskFailedFuture = new CompletableFuture<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -2226,10 +2226,9 @@ class TaskExecutorTest {
     @Test
     @Timeout(10)
     void testLogNotFoundHandling() throws Throwable {
-        configuration.setInteger(NettyShuffleEnvironmentOptions.DATA_PORT, 0);
-        configuration.setInteger(
-                NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
-        configuration.setInteger(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
+        configuration.set(NettyShuffleEnvironmentOptions.DATA_PORT, 0);
+        configuration.set(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL, 100);
+        configuration.set(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 200);
         configuration.set(TASK_MANAGER_LOG_PATH, "/i/dont/exist");
 
         try (TaskSubmissionTestEnvironment env =
@@ -2756,7 +2755,7 @@ class TaskExecutorTest {
                         .setTaskSlotTable(taskSlotTable)
                         .setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
                         .build();
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, numberOFSlots);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, numberOFSlots);
         return createTaskExecutor(taskManagerServices);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerConfigurationTest.java
@@ -146,7 +146,7 @@ class TaskManagerRunnerConfigurationTest {
         final Configuration config =
                 new Configuration(
                         createFlinkConfigWithPredefinedTaskManagerHostname("example.org"));
-        config.setString(TaskManagerOptions.RPC_PORT, "-1");
+        config.set(TaskManagerOptions.RPC_PORT, "-1");
 
         final HighAvailabilityServices highAvailabilityServices =
                 createHighAvailabilityServices(config);
@@ -212,7 +212,7 @@ class TaskManagerRunnerConfigurationTest {
         assertThat(MemorySize.parse(managedMemory + "b"))
                 .isEqualTo(configuration.get(TaskManagerOptions.MANAGED_MEMORY_SIZE));
         assertThat(jmHost).isEqualTo(configuration.get(JobManagerOptions.ADDRESS));
-        assertThat(jmPort).isEqualTo(configuration.getInteger(JobManagerOptions.PORT));
+        assertThat(jmPort).isEqualTo(configuration.get(JobManagerOptions.PORT));
     }
 
     @Test
@@ -249,24 +249,24 @@ class TaskManagerRunnerConfigurationTest {
     private static Configuration createFlinkConfigWithPredefinedTaskManagerHostname(
             final String taskmanagerHost) {
         final Configuration config = new Configuration();
-        config.setString(TaskManagerOptions.HOST, taskmanagerHost);
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
+        config.set(TaskManagerOptions.HOST, taskmanagerHost);
+        config.set(JobManagerOptions.ADDRESS, "localhost");
         return new UnmodifiableConfiguration(config);
     }
 
     private static Configuration createFlinkConfigWithHostBindPolicy(
             final HostBindPolicy bindPolicy) {
         final Configuration config = new Configuration();
-        config.setString(TaskManagerOptions.HOST_BIND_POLICY, bindPolicy.toString());
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
+        config.set(TaskManagerOptions.HOST_BIND_POLICY, bindPolicy.toString());
+        config.set(JobManagerOptions.ADDRESS, "localhost");
         config.set(AkkaOptions.LOOKUP_TIMEOUT_DURATION, Duration.ofMillis(10));
         return new UnmodifiableConfiguration(config);
     }
 
     private static Configuration createFlinkConfigWithJobManagerPort(final int port) {
         Configuration config = new Configuration();
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
-        config.setInteger(JobManagerOptions.PORT, port);
+        config.set(JobManagerOptions.ADDRESS, "localhost");
+        config.set(JobManagerOptions.PORT, port);
         return new UnmodifiableConfiguration(config);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -124,7 +124,7 @@ class TaskManagerRunnerStartupTest {
 
         try {
             Configuration cfg = createFlinkConfiguration();
-            cfg.setString(CoreOptions.TMP_DIRS, nonWritable.getAbsolutePath());
+            cfg.set(CoreOptions.TMP_DIRS, nonWritable.getAbsolutePath());
 
             assertThatThrownBy(
                             () ->
@@ -180,8 +180,8 @@ class TaskManagerRunnerStartupTest {
 
         try {
             final Configuration cfg = createFlinkConfiguration();
-            cfg.setInteger(NettyShuffleEnvironmentOptions.DATA_PORT, blocker.getLocalPort());
-            cfg.setString(TaskManagerOptions.BIND_HOST, LOCAL_HOST);
+            cfg.set(NettyShuffleEnvironmentOptions.DATA_PORT, blocker.getLocalPort());
+            cfg.set(TaskManagerOptions.BIND_HOST, LOCAL_HOST);
 
             assertThatThrownBy(
                             () ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -272,8 +272,8 @@ class TaskManagerRunnerTest {
 
     private static Configuration createConfiguration() {
         final Configuration configuration = new Configuration();
-        configuration.setString(JobManagerOptions.ADDRESS, "localhost");
-        configuration.setString(TaskManagerOptions.HOST, "localhost");
+        configuration.set(JobManagerOptions.ADDRESS, "localhost");
+        configuration.set(TaskManagerOptions.HOST, "localhost");
         return TaskExecutorResourceUtils.adjustForLocalExecution(configuration);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -289,7 +289,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
             final InetSocketAddress socketAddress =
                     new InetSocketAddress(
                             InetAddress.getByName(testingRpcService.getAddress()),
-                            configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_PORT));
+                            configuration.get(NettyShuffleEnvironmentOptions.DATA_PORT));
 
             final NettyConfig nettyConfig =
                     new NettyConfig(
@@ -303,11 +303,11 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
                     new NettyShuffleEnvironmentBuilder()
                             .setTaskManagerLocation(taskManagerLocation)
                             .setPartitionRequestInitialBackoff(
-                                    configuration.getInteger(
+                                    configuration.get(
                                             NettyShuffleEnvironmentOptions
                                                     .NETWORK_REQUEST_BACKOFF_INITIAL))
                             .setPartitionRequestMaxBackoff(
-                                    configuration.getInteger(
+                                    configuration.get(
                                             NettyShuffleEnvironmentOptions
                                                     .NETWORK_REQUEST_BACKOFF_MAX))
                             .setResultPartitionManager(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskCancelAsyncProducerConsumerITCase.java
@@ -87,7 +87,7 @@ public class TaskCancelAsyncProducerConsumerITCase {
     private static Configuration getFlinkConfiguration() {
         Configuration config = new Configuration();
         config.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4096"));
-        config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 9);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 9);
         return config;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -944,8 +944,8 @@ public class TaskTest extends TestLogger {
         final TaskManagerActions taskManagerActions = new ProhibitFatalErrorTaskManagerActions();
 
         final Configuration config = new Configuration();
-        config.setLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, 5);
-        config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 1000);
+        config.set(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, 5L);
+        config.set(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 1000L);
 
         final Task task =
                 createTaskBuilder()
@@ -976,7 +976,7 @@ public class TaskTest extends TestLogger {
                         .build();
 
         final Configuration config = new Configuration();
-        config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 10);
+        config.set(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 10L);
 
         final Task task =
                 createTaskBuilder()
@@ -1014,8 +1014,8 @@ public class TaskTest extends TestLogger {
                         .build();
 
         final Configuration config = new Configuration();
-        config.setLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, 5);
-        config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 50);
+        config.set(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, 5L);
+        config.set(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 50L);
 
         // We need to remember the original object since all changes in  `startTaskThread` applies
         // to it rather than to spy object.
@@ -1054,8 +1054,8 @@ public class TaskTest extends TestLogger {
         long timeout = interval + 19292;
 
         final Configuration config = new Configuration();
-        config.setLong(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, interval);
-        config.setLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, timeout);
+        config.set(TaskManagerOptions.TASK_CANCELLATION_INTERVAL, interval);
+        config.set(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, timeout);
 
         final ExecutionConfig executionConfig = new ExecutionConfig();
         executionConfig.setTaskCancellationInterval(interval + 1337);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/DispatcherProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/DispatcherProcess.java
@@ -115,8 +115,8 @@ public class DispatcherProcess extends TestJvmProcess {
                 Configuration config = params.getConfiguration();
                 LOG.info("Configuration: {}.", config);
 
-                config.setInteger(JobManagerOptions.PORT, 0);
-                config.setString(RestOptions.BIND_PORT, "0");
+                config.set(JobManagerOptions.PORT, 0);
+                config.set(RestOptions.BIND_PORT, "0");
 
                 final StandaloneSessionClusterEntrypoint clusterEntrypoint =
                         new StandaloneSessionClusterEntrypoint(config);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
@@ -198,8 +198,7 @@ public class MiniClusterResource extends ExternalResource {
     private void startMiniCluster() throws Exception {
         final Configuration configuration =
                 new Configuration(miniClusterResourceConfiguration.getConfiguration());
-        configuration.setString(
-                CoreOptions.TMP_DIRS, temporaryFolder.newFolder().getAbsolutePath());
+        configuration.set(CoreOptions.TMP_DIRS, temporaryFolder.newFolder().getAbsolutePath());
         if (!configuration.contains(CheckpointingOptions.CHECKPOINTS_DIRECTORY)) {
             // The channel state or checkpoint file may exceed the upper limit of
             // JobManagerCheckpointStorage, so use FileSystemCheckpointStorage as
@@ -212,7 +211,7 @@ public class MiniClusterResource extends ExternalResource {
         // we need to set this since a lot of test expect this because TestBaseUtils.startCluster()
         // enabled this by default
         if (!configuration.contains(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE)) {
-            configuration.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
+            configuration.set(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
         }
 
         if (!configuration.contains(TaskManagerOptions.MANAGED_MEMORY_SIZE)) {
@@ -220,10 +219,10 @@ public class MiniClusterResource extends ExternalResource {
         }
 
         // set rest and rpc port to 0 to avoid clashes with concurrent MiniClusters
-        configuration.setInteger(JobManagerOptions.PORT, 0);
+        configuration.set(JobManagerOptions.PORT, 0);
         if (!(configuration.contains(RestOptions.BIND_PORT)
                 || configuration.contains(RestOptions.PORT))) {
-            configuration.setString(RestOptions.BIND_PORT, "0");
+            configuration.set(RestOptions.BIND_PORT, "0");
         }
 
         randomizeConfiguration(configuration);
@@ -264,8 +263,8 @@ public class MiniClusterResource extends ExternalResource {
 
     private void createClientConfiguration(URI restAddress) {
         Configuration restClientConfig = new Configuration();
-        restClientConfig.setString(JobManagerOptions.ADDRESS, restAddress.getHost());
-        restClientConfig.setInteger(RestOptions.PORT, restAddress.getPort());
+        restClientConfig.set(JobManagerOptions.ADDRESS, restAddress.getHost());
+        restClientConfig.set(RestOptions.PORT, restAddress.getPort());
         this.restClusterClientConfig = new UnmodifiableConfiguration(restClientConfig);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingClusterEntrypointProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingClusterEntrypointProcess.java
@@ -80,8 +80,8 @@ public class TestingClusterEntrypointProcess extends TestJvmProcess {
                 final File markerFile = new File(args[0]);
 
                 final Configuration config = new Configuration();
-                config.setInteger(JobManagerOptions.PORT, 0);
-                config.setString(RestOptions.BIND_PORT, "0");
+                config.set(JobManagerOptions.PORT, 0);
+                config.set(RestOptions.BIND_PORT, "0");
 
                 final TestingClusterEntrypoint clusterEntrypoint =
                         new TestingClusterEntrypoint(config, markerFile);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
@@ -102,8 +102,8 @@ public class ZooKeeperTestUtils {
         checkNotNull(fsStateHandlePath, "File state handle backend path");
 
         // ZooKeeper recovery mode
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperQuorum);
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperQuorum);
 
         int connTimeout = 5000;
         if (runsOnCIInfrastructure()) {
@@ -113,14 +113,13 @@ public class ZooKeeperTestUtils {
             connTimeout = 30000;
         }
 
-        config.setInteger(HighAvailabilityOptions.ZOOKEEPER_CONNECTION_TIMEOUT, connTimeout);
-        config.setInteger(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, connTimeout);
+        config.set(HighAvailabilityOptions.ZOOKEEPER_CONNECTION_TIMEOUT, connTimeout);
+        config.set(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, connTimeout);
 
         // File system state backend
-        config.setString(StateBackendOptions.STATE_BACKEND, "FILESYSTEM");
-        config.setString(
-                CheckpointingOptions.CHECKPOINTS_DIRECTORY, fsStateHandlePath + "/checkpoints");
-        config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, fsStateHandlePath + "/recovery");
+        config.set(StateBackendOptions.STATE_BACKEND, "FILESYSTEM");
+        config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, fsStateHandlePath + "/checkpoints");
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, fsStateHandlePath + "/recovery");
 
         config.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofSeconds(100));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -153,7 +153,7 @@ class JvmExitOnFatalErrorTest {
             // have a test that exits accidentally due to a programming error
             try {
                 final Configuration taskManagerConfig = new Configuration();
-                taskManagerConfig.setBoolean(TaskManagerOptions.KILL_ON_OUT_OF_MEMORY, true);
+                taskManagerConfig.set(TaskManagerOptions.KILL_ON_OUT_OF_MEMORY, true);
 
                 final JobID jid = new JobID();
                 final AllocationID allocationID = new AllocationID();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTest.java
@@ -111,7 +111,7 @@ class ZooKeeperUtilsTest {
     }
 
     private Configuration setQuorum(Configuration conf, String quorum) {
-        conf.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, quorum);
+        conf.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, quorum);
         return conf;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtilsTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtilsTestBase.java
@@ -220,7 +220,7 @@ public abstract class ProcessMemoryUtilsTestBase<T extends ProcessMemorySpec> {
         Configuration conf = new Configuration();
         conf.set(options.getJvmOptions().getJvmOverheadMax(), maxSize);
         conf.set(options.getJvmOptions().getJvmOverheadMin(), minSize);
-        conf.setFloat(options.getJvmOptions().getJvmOverheadFraction(), fraction);
+        conf.set(options.getJvmOptions().getJvmOverheadFraction(), fraction);
 
         validateInAllConfigurations(
                 conf,
@@ -236,14 +236,14 @@ public abstract class ProcessMemoryUtilsTestBase<T extends ProcessMemorySpec> {
     void testConfigJvmOverheadFractionFailureNegative() {
         Configuration conf = new Configuration();
         //noinspection MagicNumber
-        conf.setFloat(options.getJvmOptions().getJvmOverheadFraction(), -0.1f);
+        conf.set(options.getJvmOptions().getJvmOverheadFraction(), -0.1f);
         validateFailInAllConfigurations(conf);
     }
 
     @Test
     void testConfigJvmOverheadFractionFailureNoLessThanOne() {
         Configuration conf = new Configuration();
-        conf.setFloat(options.getJvmOptions().getJvmOverheadFraction(), 1.0f);
+        conf.set(options.getJvmOptions().getJvmOverheadFraction(), 1.0f);
         validateFailInAllConfigurations(conf);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpointTest.java
@@ -43,8 +43,8 @@ class WebMonitorEndpointTest {
     @Test
     void cleansUpExpiredExecutionGraphs() throws Exception {
         final Configuration configuration = new Configuration();
-        configuration.setString(RestOptions.ADDRESS, "localhost");
-        configuration.setLong(WebOptions.REFRESH_INTERVAL, 5L);
+        configuration.set(RestOptions.ADDRESS, "localhost");
+        configuration.set(WebOptions.REFRESH_INTERVAL, 5L);
         final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
         final long timeout = 10000L;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerUtilsTest.java
@@ -48,7 +48,7 @@ class HistoryServerUtilsTest {
     @Test
     void testIsSSLEnabledWithoutRestSSL() {
         final Configuration configuration = new Configuration();
-        configuration.setBoolean(HistoryServerOptions.HISTORY_SERVER_WEB_SSL_ENABLED, true);
+        configuration.set(HistoryServerOptions.HISTORY_SERVER_WEB_SSL_ENABLED, true);
 
         assertThat(HistoryServerUtils.isSSLEnabled(configuration)).isFalse();
     }
@@ -56,7 +56,7 @@ class HistoryServerUtilsTest {
     @Test
     void testIsSSLEnabledOnlyRestSSL() {
         final Configuration configuration = new Configuration();
-        configuration.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        configuration.set(SecurityOptions.SSL_REST_ENABLED, true);
 
         assertThat(HistoryServerUtils.isSSLEnabled(configuration)).isFalse();
     }
@@ -70,8 +70,8 @@ class HistoryServerUtilsTest {
     }
 
     private void enableSSL(Configuration configuration) {
-        configuration.setBoolean(HistoryServerOptions.HISTORY_SERVER_WEB_SSL_ENABLED, true);
-        configuration.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        configuration.set(HistoryServerOptions.HISTORY_SERVER_WEB_SSL_ENABLED, true);
+        configuration.set(SecurityOptions.SSL_REST_ENABLED, true);
     }
 
     @Test
@@ -105,8 +105,8 @@ class HistoryServerUtilsTest {
     @Nonnull
     private Configuration createDefaultConfiguration() {
         final Configuration configuration = new Configuration();
-        configuration.setString(HistoryServerOptions.HISTORY_SERVER_WEB_ADDRESS, HOSTNAME);
-        configuration.setInteger(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, PORT);
+        configuration.set(HistoryServerOptions.HISTORY_SERVER_WEB_ADDRESS, HOSTNAME);
+        configuration.set(HistoryServerOptions.HISTORY_SERVER_WEB_PORT, PORT);
         return configuration;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
@@ -104,7 +104,7 @@ public class ZooKeeperExtension implements CustomExtension {
     private CuratorFrameworkWithUnhandledErrorListener createCuratorFramework(
             FatalErrorHandler fatalErrorHandler) {
         final Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, getConnectString());
+        config.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, getConnectString());
 
         return ZooKeeperUtils.startCuratorFramework(config, fatalErrorHandler);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperStateHandleStoreTest.java
@@ -1123,10 +1123,10 @@ class ZooKeeperStateHandleStoreTest {
         final TestingLongStateHandleHelper longStateStorage = new TestingLongStateHandleHelper();
 
         Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperExtension.getConnectString());
-        configuration.setInteger(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, 100);
-        configuration.setString(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT, "timeout");
+        configuration.set(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, 100);
+        configuration.set(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT, "timeout");
 
         try (CuratorFrameworkWithUnhandledErrorListener curatorFrameworkWrapper =
                         ZooKeeperUtils.startCuratorFramework(

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendLoadingTest.java
@@ -246,8 +246,7 @@ public class ChangelogStateBackendLoadingTest {
 
     private Configuration config(String stateBackend, boolean enableChangelogStateBackend) {
         final Configuration config = new Configuration();
-        config.setBoolean(
-                StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, enableChangelogStateBackend);
+        config.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, enableChangelogStateBackend);
         config.setString(backendKey, stateBackend);
 
         return config;
@@ -255,8 +254,7 @@ public class ChangelogStateBackendLoadingTest {
 
     private Configuration config(boolean enableChangelogStateBackend) {
         final Configuration config = new Configuration();
-        config.setBoolean(
-                StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, enableChangelogStateBackend);
+        config.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, enableChangelogStateBackend);
 
         return config;
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitorTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricMonitorTest.java
@@ -244,10 +244,10 @@ class RocksDBNativeMetricMonitorTest {
         public ScopeFormats getScopeFormats() {
             Configuration config = new Configuration();
 
-            config.setString(MetricOptions.SCOPE_NAMING_TM, "A");
-            config.setString(MetricOptions.SCOPE_NAMING_TM_JOB, "B");
-            config.setString(MetricOptions.SCOPE_NAMING_TASK, "C");
-            config.setString(MetricOptions.SCOPE_NAMING_OPERATOR, "D");
+            config.set(MetricOptions.SCOPE_NAMING_TM, "A");
+            config.set(MetricOptions.SCOPE_NAMING_TM_JOB, "B");
+            config.set(MetricOptions.SCOPE_NAMING_TASK, "C");
+            config.set(MetricOptions.SCOPE_NAMING_OPERATOR, "D");
 
             return ScopeFormats.fromConfig(config);
         }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendConfigTest.java
@@ -294,7 +294,7 @@ public class RocksDBStateBackendConfigTest {
         try {
             // set the default file system scheme
             Configuration config = new Configuration();
-            config.setString(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "s3://mydomain.com:8020/flink");
+            config.set(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "s3://mydomain.com:8020/flink");
             FileSystem.initialize(config);
             testLocalDbPaths(null, tempFolder.getRoot());
         } finally {
@@ -310,7 +310,7 @@ public class RocksDBStateBackendConfigTest {
         try {
             // set the default file system scheme
             Configuration config = new Configuration();
-            config.setString(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "s3://mydomain.com:8020/flink");
+            config.set(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "s3://mydomain.com:8020/flink");
             FileSystem.initialize(config);
 
             testLocalDbPaths(dbStoragePath, folder);
@@ -524,7 +524,7 @@ public class RocksDBStateBackendConfigTest {
 
         // verify that user could configure predefined options via flink-conf.yaml
         Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 RocksDBOptions.PREDEFINED_OPTIONS, PredefinedOptions.FLASH_SSD_OPTIMIZED.name());
         rocksDbBackend = new RocksDBStateBackend(checkpointPath);
         rocksDbBackend = rocksDbBackend.configure(configuration, getClass().getClassLoader());
@@ -810,7 +810,7 @@ public class RocksDBStateBackendConfigTest {
     @Test
     public void testConfigureManagedMemory() {
         final Configuration config = new Configuration();
-        config.setBoolean(RocksDBOptions.USE_MANAGED_MEMORY, true);
+        config.set(RocksDBOptions.USE_MANAGED_MEMORY, true);
 
         final RocksDBMemoryConfiguration memSettings =
                 RocksDBMemoryConfiguration.fromOtherAndConfiguration(
@@ -854,7 +854,7 @@ public class RocksDBStateBackendConfigTest {
     public void testConfigureRestoreOverlapThreshold() {
         EmbeddedRocksDBStateBackend rocksDBStateBackend = new EmbeddedRocksDBStateBackend(true);
         Configuration configuration = new Configuration();
-        configuration.setDouble(RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD, 0.3);
+        configuration.set(RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD, 0.3);
         rocksDBStateBackend =
                 rocksDBStateBackend.configure(configuration, getClass().getClassLoader());
         assertTrue(0.3 == rocksDBStateBackend.getOverlapFractionThreshold());

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactoryTest.java
@@ -83,13 +83,13 @@ public class RocksDBStateBackendFactoryTest {
         // to guard against config-breaking changes of the name
         final Configuration config1 = new Configuration();
         config1.setString(backendKey, "rocksdb");
-        config1.setString(RocksDBOptions.LOCAL_DIRECTORIES, localDirs);
-        config1.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, incremental);
+        config1.set(RocksDBOptions.LOCAL_DIRECTORIES, localDirs);
+        config1.set(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, incremental);
 
         final Configuration config2 = new Configuration();
         config2.setString(backendKey, EmbeddedRocksDBStateBackendFactory.class.getName());
-        config2.setString(RocksDBOptions.LOCAL_DIRECTORIES, localDirs);
-        config2.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, incremental);
+        config2.set(RocksDBOptions.LOCAL_DIRECTORIES, localDirs);
+        config2.set(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, incremental);
 
         StateBackend backend1 = StateBackendLoader.loadStateBackendFromConfig(config1, cl, null);
         StateBackend backend2 = StateBackendLoader.loadStateBackendFromConfig(config2, cl, null);
@@ -125,10 +125,10 @@ public class RocksDBStateBackendFactoryTest {
 
         final Configuration config = new Configuration();
         config.setString(backendKey, "hashmap"); // this should not be picked up
-        config.setBoolean(
+        config.set(
                 CheckpointingOptions.INCREMENTAL_CHECKPOINTS,
                 !incremental); // this should not be picked up
-        config.setString(
+        config.set(
                 RocksDBOptions.LOCAL_DIRECTORIES,
                 localDir3 + ":" + localDir4); // this should not be picked up
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -207,8 +207,8 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 
         // these should be set in the end to overwrite any values from the client config provided in
         // the constructor.
-        effectiveConfiguration.setString(DeploymentOptions.TARGET, "remote");
-        effectiveConfiguration.setBoolean(DeploymentOptions.ATTACHED, true);
+        effectiveConfiguration.set(DeploymentOptions.TARGET, "remote");
+        effectiveConfiguration.set(DeploymentOptions.ATTACHED, true);
 
         return effectiveConfiguration;
     }
@@ -220,8 +220,8 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 
     @Override
     public String toString() {
-        final String host = configuration.getString(JobManagerOptions.ADDRESS);
-        final int port = configuration.getInteger(JobManagerOptions.PORT);
+        final String host = configuration.get(JobManagerOptions.ADDRESS);
+        final int port = configuration.get(JobManagerOptions.PORT);
         final String parallelism = (getParallelism() == -1 ? "default" : "" + getParallelism());
 
         return "Remote Environment ("
@@ -239,7 +239,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
      * @return The hostname of the master
      */
     public String getHost() {
-        return configuration.getString(JobManagerOptions.ADDRESS);
+        return configuration.get(JobManagerOptions.ADDRESS);
     }
 
     /**
@@ -248,7 +248,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
      * @return The port of the master
      */
     public int getPort() {
-        return configuration.getInteger(JobManagerOptions.PORT);
+        return configuration.get(JobManagerOptions.PORT);
     }
 
     /** @deprecated This method is going to be removed in the next releases. */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -2278,7 +2278,7 @@ public class StreamExecutionEnvironment implements AutoCloseable {
         try {
             final JobExecutionResult jobExecutionResult;
 
-            if (configuration.getBoolean(DeploymentOptions.ATTACHED)) {
+            if (configuration.get(DeploymentOptions.ATTACHED)) {
                 jobExecutionResult = jobClient.getJobExecutionResult().get();
             } else {
                 jobExecutionResult = new DetachedJobExecutionResult(jobClient.getJobID());
@@ -2679,7 +2679,7 @@ public class StreamExecutionEnvironment implements AutoCloseable {
 
         if (!conf.contains(RestOptions.PORT)) {
             // explicitly set this option so that it's not set to 0 later
-            conf.setInteger(RestOptions.PORT, RestOptions.PORT.defaultValue());
+            conf.set(RestOptions.PORT, RestOptions.PORT.defaultValue());
         }
 
         return createLocalEnvironment(conf);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -248,7 +248,7 @@ public class StreamConfig implements Serializable {
                         "%s should be in range [0.0, 1.0], but was: %s",
                         configOption.key(), fraction));
 
-        config.setDouble(configOption, fraction);
+        config.set(configOption, fraction);
     }
 
     /**
@@ -262,7 +262,7 @@ public class StreamConfig implements Serializable {
             ClassLoader cl) {
         return ManagedMemoryUtils.convertToFractionOfSlot(
                 managedMemoryUseCase,
-                config.getDouble(getManagedMemoryFractionConfigOption(managedMemoryUseCase)),
+                config.get(getManagedMemoryFractionConfigOption(managedMemoryUseCase)),
                 getAllManagedMemoryUseCases(),
                 jobConfig,
                 taskManagerConfig,
@@ -526,11 +526,11 @@ public class StreamConfig implements Serializable {
     }
 
     public void setUnalignedCheckpointsEnabled(boolean enabled) {
-        config.setBoolean(ExecutionCheckpointingOptions.ENABLE_UNALIGNED, enabled);
+        config.set(ExecutionCheckpointingOptions.ENABLE_UNALIGNED, enabled);
     }
 
     public boolean isUnalignedCheckpointsEnabled() {
-        return config.getBoolean(ExecutionCheckpointingOptions.ENABLE_UNALIGNED, false);
+        return config.get(ExecutionCheckpointingOptions.ENABLE_UNALIGNED, false);
     }
 
     public boolean isExactlyOnceCheckpointMode() {
@@ -547,12 +547,12 @@ public class StreamConfig implements Serializable {
     }
 
     public void setMaxConcurrentCheckpoints(int maxConcurrentCheckpoints) {
-        config.setInteger(
+        config.set(
                 ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS, maxConcurrentCheckpoints);
     }
 
     public int getMaxConcurrentCheckpoints() {
-        return config.getInteger(
+        return config.get(
                 ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS,
                 ExecutionCheckpointingOptions.MAX_CONCURRENT_CHECKPOINTS.defaultValue());
     }
@@ -656,7 +656,7 @@ public class StreamConfig implements Serializable {
 
     @VisibleForTesting
     public void setStateBackendUsesManagedMemory(boolean usesManagedMemory) {
-        this.config.setBoolean(STATE_BACKEND_USE_MANAGED_MEMORY, usesManagedMemory);
+        this.config.set(STATE_BACKEND_USE_MANAGED_MEMORY, usesManagedMemory);
     }
 
     public StateBackend getStateBackend(ClassLoader cl) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -179,7 +179,7 @@ public abstract class AbstractStreamOperator<OUT>
 
         try {
             Configuration taskManagerConfig = environment.getTaskManagerInfo().getConfiguration();
-            int historySize = taskManagerConfig.getInteger(MetricOptions.LATENCY_HISTORY_SIZE);
+            int historySize = taskManagerConfig.get(MetricOptions.LATENCY_HISTORY_SIZE);
             if (historySize <= 0) {
                 LOG.warn(
                         "{} has been set to a value equal or below 0: {}. Using default.",
@@ -189,7 +189,7 @@ public abstract class AbstractStreamOperator<OUT>
             }
 
             final String configuredGranularity =
-                    taskManagerConfig.getString(MetricOptions.LATENCY_SOURCE_GRANULARITY);
+                    taskManagerConfig.get(MetricOptions.LATENCY_SOURCE_GRANULARITY);
             LatencyStats.Granularity granularity;
             try {
                 granularity =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -141,7 +141,7 @@ public abstract class AbstractStreamOperatorV2<OUT>
     private LatencyStats createLatencyStats(
             Configuration taskManagerConfig, int indexInSubtaskGroup) {
         try {
-            int historySize = taskManagerConfig.getInteger(MetricOptions.LATENCY_HISTORY_SIZE);
+            int historySize = taskManagerConfig.get(MetricOptions.LATENCY_HISTORY_SIZE);
             if (historySize <= 0) {
                 LOG.warn(
                         "{} has been set to a value equal or below 0: {}. Using default.",
@@ -151,7 +151,7 @@ public abstract class AbstractStreamOperatorV2<OUT>
             }
 
             final String configuredGranularity =
-                    taskManagerConfig.getString(MetricOptions.LATENCY_SOURCE_GRANULARITY);
+                    taskManagerConfig.get(MetricOptions.LATENCY_SOURCE_GRANULARITY);
             LatencyStats.Granularity granularity;
             try {
                 granularity =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -471,7 +471,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
                                 .getEnvironment()
                                 .getTaskManagerInfo()
                                 .getConfiguration()
-                                .getLong(MetricOptions.LATENCY_INTERVAL);
+                                .get(MetricOptions.LATENCY_INTERVAL);
         if (latencyTrackingInterval > 0) {
             latencyMarkerEmitter =
                     new LatencyMarkerEmitter<>(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamSource.java
@@ -84,7 +84,7 @@ public class StreamSource<OUT, SRC extends SourceFunction<OUT>>
         final long latencyTrackingInterval =
                 getExecutionConfig().isLatencyTrackingConfigured()
                         ? getExecutionConfig().getLatencyTrackingInterval()
-                        : configuration.getLong(MetricOptions.LATENCY_INTERVAL);
+                        : configuration.get(MetricOptions.LATENCY_INTERVAL);
 
         LatencyMarkerEmitter<OUT> latencyEmitter = null;
         if (latencyTrackingInterval > 0) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
@@ -494,7 +494,7 @@ public class CollectSinkFunction<IN> extends RichSinkFunction<IN>
             return getStreamingRuntimeContext()
                     .getTaskManagerRuntimeInfo()
                     .getConfiguration()
-                    .getInteger(TaskManagerOptions.COLLECT_PORT);
+                    .get(TaskManagerOptions.COLLECT_PORT);
         }
 
         private StreamingRuntimeContext getStreamingRuntimeContext() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -890,7 +890,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 || !environment
                         .getTaskManagerInfo()
                         .getConfiguration()
-                        .getBoolean(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED)) {
+                        .get(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED)) {
             return;
         }
         systemTimerService.registerTimer(
@@ -1531,7 +1531,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 getEnvironment()
                         .getTaskManagerInfo()
                         .getConfiguration()
-                        .getLong(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT_TIMERS);
+                        .get(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT_TIMERS);
         tryShutdownTimerService(timeoutMs, timerService);
         tryShutdownTimerService(timeoutMs, systemTimerService);
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
@@ -167,7 +167,7 @@ class StreamExecutionEnvironmentComplexConfigurationTest {
                 .isEqualTo(envFromConfiguration.isChangelogStateBackendEnabled());
 
         Configuration configuration = new Configuration();
-        configuration.setBoolean(ENABLE_STATE_CHANGE_LOG, true);
+        configuration.set(ENABLE_STATE_CHANGE_LOG, true);
         envFromConfiguration.configure(
                 configuration, Thread.currentThread().getContextClassLoader());
         assertThat(TernaryBoolean.TRUE)
@@ -178,7 +178,7 @@ class StreamExecutionEnvironmentComplexConfigurationTest {
         assertThat(TernaryBoolean.TRUE)
                 .isEqualTo(envFromConfiguration.isChangelogStateBackendEnabled());
 
-        configuration.setBoolean(ENABLE_STATE_CHANGE_LOG, false);
+        configuration.set(ENABLE_STATE_CHANGE_LOG, false);
         envFromConfiguration.configure(
                 configuration, Thread.currentThread().getContextClassLoader());
         assertThat(TernaryBoolean.FALSE)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -1813,7 +1813,7 @@ class StreamingJobGraphGeneratorTest {
     @Test
     void testNamingWithIndex() {
         Configuration config = new Configuration();
-        config.setBoolean(PipelineOptions.VERTEX_NAME_INCLUDE_INDEX_PREFIX, true);
+        config.set(PipelineOptions.VERTEX_NAME_INCLUDE_INDEX_PREFIX, true);
         JobGraph job = createStreamGraphForSlotSharingTest(config).getJobGraph();
         List<JobVertex> allVertices = job.getVerticesSortedTopologicallyFromSources();
         assertThat(allVertices).hasSize(4);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunctionTest.java
@@ -133,7 +133,7 @@ public class CollectSinkFunctionTest extends TestLogger {
                     .getRuntimeContext()
                     .getTaskManagerRuntimeInfo()
                     .getConfiguration()
-                    .setInteger(TaskManagerOptions.COLLECT_PORT, socket.getLocalPort());
+                    .set(TaskManagerOptions.COLLECT_PORT, socket.getLocalPort());
             assertThatThrownBy(() -> functionWrapper.openFunction())
                     .isInstanceOf(BindException.class)
                     .hasMessageContaining("Address already in use");

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/SourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/SourceOperatorLatencyMetricsTest.java
@@ -69,7 +69,7 @@ public class SourceOperatorLatencyMetricsTest extends TestLogger {
     @Test
     public void testLatencyMarkEmissionEnabledViaFlinkConfig() throws Exception {
         Configuration taskConfiguration = new Configuration();
-        taskConfiguration.setLong(MetricOptions.LATENCY_INTERVAL, LATENCY_MARK_INTERVAL);
+        taskConfiguration.set(MetricOptions.LATENCY_INTERVAL, LATENCY_MARK_INTERVAL);
         ExecutionConfig executionConfig = new ExecutionConfig();
 
         testLatencyMarkEmission(true, taskConfiguration, executionConfig);
@@ -82,7 +82,7 @@ public class SourceOperatorLatencyMetricsTest extends TestLogger {
     @Test
     public void testLatencyMarkEmissionEnabledOverrideViaExecutionConfig() throws Exception {
         Configuration taskConfiguration = new Configuration();
-        taskConfiguration.setLong(MetricOptions.LATENCY_INTERVAL, 0);
+        taskConfiguration.set(MetricOptions.LATENCY_INTERVAL, 0L);
         ExecutionConfig executionConfig = new ExecutionConfig();
         executionConfig.setLatencyTrackingInterval(LATENCY_MARK_INTERVAL);
 
@@ -96,7 +96,7 @@ public class SourceOperatorLatencyMetricsTest extends TestLogger {
     @Test
     public void testLatencyMarkEmissionDisabledOverrideViaExecutionConfig() throws Exception {
         Configuration taskConfiguration = new Configuration();
-        taskConfiguration.setLong(MetricOptions.LATENCY_INTERVAL, LATENCY_MARK_INTERVAL);
+        taskConfiguration.set(MetricOptions.LATENCY_INTERVAL, LATENCY_MARK_INTERVAL);
         ExecutionConfig executionConfig = new ExecutionConfig();
         executionConfig.setLatencyTrackingInterval(0);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -98,7 +98,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
                 (int) (maxProcessingTime / latencyMarkInterval) + 1,
                 (operator, timeProvider) -> {
                     Configuration tmConfig = new Configuration();
-                    tmConfig.setLong(MetricOptions.LATENCY_INTERVAL, latencyMarkInterval);
+                    tmConfig.set(MetricOptions.LATENCY_INTERVAL, latencyMarkInterval);
 
                     Environment env =
                             MockEnvironment.builder()
@@ -123,7 +123,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
                     executionConfig.setLatencyTrackingInterval(latencyMarkInterval);
 
                     Configuration tmConfig = new Configuration();
-                    tmConfig.setLong(MetricOptions.LATENCY_INTERVAL, 0L);
+                    tmConfig.set(MetricOptions.LATENCY_INTERVAL, 0L);
 
                     Environment env =
                             MockEnvironment.builder()
@@ -145,7 +145,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
                 0,
                 (operator, timeProvider) -> {
                     Configuration tmConfig = new Configuration();
-                    tmConfig.setLong(MetricOptions.LATENCY_INTERVAL, latencyMarkInterval);
+                    tmConfig.set(MetricOptions.LATENCY_INTERVAL, latencyMarkInterval);
 
                     Environment env =
                             MockEnvironment.builder()

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -514,7 +514,7 @@ public class StreamTaskTest {
     @Test
     void testStateBackendLoadingAndClosing() throws Exception {
         Configuration taskManagerConfig = new Configuration();
-        taskManagerConfig.setString(STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
+        taskManagerConfig.set(STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
 
         StreamConfig cfg = new StreamConfig(new Configuration());
         cfg.setStateKeySerializer(mock(TypeSerializer.class));
@@ -555,7 +555,7 @@ public class StreamTaskTest {
     @Test
     void testStateBackendClosingOnFailure() throws Exception {
         Configuration taskManagerConfig = new Configuration();
-        taskManagerConfig.setString(STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
+        taskManagerConfig.set(STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
 
         StreamConfig cfg = new StreamConfig(new Configuration());
         cfg.setStateKeySerializer(mock(TypeSerializer.class));
@@ -1527,7 +1527,7 @@ public class StreamTaskTest {
     void testTaskAvoidHangingAfterSnapshotStateThrownException() throws Exception {
         // given: Configured SourceStreamTask with source which fails on checkpoint.
         Configuration taskManagerConfig = new Configuration();
-        taskManagerConfig.setString(STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
+        taskManagerConfig.set(STATE_BACKEND, TestMemoryStateBackendFactory.class.getName());
 
         StreamConfig cfg = new StreamConfig(new Configuration());
         cfg.setStateKeySerializer(mock(TypeSerializer.class));

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/ExecutorImplITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/ExecutorImplITCase.java
@@ -188,8 +188,8 @@ class ExecutorImplITCase {
         Configuration config = new Configuration();
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
         config.set(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS, NUM_TMS);
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
-        config.setBoolean(WebOptions.SUBMIT_ENABLE, false);
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, NUM_SLOTS_PER_TM);
+        config.set(WebOptions.SUBMIT_ENABLE, false);
         config.set(StateBackendOptions.STATE_BACKEND, "hashmap");
         config.set(CheckpointingOptions.CHECKPOINT_STORAGE, "filesystem");
         config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, tempFolder.toURI().toString());

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointITCase.java
@@ -236,7 +236,7 @@ class SqlGatewayRestEndpointITCase {
      */
     @Test
     void testDefaultVersionRouting() throws Exception {
-        assertThat(config.getBoolean(SecurityOptions.SSL_REST_ENABLED)).isFalse();
+        assertThat(config.get(SecurityOptions.SSL_REST_ENABLED)).isFalse();
 
         OkHttpClient client = new OkHttpClient();
         final Request request =

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/util/DocumentingSqlGatewayRestEndpoint.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/util/DocumentingSqlGatewayRestEndpoint.java
@@ -43,7 +43,7 @@ public class DocumentingSqlGatewayRestEndpoint extends SqlGatewayRestEndpoint
     private static final Configuration config = new Configuration();
 
     static {
-        config.setString(RestOptions.ADDRESS, "localhost");
+        config.set(RestOptions.ADDRESS, "localhost");
     }
 
     public DocumentingSqlGatewayRestEndpoint() throws ConfigurationException, IOException {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -418,7 +418,7 @@ public class SqlGatewayServiceITCase {
             @TempDir File tmpDir)
             throws Exception {
         Configuration configuration = new Configuration(MINI_CLUSTER.getClientConfiguration());
-        configuration.setBoolean(TableConfigOptions.TABLE_DML_SYNC, false);
+        configuration.set(TableConfigOptions.TABLE_DML_SYNC, false);
         File savepointDir = new File(tmpDir, "savepoints");
         configuration.set(
                 CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
@@ -471,7 +471,7 @@ public class SqlGatewayServiceITCase {
         Configuration configuration = new Configuration(MINI_CLUSTER.getClientConfiguration());
 
         String pipelineName = "test-job";
-        configuration.setString(PipelineOptions.NAME, pipelineName);
+        configuration.set(PipelineOptions.NAME, pipelineName);
 
         // running jobs
         String sourceDdl = "CREATE TABLE source (a STRING) WITH ('connector'='datagen');";

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -252,7 +252,7 @@ public final class TableConfig implements WritableConfig, ReadableConfig {
      * @see org.apache.flink.table.types.logical.LocalZonedTimestampType
      */
     public ZoneId getLocalTimeZone() {
-        final String zone = configuration.getString(TableConfigOptions.LOCAL_TIME_ZONE);
+        final String zone = configuration.get(TableConfigOptions.LOCAL_TIME_ZONE);
         if (TableConfigOptions.LOCAL_TIME_ZONE.defaultValue().equals(zone)) {
             return ZoneId.systemDefault();
         }
@@ -317,7 +317,7 @@ public final class TableConfig implements WritableConfig, ReadableConfig {
         }
         validateTimeZone(zone);
 
-        configuration.setString(TableConfigOptions.LOCAL_TIME_ZONE, zone);
+        configuration.set(TableConfigOptions.LOCAL_TIME_ZONE, zone);
     }
 
     /** Returns the current configuration of Planner for Table API and SQL queries. */
@@ -342,7 +342,7 @@ public final class TableConfig implements WritableConfig, ReadableConfig {
      * more than 8K byte code.
      */
     public Integer getMaxGeneratedCodeLength() {
-        return this.configuration.getInteger(TableConfigOptions.MAX_LENGTH_GENERATED_CODE);
+        return this.configuration.get(TableConfigOptions.MAX_LENGTH_GENERATED_CODE);
     }
 
     /**
@@ -353,7 +353,7 @@ public final class TableConfig implements WritableConfig, ReadableConfig {
      * more than 8K byte code.
      */
     public void setMaxGeneratedCodeLength(Integer maxGeneratedCodeLength) {
-        this.configuration.setInteger(
+        this.configuration.set(
                 TableConfigOptions.MAX_LENGTH_GENERATED_CODE, maxGeneratedCodeLength);
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/factories/TableFactoryUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/factories/TableFactoryUtil.java
@@ -217,7 +217,7 @@ public class TableFactoryUtil {
      */
     public static CatalogStoreFactory findAndCreateCatalogStoreFactory(
             Configuration configuration, ClassLoader classLoader) {
-        String identifier = configuration.getString(CommonCatalogOptions.TABLE_CATALOG_STORE_KIND);
+        String identifier = configuration.get(CommonCatalogOptions.TABLE_CATALOG_STORE_KIND);
 
         CatalogStoreFactory catalogStoreFactory =
                 FactoryUtil.discoverFactory(classLoader, CatalogStoreFactory.class, identifier);
@@ -238,7 +238,7 @@ public class TableFactoryUtil {
      */
     public static CatalogStoreFactory.Context buildCatalogStoreFactoryContext(
             Configuration configuration, ClassLoader classLoader) {
-        String identifier = configuration.getString(CommonCatalogOptions.TABLE_CATALOG_STORE_KIND);
+        String identifier = configuration.get(CommonCatalogOptions.TABLE_CATALOG_STORE_KIND);
         String catalogStoreOptionPrefix =
                 CommonCatalogOptions.TABLE_CATALOG_STORE_OPTION_PREFIX + identifier + ".";
         Map<String, String> options =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -311,7 +311,7 @@ public class PlannerContext {
                             boolean mergeProjectsDuringSqlToRel =
                                     context.getTableConfig()
                                             .getConfiguration()
-                                            .getBoolean(
+                                            .get(
                                                     OptimizerConfigOptions
                                                             .TABLE_OPTIMIZER_SQL2REL_PROJECT_MERGE_ENABLED);
                             if (!mergeProjectsDuringSqlToRel) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
@@ -117,8 +117,7 @@ public class BatchExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                 CommonPythonUtil.extractPythonConfiguration(
                         planner.getExecEnv(), config, planner.getFlinkContext().getClassLoader());
         int groupBufferLimitSize =
-                pythonConfig.getInteger(
-                        ExecutionConfigOptions.TABLE_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT);
+                pythonConfig.get(ExecutionConfigOptions.TABLE_EXEC_WINDOW_AGG_BUFFER_SIZE_LIMIT);
 
         OneInputTransformation<RowData, RowData> transform =
                 createPythonOneInputTransformation(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/CommonPythonUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/CommonPythonUtil.java
@@ -161,7 +161,7 @@ public class CommonPythonUtil {
             Configuration config, ClassLoader classLoader) {
         Class<?> clazz = loadClass(PYTHON_OPTIONS_CLASS, classLoader);
         try {
-            return config.getBoolean(
+            return config.get(
                     (ConfigOption<Boolean>) (clazz.getField("USE_MANAGED_MEMORY").get(null)));
         } catch (IllegalAccessException | NoSuchFieldException e) {
             throw new TableException("Field USE_MANAGED_MEMORY accessed failed.", e);
@@ -173,7 +173,7 @@ public class CommonPythonUtil {
             Configuration config, ClassLoader classLoader) {
         Class<?> clazz = loadClass(PYTHON_OPTIONS_CLASS, classLoader);
         try {
-            return config.getString(
+            return config.get(
                             (ConfigOption<String>)
                                     (clazz.getField("PYTHON_EXECUTION_MODE").get(null)))
                     .equalsIgnoreCase("process");

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestFileFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestFileFactory.java
@@ -77,14 +77,13 @@ public class TestFileFactory implements DynamicTableSourceFactory, DynamicTableS
     public DynamicTableSource createDynamicTableSource(Context context) {
         Configuration conf = Configuration.fromMap(context.getCatalogTable().getOptions());
         return new TestFileTableSource(
-                new Path(conf.getString(FileSystemConnectorOptions.PATH)),
-                conf.getString(RUNTIME_SOURCE));
+                new Path(conf.get(FileSystemConnectorOptions.PATH)), conf.get(RUNTIME_SOURCE));
     }
 
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         Configuration conf = Configuration.fromMap(context.getCatalogTable().getOptions());
-        return new TestFileTableSink(new Path(conf.getString(FileSystemConnectorOptions.PATH)));
+        return new TestFileTableSink(new Path(conf.get(FileSystemConnectorOptions.PATH)));
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StreamExchangeModeUtilsTest.java
@@ -75,7 +75,7 @@ class StreamExchangeModeUtilsTest {
 
         configuration.set(
                 ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_PIPELINED);
-        configuration.setString(
+        configuration.set(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 GlobalStreamExchangeMode.ALL_EDGES_BLOCKING.toString());
 
@@ -87,43 +87,43 @@ class StreamExchangeModeUtilsTest {
     void testLegacyShuffleMode() {
         final Configuration configuration = new Configuration();
 
-        configuration.setString(
+        configuration.set(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 GlobalStreamExchangeMode.ALL_EDGES_BLOCKING.toString());
         assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
                 .isEqualTo(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
 
-        configuration.setString(
+        configuration.set(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED.toString());
         assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
                 .isEqualTo(GlobalStreamExchangeMode.FORWARD_EDGES_PIPELINED);
 
-        configuration.setString(
+        configuration.set(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 GlobalStreamExchangeMode.POINTWISE_EDGES_PIPELINED.toString());
         assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
                 .isEqualTo(GlobalStreamExchangeMode.POINTWISE_EDGES_PIPELINED);
 
-        configuration.setString(
+        configuration.set(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 GlobalStreamExchangeMode.ALL_EDGES_PIPELINED.toString());
         assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
                 .isEqualTo(GlobalStreamExchangeMode.ALL_EDGES_PIPELINED);
 
-        configuration.setString(
+        configuration.set(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 StreamExchangeModeUtils.ALL_EDGES_BLOCKING_LEGACY);
         assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
                 .isEqualTo(GlobalStreamExchangeMode.ALL_EDGES_BLOCKING);
 
-        configuration.setString(
+        configuration.set(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
                 StreamExchangeModeUtils.ALL_EDGES_PIPELINED_LEGACY);
         assertThat(getGlobalStreamExchangeMode(configuration).orElseThrow(AssertionError::new))
                 .isEqualTo(GlobalStreamExchangeMode.ALL_EDGES_PIPELINED);
 
-        configuration.setString(
+        configuration.set(
                 ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "Forward_edges_PIPELINED");
         assertThat(
                         StreamExchangeModeUtils.getGlobalStreamExchangeMode(configuration)
@@ -134,7 +134,7 @@ class StreamExchangeModeUtilsTest {
     @Test
     void testInvalidLegacyShuffleMode() {
         final Configuration configuration = new Configuration();
-        configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "invalid-value");
+        configuration.set(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "invalid-value");
         assertThatThrownBy(() -> StreamExchangeModeUtils.getGlobalStreamExchangeMode(configuration))
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/ShuffledHashJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/ShuffledHashJoinTest.scala
@@ -28,7 +28,7 @@ class ShuffledHashJoinTest extends JoinTestBase {
   @BeforeEach
   def before(): Unit = {
     util.tableEnv.getConfig.getConfiguration
-      .setLong(OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD, 1L)
+      .set(OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD, Long.box(1L))
     util.tableEnv.getConfig.set(
       ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS,
       "SortMergeJoin, NestedLoopJoin, BroadcastHashJoin")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamTableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamTableEnvironmentITCase.scala
@@ -194,7 +194,7 @@ class StreamTableEnvironmentITCase extends StreamingTestBase {
   @Test
   def testTableConfigInheritsEnvironmentSettings(): Unit = {
     val config = new Configuration
-    config.setString(TableConfigOptions.TABLE_CATALOG_NAME, "myCatalog")
+    config.set(TableConfigOptions.TABLE_CATALOG_NAME, "myCatalog")
     val env = StreamExecutionEnvironment.getExecutionEnvironment(config)
     val tEnv = StreamTableEnvironment.create(env)
     assertThat(tEnv.getConfig.get(TableConfigOptions.TABLE_CATALOG_NAME)).isEqualTo("myCatalog")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -70,7 +70,7 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
           new MemoryStateBackend("file://" + baseCheckpointPath, null).configure(conf, classLoader))
       case ROCKSDB_BACKEND =>
         val conf = new Configuration()
-        conf.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true)
+        conf.set(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, Boolean.box(true))
         env.setStateBackend(
           new RocksDBStateBackend("file://" + baseCheckpointPath).configure(conf, classLoader))
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/HashJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/HashJoinOperator.java
@@ -114,7 +114,7 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
                 getContainingTask()
                         .getEnvironment()
                         .getTaskConfiguration()
-                        .getBoolean(AlgorithmOptions.HASH_JOIN_BLOOM_FILTERS);
+                        .get(AlgorithmOptions.HASH_JOIN_BLOOM_FILTERS);
 
         int parallel = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorterTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorterTest.java
@@ -65,10 +65,10 @@ public class BinaryExternalSorterTest {
         ioManager = new IOManagerAsync();
         conf = new Configuration();
         if (!spillCompress) {
-            conf.setBoolean(ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED, false);
+            conf.set(ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED, false);
         }
         if (asyncMerge) {
-            conf.setBoolean(ExecutionConfigOptions.TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED, true);
+            conf.set(ExecutionConfigOptions.TABLE_EXEC_SORT_ASYNC_MERGE_ENABLED, true);
         }
     }
 
@@ -94,7 +94,7 @@ public class BinaryExternalSorterTest {
     public void beforeTest() {
         this.memoryManager = MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
         this.serializer = new BinaryRowDataSerializer(2);
-        this.conf.setInteger(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES, 128);
+        this.conf.set(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES, 128);
     }
 
     @After
@@ -374,7 +374,7 @@ public class BinaryExternalSorterTest {
 
         long minMemorySize =
                 memoryManager.computeNumberOfPages(0.01) * MemoryManager.DEFAULT_PAGE_SIZE;
-        conf.setInteger(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES, 8);
+        conf.set(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES, 8);
 
         BinaryExternalSorter sorter =
                 new BinaryExternalSorter(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BufferedKVExternalSorterTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sort/BufferedKVExternalSorterTest.java
@@ -69,9 +69,9 @@ public class BufferedKVExternalSorterTest {
             int spillNumber, int recordNumberPerFile, boolean spillCompress) {
         ioManager = new IOManagerAsync();
         conf = new Configuration();
-        conf.setInteger(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES, 5);
+        conf.set(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES, 5);
         if (!spillCompress) {
-            conf.setBoolean(ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED, false);
+            conf.set(ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED, false);
         }
         this.spillNumber = spillNumber;
         this.recordNumberPerFile = recordNumberPerFile;

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkContainersSettings.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkContainersSettings.java
@@ -496,7 +496,7 @@ public class FlinkContainersSettings {
      * @return The job manager hostname.
      */
     public String getJobManagerHostname() {
-        return flinkConfig.getString(JobManagerOptions.ADDRESS);
+        return flinkConfig.get(JobManagerOptions.ADDRESS);
     }
 
     /**

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
@@ -89,7 +89,7 @@ public class MiniClusterTestEnvironment implements TestEnvironment, ClusterContr
             TestEnvironmentSettings envOptions) {
         Configuration configuration = new Configuration();
         if (envOptions.getSavepointRestorePath() != null) {
-            configuration.setString(SAVEPOINT_PATH, envOptions.getSavepointRestorePath());
+            configuration.set(SAVEPOINT_PATH, envOptions.getSavepointRestorePath());
         }
         return new TestStreamEnvironment(
                 this.miniCluster.getMiniCluster(),

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/SecureTestEnvironment.java
@@ -149,11 +149,11 @@ public class SecureTestEnvironment {
             // ctx.setHadoopConfiguration() for the UGI implementation to work properly.
             // See Yarn test case module for reference
             Configuration flinkConfig = GlobalConfiguration.loadConfiguration();
-            flinkConfig.setBoolean(SecurityOptions.ZOOKEEPER_SASL_DISABLE, false);
-            flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, testKeytab);
-            flinkConfig.setBoolean(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE, false);
-            flinkConfig.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, testPrincipal);
-            flinkConfig.setString(
+            flinkConfig.set(SecurityOptions.ZOOKEEPER_SASL_DISABLE, false);
+            flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_KEYTAB, testKeytab);
+            flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE, false);
+            flinkConfig.set(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, testPrincipal);
+            flinkConfig.set(
                     SecurityOptions.KERBEROS_LOGIN_CONTEXTS,
                     "Client,KafkaClient," + KerberosUtils.getDefaultKerberosInitAppEntryName());
             SecurityConfiguration ctx = new SecurityConfiguration(flinkConfig);
@@ -224,8 +224,8 @@ public class SecureTestEnvironment {
             conf = flinkConf;
         }
 
-        conf.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, testKeytab);
-        conf.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, testPrincipal);
+        conf.set(SecurityOptions.KERBEROS_LOGIN_KEYTAB, testKeytab);
+        conf.set(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, testPrincipal);
 
         return conf;
     }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/metrics/SystemResourcesMetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/metrics/SystemResourcesMetricsITCase.java
@@ -73,10 +73,10 @@ class SystemResourcesMetricsITCase {
 
     private static Configuration getConfiguration() {
         Configuration configuration = new Configuration();
-        configuration.setBoolean(SYSTEM_RESOURCE_METRICS, true);
-        configuration.setString(REPORTERS_LIST, "test_reporter");
-        configuration.setString(MetricOptions.SCOPE_NAMING_JM, "jobmanager");
-        configuration.setString(MetricOptions.SCOPE_NAMING_TM, "taskmanager");
+        configuration.set(SYSTEM_RESOURCE_METRICS, true);
+        configuration.set(REPORTERS_LIST, "test_reporter");
+        configuration.set(MetricOptions.SCOPE_NAMING_JM, "jobmanager");
+        configuration.set(MetricOptions.SCOPE_NAMING_TM, "taskmanager");
         MetricOptions.forReporter(configuration, "test_reporter")
                 .set(MetricOptions.REPORTER_FACTORY_CLASS, TestReporter.class.getName());
         return configuration;

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
@@ -103,7 +103,7 @@ public class AccumulatorLiveITCase extends TestLogger {
     private static Configuration getConfiguration() {
         Configuration config = new Configuration();
         config.set(AkkaOptions.ASK_TIMEOUT_DURATION, TestingUtils.DEFAULT_ASK_TIMEOUT);
-        config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
+        config.set(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
 
         return config;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancelingTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/cancelling/CancelingTestBase.java
@@ -84,10 +84,10 @@ public abstract class CancelingTestBase extends TestLogger {
     private static Configuration getConfiguration() {
         verifyJvmOptions();
         Configuration config = new Configuration();
-        config.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
+        config.set(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
         config.set(AkkaOptions.ASK_TIMEOUT_DURATION, TestingUtils.DEFAULT_ASK_TIMEOUT);
         config.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4096"));
-        config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 2048);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 2048);
 
         return config;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AutoRescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AutoRescalingITCase.java
@@ -153,14 +153,13 @@ public class AutoRescalingITCase extends TestLogger {
             final File checkpointDir = temporaryFolder.newFolder();
             final File savepointDir = temporaryFolder.newFolder();
 
-            config.setString(StateBackendOptions.STATE_BACKEND, currentBackend);
-            config.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true);
-            config.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, true);
-            config.setString(
+            config.set(StateBackendOptions.STATE_BACKEND, currentBackend);
+            config.set(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true);
+            config.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+            config.set(
                     CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
-            config.setString(
-                    CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
-            config.setInteger(
+            config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+            config.set(
                     NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, buffersPerChannel);
 
             config.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogLocalRecoveryITCase.java
@@ -95,12 +95,12 @@ public class ChangelogLocalRecoveryITCase extends TestLogger {
     @Before
     public void setup() throws Exception {
         Configuration configuration = new Configuration();
-        configuration.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
+        configuration.set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
 
-        configuration.setString(PROCESS_WORKING_DIR_BASE, workingDir);
-        configuration.setString(JOB_MANAGER_PROCESS_WORKING_DIR_BASE, workingDir);
-        configuration.setString(TASK_MANAGER_PROCESS_WORKING_DIR_BASE, workingDir);
-        configuration.setBoolean(LOCAL_RECOVERY, true);
+        configuration.set(PROCESS_WORKING_DIR_BASE, workingDir);
+        configuration.set(JOB_MANAGER_PROCESS_WORKING_DIR_BASE, workingDir);
+        configuration.set(TASK_MANAGER_PROCESS_WORKING_DIR_BASE, workingDir);
+        configuration.set(LOCAL_RECOVERY, true);
         FsStateChangelogStorageFactory.configure(
                 configuration, TEMPORARY_FOLDER.newFolder(), Duration.ofMillis(1000), 1);
         cluster =
@@ -179,7 +179,7 @@ public class ChangelogLocalRecoveryITCase extends TestLogger {
                 .setExternalizedCheckpointCleanup(
                         CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
         Configuration configuration = new Configuration();
-        configuration.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
+        configuration.set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
         env.configure(configuration);
         return env;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogRecoverySwitchStateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogRecoverySwitchStateBackendITCase.java
@@ -57,7 +57,7 @@ public class ChangelogRecoverySwitchStateBackendITCase extends ChangelogRecovery
     @Override
     public void setup() throws Exception {
         Configuration configuration = new Configuration();
-        configuration.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
+        configuration.set(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
         // reduce file threshold to reproduce FLINK-28843
         configuration.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, MemorySize.parse("20b"));
         FsStateChangelogStorageFactory.configure(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointAfterAllTasksFinishedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointAfterAllTasksFinishedITCase.java
@@ -154,7 +154,7 @@ public class CheckpointAfterAllTasksFinishedITCase extends AbstractTestBase {
     @Test
     public void testFailoverAfterSomeTasksFinished() throws Exception {
         final Configuration config = new Configuration();
-        config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
+        config.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
 
         final MiniClusterConfiguration cfg =
                 new MiniClusterConfiguration.Builder()

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -168,8 +168,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
         }
 
         Configuration config = createClusterConfig();
-        config.setInteger(
-                NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, buffersPerChannel);
+        config.set(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, buffersPerChannel);
 
         switch (stateBackendEnum) {
             case MEM:
@@ -237,13 +236,12 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
         final File haDir = temporaryFolder.newFolder();
 
         Configuration config = new Configuration();
-        config.setString(AkkaOptions.FRAMESIZE, String.valueOf(MAX_MEM_STATE_SIZE) + "b");
+        config.set(AkkaOptions.FRAMESIZE, String.valueOf(MAX_MEM_STATE_SIZE) + "b");
 
         if (zkServer != null) {
-            config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-            config.setString(
-                    HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zkServer.getConnectString());
-            config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haDir.toURI().toString());
+            config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+            config.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zkServer.getConnectString());
+            config.set(HighAvailabilityOptions.HA_STORAGE_PATH, haDir.toURI().toString());
         }
         return config;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
@@ -116,7 +116,7 @@ public class LocalRecoveryITCase extends TestLogger {
         protected Configuration createClusterConfig() throws IOException {
             Configuration config = super.createClusterConfig();
 
-            config.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, localRecoveryEnabled);
+            config.set(CheckpointingOptions.LOCAL_RECOVERY, localRecoveryEnabled);
 
             return config;
         }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -114,8 +114,8 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
     @Before
     public void setup() throws Exception {
         Configuration configuration = new Configuration();
-        configuration.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, true);
-        configuration.setString(HighAvailabilityOptions.HA_MODE, TestingHAFactory.class.getName());
+        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(HighAvailabilityOptions.HA_MODE, TestingHAFactory.class.getName());
 
         checkpointPath = new Path(TEMPORARY_FOLDER.newFolder().toURI());
         cluster =

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RegionFailoverITCase.java
@@ -110,8 +110,8 @@ public class RegionFailoverITCase extends TestLogger {
     @Before
     public void setup() throws Exception {
         Configuration configuration = new Configuration();
-        configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
-        configuration.setString(HighAvailabilityOptions.HA_MODE, TestingHAFactory.class.getName());
+        configuration.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
+        configuration.set(HighAvailabilityOptions.HA_MODE, TestingHAFactory.class.getName());
 
         cluster =
                 new MiniClusterWithClientResource(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleCheckpointManuallyITCase.java
@@ -85,8 +85,8 @@ public class RescaleCheckpointManuallyITCase extends TestLogger {
     @Before
     public void setup() throws Exception {
         Configuration config = new Configuration();
-        config.setString(StateBackendOptions.STATE_BACKEND, "rocksdb");
-        config.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true);
+        config.set(StateBackendOptions.STATE_BACKEND, "rocksdb");
+        config.set(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true);
 
         cluster =
                 new MiniClusterWithClientResource(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -145,12 +145,11 @@ public class RescalingITCase extends TestLogger {
             final File checkpointDir = temporaryFolder.newFolder();
             final File savepointDir = temporaryFolder.newFolder();
 
-            config.setString(StateBackendOptions.STATE_BACKEND, currentBackend);
-            config.setString(
+            config.set(StateBackendOptions.STATE_BACKEND, currentBackend);
+            config.set(
                     CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
-            config.setString(
-                    CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
-            config.setInteger(
+            config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+            config.set(
                     NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, buffersPerChannel);
 
             cluster =

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -338,10 +338,9 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 
         final File savepointDir = temporaryFolder.newFolder();
 
-        config.setString(
-                CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
-        config.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, localRecovery);
+        config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+        config.set(CheckpointingOptions.LOCAL_RECOVERY, localRecovery);
 
         // Configure DFS DSTL for this test as it might produce too much GC pressure if
         // ChangelogStateBackend is used.
@@ -353,9 +352,9 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
         // ZooKeeper recovery mode?
         if (zooKeeperQuorum != null) {
             final File haDir = temporaryFolder.newFolder();
-            config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-            config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperQuorum);
-            config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, haDir.toURI().toString());
+            config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+            config.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperQuorum);
+            config.set(HighAvailabilityOptions.HA_STORAGE_PATH, haDir.toURI().toString());
         }
 
         MiniClusterWithClientResource cluster =

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointFormatITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointFormatITCase.java
@@ -146,7 +146,7 @@ public class SavepointFormatITCase extends TestLogger {
 
         public Configuration getConfiguration() {
             Configuration stateBackendConfig = new Configuration();
-            stateBackendConfig.setString(StateBackendOptions.STATE_BACKEND, getConfigName());
+            stateBackendConfig.set(StateBackendOptions.STATE_BACKEND, getConfigName());
             stateBackendConfig.set(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, incremental);
             stateBackendConfig.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, changelogEnabled);
             return stateBackendConfig;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -730,7 +730,7 @@ public class SavepointITCase extends TestLogger {
         final int numSlotsPerTaskManager = 1;
 
         final Configuration config = new Configuration();
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 
         final MiniClusterWithClientResource cluster =
                 new MiniClusterWithClientResource(
@@ -957,7 +957,7 @@ public class SavepointITCase extends TestLogger {
         int parallelism = numTaskManagers * numSlotsPerTaskManager;
 
         final Configuration config = new Configuration();
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 
         MiniClusterWithClientResource cluster =
                 new MiniClusterWithClientResource(
@@ -1238,7 +1238,7 @@ public class SavepointITCase extends TestLogger {
 
         // Flink configuration
         final Configuration config = new Configuration();
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
 
         String savepointPath;
 
@@ -1766,11 +1766,10 @@ public class SavepointITCase extends TestLogger {
 
     private Configuration getFileBasedCheckpointsConfig(final String savepointDir) {
         final Configuration config = new Configuration();
-        config.setString(StateBackendOptions.STATE_BACKEND, "filesystem");
-        config.setString(
-                CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+        config.set(StateBackendOptions.STATE_BACKEND, "filesystem");
+        config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
         config.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, MemorySize.ZERO);
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir);
         return config;
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
@@ -78,10 +78,10 @@ public abstract class StreamFaultToleranceTestBase extends TestLogger {
         Configuration configuration = new Configuration();
         switch (failoverStrategy) {
             case RestartPipelinedRegionFailoverStrategy:
-                configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
+                configuration.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
                 break;
             case RestartAllFailoverStrategy:
-                configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
+                configuration.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
         }
 
         // Configure DFS DSTL for this test as it might produce too much GC pressure if

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -764,11 +764,10 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
         public Configuration getConfiguration(File checkpointDir) {
             Configuration conf = new Configuration();
 
-            conf.setFloat(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 0.9f);
+            conf.set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 0.9f);
             conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
-            conf.setString(StateBackendOptions.STATE_BACKEND, "filesystem");
-            conf.setString(
-                    CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+            conf.set(StateBackendOptions.STATE_BACKEND, "filesystem");
+            conf.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
             if (restoreCheckpoint != null) {
                 conf.set(
                         SavepointConfigOptions.SAVEPOINT_PATH,

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SnapshotMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SnapshotMigrationTestBase.java
@@ -233,7 +233,7 @@ public abstract class SnapshotMigrationTestBase extends TestLogger {
         final Configuration config = new Configuration();
 
         config.set(TaskManagerOptions.MINI_CLUSTER_NUM_TASK_MANAGERS, 1);
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, DEFAULT_PARALLELISM);
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, DEFAULT_PARALLELISM);
 
         UUID id = UUID.randomUUID();
         final File checkpointDir = TEMP_FOLDER.newFolder("checkpoints_" + id).getAbsoluteFile();
@@ -246,12 +246,11 @@ public abstract class SnapshotMigrationTestBase extends TestLogger {
         LOG.info("Created temporary checkpoint directory: " + checkpointDir + ".");
         LOG.info("Created savepoint directory: " + savepointDir + ".");
 
-        config.setString(StateBackendOptions.STATE_BACKEND, "memory");
-        config.setString(
-                CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
+        config.set(StateBackendOptions.STATE_BACKEND, "memory");
+        config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
         config.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, MemorySize.ZERO);
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
-        config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 300L);
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+        config.set(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 300L);
 
         return config;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/ClassLoaderITCase.java
@@ -114,13 +114,13 @@ public class ClassLoaderITCase extends TestLogger {
 
         // we need to use the "filesystem" state backend to ensure FLINK-2543 is not happening
         // again.
-        config.setString(StateBackendOptions.STATE_BACKEND, "filesystem");
-        config.setString(
+        config.set(StateBackendOptions.STATE_BACKEND, "filesystem");
+        config.set(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY,
                 FOLDER.newFolder().getAbsoluteFile().toURI().toString());
 
         // Savepoint path
-        config.setString(
+        config.set(
                 CheckpointingOptions.SAVEPOINT_DIRECTORY,
                 FOLDER.newFolder().getAbsoluteFile().toURI().toString());
 
@@ -131,12 +131,12 @@ public class ClassLoaderITCase extends TestLogger {
         // implementation - use fs-based instead.
         // The randomization currently happens on the job level (environment); while this factory
         // can only be set on the cluster level; so we do it unconditionally here.
-        config.setString(STATE_CHANGE_LOG_STORAGE, IDENTIFIER);
-        config.setString(BASE_PATH, FOLDER.newFolder().getAbsolutePath());
+        config.set(STATE_CHANGE_LOG_STORAGE, IDENTIFIER);
+        config.set(BASE_PATH, FOLDER.newFolder().getAbsolutePath());
 
         // some tests check for serialization problems related to class-loading
         // this requires all RPCs to actually go through serialization
-        config.setBoolean(AkkaOptions.FORCE_RPC_INVOCATION_SERIALIZATION, true);
+        config.set(AkkaOptions.FORCE_RPC_INVOCATION_SERIALIZATION, true);
 
         miniClusterResource =
                 new MiniClusterResource(

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -64,8 +64,8 @@ public class JobRetrievalITCase extends TestLogger {
     @Before
     public void setUp() throws Exception {
         final Configuration clientConfig = new Configuration();
-        clientConfig.setInteger(RestOptions.RETRY_MAX_ATTEMPTS, 0);
-        clientConfig.setLong(RestOptions.RETRY_DELAY, 0);
+        clientConfig.set(RestOptions.RETRY_MAX_ATTEMPTS, 0);
+        clientConfig.set(RestOptions.RETRY_DELAY, 0L);
         clientConfig.addAll(CLUSTER.getClientConfiguration());
 
         client = new RestClusterClient<>(clientConfig, StandaloneClusterId.getInstance());

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/LocalExecutorITCase.java
@@ -77,8 +77,8 @@ public class LocalExecutorITCase extends TestLogger {
             }
 
             final Configuration config = new Configuration();
-            config.setBoolean(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
-            config.setBoolean(DeploymentOptions.ATTACHED, true);
+            config.set(CoreOptions.FILESYTEM_DEFAULT_OVERRIDE, true);
+            config.set(DeploymentOptions.ATTACHED, true);
 
             Plan wcPlan = getWordCountPlan(inFile, outFile, parallelism);
             wcPlan.setExecutionConfig(new ExecutionConfig());
@@ -99,7 +99,7 @@ public class LocalExecutorITCase extends TestLogger {
         runtimeExceptionPlan.setExecutionConfig(new ExecutionConfig());
 
         Configuration config = new Configuration();
-        config.setBoolean(DeploymentOptions.ATTACHED, true);
+        config.set(DeploymentOptions.ATTACHED, true);
 
         JobClient jobClient =
                 executor.execute(runtimeExceptionPlan, config, ClassLoader.getSystemClassLoader())

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
@@ -51,7 +51,7 @@ public class StreamingScalabilityAndLatency {
         try {
             Configuration config = new Configuration();
             config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("80m"));
-            config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 20000);
+            config.set(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 20000);
 
             config.setInteger("taskmanager.net.server.numThreads", 1);
             config.setInteger("taskmanager.net.client.numThreads", 1);

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/ExecutionEnvironmentITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/ExecutionEnvironmentITCase.java
@@ -45,7 +45,7 @@ public class ExecutionEnvironmentITCase extends TestLogger {
     @Test
     public void testLocalEnvironmentWithConfig() throws Exception {
         Configuration conf = new Configuration();
-        conf.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, PARALLELISM);
+        conf.set(TaskManagerOptions.NUM_TASK_SLOTS, PARALLELISM);
 
         final ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(conf);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/operators/RemoteEnvironmentITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/RemoteEnvironmentITCase.java
@@ -60,7 +60,7 @@ public class RemoteEnvironmentITCase extends TestLogger {
     @Test
     public void testUserSpecificParallelism() throws Exception {
         Configuration config = new Configuration();
-        config.setString(AkkaOptions.STARTUP_TIMEOUT, VALID_STARTUP_TIMEOUT);
+        config.set(AkkaOptions.STARTUP_TIMEOUT, VALID_STARTUP_TIMEOUT);
 
         final URI restAddress = MINI_CLUSTER_RESOURCE.getRestAddress();
         final String hostname = restAddress.getHost();

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -94,26 +94,26 @@ abstract class AbstractTaskManagerProcessFailureRecoveryTest {
         File coordinateTempDir;
 
         Configuration config = new Configuration();
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
-        config.setString(RestOptions.BIND_PORT, "0");
-        config.setLong(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 200L);
-        config.setLong(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 10000L);
+        config.set(JobManagerOptions.ADDRESS, "localhost");
+        config.set(RestOptions.BIND_PORT, "0");
+        config.set(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 200L);
+        config.set(HeartbeatManagerOptions.HEARTBEAT_TIMEOUT, 10000L);
         config.set(HeartbeatManagerOptions.HEARTBEAT_RPC_FAILURE_THRESHOLD, 1);
-        config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        config.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 zooKeeperExtensionWrapper.getCustomExtension().getConnectString());
-        config.setString(
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH,
                 TempDirUtils.newFolder(temporaryFolder).getAbsolutePath());
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, 2);
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
         config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.parse("3200k"));
         config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse("3200k"));
         config.set(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS, 16);
         config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
         config.set(TaskManagerOptions.CPU_CORES, 1.0);
-        config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
+        config.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
         config.set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, Duration.ofSeconds(30L));
 
         try (final StandaloneSessionClusterEntrypoint clusterEntrypoint =

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
@@ -232,7 +232,7 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 
     private static Configuration createConfiguration() {
         Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 JobManagerOptions.EXECUTION_FAILOVER_STRATEGY,
                 PIPELINED_REGION_RESTART_STRATEGY_NAME);
         return configuration;

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -140,10 +140,9 @@ class JobManagerHAProcessFailureRecoveryITCase {
             String zkQuorum, final File coordinateDir, final File zookeeperStoragePath)
             throws Exception {
         Configuration config = new Configuration();
-        config.setString(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
-        config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zkQuorum);
-        config.setString(
-                HighAvailabilityOptions.HA_STORAGE_PATH, zookeeperStoragePath.getAbsolutePath());
+        config.set(HighAvailabilityOptions.HA_MODE, "ZOOKEEPER");
+        config.set(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zkQuorum);
+        config.set(HighAvailabilityOptions.HA_STORAGE_PATH, zookeeperStoragePath.getAbsolutePath());
 
         ExecutionEnvironment env =
                 ExecutionEnvironment.createRemoteEnvironment("leader", 1, config);
@@ -260,7 +259,7 @@ class JobManagerHAProcessFailureRecoveryITCase {
         config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.parse("3200k"));
         config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse("3200k"));
         config.set(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS, 16);
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, 2);
         config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
         config.set(TaskManagerOptions.CPU_CORES, 1.0);
         TaskExecutorResourceUtils.adjustForLocalExecution(config);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -109,27 +109,27 @@ class ProcessFailureCancelingITCase {
         final TestingFatalErrorHandler fatalErrorHandler = new TestingFatalErrorHandler();
 
         Configuration config = new Configuration();
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
+        config.set(JobManagerOptions.ADDRESS, "localhost");
         config.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofSeconds(100));
-        config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
-        config.setString(
+        config.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        config.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM,
                 zooKeeperExtensionWrapper.getCustomExtension().getConnectString());
-        config.setString(
+        config.set(
                 HighAvailabilityOptions.HA_STORAGE_PATH,
                 TempDirUtils.newFolder(temporaryFolder).getAbsolutePath());
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, 2);
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
         config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.parse("3200k"));
         config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse("3200k"));
         config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
         config.set(TaskManagerOptions.CPU_CORES, 1.0);
-        config.setInteger(RestOptions.PORT, 0);
+        config.set(RestOptions.PORT, 0);
 
         final RpcService rpcService =
                 RpcSystem.load().remoteServiceBuilder(config, "localhost", "0").createAndStart();
         final int jobManagerPort = rpcService.getPort();
-        config.setInteger(JobManagerOptions.PORT, jobManagerPort);
+        config.set(JobManagerOptions.PORT, jobManagerPort);
 
         final DispatcherResourceManagerComponentFactory resourceManagerComponentFactory =
                 DefaultDispatcherResourceManagerComponentFactory.createSessionComponentFactory(

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryExponentialDelayRestartStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryExponentialDelayRestartStrategyITBase.java
@@ -41,20 +41,19 @@ public class SimpleRecoveryExponentialDelayRestartStrategyITBase extends SimpleR
 
     private static Configuration getConfiguration() {
         Configuration config = new Configuration();
-        config.setString(RestartStrategyOptions.RESTART_STRATEGY, "exponential-delay");
+        config.set(RestartStrategyOptions.RESTART_STRATEGY, "exponential-delay");
         config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_EXPONENTIAL_DELAY_INITIAL_BACKOFF,
                 Duration.ofMillis(5));
         config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_EXPONENTIAL_DELAY_MAX_BACKOFF,
                 Duration.ofMillis(100));
-        config.setDouble(
-                RestartStrategyOptions.RESTART_STRATEGY_EXPONENTIAL_DELAY_BACKOFF_MULTIPLIER, 2);
+        config.set(
+                RestartStrategyOptions.RESTART_STRATEGY_EXPONENTIAL_DELAY_BACKOFF_MULTIPLIER, 2D);
         config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_EXPONENTIAL_DELAY_RESET_BACKOFF_THRESHOLD,
                 Duration.ofMillis(1000));
-        config.setDouble(
-                RestartStrategyOptions.RESTART_STRATEGY_EXPONENTIAL_DELAY_JITTER_FACTOR, 0.2);
+        config.set(RestartStrategyOptions.RESTART_STRATEGY_EXPONENTIAL_DELAY_JITTER_FACTOR, 0.2);
 
         return config;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFailureRateStrategyITBase.java
@@ -41,8 +41,8 @@ public class SimpleRecoveryFailureRateStrategyITBase extends SimpleRecoveryITCas
 
     private static Configuration getConfiguration() {
         Configuration config = new Configuration();
-        config.setString(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
-        config.setInteger(
+        config.set(RestartStrategyOptions.RESTART_STRATEGY, "failure-rate");
+        config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_MAX_FAILURES_PER_INTERVAL, 3);
         config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_FAILURE_RATE_FAILURE_RATE_INTERVAL,

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/SimpleRecoveryFixedDelayRestartStrategyITBase.java
@@ -41,8 +41,8 @@ public class SimpleRecoveryFixedDelayRestartStrategyITBase extends SimpleRecover
 
     private static Configuration getConfiguration() {
         Configuration config = new Configuration();
-        config.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
-        config.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 3);
+        config.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+        config.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 3);
         config.set(
                 RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, Duration.ofMillis(100));
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
@@ -80,20 +80,20 @@ public class TaskManagerDisconnectOnShutdownITCase {
     @Test
     public void testTaskManagerProcessFailure() {
         Configuration config = new Configuration();
-        config.setString(JobManagerOptions.ADDRESS, "localhost");
+        config.set(JobManagerOptions.ADDRESS, "localhost");
         config.set(JobManagerOptions.PORT, 0);
         config.set(RestOptions.BIND_PORT, "0");
 
         // disable heartbeats
         config.set(HeartbeatManagerOptions.HEARTBEAT_RPC_FAILURE_THRESHOLD, -1);
-        config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
+        config.set(TaskManagerOptions.NUM_TASK_SLOTS, 2);
 
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
         config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.parse("3200k"));
         config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse("3200k"));
         config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
         config.set(TaskManagerOptions.CPU_CORES, 1.0);
-        config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
+        config.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
         config.set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, Duration.ofSeconds(30L));
 
         // check that we run this test only if the java command

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/BatchShuffleITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/BatchShuffleITCaseBase.java
@@ -97,7 +97,7 @@ class BatchShuffleITCaseBase {
             boolean deletePartitionFile,
             Configuration configuration,
             boolean enableAdaptiveAutoParallelism) {
-        configuration.setBoolean(
+        configuration.set(
                 BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED,
                 enableAdaptiveAutoParallelism);
         StreamExecutionEnvironment env =

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/BlockingShuffleITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/BlockingShuffleITCase.java
@@ -33,7 +33,7 @@ class BlockingShuffleITCase extends BatchShuffleITCaseBase {
     public void testBoundedBlockingShuffle() throws Exception {
         final int numRecordsToSend = 1000000;
         Configuration configuration = getConfiguration();
-        configuration.setInteger(
+        configuration.set(
                 NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM,
                 Integer.MAX_VALUE);
         JobGraph jobGraph = createJobGraph(numRecordsToSend, false, false, configuration, false);
@@ -43,7 +43,7 @@ class BlockingShuffleITCase extends BatchShuffleITCaseBase {
     @Test
     public void testBoundedBlockingShuffleWithoutData() throws Exception {
         Configuration configuration = getConfiguration();
-        configuration.setInteger(
+        configuration.set(
                 NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM,
                 Integer.MAX_VALUE);
         JobGraph jobGraph = createJobGraph(0, false, false, configuration, false);
@@ -54,8 +54,7 @@ class BlockingShuffleITCase extends BatchShuffleITCaseBase {
     public void testSortMergeBlockingShuffle() throws Exception {
         final int numRecordsToSend = 1000000;
         Configuration configuration = getConfiguration();
-        configuration.setInteger(
-                NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS, 64);
+        configuration.set(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS, 64);
 
         JobGraph jobGraph = createJobGraph(numRecordsToSend, false, false, configuration, false);
         executeJob(jobGraph, configuration, numRecordsToSend);
@@ -64,8 +63,7 @@ class BlockingShuffleITCase extends BatchShuffleITCaseBase {
     @Test
     public void testSortMergeBlockingShuffleWithoutData() throws Exception {
         Configuration configuration = getConfiguration();
-        configuration.setInteger(
-                NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS, 64);
+        configuration.set(NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS, 64);
 
         JobGraph jobGraph = createJobGraph(0, false, false, configuration, false);
         executeJob(jobGraph, configuration, 0);
@@ -74,7 +72,7 @@ class BlockingShuffleITCase extends BatchShuffleITCaseBase {
     @Test
     public void testDeletePartitionFileOfBoundedBlockingShuffle() throws Exception {
         Configuration configuration = getConfiguration();
-        configuration.setInteger(
+        configuration.set(
                 NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM,
                 Integer.MAX_VALUE);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
@@ -73,7 +73,7 @@ public class DefaultSchedulerLocalRecoveryITCase extends TestLogger {
 
     private void testLocalRecoveryInternal(String failoverStrategyValue) throws Exception {
         final Configuration configuration = new Configuration();
-        configuration.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
         configuration.setString(EXECUTION_FAILOVER_STRATEGY.key(), failoverStrategyValue);
 
         final int parallelism = 10;
@@ -109,7 +109,7 @@ public class DefaultSchedulerLocalRecoveryITCase extends TestLogger {
     private ArchivedExecutionGraph executeSchedulingTest(
             Configuration configuration, int parallelism) throws Exception {
         final long slotIdleTimeout = TIMEOUT;
-        configuration.setLong(JobManagerOptions.SLOT_IDLE_TIMEOUT, slotIdleTimeout);
+        configuration.set(JobManagerOptions.SLOT_IDLE_TIMEOUT, slotIdleTimeout);
 
         configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("64mb"));
         configuration.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.parse("16mb"));

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/IPv6HostnamesITCase.java
@@ -73,8 +73,8 @@ public class IPv6HostnamesITCase extends TestLogger {
         log.info("Test will use IPv6 address " + addressString + " for connection tests");
 
         Configuration config = new Configuration();
-        config.setString(JobManagerOptions.ADDRESS, addressString);
-        config.setString(TaskManagerOptions.HOST, addressString);
+        config.set(JobManagerOptions.ADDRESS, addressString);
+        config.set(TaskManagerOptions.HOST, addressString);
         config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("16m"));
         return config;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/NettyEpollITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/NettyEpollITCase.java
@@ -72,7 +72,7 @@ public class NettyEpollITCase extends TestLogger {
     private MiniClusterWithClientResource trySetUpCluster() throws Exception {
         try {
             Configuration config = new Configuration();
-            config.setString(NettyShuffleEnvironmentOptions.TRANSPORT_TYPE, "epoll");
+            config.set(NettyShuffleEnvironmentOptions.TRANSPORT_TYPE, "epoll");
             MiniClusterWithClientResource cluster =
                     new MiniClusterWithClientResource(
                             new MiniClusterResourceConfiguration.Builder()

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
@@ -62,7 +62,7 @@ public class SchedulingITCase extends TestLogger {
     @Test
     public void testDisablingLocalRecovery() throws Exception {
         final Configuration configuration = new Configuration();
-        configuration.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, false);
+        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, false);
 
         executeSchedulingTest(configuration);
     }
@@ -87,7 +87,7 @@ public class SchedulingITCase extends TestLogger {
 
     private void testLocalRecoveryInternal(String failoverStrategyValue) throws Exception {
         final Configuration configuration = new Configuration();
-        configuration.setBoolean(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
         configuration.setString(EXECUTION_FAILOVER_STRATEGY.key(), failoverStrategyValue);
 
         executeSchedulingTest(configuration);
@@ -95,7 +95,7 @@ public class SchedulingITCase extends TestLogger {
 
     private void executeSchedulingTest(Configuration configuration) throws Exception {
         final long slotIdleTimeout = 50L;
-        configuration.setLong(JobManagerOptions.SLOT_IDLE_TIMEOUT, slotIdleTimeout);
+        configuration.set(JobManagerOptions.SLOT_IDLE_TIMEOUT, slotIdleTimeout);
 
         configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/ShuffleCompressionITCase.java
@@ -84,10 +84,9 @@ public class ShuffleCompressionITCase {
     @Test
     public void testNoDataCompressionForBoundedBlockingShuffle() throws Exception {
         Configuration configuration = new Configuration();
-        configuration.setBoolean(
-                NettyShuffleEnvironmentOptions.BATCH_SHUFFLE_COMPRESSION_ENABLED, false);
+        configuration.set(NettyShuffleEnvironmentOptions.BATCH_SHUFFLE_COMPRESSION_ENABLED, false);
         configuration.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofMinutes(1));
-        configuration.setInteger(
+        configuration.set(
                 NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM,
                 Integer.MAX_VALUE);
 
@@ -98,8 +97,7 @@ public class ShuffleCompressionITCase {
     @Test
     public void testNoDataCompressionForSortMergeBlockingShuffle() throws Exception {
         Configuration configuration = new Configuration();
-        configuration.setBoolean(
-                NettyShuffleEnvironmentOptions.BATCH_SHUFFLE_COMPRESSION_ENABLED, false);
+        configuration.set(NettyShuffleEnvironmentOptions.BATCH_SHUFFLE_COMPRESSION_ENABLED, false);
         configuration.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofMinutes(1));
 
         JobGraph jobGraph = createJobGraph(ResultPartitionType.BLOCKING, ExecutionMode.BATCH);

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -98,7 +98,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
                         zkServer.getConnectString(), tempFolder.newFolder().getAbsolutePath());
 
         // speed up refused registration retries
-        configuration.setLong(ClusterOptions.REFUSED_REGISTRATION_DELAY, 50L);
+        configuration.set(ClusterOptions.REFUSED_REGISTRATION_DELAY, 50L);
 
         final TestingMiniClusterConfiguration miniClusterConfiguration =
                 TestingMiniClusterConfiguration.newBuilder()

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
@@ -180,9 +180,9 @@ class AdaptiveBatchSchedulerITCase {
 
     private static Configuration createConfiguration() {
         final Configuration configuration = new Configuration();
-        configuration.setString(RestOptions.BIND_PORT, "0");
-        configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
-        configuration.setInteger(
+        configuration.set(RestOptions.BIND_PORT, "0");
+        configuration.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
+        configuration.set(
                 BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MAX_PARALLELISM,
                 DEFAULT_MAX_PARALLELISM);
         configuration.set(

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/PipelinedRegionSchedulingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/PipelinedRegionSchedulingITCase.java
@@ -88,7 +88,7 @@ public class PipelinedRegionSchedulingITCase extends TestLogger {
     @Test(timeout = 120000)
     public void testRecoverFromPartitionException() throws Exception {
         final Configuration configuration = new Configuration();
-        configuration.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+        configuration.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
         configuration.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
 
         OneTimeFailingReceiverWithPartitionException.hasFailed.set(false);
@@ -104,7 +104,7 @@ public class PipelinedRegionSchedulingITCase extends TestLogger {
 
     private JobResult executeSchedulingTest(
             JobGraph jobGraph, int numSlots, Configuration configuration) throws Exception {
-        configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 30000L);
+        configuration.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 30000L);
         configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Default);
 
         final MiniClusterConfiguration miniClusterConfiguration =

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/SpeculativeSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/SpeculativeSchedulerITCase.java
@@ -244,9 +244,9 @@ class SpeculativeSchedulerITCase {
     }
 
     private Configuration configure(final Configuration configuration) {
-        configuration.setString(RestOptions.BIND_PORT, "0");
+        configuration.set(RestOptions.BIND_PORT, "0");
         configuration.set(JobManagerOptions.ARCHIVE_DIR, temporaryFolder.getRoot().toString());
-        configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
+        configuration.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
         configuration.set(JobManagerOptions.MAX_ATTEMPTS_HISTORY_SIZE, 1);
         configuration.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
         configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, MAX_PARALLELISM);

--- a/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogCompatibilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogCompatibilityITCase.java
@@ -288,8 +288,8 @@ public class ChangelogCompatibilityITCase {
         checkpointDir = TEMPORARY_FOLDER.newFolder();
         savepointDir = TEMPORARY_FOLDER.newFolder();
         Configuration config = new Configuration();
-        config.setString(CHECKPOINTS_DIRECTORY, pathToString(checkpointDir));
-        config.setString(SAVEPOINT_DIRECTORY, pathToString(savepointDir));
+        config.set(CHECKPOINTS_DIRECTORY, pathToString(checkpointDir));
+        config.set(SAVEPOINT_DIRECTORY, pathToString(savepointDir));
         FsStateChangelogStorageFactory.configure(
                 config, TEMPORARY_FOLDER.newFolder(), Duration.ofMinutes(1), 10);
         miniClusterResource =

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/KeyedJob.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/KeyedJob.java
@@ -62,7 +62,7 @@ public class KeyedJob {
         String savepointsPath = pt.getRequired("savepoint-path");
 
         Configuration config = new Configuration();
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointsPath);
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointsPath);
 
         StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(config);

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/NonKeyedJob.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/NonKeyedJob.java
@@ -54,7 +54,7 @@ public class NonKeyedJob {
         String savepointsPath = pt.getRequired("savepoint-path");
 
         Configuration config = new Configuration();
-        config.setString(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointsPath);
+        config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointsPath);
 
         StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.createLocalEnvironmentWithWebUI(config);

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/StreamExecutionEnvironmentITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/StreamExecutionEnvironmentITCase.java
@@ -54,7 +54,7 @@ public class StreamExecutionEnvironmentITCase {
     public void executeThrowsProgramInvocationException() {
         Configuration config = new Configuration(MINI_CLUSTER.getClientConfiguration());
         config.set(DeploymentOptions.TARGET, RemoteExecutor.NAME);
-        config.setBoolean(DeploymentOptions.ATTACHED, true);
+        config.set(DeploymentOptions.ATTACHED, true);
 
         // Create the execution environment explicitly from a Configuration so we know that we
         // don't get some other subclass. If we just did

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
@@ -90,8 +90,8 @@ public class RemoteStreamEnvironmentTest extends TestLogger {
         JobExecutionResult actualResult = env.execute("fakeJobName");
         TestClusterClient testClient = testExecutorServiceLoader.getCreatedClusterClient();
         assertThat(actualResult.getJobID(), is(jobId));
-        assertThat(testClient.getConfiguration().getString(RestOptions.ADDRESS), is(host));
-        assertThat(testClient.getConfiguration().getInteger(RestOptions.PORT), is(99));
+        assertThat(testClient.getConfiguration().get(RestOptions.ADDRESS), is(host));
+        assertThat(testClient.getConfiguration().get(RestOptions.PORT), is(99));
     }
 
     @Test

--- a/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/typeserializerupgrade/PojoSerializerUpgradeTest.java
@@ -97,8 +97,8 @@ public class PojoSerializerUpgradeTest extends TestLogger {
     public PojoSerializerUpgradeTest(String backendType)
             throws IOException, DynamicCodeLoadingException {
         Configuration config = new Configuration();
-        config.setString(StateBackendOptions.STATE_BACKEND, backendType);
-        config.setString(
+        config.set(StateBackendOptions.STATE_BACKEND, backendType);
+        config.set(
                 CheckpointingOptions.CHECKPOINTS_DIRECTORY,
                 temporaryFolder.newFolder().toURI().toString());
         stateBackend =

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNFileReplicationITCase.java
@@ -68,7 +68,7 @@ class YARNFileReplicationITCase extends YarnTestBase {
     @Test
     void testPerJobModeWithCustomizedFileReplication() throws Exception {
         final Configuration configuration = getDefaultConfiguration();
-        configuration.setInteger(YarnConfigOptions.FILE_REPLICATION, 4);
+        configuration.set(YarnConfigOptions.FILE_REPLICATION, 4);
 
         runTest(() -> deployPerJob(configuration, getTestingJobGraph()));
     }
@@ -174,8 +174,7 @@ class YARNFileReplicationITCase extends YarnTestBase {
 
         FileStatus fsStatus = fs.getFileStatus(uberJarHDFSPath);
 
-        final int flinkFileReplication =
-                configuration.getInteger(YarnConfigOptions.FILE_REPLICATION);
+        final int flinkFileReplication = configuration.get(YarnConfigOptions.FILE_REPLICATION);
         final int replication =
                 YARN_CONFIGURATION.getInt(
                         DFSConfigKeys.DFS_REPLICATION_KEY, DFSConfigKeys.DFS_REPLICATION_DEFAULT);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -327,15 +327,15 @@ class YARNHighAvailabilityITCase extends YarnTestBase {
         final Configuration flinkConfiguration = new Configuration();
         flinkConfiguration.set(JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(768));
         flinkConfiguration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("1g"));
-        flinkConfiguration.setString(YarnConfigOptions.APPLICATION_ATTEMPTS, "10");
-        flinkConfiguration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
-        flinkConfiguration.setString(HighAvailabilityOptions.HA_STORAGE_PATH, storageDir);
-        flinkConfiguration.setString(
+        flinkConfiguration.set(YarnConfigOptions.APPLICATION_ATTEMPTS, "10");
+        flinkConfiguration.set(HighAvailabilityOptions.HA_MODE, "zookeeper");
+        flinkConfiguration.set(HighAvailabilityOptions.HA_STORAGE_PATH, storageDir);
+        flinkConfiguration.set(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zkServer.getConnectString());
-        flinkConfiguration.setInteger(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, 20000);
+        flinkConfiguration.set(HighAvailabilityOptions.ZOOKEEPER_SESSION_TIMEOUT, 20000);
 
-        flinkConfiguration.setString(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
-        flinkConfiguration.setInteger(
+        flinkConfiguration.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
+        flinkConfiguration.set(
                 RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, Integer.MAX_VALUE);
 
         return createYarnClusterDescriptor(flinkConfiguration);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOITCase.java
@@ -222,8 +222,7 @@ class YARNSessionFIFOITCase extends YarnTestBase {
             try {
                 File yarnPropertiesFile =
                         FlinkYarnSessionCli.getYarnPropertiesLocation(
-                                configuration.getString(
-                                        YarnConfigOptions.PROPERTIES_FILE_LOCATION));
+                                configuration.get(YarnConfigOptions.PROPERTIES_FILE_LOCATION));
                 if (yarnPropertiesFile.exists()) {
                     log.info(
                             "testDetachedPerJobYarnClusterInternal: Cleaning up temporary Yarn address reference: {}",

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNSessionFIFOSecuredITCase.java
@@ -83,9 +83,9 @@ class YARNSessionFIFOSecuredITCase extends YARNSessionFIFOITCase {
                 SecureTestEnvironment.getTestKeytab());
 
         Configuration flinkConfig = new Configuration();
-        flinkConfig.setString(
+        flinkConfig.set(
                 SecurityOptions.KERBEROS_LOGIN_KEYTAB, SecureTestEnvironment.getTestKeytab());
-        flinkConfig.setString(
+        flinkConfig.set(
                 SecurityOptions.KERBEROS_LOGIN_PRINCIPAL,
                 SecureTestEnvironment.getHadoopServicePrincipal());
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -708,7 +708,7 @@ public final class Utils {
             org.apache.flink.configuration.Configuration configuration,
             YarnConfiguration yarnConfiguration)
             throws IOException, IllegalArgumentException {
-        String usrlib = configuration.getString(YarnConfigOptions.PROVIDED_USRLIB_DIR);
+        String usrlib = configuration.get(YarnConfigOptions.PROVIDED_USRLIB_DIR);
         if (usrlib == null) {
             return Optional.empty();
         }
@@ -778,8 +778,8 @@ public final class Utils {
             ContainerLaunchContext amContainer,
             org.apache.flink.configuration.Configuration flinkConfig) {
         Map<ApplicationAccessType, String> acls = new HashMap<>();
-        final String viewAcls = flinkConfig.getString(YarnConfigOptions.APPLICATION_VIEW_ACLS);
-        final String modifyAcls = flinkConfig.getString(YarnConfigOptions.APPLICATION_MODIFY_ACLS);
+        final String viewAcls = flinkConfig.get(YarnConfigOptions.APPLICATION_VIEW_ACLS);
+        final String modifyAcls = flinkConfig.get(YarnConfigOptions.APPLICATION_MODIFY_ACLS);
         validateAclString(viewAcls);
         validateAclString(modifyAcls);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -46,7 +46,7 @@ public class YarnClusterClientFactory
     @Override
     public boolean isCompatibleWith(Configuration configuration) {
         checkNotNull(configuration);
-        final String deploymentTarget = configuration.getString(DeploymentOptions.TARGET);
+        final String deploymentTarget = configuration.get(DeploymentOptions.TARGET);
         return YarnDeploymentTarget.isValidYarnTarget(deploymentTarget);
     }
 
@@ -64,7 +64,7 @@ public class YarnClusterClientFactory
     @Override
     public ApplicationId getClusterId(Configuration configuration) {
         checkNotNull(configuration);
-        final String clusterId = configuration.getString(YarnConfigOptions.APPLICATION_ID);
+        final String clusterId = configuration.get(YarnConfigOptions.APPLICATION_ID);
         return clusterId != null ? ApplicationId.fromString(clusterId) : null;
     }
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -218,10 +218,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         decodeFilesToShipToCluster(flinkConfiguration, YarnConfigOptions.SHIP_ARCHIVES)
                 .ifPresent(this::addShipArchives);
 
-        this.yarnQueue = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_QUEUE);
-        this.customName = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_NAME);
-        this.applicationType = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_TYPE);
-        this.nodeLabel = flinkConfiguration.getString(YarnConfigOptions.NODE_LABEL);
+        this.yarnQueue = flinkConfiguration.get(YarnConfigOptions.APPLICATION_QUEUE);
+        this.customName = flinkConfiguration.get(YarnConfigOptions.APPLICATION_NAME);
+        this.applicationType = flinkConfiguration.get(YarnConfigOptions.APPLICATION_TYPE);
+        this.nodeLabel = flinkConfiguration.get(YarnConfigOptions.NODE_LABEL);
     }
 
     /** Adapt flink env setting. */
@@ -259,7 +259,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
     }
 
     private Optional<Path> getLocalFlinkDistPath(final Configuration configuration) {
-        final String localJarPath = configuration.getString(YarnConfigOptions.FLINK_DIST_JAR);
+        final String localJarPath = configuration.get(YarnConfigOptions.FLINK_DIST_JAR);
         if (localJarPath != null) {
             return Optional.of(new Path(localJarPath));
         }
@@ -398,7 +398,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         // Check if we don't exceed YARN's maximum virtual cores.
         final int numYarnMaxVcores = yarnClusterInformationRetriever.getMaxVcores();
 
-        int configuredAmVcores = flinkConfiguration.getInteger(YarnConfigOptions.APP_MASTER_VCORES);
+        int configuredAmVcores = flinkConfiguration.get(YarnConfigOptions.APP_MASTER_VCORES);
         if (configuredAmVcores > numYarnMaxVcores) {
             throw new IllegalConfigurationException(
                     String.format(
@@ -408,7 +408,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         }
 
         int configuredVcores =
-                flinkConfiguration.getInteger(
+                flinkConfiguration.get(
                         YarnConfigOptions.VCORES, clusterSpecification.getSlotsPerTaskManager());
         // don't configure more than the maximum configured number of vcores
         if (configuredVcores > numYarnMaxVcores) {
@@ -607,7 +607,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         final UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
         if (HadoopUtils.isKerberosSecurityEnabled(currentUser)) {
             boolean useTicketCache =
-                    flinkConfiguration.getBoolean(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE);
+                    flinkConfiguration.get(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE);
 
             if (!HadoopUtils.areKerberosCredentialsValid(currentUser, useTicketCache)) {
                 throw new RuntimeException(
@@ -616,7 +616,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
             }
 
             final boolean fetchToken =
-                    flinkConfiguration.getBoolean(SecurityOptions.KERBEROS_FETCH_DELEGATION_TOKEN);
+                    flinkConfiguration.get(SecurityOptions.KERBEROS_FETCH_DELEGATION_TOKEN);
             final boolean yarnAccessFSEnabled =
                     !CollectionUtil.isNullOrEmpty(
                             flinkConfiguration.get(
@@ -685,7 +685,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                         ? ClusterEntrypoint.ExecutionMode.DETACHED
                         : ClusterEntrypoint.ExecutionMode.NORMAL;
 
-        flinkConfiguration.setString(
+        flinkConfiguration.set(
                 ClusterEntrypoint.INTERNAL_CLUSTER_EXECUTION_MODE, executionMode.toString());
 
         ApplicationReport report =
@@ -899,7 +899,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         Set<Path> systemShipFiles = new HashSet<>(shipFiles);
 
         final String logConfigFilePath =
-                configuration.getString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE);
+                configuration.get(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE);
         if (logConfigFilePath != null) {
             systemShipFiles.add(getPathFromLocalFilePathStr(logConfigFilePath));
         }
@@ -1065,7 +1065,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                 }
 
                 final String jobGraphFilename = "job.graph";
-                configuration.setString(JOB_GRAPH_FILE_PATH, jobGraphFilename);
+                configuration.set(JOB_GRAPH_FILE_PATH, jobGraphFilename);
 
                 fileUploader.registerSingleLocalResource(
                         jobGraphFilename,
@@ -1174,12 +1174,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
         Path remotePathKeytab = null;
         String localizedKeytabPath = null;
-        String keytab = configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB);
+        String keytab = configuration.get(SecurityOptions.KERBEROS_LOGIN_KEYTAB);
         if (keytab != null) {
-            boolean localizeKeytab =
-                    flinkConfiguration.getBoolean(YarnConfigOptions.SHIP_LOCAL_KEYTAB);
-            localizedKeytabPath =
-                    flinkConfiguration.getString(YarnConfigOptions.LOCALIZED_KEYTAB_PATH);
+            boolean localizeKeytab = flinkConfiguration.get(YarnConfigOptions.SHIP_LOCAL_KEYTAB);
+            localizedKeytabPath = flinkConfiguration.get(YarnConfigOptions.LOCALIZED_KEYTAB_PATH);
             if (localizeKeytab) {
                 // Localize the keytab to YARN containers via local resource.
                 LOG.info("Adding keytab {} to the AM container local resource bucket", keytab);
@@ -1196,7 +1194,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
             } else {
                 // // Assume Keytab is pre-installed in the container.
                 localizedKeytabPath =
-                        flinkConfiguration.getString(YarnConfigOptions.LOCALIZED_KEYTAB_PATH);
+                        flinkConfiguration.get(YarnConfigOptions.LOCALIZED_KEYTAB_PATH);
             }
         }
 
@@ -1206,7 +1204,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         final ContainerLaunchContext amContainer =
                 setupApplicationMasterContainer(yarnClusterEntrypoint, hasKrb5, processSpec);
 
-        boolean fetchToken = configuration.getBoolean(SecurityOptions.DELEGATION_TOKENS_ENABLED);
+        boolean fetchToken = configuration.get(SecurityOptions.DELEGATION_TOKENS_ENABLED);
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
         if (kerberosLoginProvider.isLoginPossible(true)) {
             setTokensFor(amContainer, fetchToken);
@@ -1230,7 +1228,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
         if (localizedKeytabPath != null) {
             appMasterEnv.put(YarnConfigKeys.LOCAL_KEYTAB_PATH, localizedKeytabPath);
-            String principal = configuration.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL);
+            String principal = configuration.get(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL);
             appMasterEnv.put(YarnConfigKeys.KEYTAB_PRINCIPAL, principal);
             if (remotePathKeytab != null) {
                 appMasterEnv.put(YarnConfigKeys.REMOTE_KEYTAB_PATH, remotePathKeytab.toString());
@@ -1251,8 +1249,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         // Set up resource type requirements for ApplicationMaster
         Resource capability = Records.newRecord(Resource.class);
         capability.setMemorySize(clusterSpecification.getMasterMemoryMB());
-        capability.setVirtualCores(
-                flinkConfiguration.getInteger(YarnConfigOptions.APP_MASTER_VCORES));
+        capability.setVirtualCores(flinkConfiguration.get(YarnConfigOptions.APP_MASTER_VCORES));
 
         final String customApplicationName = customName != null ? customName : applicationName;
 
@@ -1262,7 +1259,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         appContext.setResource(capability);
 
         // Set priority for application
-        int priorityNum = flinkConfiguration.getInteger(YarnConfigOptions.APPLICATION_PRIORITY);
+        int priorityNum = flinkConfiguration.get(YarnConfigOptions.APPLICATION_PRIORITY);
         if (priorityNum >= 0) {
             Priority priority = Priority.newInstance(priorityNum);
             appContext.setPriority(priority);
@@ -1397,7 +1394,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
     @VisibleForTesting
     Path getStagingDir(FileSystem defaultFileSystem) throws IOException {
         final String configuredStagingDir =
-                flinkConfiguration.getString(YarnConfigOptions.STAGING_DIRECTORY);
+                flinkConfiguration.get(YarnConfigOptions.STAGING_DIRECTORY);
         if (configuredStagingDir == null) {
             return defaultFileSystem.getHomeDirectory();
         }
@@ -1410,8 +1407,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         final int yarnFileReplication =
                 yarnConfiguration.getInt(
                         DFSConfigKeys.DFS_REPLICATION_KEY, DFSConfigKeys.DFS_REPLICATION_DEFAULT);
-        final int fileReplication =
-                flinkConfiguration.getInteger(YarnConfigOptions.FILE_REPLICATION);
+        final int fileReplication = flinkConfiguration.get(YarnConfigOptions.FILE_REPLICATION);
         return fileReplication > 0 ? fileReplication : yarnFileReplication;
     }
 
@@ -1538,7 +1534,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
         reflector.setAttemptFailuresValidityInterval(
                 appContext,
-                flinkConfiguration.getLong(
+                flinkConfiguration.get(
                         YarnConfigOptions.APPLICATION_ATTEMPT_FAILURE_VALIDITY_INTERVAL));
     }
 
@@ -1547,7 +1543,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
         final ApplicationSubmissionContextReflector reflector =
                 ApplicationSubmissionContextReflector.getInstance();
-        final String tagsString = flinkConfiguration.getString(YarnConfigOptions.APPLICATION_TAGS);
+        final String tagsString = flinkConfiguration.get(YarnConfigOptions.APPLICATION_TAGS);
 
         final Set<String> applicationTags = new HashSet<>();
 
@@ -1926,11 +1922,11 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
         LOG.info("Found Web Interface {}:{} of application '{}'.", host, port, appId);
 
-        flinkConfiguration.setString(JobManagerOptions.ADDRESS, host);
-        flinkConfiguration.setInteger(JobManagerOptions.PORT, port);
+        flinkConfiguration.set(JobManagerOptions.ADDRESS, host);
+        flinkConfiguration.set(JobManagerOptions.PORT, port);
 
-        flinkConfiguration.setString(RestOptions.ADDRESS, host);
-        flinkConfiguration.setInteger(RestOptions.PORT, port);
+        flinkConfiguration.set(RestOptions.ADDRESS, host);
+        flinkConfiguration.set(RestOptions.PORT, port);
 
         flinkConfiguration.set(YarnConfigOptions.APPLICATION_ID, ConverterUtils.toString(appId));
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
@@ -141,7 +141,7 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
         this.configuration = configuration;
 
         final int yarnHeartbeatIntervalMS =
-                flinkConfig.getInteger(YarnConfigOptions.HEARTBEAT_DELAY_SECONDS) * 1000;
+                flinkConfig.get(YarnConfigOptions.HEARTBEAT_DELAY_SECONDS) * 1000;
 
         final long yarnExpiryIntervalMS =
                 yarnConfig.getLong(
@@ -157,11 +157,10 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
         }
         yarnHeartbeatIntervalMillis = yarnHeartbeatIntervalMS;
         containerRequestHeartbeatIntervalMillis =
-                flinkConfig.getInteger(
+                flinkConfig.get(
                         YarnConfigOptions.CONTAINER_REQUEST_HEARTBEAT_INTERVAL_MILLISECONDS);
 
-        this.taskManagerNodeLabel =
-                flinkConfig.getString(YarnConfigOptions.TASK_MANAGER_NODE_LABEL);
+        this.taskManagerNodeLabel = flinkConfig.get(YarnConfigOptions.TASK_MANAGER_NODE_LABEL);
 
         this.registerApplicationMasterResponseReflector =
                 new RegisterApplicationMasterResponseReflector(log);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -118,7 +118,7 @@ public class YarnTaskExecutorRunner {
         LOG.info("TM: keytab principal obtained {}", keytabPrincipal);
 
         // tell pekko to die in case of an error
-        configuration.setBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);
+        configuration.set(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);
 
         String keytabPath = Utils.resolveKeytabPath(currDir, localKeytabPath);
 
@@ -130,16 +130,16 @@ public class YarnTaskExecutorRunner {
                 yarnClientUsername);
 
         if (keytabPath != null && keytabPrincipal != null) {
-            configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
-            configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, keytabPrincipal);
+            configuration.set(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
+            configuration.set(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, keytabPrincipal);
         }
 
         // use the hostname passed by job manager
         final String taskExecutorHostname =
                 variables.get(YarnResourceManagerDriver.ENV_FLINK_NODE_ID);
         if (taskExecutorHostname != null) {
-            configuration.setString(TaskManagerOptions.HOST, taskExecutorHostname);
-            configuration.setString(
+            configuration.set(TaskManagerOptions.HOST, taskExecutorHostname);
+            configuration.set(
                     TaskManagerOptionsInternal.TASK_MANAGER_NODE_ID, taskExecutorHostname);
         }
     }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -285,7 +285,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
 
         // try loading a potential yarn properties file
         this.yarnPropertiesFileLocation =
-                configuration.getString(YarnConfigOptions.PROPERTIES_FILE_LOCATION);
+                configuration.get(YarnConfigOptions.PROPERTIES_FILE_LOCATION);
         final File yarnPropertiesLocation = getYarnPropertiesLocation(yarnPropertiesFileLocation);
 
         yarnPropertiesFile = new Properties();
@@ -401,16 +401,14 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
                 zooKeeperNamespace = commandLine.getOptionValue(zookeeperNamespace.getOpt());
             } else {
                 zooKeeperNamespace =
-                        effectiveConfiguration.getString(HA_CLUSTER_ID, applicationId.toString());
+                        effectiveConfiguration.get(HA_CLUSTER_ID, applicationId.toString());
             }
 
-            effectiveConfiguration.setString(HA_CLUSTER_ID, zooKeeperNamespace);
-            effectiveConfiguration.setString(
-                    YarnConfigOptions.APPLICATION_ID, applicationId.toString());
-            effectiveConfiguration.setString(
-                    DeploymentOptions.TARGET, YarnSessionClusterExecutor.NAME);
+            effectiveConfiguration.set(HA_CLUSTER_ID, zooKeeperNamespace);
+            effectiveConfiguration.set(YarnConfigOptions.APPLICATION_ID, applicationId.toString());
+            effectiveConfiguration.set(DeploymentOptions.TARGET, YarnSessionClusterExecutor.NAME);
         } else {
-            effectiveConfiguration.setString(DeploymentOptions.TARGET, YarnJobClusterExecutor.NAME);
+            effectiveConfiguration.set(DeploymentOptions.TARGET, YarnJobClusterExecutor.NAME);
         }
 
         if (commandLine.hasOption(jmMemory.getOpt())) {
@@ -432,7 +430,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
         }
 
         if (commandLine.hasOption(slots.getOpt())) {
-            effectiveConfiguration.setInteger(
+            effectiveConfiguration.set(
                     TaskManagerOptions.NUM_TASK_SLOTS,
                     Integer.parseInt(commandLine.getOptionValue(slots.getOpt())));
         }
@@ -471,44 +469,44 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
 
         final Path localJarPath = getLocalFlinkDistPathFromCmd(commandLine);
         if (localJarPath != null) {
-            configuration.setString(YarnConfigOptions.FLINK_DIST_JAR, localJarPath.toString());
+            configuration.set(YarnConfigOptions.FLINK_DIST_JAR, localJarPath.toString());
         }
 
         encodeFilesToShipToCluster(configuration, commandLine);
 
         if (commandLine.hasOption(queue.getOpt())) {
             final String queueName = commandLine.getOptionValue(queue.getOpt());
-            configuration.setString(YarnConfigOptions.APPLICATION_QUEUE, queueName);
+            configuration.set(YarnConfigOptions.APPLICATION_QUEUE, queueName);
         }
 
         final boolean detached =
                 commandLine.hasOption(YARN_DETACHED_OPTION.getOpt())
                         || commandLine.hasOption(DETACHED_OPTION.getOpt());
-        configuration.setBoolean(DeploymentOptions.ATTACHED, !detached);
+        configuration.set(DeploymentOptions.ATTACHED, !detached);
 
         if (commandLine.hasOption(name.getOpt())) {
             final String appName = commandLine.getOptionValue(name.getOpt());
-            configuration.setString(YarnConfigOptions.APPLICATION_NAME, appName);
+            configuration.set(YarnConfigOptions.APPLICATION_NAME, appName);
         }
 
         if (commandLine.hasOption(applicationType.getOpt())) {
             final String appType = commandLine.getOptionValue(applicationType.getOpt());
-            configuration.setString(YarnConfigOptions.APPLICATION_TYPE, appType);
+            configuration.set(YarnConfigOptions.APPLICATION_TYPE, appType);
         }
 
         if (commandLine.hasOption(zookeeperNamespace.getOpt())) {
             String zookeeperNamespaceValue =
                     commandLine.getOptionValue(zookeeperNamespace.getOpt());
-            configuration.setString(HA_CLUSTER_ID, zookeeperNamespaceValue);
+            configuration.set(HA_CLUSTER_ID, zookeeperNamespaceValue);
         } else if (commandLine.hasOption(zookeeperNamespaceOption.getOpt())) {
             String zookeeperNamespaceValue =
                     commandLine.getOptionValue(zookeeperNamespaceOption.getOpt());
-            configuration.setString(HA_CLUSTER_ID, zookeeperNamespaceValue);
+            configuration.set(HA_CLUSTER_ID, zookeeperNamespaceValue);
         }
 
         if (commandLine.hasOption(nodeLabel.getOpt())) {
             final String nodeLabelValue = commandLine.getOptionValue(this.nodeLabel.getOpt());
-            configuration.setString(YarnConfigOptions.NODE_LABEL, nodeLabelValue);
+            configuration.set(YarnConfigOptions.NODE_LABEL, nodeLabelValue);
         }
 
         configuration.set(DeploymentOptionsInternal.CONF_DIR, configurationDirectory);
@@ -542,7 +540,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
 
         String applicationId = yarnPropertiesFile.getProperty(YARN_APPLICATION_ID_KEY);
         if (applicationId != null) {
-            effectiveConfiguration.setString(YarnConfigOptions.APPLICATION_ID, applicationId);
+            effectiveConfiguration.set(YarnConfigOptions.APPLICATION_ID, applicationId);
         }
 
         // handle the YARN client's dynamic properties
@@ -633,7 +631,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
                     }
                 }
 
-                if (!effectiveConfiguration.getBoolean(DeploymentOptions.ATTACHED)) {
+                if (!effectiveConfiguration.get(DeploymentOptions.ATTACHED)) {
                     YarnClusterDescriptor.logDetachedClusterInformation(yarnApplicationId, LOG);
                 } else {
                     ScheduledExecutorService scheduledExecutorService =

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnLogConfigUtil.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnLogConfigUtil.java
@@ -86,7 +86,7 @@ public class YarnLogConfigUtil {
         checkNotNull(configuration);
 
         final String logConfigFilePath =
-                configuration.getString(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE);
+                configuration.get(YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE);
         if (logConfigFilePath == null) {
             return "";
         }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnApplicationClusterEntryPoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnApplicationClusterEntryPoint.java
@@ -59,7 +59,7 @@ public final class YarnApplicationClusterEntryPoint extends ApplicationClusterEn
 
     @Override
     protected String getRPCPortRange(Configuration configuration) {
-        return configuration.getString(YarnConfigOptions.APPLICATION_MASTER_PORT);
+        return configuration.get(YarnConfigOptions.APPLICATION_MASTER_PORT);
     }
 
     public static void main(final String[] args) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -63,18 +63,18 @@ public class YarnEntrypointUtils {
                 "ApplicationMaster hostname variable %s not set",
                 ApplicationConstants.Environment.NM_HOST.key());
 
-        configuration.setString(JobManagerOptions.ADDRESS, hostname);
-        configuration.setString(RestOptions.ADDRESS, hostname);
-        configuration.setString(RestOptions.BIND_ADDRESS, hostname);
+        configuration.set(JobManagerOptions.ADDRESS, hostname);
+        configuration.set(RestOptions.ADDRESS, hostname);
+        configuration.set(RestOptions.BIND_ADDRESS, hostname);
 
         // if a web monitor shall be started, set the port to random binding
-        if (configuration.getInteger(WebOptions.PORT, 0) >= 0) {
-            configuration.setInteger(WebOptions.PORT, 0);
+        if (configuration.get(WebOptions.PORT, 0) >= 0) {
+            configuration.set(WebOptions.PORT, 0);
         }
 
         if (!configuration.contains(RestOptions.BIND_PORT)) {
             // set the REST port to 0 to select it randomly
-            configuration.setString(RestOptions.BIND_PORT, "0");
+            configuration.set(RestOptions.BIND_PORT, "0");
         }
 
         // if the user has set the deprecated YARN-specific config keys, we add the
@@ -96,8 +96,8 @@ public class YarnEntrypointUtils {
                         workingDirectory, env.get(YarnConfigKeys.LOCAL_KEYTAB_PATH));
 
         if (keytabPath != null && keytabPrincipal != null) {
-            configuration.setString(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
-            configuration.setString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, keytabPrincipal);
+            configuration.set(SecurityOptions.KERBEROS_LOGIN_KEYTAB, keytabPath);
+            configuration.set(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL, keytabPrincipal);
         }
 
         final String localDirs = env.get(ApplicationConstants.Environment.LOCAL_DIRS.key());

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnJobClusterEntrypoint.java
@@ -51,7 +51,7 @@ public class YarnJobClusterEntrypoint extends JobClusterEntrypoint {
 
     @Override
     protected String getRPCPortRange(Configuration configuration) {
-        return configuration.getString(YarnConfigOptions.APPLICATION_MASTER_PORT);
+        return configuration.get(YarnConfigOptions.APPLICATION_MASTER_PORT);
     }
 
     @Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnSessionClusterEntrypoint.java
@@ -45,7 +45,7 @@ public class YarnSessionClusterEntrypoint extends SessionClusterEntrypoint {
 
     @Override
     protected String getRPCPortRange(Configuration configuration) {
-        return configuration.getString(YarnConfigOptions.APPLICATION_MASTER_PORT);
+        return configuration.get(YarnConfigOptions.APPLICATION_MASTER_PORT);
     }
 
     @Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactory.java
@@ -47,7 +47,7 @@ public class YarnWorkerResourceSpecFactory extends WorkerResourceSpecFactory {
 
     @VisibleForTesting
     static CPUResource getDefaultCpus(final Configuration configuration) {
-        int fallback = configuration.getInteger(YarnConfigOptions.VCORES);
+        int fallback = configuration.get(YarnConfigOptions.VCORES);
         double cpuCoresDouble =
                 TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback)
                         .getValue()

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -185,7 +185,7 @@ class FlinkYarnSessionCliTest {
         final File directoryPath = writeYarnPropertiesFile(validPropertiesFile);
 
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 YarnConfigOptions.PROPERTIES_FILE_LOCATION, directoryPath.getAbsolutePath());
 
         validateYarnCLIisActive(configuration);
@@ -232,7 +232,7 @@ class FlinkYarnSessionCliTest {
         File directoryPath = writeYarnPropertiesFile(validPropertiesFile);
 
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 YarnConfigOptions.PROPERTIES_FILE_LOCATION, directoryPath.getAbsolutePath());
 
         final FlinkYarnSessionCli flinkYarnSessionCli = createFlinkYarnSessionCli(configuration);
@@ -258,7 +258,7 @@ class FlinkYarnSessionCliTest {
         File directoryPath = writeYarnPropertiesFile(invalidPropertiesFile);
 
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 YarnConfigOptions.PROPERTIES_FILE_LOCATION, directoryPath.getAbsolutePath());
         assertThatThrownBy(() -> createFlinkYarnSessionCli(configuration))
                 .isInstanceOf(FlinkException.class);
@@ -333,7 +333,7 @@ class FlinkYarnSessionCliTest {
         File directoryPath = writeYarnPropertiesFile(validPropertiesFile);
 
         final Configuration configuration = new Configuration();
-        configuration.setString(
+        configuration.set(
                 YarnConfigOptions.PROPERTIES_FILE_LOCATION, directoryPath.getAbsolutePath());
 
         final FlinkYarnSessionCli flinkYarnSessionCli = createFlinkYarnSessionCli(configuration);
@@ -364,7 +364,7 @@ class FlinkYarnSessionCliTest {
                 JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(jobManagerMemory));
         configuration.set(
                 TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(taskManagerMemory));
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
         final String[] args = {
             "-yjm",
@@ -401,7 +401,7 @@ class FlinkYarnSessionCliTest {
         configuration.set(
                 TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(taskManagerMemory));
         final int slotsPerTaskManager = 42;
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
         final String[] args = {};
         final FlinkYarnSessionCli flinkYarnSessionCli = createFlinkYarnSessionCli(configuration);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterClientFactoryTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterClientFactoryTest.java
@@ -46,7 +46,7 @@ class YarnClusterClientFactoryTest {
 
     private void testYarnClusterClientFactoryDiscoveryHelper(final String targetName) {
         final Configuration configuration = new Configuration();
-        configuration.setString(DeploymentOptions.TARGET, targetName);
+        configuration.set(DeploymentOptions.TARGET, targetName);
 
         final ClusterClientServiceLoader serviceLoader = new DefaultClusterClientServiceLoader();
         final ClusterClientFactory<ApplicationId> factory =

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -138,7 +138,7 @@ class YarnClusterDescriptorTest {
     void testConfigOverwrite() throws ClusterDeploymentException {
         Configuration configuration = new Configuration();
         // overwrite vcores in config
-        configuration.setInteger(YarnConfigOptions.VCORES, Integer.MAX_VALUE);
+        configuration.set(YarnConfigOptions.VCORES, Integer.MAX_VALUE);
 
         YarnClusterDescriptor clusterDescriptor = createYarnClusterDescriptor(configuration);
 
@@ -372,8 +372,8 @@ class YarnClusterDescriptorTest {
             // YarnClusterDescriptor,
             // because we have a reference to the ClusterDescriptor's configuration which we modify
             // continuously
-            cfg.setString(CoreOptions.FLINK_DEFAULT_JVM_OPTIONS, defaultJvmOpts);
-            cfg.setString(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
+            cfg.set(CoreOptions.FLINK_DEFAULT_JVM_OPTIONS, defaultJvmOpts);
+            cfg.set(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
             cfg.set(
                     YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE,
                     YarnLogConfigUtil.CONFIG_FILE_LOGBACK_NAME);
@@ -424,8 +424,8 @@ class YarnClusterDescriptorTest {
             // log4j, with/out krb5, different JVM opts
             // IMPORTANT: Be aware that we are using side effects here to modify the created
             // YarnClusterDescriptor
-            cfg.setString(CoreOptions.FLINK_DEFAULT_JM_JVM_OPTIONS, defaultJmJvmOpts);
-            cfg.setString(CoreOptions.FLINK_JM_JVM_OPTIONS, jmJvmOpts);
+            cfg.set(CoreOptions.FLINK_DEFAULT_JM_JVM_OPTIONS, defaultJmJvmOpts);
+            cfg.set(CoreOptions.FLINK_JM_JVM_OPTIONS, jmJvmOpts);
             cfg.set(
                     YarnConfigOptionsInternal.APPLICATION_LOG_CONFIG_FILE,
                     YarnLogConfigUtil.CONFIG_FILE_LOG4J_NAME);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTaskExecutorRunnerTest.java
@@ -80,13 +80,13 @@ public class YarnTaskExecutorRunnerTest {
             fail("Can not find HadoopModule!");
         }
 
-        assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB))
+        assertThat(configuration.get(SecurityOptions.KERBEROS_LOGIN_KEYTAB))
                 .isEqualTo(
                         new File(
                                         resourceDirPath,
                                         YarnConfigOptions.LOCALIZED_KEYTAB_PATH.defaultValue())
                                 .getAbsolutePath());
-        assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL))
+        assertThat(configuration.get(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL))
                 .isEqualTo("testuser1@domain");
     }
 
@@ -122,9 +122,9 @@ public class YarnTaskExecutorRunnerTest {
             fail("Can not find HadoopModule!");
         }
 
-        assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_KEYTAB))
+        assertThat(configuration.get(SecurityOptions.KERBEROS_LOGIN_KEYTAB))
                 .containsSequence("src/test/resources/krb5.keytab");
-        assertThat(configuration.getString(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL))
+        assertThat(configuration.get(SecurityOptions.KERBEROS_LOGIN_PRINCIPAL))
                 .isEqualTo("testuser1@domain");
     }
 
@@ -137,7 +137,7 @@ public class YarnTaskExecutorRunnerTest {
                 configuration,
                 resourceDirPath,
                 Collections.singletonMap(YarnResourceManagerDriver.ENV_FLINK_NODE_ID, "test"));
-        assertThat(configuration.getString(TaskManagerOptionsInternal.TASK_MANAGER_NODE_ID))
+        assertThat(configuration.get(TaskManagerOptionsInternal.TASK_MANAGER_NODE_ID))
                 .isEqualTo("test");
     }
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
@@ -58,7 +58,7 @@ class YarnEntrypointUtilsTest {
         final Configuration configuration = loadConfiguration(initialConfiguration);
 
         // having not specified the ports should set the rest bind port to 0
-        assertThat(configuration.getString(RestOptions.BIND_PORT)).isEqualTo("0");
+        assertThat(configuration.get(RestOptions.BIND_PORT)).isEqualTo("0");
     }
 
     /** Tests that the binding REST port is set to the REST port if set. */
@@ -66,12 +66,12 @@ class YarnEntrypointUtilsTest {
     void testRestPortSpecified() throws IOException {
         final Configuration initialConfiguration = new Configuration();
         final int port = 1337;
-        initialConfiguration.setInteger(RestOptions.PORT, port);
+        initialConfiguration.set(RestOptions.PORT, port);
 
         final Configuration configuration = loadConfiguration(initialConfiguration);
 
         // if the bind port is not specified it should fall back to the rest port
-        assertThat(configuration.getString(RestOptions.BIND_PORT)).isEqualTo(String.valueOf(port));
+        assertThat(configuration.get(RestOptions.BIND_PORT)).isEqualTo(String.valueOf(port));
     }
 
     /** Tests that the binding REST port has precedence over the REST port if both are set. */
@@ -80,13 +80,13 @@ class YarnEntrypointUtilsTest {
         final Configuration initialConfiguration = new Configuration();
         final int port = 1337;
         final String bindingPortRange = "1337-7331";
-        initialConfiguration.setInteger(RestOptions.PORT, port);
-        initialConfiguration.setString(RestOptions.BIND_PORT, bindingPortRange);
+        initialConfiguration.set(RestOptions.PORT, port);
+        initialConfiguration.set(RestOptions.BIND_PORT, bindingPortRange);
 
         final Configuration configuration = loadConfiguration(initialConfiguration);
 
         // bind port should have precedence over the rest port
-        assertThat(configuration.getString(RestOptions.BIND_PORT)).isEqualTo(bindingPortRange);
+        assertThat(configuration.get(RestOptions.BIND_PORT)).isEqualTo(bindingPortRange);
     }
 
     @Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactoryTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactoryTest.java
@@ -35,9 +35,9 @@ class YarnWorkerResourceSpecFactoryTest {
     @Test
     void testGetCpuCoresCommonOption() {
         final Configuration configuration = new Configuration();
-        configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
-        configuration.setInteger(YarnConfigOptions.VCORES, 2);
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+        configuration.set(TaskManagerOptions.CPU_CORES, 1.0);
+        configuration.set(YarnConfigOptions.VCORES, 2);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 3);
         assertThat(YarnWorkerResourceSpecFactory.getDefaultCpus(configuration))
                 .isEqualTo(new CPUResource(1.0));
     }
@@ -45,8 +45,8 @@ class YarnWorkerResourceSpecFactoryTest {
     @Test
     void testGetCpuCoresYarnOption() {
         final Configuration configuration = new Configuration();
-        configuration.setInteger(YarnConfigOptions.VCORES, 2);
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+        configuration.set(YarnConfigOptions.VCORES, 2);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
         assertThat(YarnWorkerResourceSpecFactory.getDefaultCpus(configuration))
                 .isEqualTo(new CPUResource(2.0));
@@ -55,7 +55,7 @@ class YarnWorkerResourceSpecFactoryTest {
     @Test
     void testGetCpuCoresNumSlots() {
         final Configuration configuration = new Configuration();
-        configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
         assertThat(YarnWorkerResourceSpecFactory.getDefaultCpus(configuration))
                 .isEqualTo(new CPUResource(3.0));
@@ -64,7 +64,7 @@ class YarnWorkerResourceSpecFactoryTest {
     @Test
     void testGetCpuRoundUp() {
         final Configuration configuration = new Configuration();
-        configuration.setDouble(TaskManagerOptions.CPU_CORES, 0.5);
+        configuration.set(TaskManagerOptions.CPU_CORES, 0.5);
 
         assertThat(YarnWorkerResourceSpecFactory.getDefaultCpus(configuration))
                 .isEqualTo(new CPUResource(1.0));
@@ -73,7 +73,7 @@ class YarnWorkerResourceSpecFactoryTest {
     @Test
     void testGetCpuExceedMaxInt() {
         final Configuration configuration = new Configuration();
-        configuration.setDouble(TaskManagerOptions.CPU_CORES, Double.MAX_VALUE);
+        configuration.set(TaskManagerOptions.CPU_CORES, Double.MAX_VALUE);
         assertThatThrownBy(() -> YarnWorkerResourceSpecFactory.getDefaultCpus(configuration))
                 .isInstanceOf(IllegalConfigurationException.class);
     }


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-34080](https://issues.apache.org/jira/browse/FLINK-34080) deprecate some methods of Configuration, we should refactor all callers of deprecated methods to use the recommended method.


## Change

- [FLINK-34081][configuration] Refactor all callers of deprecated `getXxx(ConfigOption<Xxx>)`, `getXxx(ConfigOption<Xxx>, Xxx)` and `setXxx(ConfigOption<Integer>, Xxx)` methods of Configuration

