### PR TITLE
[FLINK-34133][table-planner] fix incorrect inference of minibatch interval traits

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -30,6 +30,7 @@ import org.apache.flink.table.planner.plan.nodes.physical.stream.{StreamPhysical
 import org.apache.flink.table.planner.plan.optimize.program.{FlinkStreamProgram, StreamOptimizeContext}
 import org.apache.flink.table.planner.plan.schema.IntermediateRelTable
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
+import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapContext
 import org.apache.flink.table.planner.utils.TableConfigUtils
 import org.apache.flink.util.Preconditions
@@ -246,7 +247,10 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
         if (inputBlocks.size == 1) {
           val childBlock = inputBlocks.head
           // propagate miniBatchInterval trait to child block
-          childBlock.setMiniBatchInterval(miniBatchIntervalTrait.getMiniBatchInterval)
+          val mergedMiniBatchInterval = FlinkRelOptUtil.mergeMiniBatchInterval(
+            childBlock.getMiniBatchInterval,
+            miniBatchIntervalTrait.getMiniBatchInterval)
+          childBlock.setMiniBatchInterval(mergedMiniBatchInterval)
           // propagate updateKind trait to child block
           val requireUB = updateKindTrait.updateKind == UpdateKind.BEFORE_AND_AFTER
           childBlock.setUpdateBeforeRequired(requireUB || childBlock.isUpdateBeforeRequired)


### PR DESCRIPTION
## What is the purpose of the change

fix incorrect inference of minibatch interval traits, related issue [FLINK-34133](https://issues.apache.org/jira/browse/FLINK-34133).


## Brief change log

- merge MiniBatchInterval when propagate traits to child block


## Verifying this change

- covered by existing tests.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
