### PR TITLE
[FLINK-34134] Add tracing for restored state size and locations

### DIFF
--- a/docs/content.zh/docs/ops/traces.md
+++ b/docs/content.zh/docs/ops/traces.md
@@ -97,7 +97,7 @@ Flink reports a single span trace for the whole checkpoint and job initializatio
   </thead>
   <tbody>
     <tr>
-      <th rowspan="15">org.apache.flink.</br>runtime.checkpoint.</br>CheckpointStatsTracker</th>
+      <th rowspan="16">org.apache.flink.</br>runtime.checkpoint.</br>CheckpointStatsTracker</th>
       <th rowspan="6"><strong>Checkpoint</strong></th>
       <td>startTs</td>
       <td>Timestamp when the checkpoint has started.</td>
@@ -123,7 +123,7 @@ Flink reports a single span trace for the whole checkpoint and job initializatio
       <td>What was the state of this checkpoint: FAILED or COMPLETED.</td>
     </tr>
     <tr>
-      <th rowspan="9"><strong>JobInitialization</strong></th>
+      <th rowspan="10"><strong>JobInitialization</strong></th>
       <td>startTs</td>
       <td>Timestamp when the job initialization has started.</td>
     </tr>
@@ -158,6 +158,14 @@ Flink reports a single span trace for the whole checkpoint and job initializatio
     <tr>
       <td>(Max/Sum)DownloadStateDurationMs<br><br>(optional - currently only supported by RocksDB Incremental)</td>
       <td>The aggregated (max and sum) across all subtasks duration of downloading state files from the DFS.</td>
+    </tr>
+    <tr>
+      <td>(Max/Sum)RestoredStateSizeBytes.[location]</td>
+      <td>The aggregated (max and sum) across all subtasks size of restored state by location. Possible locations are defined in Enum StateObjectSizeStatsCollector as 
+        LOCAL_MEMORY,
+        LOCAL_DISK,
+        REMOTE,
+        UNKNOWN.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/content/docs/ops/traces.md
+++ b/docs/content/docs/ops/traces.md
@@ -97,7 +97,7 @@ Flink reports a single span trace for the whole checkpoint and job initializatio
   </thead>
   <tbody>
     <tr>
-      <th rowspan="15">org.apache.flink.</br>runtime.checkpoint.</br>CheckpointStatsTracker</th>
+      <th rowspan="16">org.apache.flink.</br>runtime.checkpoint.</br>CheckpointStatsTracker</th>
       <th rowspan="6"><strong>Checkpoint</strong></th>
       <td>startTs</td>
       <td>Timestamp when the checkpoint has started.</td>
@@ -123,7 +123,7 @@ Flink reports a single span trace for the whole checkpoint and job initializatio
       <td>What was the state of this checkpoint: FAILED or COMPLETED.</td>
     </tr>
     <tr>
-      <th rowspan="9"><strong>JobInitialization</strong></th>
+      <th rowspan="10"><strong>JobInitialization</strong></th>
       <td>startTs</td>
       <td>Timestamp when the job initialization has started.</td>
     </tr>
@@ -158,6 +158,14 @@ Flink reports a single span trace for the whole checkpoint and job initializatio
     <tr>
       <td>(Max/Sum)DownloadStateDurationMs<br><br>(optional - currently only supported by RocksDB Incremental)</td>
       <td>The aggregated (max and sum) across all subtasks duration of downloading state files from the DFS.</td>
+    </tr>
+    <tr>
+      <td>(Max/Sum)RestoredStateSizeBytes.[location]</td>
+      <td>The aggregated (max and sum) across all subtasks size of restored state by location. Possible locations are defined in Enum StateObjectSizeStatsCollector as 
+        LOCAL_MEMORY,
+        LOCAL_DISK,
+        REMOTE,
+        UNKNOWN.</td>
     </tr>
   </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -581,6 +581,30 @@ public final class FileUtils {
     }
 
     /**
+     * Computes the sum of sizes of all files in the directory and it's subdirectories.
+     *
+     * @param path the root path from which to start the calculation.
+     * @param options visitation options for the directory traversal.
+     * @return sum of sizes of all files in the directory and it's subdirectories.
+     * @throws IOException if the size cannot be determined.
+     */
+    public static long getDirectoryFilesSize(java.nio.file.Path path, FileVisitOption... options)
+            throws IOException {
+
+        if (path == null) {
+            return 0L;
+        }
+
+        try (Stream<java.nio.file.Path> pathStream = Files.walk(path, options)) {
+            return pathStream
+                    .map(java.nio.file.Path::toFile)
+                    .filter(File::isFile)
+                    .mapToLong(File::length)
+                    .sum();
+        }
+    }
+
+    /**
      * Absolutize the given path if it is relative.
      *
      * @param pathToAbsolutize path which is being absolutized if it is a relative path

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -361,6 +362,18 @@ public class FileUtilsTest {
                         // path contains multiple symlink : xxx/symlink1/symlink3/one
                         symlink3.resolve("one"));
         assertThat(targetPath).isEqualTo(dirInLinked2);
+    }
+
+    @Test
+    void testGetDirectorySize() throws Exception {
+        final File parent = TempDirUtils.newFolder(temporaryFolder);
+
+        // Empty directory should have size 0
+        Assertions.assertEquals(0, FileUtils.getDirectoryFilesSize(parent.toPath()));
+
+        // Expected size: (20*5^0 + 20*5^1 + 20*5^2 + 20*5^3) * 1 byte = 3120 bytes
+        generateRandomDirs(parent, 20, 5, 3);
+        Assertions.assertEquals(3120, FileUtils.getDirectoryFilesSize(parent.toPath()));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStore.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesStateHandleStore.java
@@ -137,6 +137,11 @@ public class KubernetesStateHandleStore<T extends Serializable>
             return inner.getStateSize();
         }
 
+        @Override
+        public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+            inner.collectSizeStats(collector);
+        }
+
         RetrievableStateHandle<T> getInner() {
             return inner;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.state.AbstractChannelStateHandle;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
@@ -33,8 +34,12 @@ import org.apache.flink.runtime.state.StateUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.state.AbstractChannelStateHandle.collectUniqueDelegates;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -130,21 +135,26 @@ public class OperatorSubtaskState implements CompositeStateHandle {
         this.inputRescalingDescriptor = checkNotNull(inputRescalingDescriptor);
         this.outputRescalingDescriptor = checkNotNull(outputRescalingDescriptor);
 
-        long calculateStateSize = managedOperatorState.getStateSize();
-        calculateStateSize += rawOperatorState.getStateSize();
-        calculateStateSize += managedKeyedState.getStateSize();
-        calculateStateSize += rawKeyedState.getStateSize();
-        calculateStateSize += inputChannelState.getStateSize();
-        calculateStateSize += resultSubpartitionState.getStateSize();
-        stateSize = calculateStateSize;
+        this.stateSize = streamSubCollections().mapToLong(StateObject::getStateSize).sum();
+        this.checkpointedSize =
+                streamSubCollections().mapToLong(StateObjectCollection::getCheckpointedSize).sum();
+    }
 
-        long calculateCheckpointedSize = managedOperatorState.getCheckpointedSize();
-        calculateCheckpointedSize += rawOperatorState.getCheckpointedSize();
-        calculateCheckpointedSize += managedKeyedState.getCheckpointedSize();
-        calculateCheckpointedSize += rawKeyedState.getCheckpointedSize();
-        calculateCheckpointedSize += inputChannelState.getCheckpointedSize();
-        calculateCheckpointedSize += resultSubpartitionState.getCheckpointedSize();
-        this.checkpointedSize = calculateCheckpointedSize;
+    private Stream<StateObjectCollection<?>> streamSubCollections() {
+        return Stream.of(streamOperatorAndKeyedStates(), streamChannelStates())
+                .flatMap(Function.identity());
+    }
+
+    private Stream<StateObjectCollection<? extends StateObject>> streamOperatorAndKeyedStates() {
+        return Stream.of(managedOperatorState, rawOperatorState, managedKeyedState, rawKeyedState)
+                .filter(Objects::nonNull);
+    }
+
+    private Stream<StateObjectCollection<? extends AbstractChannelStateHandle<?>>>
+            streamChannelStates() {
+        return Stream.<StateObjectCollection<? extends AbstractChannelStateHandle<?>>>of(
+                        inputChannelState, resultSubpartitionState)
+                .filter(Objects::nonNull);
     }
 
     @VisibleForTesting
@@ -195,20 +205,10 @@ public class OperatorSubtaskState implements CompositeStateHandle {
     }
 
     public List<StateObject> getDiscardables() {
-        List<StateObject> toDispose =
-                new ArrayList<>(
-                        managedOperatorState.size()
-                                + rawOperatorState.size()
-                                + managedKeyedState.size()
-                                + rawKeyedState.size()
-                                + inputChannelState.size()
-                                + resultSubpartitionState.size());
-        toDispose.addAll(managedOperatorState);
-        toDispose.addAll(rawOperatorState);
-        toDispose.addAll(managedKeyedState);
-        toDispose.addAll(rawKeyedState);
-        toDispose.addAll(collectUniqueDelegates(inputChannelState, resultSubpartitionState));
-        return toDispose;
+        return Stream.concat(
+                        streamOperatorAndKeyedStates().flatMap(Collection::stream),
+                        collectUniqueDelegates(streamChannelStates()))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateSnapshot.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -38,6 +39,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptor.NO_RESCALE;
 
@@ -159,15 +161,16 @@ public class TaskStateSnapshot implements CompositeStateHandle {
 
     @Override
     public long getStateSize() {
-        long size = 0L;
+        return streamOperatorSubtaskStates().mapToLong(StateObject::getStateSize).sum();
+    }
 
-        for (OperatorSubtaskState subtaskState : subtaskStatesByOperatorID.values()) {
-            if (subtaskState != null) {
-                size += subtaskState.getStateSize();
-            }
-        }
+    @Override
+    public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+        streamOperatorSubtaskStates().forEach(oss -> oss.collectSizeStats(collector));
+    }
 
-        return size;
+    private Stream<OperatorSubtaskState> streamOperatorSubtaskStates() {
+        return subtaskStatesByOperatorID.values().stream().filter(Objects::nonNull);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -69,6 +69,7 @@ public class MetricNames {
     public static final String INITIALIZE_STATE_DURATION = "InitializeStateDurationMs";
     public static final String GATE_RESTORE_DURATION = "GateRestoreDurationMs";
     public static final String DOWNLOAD_STATE_DURATION = "DownloadStateDurationMs";
+    public static final String RESTORED_STATE_SIZE = "RestoredStateSizeBytes";
 
     public static final String START_WORKER_FAILURE_RATE = "startWorkFailure" + SUFFIX_RATE;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractChannelStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractChannelStateHandle.java
@@ -18,14 +18,14 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -66,15 +66,12 @@ public abstract class AbstractChannelStateHandle<Info> implements StateObject {
         this.size = size;
     }
 
-    public static Set<StreamStateHandle> collectUniqueDelegates(
-            Collection<? extends AbstractChannelStateHandle<?>>... collections) {
-        Set<StreamStateHandle> result = new HashSet<>();
-        for (Collection<? extends AbstractChannelStateHandle<?>> collection : collections) {
-            for (AbstractChannelStateHandle<?> handle : collection) {
-                result.add(handle.getDelegate());
-            }
-        }
-        return result;
+    public static Stream<StreamStateHandle> collectUniqueDelegates(
+            Stream<StateObjectCollection<? extends AbstractChannelStateHandle<?>>> collections) {
+        return collections
+                .flatMap(Collection::stream)
+                .map(AbstractChannelStateHandle::getDelegate)
+                .distinct();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DirectoryStateHandle.java
@@ -38,12 +38,26 @@ public class DirectoryStateHandle implements StateObject {
     /** The path that describes the directory, as a string, to be serializable. */
     private final String directoryString;
 
+    /** (Optional) Size of the directory, used for metrics. Can be 0 if unknown or empty. */
+    private final long directorySize;
+
     /** Transient path cache, to avoid re-parsing the string. */
     private transient Path directory;
 
-    public DirectoryStateHandle(@Nonnull Path directory) {
+    public DirectoryStateHandle(@Nonnull Path directory, long directorySize) {
         this.directory = directory;
         this.directoryString = directory.toString();
+        this.directorySize = directorySize;
+    }
+
+    public static DirectoryStateHandle forPathWithSize(@Nonnull Path directory) {
+        long size;
+        try {
+            size = FileUtils.getDirectoryFilesSize(directory);
+        } catch (IOException e) {
+            size = 0L;
+        }
+        return new DirectoryStateHandle(directory, size);
     }
 
     @Override
@@ -54,9 +68,12 @@ public class DirectoryStateHandle implements StateObject {
 
     @Override
     public long getStateSize() {
-        // For now, we will not report any size, but in the future this could (if needed) return the
-        // total dir size.
-        return 0L; // unknown
+        return directorySize;
+    }
+
+    @Override
+    public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+        collector.add(StateObjectLocation.LOCAL_DISK, directorySize);
     }
 
     @Nonnull

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalLocalKeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/IncrementalLocalKeyedStateHandle.java
@@ -95,6 +95,12 @@ public class IncrementalLocalKeyedStateHandle extends AbstractIncrementalStateHa
     }
 
     @Override
+    public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+        metaStateHandle.collectSizeStats(collector);
+        directoryStateHandle.collectSizeStats(collector);
+    }
+
+    @Override
     public String toString() {
         return "IncrementalLocalKeyedStateHandle{"
                 + "directoryStateHandle="

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -136,6 +136,17 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
     }
 
     @Override
+    public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+        // TODO: for now this ignores that only some key groups might be accessed when reading the
+        //  state, so this only reports the upper bound. We could introduce
+        //  #collectSizeStats(StateObjectSizeStatsCollector, KeyGroupRange) in KeyedStateHandle
+        //  that computes which groups where actually touched and computes the size, depending on
+        //  the exact state handle type, from either the offsets (e.g. here) or for the full size
+        //  (e.g. remote incremental) when we restore from managed/raw keyed state.
+        stateHandle.collectSizeStats(collector);
+    }
+
+    @Override
     public long getCheckpointedSize() {
         return getStateSize();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/OperatorStreamStateHandle.java
@@ -62,6 +62,11 @@ public class OperatorStreamStateHandle implements OperatorStateHandle {
     }
 
     @Override
+    public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+        delegateStateHandle.collectSizeStats(collector);
+    }
+
+    @Override
     public FSDataInputStream openInputStream() throws IOException {
         return delegateStateHandle.openInputStream();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RetrievableStreamStateHandle.java
@@ -87,6 +87,11 @@ public class RetrievableStreamStateHandle<T extends Serializable>
     }
 
     @Override
+    public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+        wrappedStreamStateHandle.collectSizeStats(collector);
+    }
+
+    @Override
     public void close() throws IOException {
         //		wrappedStreamStateHandle.close();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotDirectory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotDirectory.java
@@ -172,7 +172,7 @@ public abstract class SnapshotDirectory {
 
     private static class PermanentSnapshotDirectory extends SnapshotDirectory {
 
-        PermanentSnapshotDirectory(@Nonnull Path directory) throws IOException {
+        PermanentSnapshotDirectory(@Nonnull Path directory) {
             super(directory);
         }
 
@@ -180,7 +180,7 @@ public abstract class SnapshotDirectory {
         public DirectoryStateHandle completeSnapshotAndGetHandle() throws IOException {
             if (State.COMPLETED == state.get()
                     || state.compareAndSet(State.ONGOING, State.COMPLETED)) {
-                return new DirectoryStateHandle(directory);
+                return DirectoryStateHandle.forPathWithSize(directory);
             } else {
                 throw new IOException(
                         "Expected state " + State.ONGOING + " but found state " + state.get());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateObject.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateObject.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state;
 
 import java.io.Serializable;
+import java.util.EnumMap;
 
 /**
  * Base of all handles that represent checkpointed state in some form. The object may hold the
@@ -63,4 +64,60 @@ public interface StateObject extends Serializable {
      * @return Size of the state in bytes.
      */
     long getStateSize();
+
+    /**
+     * Collects statistics about state size and location from the state object.
+     *
+     * @implNote default implementation reports {@link StateObject#getStateSize()} as size and
+     *     {@link StateObjectLocation#UNKNOWN} as location.
+     * @param collector the statistics collector.
+     */
+    default void collectSizeStats(StateObjectSizeStatsCollector collector) {
+        collector.add(StateObjectLocation.UNKNOWN, getStateSize());
+    }
+
+    /** Enum for state locations. */
+    enum StateObjectLocation {
+        LOCAL_MEMORY,
+        LOCAL_DISK,
+        REMOTE,
+        UNKNOWN,
+    }
+
+    /**
+     * Collector for size and location stats from a state object via {@link
+     * StateObject#collectSizeStats(StateObjectSizeStatsCollector)}.
+     */
+    final class StateObjectSizeStatsCollector {
+        private final EnumMap<StateObjectLocation, Long> stats;
+
+        private StateObjectSizeStatsCollector() {
+            stats = new EnumMap<>(StateObjectLocation.class);
+        }
+
+        public void add(StateObjectLocation key, long value) {
+            stats.compute(
+                    key,
+                    (k, v) -> {
+                        if (v != null) {
+                            return v + value;
+                        } else {
+                            return value;
+                        }
+                    });
+        }
+
+        public EnumMap<StateObjectLocation, Long> getStats() {
+            return stats;
+        }
+
+        public static StateObjectSizeStatsCollector create() {
+            return new StateObjectSizeStatsCollector();
+        }
+
+        @Override
+        public String toString() {
+            return "StateObjectSizeStatsCollector{" + "stats=" + stats + '}';
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -366,6 +366,11 @@ public interface ChangelogStateBackendHandle
             }
 
             @Override
+            public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+                keyedStateHandle.collectSizeStats(collector);
+            }
+
+            @Override
             public FSDataInputStream openInputStream() throws IOException {
                 throw new UnsupportedOperationException("Should not call here.");
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryChangelogStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryChangelogStateHandle.java
@@ -88,6 +88,11 @@ public class InMemoryChangelogStateHandle implements ChangelogStateHandle {
         return getStateSize();
     }
 
+    @Override
+    public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+        collector.add(StateObjectLocation.LOCAL_MEMORY, getStateSize());
+    }
+
     public List<StateChange> getChanges() {
         return Collections.unmodifiableList(changes);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
@@ -79,6 +79,11 @@ public class ByteStreamStateHandle implements StreamStateHandle {
     }
 
     @Override
+    public void collectSizeStats(StateObjectSizeStatsCollector collector) {
+        collector.add(StateObjectLocation.LOCAL_MEMORY, getStateSize());
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalLocalKeyedStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalLocalKeyedStateHandleTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.util.Preconditions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.UUID;
+
+/** Unit tests for {@link IncrementalLocalKeyedStateHandle}. */
+public class IncrementalLocalKeyedStateHandleTest {
+
+    @Test
+    public void testDirectorySize(@TempDir Path directory) throws IOException {
+        final int metaDataBytes = 42;
+        ByteStreamStateHandle metaDataStateHandle =
+                new ByteStreamStateHandle("MetaDataTest", new byte[metaDataBytes]);
+
+        final int fileOneBytes = 1024;
+        File outputFile = new File(directory.toFile(), "out.001");
+        try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
+            outputStream.write(new byte[fileOneBytes]);
+        }
+
+        File subPath = new File(directory.toFile(), "subdir");
+        Preconditions.checkState(subPath.mkdirs());
+        final int fileTwoBytes = 128;
+        outputFile = new File(subPath, "out.002");
+        try (FileOutputStream outputStream = new FileOutputStream(outputFile)) {
+            outputStream.write(new byte[fileTwoBytes]);
+        }
+
+        DirectoryStateHandle directoryStateHandle = DirectoryStateHandle.forPathWithSize(directory);
+        IncrementalLocalKeyedStateHandle handle =
+                new IncrementalLocalKeyedStateHandle(
+                        UUID.randomUUID(),
+                        0,
+                        directoryStateHandle,
+                        new KeyGroupRange(0, 1),
+                        metaDataStateHandle,
+                        Collections.emptyList());
+
+        StateObject.StateObjectSizeStatsCollector stats =
+                StateObject.StateObjectSizeStatsCollector.create();
+        handle.collectSizeStats(stats);
+        Assertions.assertEquals(
+                metaDataBytes + fileOneBytes + fileTwoBytes, extractLocalStateSizes(stats));
+    }
+
+    private long extractLocalStateSizes(StateObject.StateObjectSizeStatsCollector stats) {
+        EnumMap<StateObject.StateObjectLocation, Long> statsMap = stats.getStats();
+        Assertions.assertFalse(statsMap.containsKey(StateObject.StateObjectLocation.REMOTE));
+        Assertions.assertFalse(statsMap.containsKey(StateObject.StateObjectLocation.UNKNOWN));
+        // Might be in a byte handle or a file.
+        return statsMap.get(StateObject.StateObjectLocation.LOCAL_DISK)
+                + statsMap.get(StateObject.StateObjectLocation.LOCAL_MEMORY);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileStateHandleTest.java
@@ -24,10 +24,12 @@ import org.apache.flink.core.fs.FileSystemFactory;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.plugin.TestingPluginManager;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.util.function.BiFunctionWithException;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.RunnableWithException;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -150,6 +152,41 @@ class FileStateHandleTest {
                         .setDeleteFunction((ignoredPath, ignoredRecursionMarker) -> false)
                         .setExistsFunction(path -> true)
                         .build());
+    }
+
+    @Test
+    void testCollectSizeStats() throws Exception {
+        final long stateSize = 123L;
+
+        StateObject.StateObjectSizeStatsCollector statsCollector =
+                StateObject.StateObjectSizeStatsCollector.create();
+        FileStateHandle handle =
+                new FileStateHandle(new Path(new URI("file:///home/test.txt")), stateSize);
+        handle.collectSizeStats(statsCollector);
+        checkStats(statsCollector, StateObject.StateObjectLocation.LOCAL_DISK, stateSize);
+
+        statsCollector = StateObject.StateObjectSizeStatsCollector.create();
+        handle = new FileStateHandle(new Path(new URI("/home/test.txt")), stateSize);
+        handle.collectSizeStats(statsCollector);
+        checkStats(statsCollector, StateObject.StateObjectLocation.LOCAL_DISK, stateSize);
+
+        statsCollector = StateObject.StateObjectSizeStatsCollector.create();
+        handle = new FileStateHandle(new Path(new URI("s3:///folder/test.txt")), stateSize);
+        handle.collectSizeStats(statsCollector);
+        checkStats(statsCollector, StateObject.StateObjectLocation.REMOTE, stateSize);
+    }
+
+    private void checkStats(
+            StateObject.StateObjectSizeStatsCollector statsCollector,
+            StateObject.StateObjectLocation expectedLocation,
+            long expectedSize) {
+        Assertions.assertEquals(
+                new HashMap<StateObject.StateObjectLocation, Long>() {
+                    {
+                        put(expectedLocation, expectedSize);
+                    }
+                },
+                statsCollector.getStats());
     }
 
     private static void testDiscardStateFailed(FileSystem fileSystem) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandleTest.java
@@ -19,10 +19,13 @@
 package org.apache.flink.runtime.state.memory;
 
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.state.StateObject;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -142,5 +145,21 @@ class ByteStreamStateHandleTest {
             assertThat(in.read(dataGot, 0, 0)).isZero(); // got return 0 because len == 0.
             assertThat(in.read()).isEqualTo(-1); // got -1 because of EOF.
         }
+    }
+
+    @Test
+    void testCollectSizeStats() {
+        final byte[] data = new byte[5];
+        final ByteStreamStateHandle handle = new ByteStreamStateHandle("name", data);
+        StateObject.StateObjectSizeStatsCollector statsCollector =
+                StateObject.StateObjectSizeStatsCollector.create();
+        handle.collectSizeStats(statsCollector);
+        Assertions.assertEquals(
+                new HashMap<StateObject.StateObjectLocation, Long>() {
+                    {
+                        put(StateObject.StateObjectLocation.LOCAL_MEMORY, (long) data.length);
+                    }
+                },
+                statsCollector.getStats());
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -358,10 +358,8 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
             // init snapshot strategy after db is assured to be initialized
             checkpointStrategy =
                     initializeSavepointAndCheckpointStrategies(
-                            cancelStreamRegistryForBackend,
                             rocksDBResourceGuard,
                             kvStateInformation,
-                            registeredPQStates,
                             keyGroupPrefixBytes,
                             db,
                             backendUID,
@@ -523,10 +521,8 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
     }
 
     private RocksDBSnapshotStrategyBase<K, ?> initializeSavepointAndCheckpointStrategies(
-            CloseableRegistry cancelStreamRegistry,
             ResourceGuard rocksDBResourceGuard,
             LinkedHashMap<String, RocksDBKeyedStateBackend.RocksDbKvStateInfo> kvStateInformation,
-            LinkedHashMap<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates,
             int keyGroupPrefixBytes,
             RocksDB db,
             UUID backendUID,
@@ -547,7 +543,6 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                             keyGroupRange,
                             keyGroupPrefixBytes,
                             localRecoveryConfig,
-                            cancelStreamRegistry,
                             instanceBasePath,
                             backendUID,
                             materializedSstFiles,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/StateHandleDownloadSpec.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/StateHandleDownloadSpec.java
@@ -53,7 +53,7 @@ public class StateHandleDownloadSpec {
         return new IncrementalLocalKeyedStateHandle(
                 stateHandle.getBackendIdentifier(),
                 stateHandle.getCheckpointId(),
-                new DirectoryStateHandle(downloadDestination),
+                new DirectoryStateHandle(downloadDestination, stateHandle.getStateSize()),
                 stateHandle.getKeyGroupRange(),
                 stateHandle.getMetaDataStateHandle(),
                 stateHandle.getSharedState());

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -97,7 +97,6 @@ public class RocksIncrementalSnapshotStrategy<K>
             @Nonnull KeyGroupRange keyGroupRange,
             @Nonnegative int keyGroupPrefixBytes,
             @Nonnull LocalRecoveryConfig localRecoveryConfig,
-            @Nonnull CloseableRegistry cancelStreamRegistry,
             @Nonnull File instanceBasePath,
             @Nonnull UUID backendUID,
             @Nonnull SortedMap<Long, Collection<HandleAndLocalPath>> uploadedStateHandles,
@@ -358,7 +357,9 @@ public class RocksIncrementalSnapshotStrategy<K>
                                 snapshotCloseableRegistry,
                                 tmpResourcesRegistry);
                 uploadedSize +=
-                        sstFilesUploadResult.stream().mapToLong(e -> e.getStateSize()).sum();
+                        sstFilesUploadResult.stream()
+                                .mapToLong(HandleAndLocalPath::getStateSize)
+                                .sum();
                 sstFiles.addAll(sstFilesUploadResult);
 
                 List<HandleAndLocalPath> miscFilesUploadResult =
@@ -369,7 +370,9 @@ public class RocksIncrementalSnapshotStrategy<K>
                                 snapshotCloseableRegistry,
                                 tmpResourcesRegistry);
                 uploadedSize +=
-                        miscFilesUploadResult.stream().mapToLong(e -> e.getStateSize()).sum();
+                        miscFilesUploadResult.stream()
+                                .mapToLong(HandleAndLocalPath::getStateSize)
+                                .sum();
                 miscFiles.addAll(miscFilesUploadResult);
 
                 synchronized (uploadedSstFiles) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategyTest.java
@@ -70,8 +70,8 @@ class RocksIncrementalSnapshotStrategyTest {
     void testCheckpointIsIncremental() throws Exception {
 
         try (CloseableRegistry closeableRegistry = new CloseableRegistry();
-                RocksIncrementalSnapshotStrategy checkpointSnapshotStrategy =
-                        createSnapshotStrategy(closeableRegistry)) {
+                RocksIncrementalSnapshotStrategy<?> checkpointSnapshotStrategy =
+                        createSnapshotStrategy()) {
             FsCheckpointStreamFactory checkpointStreamFactory = createFsCheckpointStreamFactory();
 
             // make and notify checkpoint with id 1
@@ -96,8 +96,8 @@ class RocksIncrementalSnapshotStrategyTest {
         }
     }
 
-    public RocksIncrementalSnapshotStrategy createSnapshotStrategy(
-            CloseableRegistry closeableRegistry) throws IOException, RocksDBException {
+    public RocksIncrementalSnapshotStrategy<?> createSnapshotStrategy()
+            throws IOException, RocksDBException {
 
         ColumnFamilyHandle columnFamilyHandle = rocksDBExtension.createNewColumnFamily("test");
         RocksDB rocksDB = rocksDBExtension.getRocksDB();
@@ -138,7 +138,6 @@ class RocksIncrementalSnapshotStrategyTest {
                 new KeyGroupRange(0, 1),
                 keyGroupPrefixBytes,
                 TestLocalRecoveryConfig.disabled(),
-                closeableRegistry,
                 TempDirUtils.newFolder(tmp),
                 UUID.randomUUID(),
                 materializedSstFiles,
@@ -160,7 +159,7 @@ class RocksIncrementalSnapshotStrategyTest {
 
     public IncrementalRemoteKeyedStateHandle snapshot(
             long checkpointId,
-            RocksIncrementalSnapshotStrategy checkpointSnapshotStrategy,
+            RocksIncrementalSnapshotStrategy<?> checkpointSnapshotStrategy,
             FsCheckpointStreamFactory checkpointStreamFactory,
             CloseableRegistry closeableRegistry)
             throws Exception {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BackendRestorerProcedure.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/BackendRestorerProcedure.java
@@ -91,7 +91,9 @@ public class BackendRestorerProcedure<T extends Closeable & Disposable, S extend
      * @throws Exception if the backend could not be created or restored.
      */
     @Nonnull
-    public T createAndRestore(@Nonnull List<? extends Collection<S>> restoreOptions)
+    public T createAndRestore(
+            @Nonnull List<? extends Collection<S>> restoreOptions,
+            @Nonnull StateObject.StateObjectSizeStatsCollector stats)
             throws Exception {
 
         if (restoreOptions.isEmpty()) {
@@ -132,7 +134,10 @@ public class BackendRestorerProcedure<T extends Closeable & Disposable, S extend
             }
 
             try {
-                return attemptCreateAndRestore(restoreState);
+                T successfullyRestored = attemptCreateAndRestore(restoreState);
+                // Obtain and report stats for the state objects used in our successful restore
+                restoreState.forEach(handle -> handle.collectSizeStats(stats));
+                return successfullyRestored;
             } catch (Exception ex) {
 
                 collectedException = ExceptionUtils.firstOrSuppressed(ex, collectedException);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/BackendRestorerProcedureTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/BackendRestorerProcedureTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.DefaultOperatorStateBackendBuilder;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.util.BlockingFSDataInputStream;
 import org.apache.flink.util.FlinkException;
@@ -121,7 +122,8 @@ public class BackendRestorerProcedureTest extends TestLogger {
                         backendSupplier, closeableRegistry, "test op state backend");
 
         OperatorStateBackend restoredBackend =
-                restorerProcedure.createAndRestore(sortedRestoreOptions);
+                restorerProcedure.createAndRestore(
+                        sortedRestoreOptions, StateObject.StateObjectSizeStatsCollector.create());
         Assert.assertNotNull(restoredBackend);
 
         try {
@@ -165,7 +167,8 @@ public class BackendRestorerProcedureTest extends TestLogger {
                         backendSupplier, closeableRegistry, "test op state backend");
 
         try {
-            restorerProcedure.createAndRestore(sortedRestoreOptions);
+            restorerProcedure.createAndRestore(
+                    sortedRestoreOptions, StateObject.StateObjectSizeStatsCollector.create());
             Assert.fail();
         } catch (Exception ignore) {
         }
@@ -199,7 +202,9 @@ public class BackendRestorerProcedureTest extends TestLogger {
                 new Thread(
                         () -> {
                             try {
-                                restorerProcedure.createAndRestore(sortedRestoreOptions);
+                                restorerProcedure.createAndRestore(
+                                        sortedRestoreOptions,
+                                        StateObject.StateObjectSizeStatsCollector.create());
                             } catch (Exception e) {
                                 exceptionReference.set(e);
                             }


### PR DESCRIPTION
## What is the purpose of the change

Introduces tracing for state sizes and locations in task recovery. This is particularly interesting for a mixed recovery with some local and some remote state.


## Brief change log

- Add new stats collection default method to state object interface.
- Implement StateObject type-specific overrides.
- Perform stats collecting and reporting during restore.
- Documentation.


## Verifying this change

- Added tests for stats collecting implementations.
- Enhanced StreamTaskStateInitializerImplTest with checking tracing results.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( docs / JavaDocs)
