### PR TITLE
[FLINK-27992] Set ALWAYS chaining strategy for CepOperator in ExecMatch

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecMatch.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecMatch.java
@@ -31,6 +31,7 @@ import org.apache.flink.cep.pattern.Quantifier;
 import org.apache.flink.cep.pattern.conditions.BooleanConditions;
 import org.apache.flink.cep.pattern.conditions.IterativeCondition;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.table.api.TableException;
@@ -187,6 +188,9 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
                         planner.getFlinkContext().getClassLoader(), partitionKeys, inputTypeInfo);
         transform.setStateKeySelector(selector);
         transform.setStateKeyType(selector.getProducedType());
+
+        // should be chained with the timestamp inserter
+        transform.setChainingStrategy(ChainingStrategy.ALWAYS);
 
         if (inputsContainSingleton()) {
             transform.setParallelism(1);


### PR DESCRIPTION
## What is the purpose of the change

Set the chaining strategy of CepOperator to ALWAYS so that it can be chained with StreamRecordInserter. This is important to keep those two operators as close as possible because CepOperator depends on the shuffling that is applied before the inserter.

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
