### PR TITLE
[FLINK-34029][runtime-web] Support different profiling mode on Flink WEB

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job-manager/profiler/job-manager-profiler.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job-manager/profiler/job-manager-profiler.component.html
@@ -32,6 +32,58 @@
         </nz-form-control>
       </nz-form-item>
       <nz-form-item>
+        <nz-form-label nzFor="mode">Profiling Mode</nz-form-label>
+        <nz-form-control>
+          <nz-select
+            [(ngModel)]="selectMode"
+            nzPlaceHolder="Profiling Mode"
+            name="mode"
+            style="width: 200px"
+          >
+            <nz-option nzCustomContent nzValue="CPU" nzLabel="CPU">
+              <span
+                nz-tooltip
+                nzTooltipTitle="In this mode profiler collects stack trace samples that include Java methods, native calls, JVM code and kernel functions."
+              >
+                CPU
+              </span>
+            </nz-option>
+            <nz-option nzCustomContent nzValue="LOCK" nzLabel="Lock">
+              <span
+                nz-tooltip
+                nzTooltipTitle="In lock profiling mode the top frame is the class of lock/monitor, and the counter is number of nanoseconds it took to enter this lock/monitor."
+              >
+                Lock
+              </span>
+            </nz-option>
+            <nz-option nzCustomContent nzValue="WALL" nzLabel="Wall-Clock">
+              <span
+                nz-tooltip
+                nzTooltipTitle="Wall-Clock option tells async-profiler to sample all threads equally every given period of time regardless of thread status: Running, Sleeping or Blocked. For instance, this can be helpful when profiling application start-up time."
+              >
+                Wall-Clock
+              </span>
+            </nz-option>
+            <nz-option nzCustomContent nzValue="ALLOC" nzLabel="Allocation">
+              <span
+                nz-tooltip
+                nzTooltipTitle="In allocation profiling mode the top frame of every call trace is the class of the allocated object, and the counter is the heap pressure (the total size of allocated TLABs or objects outside TLAB)."
+              >
+                Allocation
+              </span>
+            </nz-option>
+            <nz-option nzCustomContent nzValue="ITIMER" nzLabel="ITIMER">
+              <span
+                nz-tooltip
+                nzTooltipTitle="You can fall back to itimer profiling mode. It is similar to cpu mode, but does not require perf_events support. As a drawback, there will be no kernel stack traces."
+              >
+                ITIMER
+              </span>
+            </nz-option>
+          </nz-select>
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
         <nz-form-control>
           <button
             nz-button

--- a/flink-runtime-web/web-dashboard/src/app/pages/job-manager/profiler/job-manager-profiler.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job-manager/profiler/job-manager-profiler.component.ts
@@ -68,7 +68,7 @@ export class JobManagerProfilerComponent implements OnInit, OnDestroy {
   isLoading = true;
   isCreating = false;
   duration = 30;
-  selectMode = 'CPU';
+  selectMode = 'ITIMER';
   isEnabled = false;
   formatterDuration = (value: number): string => `${value} s`;
   parserDuration = (value: string): string => value.replace(' s', '');

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.html
@@ -32,6 +32,58 @@
         </nz-form-control>
       </nz-form-item>
       <nz-form-item>
+        <nz-form-label nzFor="mode">Profiling Mode</nz-form-label>
+        <nz-form-control>
+          <nz-select
+            [(ngModel)]="selectMode"
+            nzPlaceHolder="Profiling Mode"
+            name="mode"
+            style="width: 200px"
+          >
+            <nz-option nzCustomContent nzValue="CPU" nzLabel="CPU">
+              <span
+                nz-tooltip
+                nzTooltipTitle="In this mode profiler collects stack trace samples that include Java methods, native calls, JVM code and kernel functions."
+              >
+                CPU
+              </span>
+            </nz-option>
+            <nz-option nzCustomContent nzValue="LOCK" nzLabel="Lock">
+              <span
+                nz-tooltip
+                nzTooltipTitle="In lock profiling mode the top frame is the class of lock/monitor, and the counter is number of nanoseconds it took to enter this lock/monitor."
+              >
+                Lock
+              </span>
+            </nz-option>
+            <nz-option nzCustomContent nzValue="WALL" nzLabel="Wall-Clock">
+              <span
+                nz-tooltip
+                nzTooltipTitle="Wall-Clock option tells async-profiler to sample all threads equally every given period of time regardless of thread status: Running, Sleeping or Blocked. For instance, this can be helpful when profiling application start-up time."
+              >
+                Wall-Clock
+              </span>
+            </nz-option>
+            <nz-option nzCustomContent nzValue="ALLOC" nzLabel="Allocation">
+              <span
+                nz-tooltip
+                nzTooltipTitle="In allocation profiling mode the top frame of every call trace is the class of the allocated object, and the counter is the heap pressure (the total size of allocated TLABs or objects outside TLAB)."
+              >
+                Allocation
+              </span>
+            </nz-option>
+            <nz-option nzCustomContent nzValue="ITIMER" nzLabel="ITIMER">
+              <span
+                nz-tooltip
+                nzTooltipTitle="You can fall back to itimer profiling mode. It is similar to cpu mode, but does not require perf_events support. As a drawback, there will be no kernel stack traces."
+              >
+                ITIMER
+              </span>
+            </nz-option>
+          </nz-select>
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item>
         <nz-form-control>
           <button
             nz-button
@@ -43,6 +95,24 @@
           >
             Create Profiling Instance
           </button>
+          <i
+            class="header-icon"
+            style="margin-left: 10px"
+            nz-icon
+            nz-tooltip
+            [nzTooltipTitle]="titleTemplate"
+            nzTooltipTitle=""
+            nzType="info-circle"
+          ></i>
+          <ng-template #titleTemplate>
+            <span>
+              Please refer to
+              <a href="https://github.com/async-profiler/async-profiler/wiki">
+                async-profiler's wiki
+              </a>
+              for more detailed info of this feature.
+            </span>
+          </ng-template>
         </nz-form-control>
       </nz-form-item>
     </form>

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.ts
@@ -31,11 +31,13 @@ import { NzAlertModule } from 'ng-zorro-antd/alert';
 import { NzButtonModule } from 'ng-zorro-antd/button';
 import { NzCardModule } from 'ng-zorro-antd/card';
 import { NzFormModule } from 'ng-zorro-antd/form';
+import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzInputNumberModule } from 'ng-zorro-antd/input-number';
 import { NzMessageModule, NzMessageService } from 'ng-zorro-antd/message';
 import { NzSelectModule } from 'ng-zorro-antd/select';
 import { NzSpaceModule } from 'ng-zorro-antd/space';
 import { NzTableModule } from 'ng-zorro-antd/table';
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 
 @Component({
   selector: 'flink-task-manager-profiler',
@@ -55,7 +57,9 @@ import { NzTableModule } from 'ng-zorro-antd/table';
     CommonModule,
     NzSpaceModule,
     HumanizeWatermarkToDatetimePipe,
-    NzSelectModule
+    NzSelectModule,
+    NzToolTipModule,
+    NzIconModule
   ],
   standalone: true
 })
@@ -65,7 +69,7 @@ export class TaskManagerProfilerComponent implements OnInit, OnDestroy {
   isLoading = true;
   isCreating = false;
   duration = 30;
-  selectMode = 'CPU';
+  selectMode = 'ITIMER';
   isEnabled = false;
   formatterDuration = (value: number): string => `${value} s`;
   parserDuration = (value: string): string => value.replace(' s', '');


### PR DESCRIPTION
## What is the purpose of the change

This is a subtask of [FLIP-375](https://cwiki.apache.org/confluence/x/64lEE), which introduces the different profiling modes on the Flink Web for profiling Taskmanager & Jobmanager. 


## Brief change log

*(for example:)*
  - Provide profiling mode selector and hint on Flink Web


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented, it will be added in [FLINK-33436]
