### PR TITLE
[FLINK-34150][ci] Enables local file sink e2e tests in general CI setups

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_file_sink.sh
@@ -24,7 +24,12 @@ S3_PREFIX=temp/test_file_sink-$(uuidgen)
 OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
 S3_OUTPUT_PATH="s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
 source "$(dirname "$0")"/common.sh
-source "$(dirname "$0")"/common_s3.sh
+
+if [ "${OUT_TYPE}" == "s3" ]; then
+  source "$(dirname "$0")"/common_s3.sh
+else
+  echo "S3 environment is not loaded for non-s3 test runs (test run type: $OUT_TYPE)."
+fi
 
 # randomly set up openSSL with dynamically/statically linked libraries
 OPENSSL_LINKAGE=$(if (( RANDOM % 2 )) ; then echo "dynamic"; else echo "static"; fi)


### PR DESCRIPTION
## What is the purpose of the change

See further details in FLINK-34150

## Brief change log

Enables local tests in generic CI builds (w/o s3 setup)

## Verifying this change

The local file sink e2e tests should be executed in this PR's CI run:
| Test | This PR | PR #24130 for comparison w/o the fix |
| ----- | ----------- | --------------- |
| New File Sink end-to-end test | [enabled](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=56570&view=logs&j=af184cdd-c6d8-5084-0b69-7e9c67b35f7a&t=0f3adb59-eefa-51c6-2858-3654d9e0749d&l=2825) | [disabled](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=56566&view=logs&j=af184cdd-c6d8-5084-0b69-7e9c67b35f7a&t=0f3adb59-eefa-51c6-2858-3654d9e0749d&l=2591) |
| New File Sink s3 end-to-end test | [disabled](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=56570&view=logs&j=af184cdd-c6d8-5084-0b69-7e9c67b35f7a&t=0f3adb59-eefa-51c6-2858-3654d9e0749d&l=3430) | [disabled](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=56566&view=logs&j=af184cdd-c6d8-5084-0b69-7e9c67b35f7a&t=0f3adb59-eefa-51c6-2858-3654d9e0749d&l=2624) |
| Streaming File Sink end-to-end test | [enabled](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=56570&view=logs&j=af184cdd-c6d8-5084-0b69-7e9c67b35f7a&t=0f3adb59-eefa-51c6-2858-3654d9e0749d&l=2189) | [disabled](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=56566&view=logs&j=af184cdd-c6d8-5084-0b69-7e9c67b35f7a&t=0f3adb59-eefa-51c6-2858-3654d9e0749d&l=2525) |
| Streaming File Sink s3 end-to-end test | [disabled](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=56570&view=logs&j=af184cdd-c6d8-5084-0b69-7e9c67b35f7a&t=0f3adb59-eefa-51c6-2858-3654d9e0749d&l=2792) | [disabled](https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=56566&view=logs&j=af184cdd-c6d8-5084-0b69-7e9c67b35f7a&t=0f3adb59-eefa-51c6-2858-3654d9e0749d&l=2558) |

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable