### PR TITLE
[hotfix] Add test dependency to fix tests in flink-table-planner module

### DIFF
--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -150,6 +150,13 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-swagger</artifactId>
+			<version>${flink.shaded.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- ArchUnit test dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>


### PR DESCRIPTION
## What is the purpose of the change

Running tests in `flink-table/flink-table-planner` were failing with errors like:

```
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594) [?:?]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183) [?:?]
Caused by: java.lang.NoClassDefFoundError: javax/activation/UnsupportedDataTypeException
	at org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory.createKnownInputChannel(SingleInputGateFactory.java:387) ~[classes/:?]
	at org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory.lambda$createInputChannel$2(SingleInputGateFactory.java:353) ~[classes/:?]
````

This [commit](https://github.com/apache/flink/commit/439d1091daa12803268bb8ff7c0642bcc5f9127c#diff-f88d94fa818321061497eeddb0724a24c7fcd9799e5508b74fc9fa4fe7b8c7e5R39) adds a dependency on `javax.activation.UnsupportedDataTypeException`.  

The runtime module gets this class from `flink-shaded-swagger`; this PR adds a test dependency on it.

## Brief change log

Adds test dependency.

## Verifying this change

This change can be verified by running a test like this:
`mvn test -Pfast -pl flink-table/flink-table-planner -Dtest=DeduplicationRestoreTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
