### PR TITLE
[FLINK-34149][Runtime/Checkpointing] Fix SplitEnumeratorContext compatibility issue

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumeratorContext.java
@@ -195,5 +195,7 @@ public interface SplitEnumeratorContext<SplitT extends SourceSplit> {
      * source is considered to have isProcessingBacklog=false by default.
      */
     @PublicEvolving
-    void setIsProcessingBacklog(boolean isProcessingBacklog);
+    default void setIsProcessingBacklog(boolean isProcessingBacklog) {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a default implementation to SplitEnumeratorContext#setIsProcessingBacklog to fix the compatibility issue introduced in #22931.


## Brief change log

- Adds a default implementation to SplitEnumeratorContext#setIsProcessingBacklog.


## Verifying this change

It has been verified that the flink-connector-kafka repo will not throw compatibility exception about this method when building against flink-1.19-snapshot after the changes in this PR are introduced. The build would still fail due to other API-incompatible changes, though, and those changes are not related to #22931.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
