### PR TITLE
[hotfix] peekNextBufferSubpartitionId shouldn't throw UnsupportedDataTypeException

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -36,7 +36,6 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.activation.UnsupportedDataTypeException;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -193,7 +192,7 @@ public abstract class RecoveredInputChannel extends InputChannel implements Chan
 
     @Override
     protected int peekNextBufferSubpartitionIdInternal() throws IOException {
-        throw new UnsupportedDataTypeException();
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingNettyConnectionReader.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/netty/TestingNettyConnectionReader.java
@@ -20,24 +20,28 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty;
 
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 
-import javax.activation.UnsupportedDataTypeException;
-
 import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /** Test implementation for {@link NettyConnectionReader}. */
 public class TestingNettyConnectionReader implements NettyConnectionReader {
 
     private final Function<Integer, Buffer> readBufferFunction;
 
-    private TestingNettyConnectionReader(Function<Integer, Buffer> readBufferFunction) {
+    private final Supplier<Integer> peekNextBufferSubpartitionIdSupplier;
+
+    private TestingNettyConnectionReader(
+            Function<Integer, Buffer> readBufferFunction,
+            Supplier<Integer> peekNextBufferSubpartitionIdSupplier) {
         this.readBufferFunction = readBufferFunction;
+        this.peekNextBufferSubpartitionIdSupplier = peekNextBufferSubpartitionIdSupplier;
     }
 
     @Override
     public int peekNextBufferSubpartitionId() throws IOException {
-        throw new UnsupportedDataTypeException();
+        return peekNextBufferSubpartitionIdSupplier.get();
     }
 
     @Override
@@ -50,6 +54,8 @@ public class TestingNettyConnectionReader implements NettyConnectionReader {
 
         private Function<Integer, Buffer> readBufferFunction = segmentId -> null;
 
+        private Supplier<Integer> peekNextBufferSubpartitionIdSupplier = () -> -1;
+
         public Builder() {}
 
         public Builder setReadBufferFunction(Function<Integer, Buffer> readBufferFunction) {
@@ -57,8 +63,15 @@ public class TestingNettyConnectionReader implements NettyConnectionReader {
             return this;
         }
 
+        public Builder setPeekNextBufferSubpartitionIdSupplier(
+                Supplier<Integer> peekNextBufferSubpartitionIdSupplier) {
+            this.peekNextBufferSubpartitionIdSupplier = peekNextBufferSubpartitionIdSupplier;
+            return this;
+        }
+
         public TestingNettyConnectionReader build() {
-            return new TestingNettyConnectionReader(readBufferFunction);
+            return new TestingNettyConnectionReader(
+                    readBufferFunction, peekNextBufferSubpartitionIdSupplier);
         }
     }
 }


### PR DESCRIPTION
We shouldn't throw this `UnsupportedDataTypeException` here. If we really want, can also use generic `IOException` or `UnsupportedOperationException` instead.