### PR TITLE
[FLINK-33233][hive] Fix NPE when non-native udf is used in join condition with Hive dialect, back port to 1.17

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
@@ -477,6 +477,7 @@ public class HiveParserCalcitePlanner {
             HiveParserJoinTypeCheckCtx jCtx =
                     new HiveParserJoinTypeCheckCtx(
                             leftRR, rightRR, hiveJoinType, frameworkConfig, cluster);
+            jCtx.setUnparseTranslator(semanticAnalyzer.unparseTranslator);
             HiveParserRowResolver combinedRR = HiveParserRowResolver.getCombinedRR(leftRR, rightRR);
             if (joinCondAst.getType() == HiveASTParser.TOK_TABCOLNAME
                     && !hiveJoinType.equals(JoinType.LEFTSEMI)) {

--- a/flink-connectors/flink-connector-hive/src/test/resources/query-test/join.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/query-test/join.q
@@ -37,3 +37,7 @@ select * from (select a.value, a.* from (select * from src) a join (select * fro
 select f1.x,f1.y,f2.x,f2.y from (select * from foo order by x,y) f1 join (select * from foo order by x,y) f2;
 
 [+I[1, 1, 1, 1], +I[1, 1, 2, 2], +I[1, 1, 3, 3], +I[1, 1, 4, 4], +I[1, 1, 5, 5], +I[2, 2, 1, 1], +I[2, 2, 2, 2], +I[2, 2, 3, 3], +I[2, 2, 4, 4], +I[2, 2, 5, 5], +I[3, 3, 1, 1], +I[3, 3, 2, 2], +I[3, 3, 3, 3], +I[3, 3, 4, 4], +I[3, 3, 5, 5], +I[4, 4, 1, 1], +I[4, 4, 2, 2], +I[4, 4, 3, 3], +I[4, 4, 4, 4], +I[4, 4, 5, 5], +I[5, 5, 1, 1], +I[5, 5, 2, 2], +I[5, 5, 3, 3], +I[5, 5, 4, 4], +I[5, 5, 5, 5]]
+
+select foo.y, bar.I from bar join foo on hiveudf(foo.x) = bar.I where bar.I > 1;
+
+[+I[2, 2]]


### PR DESCRIPTION
## What is the purpose of the change
Fix NPE when non-native udf used in join condition in hive-parser

## Brief change log
This problem caused by not set  UnparseTranslator when init HiveParserJoinTypeCheckCtx.


## Verifying this change
This change is verified by added test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
