### PR TITLE
[FLINK-34166][table] Fix KeyedLookupJoinWrapper incorrectly process delete message for inner join when previous lookup result is empty

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/KeyedLookupJoinWrapper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/KeyedLookupJoinWrapper.java
@@ -136,7 +136,7 @@ public class KeyedLookupJoinWrapper extends KeyedProcessFunction<RowData, RowDat
                 // fetcher has copied the input field when object reuse is enabled
                 lookupJoinRunner.doFetch(in);
 
-                // update state with empty row if lookup miss or pre-filtered
+                // update state with empty row if join condition unsatisfied
                 if (!collectListener.collected) {
                     updateState(emptyRow);
                 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/KeyedLookupJoinWrapper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/KeyedLookupJoinWrapper.java
@@ -129,40 +129,55 @@ public class KeyedLookupJoinWrapper extends KeyedProcessFunction<RowData, RowDat
 
         // do lookup for acc msg
         if (RowDataUtil.isAccumulateMsg(in)) {
-            // clear local state first
-            deleteState();
+            if (lookupJoinRunner.preFilter(in)) {
+                // clear local state first
+                deleteState();
 
-            // fetcher has copied the input field when object reuse is enabled
-            lookupJoinRunner.doFetch(in);
+                // fetcher has copied the input field when object reuse is enabled
+                lookupJoinRunner.doFetch(in);
 
-            // update state with empty row if lookup miss or pre-filtered
-            if (!collectListener.collected) {
-                updateState(emptyRow);
+                // update state with empty row if lookup miss or pre-filtered
+                if (!collectListener.collected) {
+                    updateState(emptyRow);
+                }
             }
-
             lookupJoinRunner.padNullForLeftJoin(in, out);
         } else {
-            // do state access for non-acc msg
-            if (lookupKeyContainsPrimaryKey) {
-                RowData rightRow = uniqueState.value();
-                // should distinguish null from empty(lookup miss)
-                if (null == rightRow) {
-                    stateStaledErrorHandle(in, out);
+            boolean collected = false;
+            if (lookupJoinRunner.preFilter(in)) {
+                // do state access for non-acc msg
+                if (lookupKeyContainsPrimaryKey) {
+                    RowData rightRow = uniqueState.value();
+                    // should distinguish null from empty(join condition unsatisfied)
+                    if (null == rightRow) {
+                        stateStaledErrorHandle(in, out);
+                    } else if (!emptyRow.equals(rightRow)) {
+                        collectDeleteRow(in, rightRow, out);
+                        collected = true;
+                    }
                 } else {
-                    collectDeleteRow(in, rightRow, out);
-                }
-            } else {
-                List<RowData> rightRows = state.value();
-                if (null == rightRows) {
-                    stateStaledErrorHandle(in, out);
-                } else {
-                    for (RowData row : rightRows) {
-                        collectDeleteRow(in, row, out);
+                    List<RowData> rightRows = state.value();
+                    if (null == rightRows) {
+                        stateStaledErrorHandle(in, out);
+                    } else {
+                        for (RowData row : rightRows) {
+                            if (!emptyRow.equals(row)) {
+                                collectDeleteRow(in, row, out);
+                                collected = true;
+                            }
+                        }
                     }
                 }
+                // clear state at last
+                deleteState();
             }
-            // clear state at last
-            deleteState();
+
+            // pad null for left join if no delete row collected from state, here we can't use the
+            // collector's status to determine whether the row is collected or not, because data
+            // fetched from state is not collected by the collector
+            if (lookupJoinRunner.isLeftOuterJoin && !collected) {
+                collectDeleteRow(in, lookupJoinRunner.nullRow, out);
+            }
         }
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/KeyedLookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/KeyedLookupJoinHarnessTest.java
@@ -200,7 +200,6 @@ public class KeyedLookupJoinHarnessTest {
         List<Object> expectedOutput = new ArrayList<>();
         expectedOutput.add(insertRecord(1, "a", 1, "Julian"));
         expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
-        expectedOutput.add(deleteRecord(3, "c", null, null));
         expectedOutput.add(insertRecord(3, "c2", 6, "Jark-2"));
         expectedOutput.add(deleteRecord(3, "c2", 6, "Jark-2"));
         expectedOutput.add(insertRecord(3, "c3", 9, "Jark-3"));
@@ -288,6 +287,7 @@ public class KeyedLookupJoinHarnessTest {
         testHarness.processElement(updateAfterRecord(3, "c2"));
         testHarness.processElement(deleteRecord(3, "c2"));
         testHarness.processElement(insertRecord(3, "c3"));
+        testHarness.processElement(deleteRecord(4, "d"));
         testHarness.processElement(insertRecord(4, null));
 
         List<Object> expectedOutput = new ArrayList<>();
@@ -305,6 +305,7 @@ public class KeyedLookupJoinHarnessTest {
         expectedOutput.add(deleteRecord(3, "c2", 6, "Jackson-2"));
         expectedOutput.add(insertRecord(3, "c3", 9, "Jark-3"));
         expectedOutput.add(insertRecord(3, "c3", 9, "Jackson-3"));
+        expectedOutput.add(deleteRecord(4, "d", 4, "Fabian"));
         expectedOutput.add(insertRecord(4, null, null, null));
 
         assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
@@ -329,6 +330,7 @@ public class KeyedLookupJoinHarnessTest {
         testHarness.processElement(updateAfterRecord(3, "c2"));
         testHarness.processElement(deleteRecord(3, "c2"));
         testHarness.processElement(insertRecord(3, "c3"));
+        testHarness.processElement(deleteRecord(4, "d"));
         testHarness.processElement(insertRecord(4, null));
 
         List<Object> expectedOutput = new ArrayList<>();
@@ -343,6 +345,7 @@ public class KeyedLookupJoinHarnessTest {
         expectedOutput.add(insertRecord(3, "c2", 6, "Jark-2"));
         expectedOutput.add(deleteRecord(3, "c2", 6, "Jark-2"));
         expectedOutput.add(insertRecord(3, "c3", 9, "Jark-3"));
+        expectedOutput.add(deleteRecord(4, "d", 4, "Fabian"));
         expectedOutput.add(insertRecord(4, null, null, null));
 
         assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
@@ -494,8 +497,8 @@ public class KeyedLookupJoinHarnessTest {
             int currentCnt = counter(id);
             List<GenericRowData> rows = lookup(id);
             if (rows != null) {
-                for (int i = 0; i < rows.size(); i++) {
-                    collectUpdatedRow(rows.get(i), currentCnt, out);
+                for (GenericRowData row : rows) {
+                    collectUpdatedRow(row, currentCnt, out);
                 }
             } else if (currentCnt > 1) {
                 // return a default value for which lookup miss at 1st time


### PR DESCRIPTION
## What is the purpose of the change
KeyedLookupJoinWrapper(when 'table.optimizer.non-deterministic-update.strategy
' is set to 'TRY_RESOLVE' and the lookup join exists NDU problemns) incorrectly process delete message for inner join when previous lookup result is empty.
The reason is unaligned processing between retract (which access local state) and add (which do fetch via lookup function ) logic.

## Brief change log
* sync the retract and add process logic
* update related tests

## Verifying this change
* KeyedLookupJoinHarnessTest

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)