### PR TITLE
[FLINK-34111][table] Add JSON_QUOTE and JSON_UNQUOTE function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -382,7 +382,7 @@ string:
     description: Quotes a string as a JSON value by wrapping it with double quote characters, escaping interior quote and other characters, and returning the result as a utf8mb4 string. If the argument is NULL, the function returns NULL.
   - sql: JSON_UNQUOTE(string)
     table: STRING.JsonUnquote()
-    description: Unquotes JSON value and returns the result as a utf8mb4 string. If the argument is NULL, returns NULL. If the value starts and ends with double quotes but is not a valid JSON string literal, this value skipped as NULL.
+    description: Unquotes JSON value and returns the result as a utf8mb4 string. If the argument is NULL, returns NULL. If the value starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
 
 temporal:
   - sql: DATE string

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -377,6 +377,12 @@ string:
   - sql: SUBSTR(string, integer1[, integer2])
     table: STRING.substr(INTEGER1[, INTEGER2])
     description: Returns a substring of string starting from position integer1 with length integer2 (to the end by default).
+  - sql: JSON_QUOTE(string)
+    table: STRING.JsonQuote()
+    description: Quotes a string as a JSON value by wrapping it with double quote characters, escaping interior quote and other characters, and returning the result as a utf8mb4 string. If the argument is NULL, the function returns NULL.
+  - sql: JSON_UNQUOTE(string)
+    table: STRING.JsonUnquote()
+    description: Unquotes JSON value and returns the result as a utf8mb4 string. If the argument is NULL, returns NULL. If the value starts and ends with double quotes but is not a valid JSON string literal, this value skipped as NULL.
 
 temporal:
   - sql: DATE string

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -379,10 +379,10 @@ string:
     description: Returns a substring of string starting from position integer1 with length integer2 (to the end by default).
   - sql: JSON_QUOTE(string)
     table: STRING.JsonQuote()
-    description: Quotes a string as a JSON value by wrapping it with double quote characters, escaping interior quote and other characters, and returning the result as a utf8mb4 string. If the argument is NULL, the function returns NULL.
+    description: Quotes a string as a JSON value by wrapping it with double quote characters, escaping interior quote and special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't'), and returning the result as a utf8mb4 string. If the argument is NULL, the function returns NULL.
   - sql: JSON_UNQUOTE(string)
     table: STRING.JsonUnquote()
-    description: Unquotes JSON value and returns the result as a utf8mb4 string. If the argument is NULL, returns NULL. If the value starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
+    description: Unquotes JSON value, escapes special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't', 'u' hex hex hex hex), and returns the result as a utf8mb4 string. If the argument is NULL, returns NULL. If the value starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
 
 temporal:
   - sql: DATE string

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -195,8 +195,6 @@ string functions
     Expression.reverse
     Expression.split_index
     Expression.str_to_map
-    Expression.json_quote
-    Expression.json_unquote
 
 temporal functions
 ------------------
@@ -302,3 +300,5 @@ JSON functions
     Expression.json_exists
     Expression.json_value
     Expression.json_query
+    Expression.json_quote
+    Expression.json_unquote

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -195,6 +195,8 @@ string functions
     Expression.reverse
     Expression.split_index
     Expression.str_to_map
+    Expression.json_quote
+    Expression.json_unquote
 
 temporal functions
 ------------------

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -88,7 +88,8 @@ _string_doc_seealso = """
              :func:`~Expression.overlay`, :func:`~Expression.regexp_replace`,
              :func:`~Expression.regexp_extract`, :func:`~Expression.substring`,
              :py:attr:`~Expression.from_base64`, :py:attr:`~Expression.to_base64`,
-             :py:attr:`~Expression.ltrim`, :py:attr:`~Expression.rtrim`, :func:`~Expression.repeat`
+             :py:attr:`~Expression.ltrim`, :py:attr:`~Expression.rtrim`, :func:`~Expression.repeat`,
+             :func:`~Expression.json_quote`, :func:`~Expression.json_unquote`
 """
 
 _temporal_doc_seealso = """
@@ -186,7 +187,8 @@ def _make_string_doc():
         Expression.init_cap, Expression.like, Expression.similar, Expression.position,
         Expression.lpad, Expression.rpad, Expression.overlay, Expression.regexp_replace,
         Expression.regexp_extract, Expression.from_base64, Expression.to_base64,
-        Expression.ltrim, Expression.rtrim, Expression.repeat
+        Expression.ltrim, Expression.rtrim, Expression.repeat,
+        Expression.json_quote, Expression.json_unquote
     ]
 
     for func in string_funcs:
@@ -1200,6 +1202,22 @@ class Expression(Generic[T]):
             return _ternary_op("regexpExtract")(self, regex)
         else:
             return _ternary_op("regexpExtract")(self, regex, extract_index)
+
+    def json_quote(self) -> 'Expression':
+        """
+        Quotes a string as a JSON value by wrapping it with double quote characters,
+        escaping interior quote and other characters, and returning the result as
+        a utf8mb4 string. If the argument is NULL, the function returns NULL.
+        """
+        return _unary_op("jsonQuote")(self)
+
+    def json_unquote(self) -> 'Expression':
+        """
+        Unquotes JSON value and returns the result as a utf8mb4 string.
+        If the argument is NULL, returns NULL. If the value starts and ends with
+        double quotes but is not a valid JSON string literal, an error occurs.
+        """
+        return _unary_op("jsonUnquote")(self)
 
     @property
     def from_base64(self) -> 'Expression[str]':

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1203,22 +1203,6 @@ class Expression(Generic[T]):
         else:
             return _ternary_op("regexpExtract")(self, regex, extract_index)
 
-    def json_quote(self) -> 'Expression':
-        """
-        Quotes a string as a JSON value by wrapping it with double quote characters,
-        escaping interior quote and other characters, and returning the result as
-        a utf8mb4 string. If the argument is NULL, the function returns NULL.
-        """
-        return _unary_op("jsonQuote")(self)
-
-    def json_unquote(self) -> 'Expression':
-        """
-        Unquotes JSON value and returns the result as a utf8mb4 string.
-        If the argument is NULL, returns NULL. If the value starts and ends with
-        double quotes but is not a valid JSON string literal, an error occurs.
-        """
-        return _unary_op("jsonUnquote")(self)
-
     @property
     def from_base64(self) -> 'Expression[str]':
         """
@@ -1892,6 +1876,25 @@ class Expression(Generic[T]):
         return _varargs_op("jsonQuery")(self, path, wrapping_behavior._to_j_json_query_wrapper(),
                                         on_empty._to_j_json_query_on_error_or_empty(),
                                         on_error._to_j_json_query_on_error_or_empty())
+
+    def json_quote(self) -> 'Expression':
+        """
+        Quotes a string as a JSON value by wrapping it with double quote characters,
+        escaping interior quote and special characters
+        ('"', '\', '/', 'b', 'f', 'n', 'r', 't'), and returning
+        the result as a utf8mb4 string. If the argument is NULL, the function returns NULL.
+        """
+        return _unary_op("jsonQuote")(self)
+
+    def json_unquote(self) -> 'Expression':
+        """
+        Unquotes JSON value, escapes spacial characters
+        ('"', '\', '/', 'b', 'f', 'n', 'r', 't', 'u' hex hex hex hex) and
+        returns the result as a utf8mb4 string.
+        If the argument is NULL, returns NULL. If the value starts and ends with
+        double quotes but is not a valid JSON string literal, an error occurs.
+        """
+        return _unary_op("jsonUnquote")(self)
 
 
 # add the docs

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1096,15 +1096,13 @@ public abstract class BaseExpressions<InType, OutType> {
      * Returns a string by quotes a string as a JSON value and wrapping it with double quote
      * characters.
      */
-    public OutType jsonQuote(InType input) {
-        return toApiSpecificExpression(
-                unresolvedCall(JSON_QUOTE, toExpr(), objectToExpression(input)));
+    public OutType jsonQuote() {
+        return toApiSpecificExpression(unresolvedCall(JSON_QUOTE, objectToExpression(toExpr())));
     }
 
     /** Returns utf8mb4 string by unquoting JSON value. */
-    public OutType jsonUnquote(InType input) {
-        return toApiSpecificExpression(
-                unresolvedCall(JSON_UNQUOTE, toExpr(), objectToExpression(input)));
+    public OutType jsonUnquote() {
+        return toApiSpecificExpression(unresolvedCall(JSON_UNQUOTE, objectToExpression(toExpr())));
     }
 
     /** Returns the base string decoded with base64. */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -111,6 +111,8 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_NUL
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_TRUE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_EXISTS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_QUERY;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_QUOTE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_UNQUOTE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.JSON_VALUE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LAST_VALUE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LEFT;
@@ -1088,6 +1090,21 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType regexpExtract(InType regex) {
         return toApiSpecificExpression(
                 unresolvedCall(REGEXP_EXTRACT, toExpr(), objectToExpression(regex)));
+    }
+
+    /**
+     * Returns a string by quotes a string as a JSON value and wrapping it with double quote
+     * characters.
+     */
+    public OutType jsonQuote(InType input) {
+        return toApiSpecificExpression(
+                unresolvedCall(JSON_QUOTE, toExpr(), objectToExpression(input)));
+    }
+
+    /** Returns utf8mb4 string by unquoting JSON value. */
+    public OutType jsonUnquote(InType input) {
+        return toApiSpecificExpression(
+                unresolvedCall(JSON_UNQUOTE, toExpr(), objectToExpression(input)));
     }
 
     /** Returns the base string decoded with base64. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -988,6 +988,24 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(explicit(DataTypes.STRING().nullable()))
                     .build();
 
+    public static final BuiltInFunctionDefinition JSON_QUOTE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("JSON_QUOTE")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.JsonQuoteFunction")
+                    .build();
+    public static final BuiltInFunctionDefinition JSON_UNQUOTE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("JSON_UNQUOTE")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.JsonUnquoteFunction")
+                    .build();
     public static final BuiltInFunctionDefinition FROM_BASE64 =
             BuiltInFunctionDefinition.newBuilder()
                     .name("fromBase64")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -86,6 +86,8 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
         testCases.addAll(jsonStringSpec());
         testCases.addAll(jsonObjectSpec());
         testCases.addAll(jsonArraySpec());
+        testCases.addAll(jsonQuoteSpec());
+        testCases.addAll(jsonUnquoteSpec());
 
         return testCases.stream();
     }
@@ -684,6 +686,135 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         + "\"R\":{\"f0\":\"V\",\"f1\":null}"
                                         + "}",
                                 STRING().notNull(),
+                                STRING().notNull()));
+    }
+
+    private static List<TestSetSpec> jsonQuoteSpec() {
+
+        return Arrays.asList(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUOTE)
+                        .onFieldsWithData(0)
+                        .testResult(
+                                nullOf(STRING()).jsonQuote(),
+                                "JSON_QUOTE(CAST(NULL AS STRING))",
+                                null,
+                                STRING().nullable()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_QUOTE)
+                        .onFieldsWithData(
+                                "V",
+                                "\"null\"",
+                                "[1, 2, 3]",
+                                "This is a \t test \n with special characters: \" \\ \b \f \r \u0041",
+                                "\"special\": \"\\b\\f\\r\"")
+                        .andDataTypes(
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull())
+                        .testResult(
+                                $("f0").jsonQuote(), "JSON_QUOTE(f0)", "\"V\"", STRING().notNull())
+                        .testResult(
+                                $("f1").jsonQuote(),
+                                "JSON_QUOTE(f1)",
+                                "\"\\\"null\\\"\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f2").jsonQuote(),
+                                "JSON_QUOTE(f2)",
+                                "\"[1, 2, 3]\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f3").jsonQuote(),
+                                "JSON_QUOTE(f3)",
+                                "\"This is a \\t test \\n with special characters: \\\" \\\\ \\b \\f \\r A\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f4").jsonQuote(),
+                                "JSON_QUOTE(f4)",
+                                "\"\\\"special\\\": \\\"\\\\b\\\\f\\\\r\\\"\"",
+                                STRING().notNull()));
+    }
+
+    private static List<TestSetSpec> jsonUnquoteSpec() {
+
+        return Arrays.asList(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_UNQUOTE)
+                        .onFieldsWithData(0)
+                        .testResult(
+                                nullOf(STRING()).jsonQuote(),
+                                "JSON_UNQUOTE(CAST(NULL AS STRING))",
+                                null,
+                                STRING().nullable()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.JSON_UNQUOTE)
+                        .onFieldsWithData(
+                                "\"abc\"",
+                                "\"[\"abc\"]\"",
+                                "\"[\"\\u0041\"]\"",
+                                "\"[\"\\u006z\"]\"",
+                                "\"[1,2,3]",
+                                "\"[1, 2, 3}",
+                                "\"",
+                                "\"[\"\\t\\u0032\"]\"",
+                                "\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"",
+                                "\"[\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"]\"")
+                        .andDataTypes(
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull(),
+                                STRING().notNull())
+                        .testResult(
+                                $("f0").jsonUnquote(),
+                                "JSON_UNQUOTE(f0)",
+                                "\"abc\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f1").jsonUnquote(),
+                                "JSON_UNQUOTE(f1)",
+                                "[\"abc\"]",
+                                STRING().notNull())
+                        .testResult(
+                                $("f2").jsonUnquote(),
+                                "JSON_UNQUOTE(f2)",
+                                "[\"A\"]",
+                                STRING().notNull())
+                        .testResult(
+                                $("f3").jsonUnquote(),
+                                "JSON_UNQUOTE(f3)",
+                                "\"[\"\\u006z\"]\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f4").jsonUnquote(),
+                                "JSON_UNQUOTE(f4)",
+                                "\"[1,2,3]",
+                                STRING().notNull())
+                        .testResult(
+                                $("f5").jsonUnquote(),
+                                "JSON_UNQUOTE(f5)",
+                                "\"[1, 2, 3}",
+                                STRING().notNull())
+                        .testResult(
+                                $("f6").jsonUnquote(), "JSON_UNQUOTE(f6)", "\"", STRING().notNull())
+                        .testResult(
+                                $("f7").jsonUnquote(),
+                                "JSON_UNQUOTE(f7)",
+                                "[\"\\t2\"]",
+                                STRING().notNull())
+                        .testResult(
+                                $("f8").jsonUnquote(),
+                                "JSON_UNQUOTE(f8)",
+                                "\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"",
+                                STRING().notNull())
+                        .testResult(
+                                $("f9").jsonUnquote(),
+                                "JSON_UNQUOTE(f9)",
+                                "[\"This is a \\t test \\n with special characters: \\b \\f \\r A\"]",
                                 STRING().notNull()));
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -717,7 +717,7 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f1").jsonQuote(),
                                 "JSON_QUOTE(f1)",
-                                "\"\\\"null\\\"\"",
+                                "\"\"null\"\"",
                                 STRING().notNull())
                         .testResult(
                                 $("f2").jsonQuote(),
@@ -727,12 +727,12 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f3").jsonQuote(),
                                 "JSON_QUOTE(f3)",
-                                "\"This is a \\t test \\n with special characters: \\\" \\\\ \\b \\f \\r A\"",
+                                "\"This is a \t test \n with special characters: \" \\ \b \f \r A\"",
                                 STRING().notNull())
                         .testResult(
                                 $("f4").jsonQuote(),
                                 "JSON_QUOTE(f4)",
-                                "\"\\\"special\\\": \\\"\\\\b\\\\f\\\\r\\\"\"",
+                                "\"\"special\": \"\\b\\f\\r\"\"",
                                 STRING().notNull()));
     }
 
@@ -751,7 +751,7 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "\"abc\"",
                                 "\"[\"abc\"]\"",
                                 "\"[\"\\u0041\"]\"",
-                                "\"[\"\\u006z\"]\"",
+                                "\"\\u0041\"",
                                 "\"[1,2,3]",
                                 "\"[1, 2, 3}",
                                 "\"",
@@ -772,7 +772,7 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f0").jsonUnquote(),
                                 "JSON_UNQUOTE(f0)",
-                                "\"abc\"",
+                                "abc",
                                 STRING().notNull())
                         .testResult(
                                 $("f1").jsonUnquote(),
@@ -785,10 +785,7 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 "[\"A\"]",
                                 STRING().notNull())
                         .testResult(
-                                $("f3").jsonUnquote(),
-                                "JSON_UNQUOTE(f3)",
-                                "\"[\"\\u006z\"]\"",
-                                STRING().notNull())
+                                $("f3").jsonUnquote(), "JSON_UNQUOTE(f3)", "A", STRING().notNull())
                         .testResult(
                                 $("f4").jsonUnquote(),
                                 "JSON_UNQUOTE(f4)",
@@ -809,7 +806,7 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f8").jsonUnquote(),
                                 "JSON_UNQUOTE(f8)",
-                                "\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"",
+                                "This is a \\t test \\n with special characters: \\b \\f \\r A",
                                 STRING().notNull())
                         .testResult(
                                 $("f9").jsonUnquote(),

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -625,17 +625,18 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
 
   @Test
   def testJsonUnquote(): Unit = {
-    testSqlApi("JSON_UNQUOTE('\"abc\"')", "")
+    testSqlApi("JSON_UNQUOTE('\"abc\"')", "\"abc\"")
     testSqlApi("JSON_UNQUOTE('\"[\"abc\"]\"')", "[\"abc\"]")
     testSqlApi("JSON_UNQUOTE('\"[\"\\u0041\"]\"')", "[\"A\"]")
-    testSqlApi("JSON_UNQUOTE('\"[\"\\u006z\"]\"')", "")
-    testSqlApi("JSON_UNQUOTE('\"[1,2,3]')", "")
-    testSqlApi("JSON_UNQUOTE('\"[1, 2, 3}')", "")
-    testSqlApi("JSON_UNQUOTE('\"')", "")
+    testSqlApi("JSON_UNQUOTE('\"[\"\\u006z\"]\"')", "\"[\"\\u006z\"]\"")
+    testSqlApi("JSON_UNQUOTE('\"[1,2,3]')", "\"[1,2,3]")
+    testSqlApi("JSON_UNQUOTE('\"[1, 2, 3}')", "\"[1, 2, 3}")
+    testSqlApi("JSON_UNQUOTE('\"')", "\"")
     testSqlApi("JSON_UNQUOTE('\"[\"\\t\\u0032\"]\"')", "[\"\\t2\"]")
     testSqlApi(
       "JSON_UNQUOTE('\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"')",
-      "")
+      "\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\""
+    )
     testSqlApi(
       "JSON_UNQUOTE('\"[\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"]\"')",
       "[\"This is a \\t test \\n with special characters: \\b \\f \\r A\"]"

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -607,15 +607,16 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testJsonQuote(): Unit = {
     testSqlApi("JSON_QUOTE('null')", "\"null\"")
-    testSqlApi("JSON_QUOTE('\"null\"')", "\"\\\"null\\\"\"")
-    testSqlApi("JSON_QUOTE('[1, 2, 3]')", "\"[1, 2, 3]\"")
+    testSqlApi("JSON_QUOTE('\"null\"')", "\"\"null\"\"")
+    testSqlApi("JSON_QUOTE('[1,2,3]')", "\"[1,2,3]\"")
+    testSqlApi("JSON_UNQUOTE(JSON_QUOTE('[1,2,3]'))", "[1,2,3]")
     testSqlApi(
-      "JSON_QUOTE('This is a \t test \n with special characters: \" \\ \b \f \r \u0041')",
-      "\"This is a \\t test \\n with special characters: \\\" \\\\ \\b \\f \\r A\""
+      "JSON_QUOTE('This is a \\t test \\n with special characters: \" \\ \\b \\f \\r \\u0041')",
+      "\"This is a \\t test \\n with special characters: \" \\ \\b \\f \\r \\u0041\""
     )
     testSqlApi(
       "JSON_QUOTE('\"special\": \"\\b\\f\\r\"')",
-      "\"\\\"special\\\": \\\"\\\\b\\\\f\\\\r\\\"\""
+      "\"\"special\": \"\\b\\f\\r\"\""
     )
     testSqlApi(
       "JSON_QUOTE('skipping backslash \')",
@@ -625,22 +626,26 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
 
   @Test
   def testJsonUnquote(): Unit = {
-    testSqlApi("JSON_UNQUOTE('\"abc\"')", "\"abc\"")
-    testSqlApi("JSON_UNQUOTE('\"[\"abc\"]\"')", "[\"abc\"]")
-    testSqlApi("JSON_UNQUOTE('\"[\"\\u0041\"]\"')", "[\"A\"]")
-    testSqlApi("JSON_UNQUOTE('\"[\"\\u006z\"]\"')", "\"[\"\\u006z\"]\"")
+    testSqlApi("JSON_UNQUOTE('\"abc\"')", "abc")
+    testSqlApi("JSON_UNQUOTE('\"[abc]\"')", "[abc]")
+    testSqlApi("JSON_UNQUOTE('\"[abc}\"')", "[abc}")
+    testSqlApi("JSON_UNQUOTE('\"[\\u0041]\"')", "[A]")
+    testSqlApi("JSON_UNQUOTE('\"[\\u006z]\"')", "\"[\\u006z]\"")
     testSqlApi("JSON_UNQUOTE('\"[1,2,3]')", "\"[1,2,3]")
     testSqlApi("JSON_UNQUOTE('\"[1, 2, 3}')", "\"[1, 2, 3}")
+    testSqlApi("JSON_UNQUOTE('\"[1, 2, 3}\"')", "[1, 2, 3}")
     testSqlApi("JSON_UNQUOTE('\"')", "\"")
-    testSqlApi("JSON_UNQUOTE('\"[\"\\t\\u0032\"]\"')", "[\"\\t2\"]")
+    testSqlApi("JSON_UNQUOTE('\"[\\t\\u0032]\"')", "[\\t2]")
     testSqlApi(
       "JSON_UNQUOTE('\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"')",
-      "\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\""
+      "This is a \\t test \\n with special characters: \\b \\f \\r A"
     )
     testSqlApi(
       "JSON_UNQUOTE('\"[\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"]\"')",
       "[\"This is a \\t test \\n with special characters: \\b \\f \\r A\"]"
     )
+    testSqlApi("json_unquote(json_quote('\"key\"'))", "\"key\"")
+    testSqlApi("json_unquote(json_quote('\"[]\"'))", "\"[]\"")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -605,6 +605,44 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   }
 
   @Test
+  def testJsonQuote(): Unit = {
+    testSqlApi("JSON_QUOTE('null')", "\"null\"")
+    testSqlApi("JSON_QUOTE('\"null\"')", "\"\\\"null\\\"\"")
+    testSqlApi("JSON_QUOTE('[1, 2, 3]')", "\"[1, 2, 3]\"")
+    testSqlApi(
+      "JSON_QUOTE('This is a \t test \n with special characters: \" \\ \b \f \r \u0041')",
+      "\"This is a \\t test \\n with special characters: \\\" \\\\ \\b \\f \\r A\""
+    )
+    testSqlApi(
+      "JSON_QUOTE('\"special\": \"\\b\\f\\r\"')",
+      "\"\\\"special\\\": \\\"\\\\b\\\\f\\\\r\\\"\""
+    )
+    testSqlApi(
+      "JSON_QUOTE('skipping backslash \')",
+      "\"skipping backslash \""
+    )
+  }
+
+  @Test
+  def testJsonUnquote(): Unit = {
+    testSqlApi("JSON_UNQUOTE('\"abc\"')", "")
+    testSqlApi("JSON_UNQUOTE('\"[\"abc\"]\"')", "[\"abc\"]")
+    testSqlApi("JSON_UNQUOTE('\"[\"\\u0041\"]\"')", "[\"A\"]")
+    testSqlApi("JSON_UNQUOTE('\"[\"\\u006z\"]\"')", "")
+    testSqlApi("JSON_UNQUOTE('\"[1,2,3]')", "")
+    testSqlApi("JSON_UNQUOTE('\"[1, 2, 3}')", "")
+    testSqlApi("JSON_UNQUOTE('\"')", "")
+    testSqlApi("JSON_UNQUOTE('\"[\"\\t\\u0032\"]\"')", "[\"\\t2\"]")
+    testSqlApi(
+      "JSON_UNQUOTE('\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"')",
+      "")
+    testSqlApi(
+      "JSON_UNQUOTE('\"[\"This is a \\t test \\n with special characters: \\b \\f \\r \\u0041\"]\"')",
+      "[\"This is a \\t test \\n with special characters: \\b \\f \\r A\"]"
+    )
+  }
+
+  @Test
   def testFromBase64(): Unit = {
     testSqlApi("FROM_BASE64('aGVsbG8gd29ybGQ=')", "hello world")
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import javax.annotation.Nullable;
@@ -42,12 +41,7 @@ public class JsonQuoteFunction extends BuiltInScalarFunction {
             return null;
         }
         BinaryStringData bs = (BinaryStringData) input;
-        String inputStr = bs.toString();
-        try {
-            String res = objectMapper.writeValueAsString(inputStr);
-            return new BinaryStringData(res);
-        } catch (JsonProcessingException e) {
-            return input;
-        }
+        String stringWithQuotes = String.format("\"%s\"", bs);
+        return new BinaryStringData(stringWithQuotes);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
@@ -47,7 +47,7 @@ public class JsonQuoteFunction extends BuiltInScalarFunction {
             String res = objectMapper.writeValueAsString(inputStr);
             return new BinaryStringData(res);
         } catch (JsonProcessingException e) {
-            return BinaryStringData.EMPTY_UTF8;
+            return input;
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonQuoteFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#JSON_QUOTE}. */
+@Internal
+public class JsonQuoteFunction extends BuiltInScalarFunction {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JsonQuoteFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.JSON_QUOTE, context);
+    }
+
+    public @Nullable Object eval(Object input) {
+        if (input == null) {
+            return null;
+        }
+        BinaryStringData bs = (BinaryStringData) input;
+        String inputStr = bs.toString();
+        try {
+            String res = objectMapper.writeValueAsString(inputStr);
+            return new BinaryStringData(res);
+        } catch (JsonProcessingException e) {
+            return BinaryStringData.EMPTY_UTF8;
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
@@ -53,7 +53,7 @@ public class JsonUnquoteFunction extends BuiltInScalarFunction {
             String res = objectMapper.writeValueAsString(jsonNode);
             return new BinaryStringData(res);
         } catch (JsonProcessingException e) {
-            return BinaryStringData.EMPTY_UTF8;
+            return input;
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/JsonUnquoteFunction.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#JSON_UNQUOTE}. */
+@Internal
+public class JsonUnquoteFunction extends BuiltInScalarFunction {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JsonUnquoteFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.JSON_UNQUOTE, context);
+    }
+
+    public @Nullable Object eval(Object input) {
+        if (input == null) {
+            return null;
+        }
+        BinaryStringData bs = (BinaryStringData) input;
+        String inputStr = bs.toString();
+
+        if (inputStr.length() > 1 && inputStr.startsWith("\"") && inputStr.endsWith("\"")) {
+            inputStr = inputStr.substring(1, inputStr.length() - 1);
+        }
+        try {
+            JsonNode jsonNode = objectMapper.readTree(inputStr);
+            String res = objectMapper.writeValueAsString(jsonNode);
+            return new BinaryStringData(res);
+        } catch (JsonProcessingException e) {
+            return BinaryStringData.EMPTY_UTF8;
+        }
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

This pull request adds JSON_QUOTE and JSON_UNQUOTE functions

## Brief change log

  - Add the necessary documentation and functions to support  JSON_QUOTE and JSON_UNQUOTE functions


## Verifying this change

This change added tests and can be verified via `org.apache.flink.table.planner.expressions.ScalarFunctionsTests.testJsonQuote` and `org.apache.flink.table.planner.expressions.ScalarFunctionsTests.testJsonUnquote`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? docs
