### PR TITLE
[FLINK-33728] Do not rewatch when KubernetesResourceManagerDriver wat…

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -285,10 +285,22 @@
             <td>The user-specified tolerations to be set to the TaskManager pod. The value should be in the form of key:key1,operator:Equal,value:value1,effect:NoSchedule;key:key2,operator:Exists,effect:NoExecute,tolerationSeconds:6000</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.transactional-operation.initial-retry-delay</h5></td>
+            <td style="word-wrap: break-word;">50 ms</td>
+            <td>Duration</td>
+            <td>Defines the initial duration of Kubernetes transactional operation retries after fail</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.transactional-operation.max-retries</h5></td>
-            <td style="word-wrap: break-word;">5</td>
+            <td style="word-wrap: break-word;">15</td>
             <td>Integer</td>
             <td>Defines the number of Kubernetes transactional operation retries before the client gives up. For example, <code class="highlighter-rouge">FlinkKubeClient#checkAndUpdateConfigMap</code>.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.transactional-operation.max-retry-delay</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>Defines the max duration of Kubernetes transactional operation retries after fail</td>
         </tr>
     </tbody>
 </table>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -62,11 +62,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 
 /** Implementation of {@link ResourceManagerDriver} for Kubernetes deployment. */
 public class KubernetesResourceManagerDriver
@@ -74,6 +74,8 @@ public class KubernetesResourceManagerDriver
 
     /** The taskmanager pod name pattern is {clusterId}-{taskmanager}-{attemptId}-{podIndex}. */
     private static final String TASK_MANAGER_POD_FORMAT = "%s-taskmanager-%d-%d";
+
+    private static final Long TERMINATION_WAIT_SECOND = 5L;
 
     private final String clusterId;
 
@@ -90,7 +92,7 @@ public class KubernetesResourceManagerDriver
     /** Current max pod index. When creating a new pod, it should increase one. */
     private long currentMaxPodId = 0;
 
-    private Optional<KubernetesWatch> podsWatchOpt;
+    private CompletableFuture<KubernetesWatch> podsWatchOptFuture;
 
     private volatile boolean running;
 
@@ -114,7 +116,7 @@ public class KubernetesResourceManagerDriver
 
     @Override
     protected void initializeInternal() throws Exception {
-        podsWatchOpt = watchTaskManagerPods();
+        podsWatchOptFuture = watchTaskManagerPods();
         final File podTemplateFile = KubernetesUtils.getTaskManagerPodTemplateFileInPod();
         if (podTemplateFile.exists()) {
             taskManagerPodTemplate =
@@ -139,7 +141,7 @@ public class KubernetesResourceManagerDriver
         Exception exception = null;
 
         try {
-            podsWatchOpt.ifPresent(KubernetesWatch::close);
+            podsWatchOptFuture.get(TERMINATION_WAIT_SECOND, TimeUnit.SECONDS).close();
         } catch (Exception e) {
             exception = e;
         }
@@ -412,11 +414,21 @@ public class KubernetesResourceManagerDriver
                         });
     }
 
-    private Optional<KubernetesWatch> watchTaskManagerPods() throws Exception {
-        return Optional.of(
+    private CompletableFuture<KubernetesWatch> watchTaskManagerPods() throws Exception {
+        CompletableFuture<KubernetesWatch> kubernetesWatchCompletableFuture =
                 flinkKubeClient.watchPodsAndDoCallback(
                         KubernetesUtils.getTaskManagerSelectors(clusterId),
-                        new PodCallbackHandlerImpl()));
+                        new PodCallbackHandlerImpl());
+        kubernetesWatchCompletableFuture.whenCompleteAsync(
+                (KubernetesWatch watch, Throwable throwable) -> {
+                    if (throwable != null) {
+                        getResourceEventHandler().onError(throwable);
+                    } else {
+                        log.info("Create watch on TaskManager pods successfully.");
+                    }
+                },
+                getMainThreadExecutor());
+        return kubernetesWatchCompletableFuture;
     }
 
     // ------------------------------------------------------------------------
@@ -450,17 +462,30 @@ public class KubernetesResourceManagerDriver
             if (throwable instanceof KubernetesTooOldResourceVersionException) {
                 getMainThreadExecutor()
                         .execute(
-                                () -> {
-                                    if (running) {
-                                        podsWatchOpt.ifPresent(KubernetesWatch::close);
-                                        log.info("Creating a new watch on TaskManager pods.");
-                                        try {
-                                            podsWatchOpt = watchTaskManagerPods();
-                                        } catch (Exception e) {
-                                            getResourceEventHandler().onError(e);
-                                        }
-                                    }
-                                });
+                                () ->
+                                        podsWatchOptFuture.whenCompleteAsync(
+                                                (KubernetesWatch watch, Throwable throwable1) -> {
+                                                    if (running) {
+                                                        try {
+                                                            if (watch != null) {
+                                                                watch.close();
+                                                            }
+                                                        } catch (Exception e) {
+                                                            log.warn(
+                                                                    "Error when get old watch to close, which is not supposed to happen",
+                                                                    e);
+                                                        }
+                                                        log.info(
+                                                                "Creating a new watch on TaskManager pods.");
+                                                        try {
+                                                            podsWatchOptFuture =
+                                                                    watchTaskManagerPods();
+                                                        } catch (Exception e) {
+                                                            getResourceEventHandler().onError(e);
+                                                        }
+                                                    }
+                                                },
+                                                getMainThreadExecutor()));
             } else {
                 getResourceEventHandler().onError(throwable);
             }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -33,6 +33,7 @@ import org.apache.flink.kubernetes.kubeclient.services.ServiceType;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -431,13 +432,36 @@ public class KubernetesConfigOptions {
     public static final ConfigOption<Integer> KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRIES =
             key("kubernetes.transactional-operation.max-retries")
                     .intType()
-                    .defaultValue(5)
+                    .defaultValue(15)
                     .withDescription(
                             Description.builder()
                                     .text(
                                             "Defines the number of Kubernetes transactional operation retries before the "
                                                     + "client gives up. For example, %s.",
                                             code("FlinkKubeClient#checkAndUpdateConfigMap"))
+                                    .build());
+
+    public static final ConfigOption<Duration>
+            KUBERNETES_TRANSACTIONAL_OPERATION_INITIAL_RETRY_DEALY =
+                    key("kubernetes.transactional-operation.initial-retry-delay")
+                            .durationType()
+                            .defaultValue(Duration.ofMillis(50))
+                            .withDescription(
+                                    Description.builder()
+                                            .text(
+                                                    "Defines the initial duration of Kubernetes transactional operation retries "
+                                                            + "after fail")
+                                            .build());
+
+    public static final ConfigOption<Duration> KUBERNETES_TRANSACTIONAL_OPERATION_MAX_RETRY_DEALY =
+            key("kubernetes.transactional-operation.max-retry-delay")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(1))
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines the max duration of Kubernetes transactional operation retries "
+                                                    + "after fail")
                                     .build());
 
     public static final ConfigOption<String> JOB_MANAGER_POD_TEMPLATE;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -105,7 +105,7 @@ public interface FlinkKubeClient extends AutoCloseable {
      * @param podCallbackHandler podCallbackHandler which reacts to pod events
      * @return Return a watch for pods. It needs to be closed after use.
      */
-    KubernetesWatch watchPodsAndDoCallback(
+    CompletableFuture<KubernetesWatch> watchPodsAndDoCallback(
             Map<String, String> labels, WatchCallbackHandler<KubernetesPod> podCallbackHandler)
             throws Exception;
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClientFactory.java
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** A {@link FlinkKubeClientFactory} for creating the {@link FlinkKubeClient}. */
 public class FlinkKubeClientFactory {
@@ -107,11 +107,12 @@ public class FlinkKubeClientFactory {
         final int poolSize =
                 flinkConfig.get(KubernetesConfigOptions.KUBERNETES_CLIENT_IO_EXECUTOR_POOL_SIZE);
         return new Fabric8FlinkKubeClient(
-                flinkConfig, client, createThreadPoolForAsyncIO(poolSize, useCase));
+                flinkConfig, client, createScheduledThreadPoolForAsyncIO(poolSize, useCase));
     }
 
-    private static ExecutorService createThreadPoolForAsyncIO(int poolSize, String useCase) {
-        return Executors.newFixedThreadPool(
+    private static ScheduledExecutorService createScheduledThreadPoolForAsyncIO(
+            int poolSize, String useCase) {
+        return Executors.newScheduledThreadPool(
                 poolSize, new ExecutorThreadFactory("flink-kubeclient-io-for-" + useCase));
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -39,7 +39,6 @@ import org.apache.flink.kubernetes.kubeclient.FlinkKubeClientFactory;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
-import org.apache.flink.util.concurrent.Executors;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
@@ -49,6 +48,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.Executors;
 
 import static org.apache.flink.kubernetes.utils.Constants.ENV_FLINK_POD_IP_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -84,7 +84,7 @@ class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
                                 return new Fabric8FlinkKubeClient(
                                         flinkConfig,
                                         server.createClient().inNamespace(NAMESPACE),
-                                        Executors.newDirectExecutorService());
+                                        Executors.newSingleThreadScheduledExecutor());
                             }
                         });
     }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -334,7 +334,8 @@ class KubernetesResourceManagerDriverTest
                             } else {
                                 initWatchFuture.complete(null);
                                 getSetWatchPodsAndDoCallbackFuture().complete(handler);
-                                return new TestingFlinkKubeClient.MockKubernetesWatch();
+                                return CompletableFuture.supplyAsync(
+                                        TestingFlinkKubeClient.MockKubernetesWatch::new);
                             }
                         });
                 runTest(
@@ -383,7 +384,7 @@ class KubernetesResourceManagerDriverTest
                                                 }
                                             };
                                     podsWatches.add(watch);
-                                    return watch;
+                                    return CompletableFuture.supplyAsync(() -> watch);
                                 })
                         .setStopAndCleanupClusterConsumer(stopAndCleanupClusterFuture::complete)
                         .setCreateTaskManagerPodFunction(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/TestingFlinkKubeClient.java
@@ -52,7 +52,9 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     private final Consumer<String> stopAndCleanupClusterConsumer;
     private final Function<Map<String, String>, List<KubernetesPod>> getPodsWithLabelsFunction;
     private final BiFunction<
-                    Map<String, String>, WatchCallbackHandler<KubernetesPod>, KubernetesWatch>
+                    Map<String, String>,
+                    WatchCallbackHandler<KubernetesPod>,
+                    CompletableFuture<KubernetesWatch>>
             watchPodsAndDoCallbackFunction;
     private final Function<KubernetesConfigMap, CompletableFuture<Void>> createConfigMapFunction;
     private final Function<String, Optional<KubernetesConfigMap>> getConfigMapFunction;
@@ -77,7 +79,10 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
             Function<String, CompletableFuture<Void>> stopPodFunction,
             Consumer<String> stopAndCleanupClusterConsumer,
             Function<Map<String, String>, List<KubernetesPod>> getPodsWithLabelsFunction,
-            BiFunction<Map<String, String>, WatchCallbackHandler<KubernetesPod>, KubernetesWatch>
+            BiFunction<
+                            Map<String, String>,
+                            WatchCallbackHandler<KubernetesPod>,
+                            CompletableFuture<KubernetesWatch>>
                     watchPodsAndDoCallbackFunction,
             Function<KubernetesConfigMap, CompletableFuture<Void>> createConfigMapFunction,
             Function<String, Optional<KubernetesConfigMap>> getConfigMapFunction,
@@ -149,7 +154,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
     }
 
     @Override
-    public KubernetesWatch watchPodsAndDoCallback(
+    public CompletableFuture<KubernetesWatch> watchPodsAndDoCallback(
             Map<String, String> labels, WatchCallbackHandler<KubernetesPod> podCallbackHandler) {
         return watchPodsAndDoCallbackFunction.apply(labels, podCallbackHandler);
     }
@@ -218,8 +223,12 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
         private Function<Map<String, String>, List<KubernetesPod>> getPodsWithLabelsFunction =
                 (ignore) -> Collections.emptyList();
         private BiFunction<
-                        Map<String, String>, WatchCallbackHandler<KubernetesPod>, KubernetesWatch>
-                watchPodsAndDoCallbackFunction = (ignore1, ignore2) -> new MockKubernetesWatch();
+                        Map<String, String>,
+                        WatchCallbackHandler<KubernetesPod>,
+                        CompletableFuture<KubernetesWatch>>
+                watchPodsAndDoCallbackFunction =
+                        (ignore1, ignore2) ->
+                                CompletableFuture.supplyAsync(MockKubernetesWatch::new);
 
         private Function<KubernetesConfigMap, CompletableFuture<Void>> createConfigMapFunction =
                 (ignore) -> FutureUtils.completedVoidFuture();
@@ -277,7 +286,7 @@ public class TestingFlinkKubeClient implements FlinkKubeClient {
                 BiFunction<
                                 Map<String, String>,
                                 WatchCallbackHandler<KubernetesPod>,
-                                KubernetesWatch>
+                                CompletableFuture<KubernetesWatch>>
                         watchPodsAndDoCallbackFunction) {
             this.watchPodsAndDoCallbackFunction =
                     Preconditions.checkNotNull(watchPodsAndDoCallbackFunction);


### PR DESCRIPTION
…ch fail



## What is the purpose of the change

prevent jm restart in case kubernetes fails to handle watch request


## Brief change log

use ExponentialBackoffRetryStrategy to retry watch


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
