### PR TITLE
[hotfix][table] Avoid sending duplicate delete record for left join when state expired

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/KeyedLookupJoinWrapper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/KeyedLookupJoinWrapper.java
@@ -150,7 +150,7 @@ public class KeyedLookupJoinWrapper extends KeyedProcessFunction<RowData, RowDat
                     RowData rightRow = uniqueState.value();
                     // should distinguish null from empty(join condition unsatisfied)
                     if (null == rightRow) {
-                        stateStaledErrorHandle(in, out);
+                        stateStaledErrorHandle();
                     } else if (!emptyRow.equals(rightRow)) {
                         collectDeleteRow(in, rightRow, out);
                         collected = true;
@@ -158,7 +158,7 @@ public class KeyedLookupJoinWrapper extends KeyedProcessFunction<RowData, RowDat
                 } else {
                     List<RowData> rightRows = state.value();
                     if (null == rightRows) {
-                        stateStaledErrorHandle(in, out);
+                        stateStaledErrorHandle();
                     } else {
                         for (RowData row : rightRows) {
                             if (!emptyRow.equals(row)) {
@@ -238,12 +238,9 @@ public class KeyedLookupJoinWrapper extends KeyedProcessFunction<RowData, RowDat
         }
     }
 
-    private void stateStaledErrorHandle(RowData in, Collector out) {
+    private void stateStaledErrorHandle() {
         if (lenient) {
             LOG.warn(STATE_CLEARED_WARN_MSG);
-            if (lookupJoinRunner.isLeftOuterJoin) {
-                lookupJoinRunner.padNullForLeftJoin(in, out);
-            }
         } else {
             throw new RuntimeException(STATE_CLEARED_WARN_MSG);
         }


### PR DESCRIPTION
## What is the purpose of the change
This is a hotfix for FLINK-34166 (which fixes KeyedLookupJoinWrapper not sending incorrect delete message for inner join when previous lookup result is empty), it cause duplicate delete message for a left join when state expired(lack of ttl expiration case before), this pr fix the state stale logic and add corresponding tests. 

## Brief change log
* reserve single pad null logic for left join when process retract message
* update related tests

## Verifying this change
* KeyedLookupJoinHarnessTest

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)