### PR TITLE
[FLINK-34194][ci] Updates test CI container to be based on Ubuntu 22.04

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
           fi
       - name: Build documentation
         run: |
-          docker run --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink && ./.github/workflows/docs.sh"
+          docker run --rm --volume "$PWD:/root/flink" mapohl/flink-ci:FLINK-34194 bash -c "cd /root/flink && ./.github/workflows/docs.sh"
       - name: Upload documentation
         uses: burnett01/rsync-deployments@5.2
         with:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ resources:
   # Container with SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17_21_maven_386
+    image: mapohl/flink-ci:FLINK-34194
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 
@@ -73,16 +73,16 @@ stages:
         parameters: # see template file for a definition of the parameters.
           stage_name: ci_build
           test_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           e2e_pool_definition:
-            vmImage: 'ubuntu-20.04'
+            vmImage: 'ubuntu-22.04'
           environment: PROFILE="-Dflink.hadoop.version=2.10.2"
           run_end_to_end: false
           container: flink-build-container
           jdk: 8
       - job: docs_404_check # run on a MSFT provided machine
         pool:
-          vmImage: 'ubuntu-20.04'
+          vmImage: 'ubuntu-22.04'
         steps:
           - task: GoTool@0
             inputs:

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -39,7 +39,7 @@ resources:
   # Container with SSL to have the same environment everywhere.
   # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17_21_maven_386
+    image: mapohl/flink-ci:FLINK-34194
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository


### PR DESCRIPTION
## What is the purpose of the change

The GitHub Actions workflow (FLINK-33901) requires us to upgrade to Ubuntu 22.04 (or 20.04) (see further details in sub-issue FLINK-33923). The Azure Pipeline's Docker image is currently relying on 16.04. The e2e tests in the Azure Pipeline are actually relying on 20.04.

This PR is about aligning all these workflow with what we're planning to use for GitHub Actions.

The corresponding Dockerfile changes can be reviewed https://github.com/zentol/flink-ci-docker/pull/4.

We might want to wait with this change till after 1.19 was released to avoid running into suprises during the release. :thinking: 

## Brief change log

* Updates Docker container to use `mapohl/flink-ci:FLINK-34914`
* Updates test pool vmImage from 20.04 to 22.04

## Verifying this change

* CI should pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable