### PR TITLE
[FLINK-34143] Modify the effective strategy of `execution.batch.adaptive.auto-parallelism.default-source-parallelism`

### DIFF
--- a/docs/layouts/shortcodes/generated/batch_execution_configuration.html
+++ b/docs/layouts/shortcodes/generated/batch_execution_configuration.html
@@ -16,9 +16,9 @@
         </tr>
         <tr>
             <td><h5>execution.batch.adaptive.auto-parallelism.default-source-parallelism</h5></td>
-            <td style="word-wrap: break-word;">1</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The default parallelism of source vertices or the upper bound of source parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Note that <code class="highlighter-rouge">execution.batch.adaptive.auto-parallelism.max-parallelism</code> will be used if this configuration is not configured. If <code class="highlighter-rouge">execution.batch.adaptive.auto-parallelism.max-parallelism</code> is not set either, then the default parallelism set via <code class="highlighter-rouge">parallelism.default</code> will be used instead.</td>
         </tr>
         <tr>
             <td><h5>execution.batch.adaptive.auto-parallelism.enabled</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -16,9 +16,9 @@
         </tr>
         <tr>
             <td><h5>execution.batch.adaptive.auto-parallelism.default-source-parallelism</h5></td>
-            <td style="word-wrap: break-word;">1</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>The default parallelism of source vertices if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code></td>
+            <td>The default parallelism of source vertices or the upper bound of source parallelism to set adaptively if <code class="highlighter-rouge">jobmanager.scheduler</code> has been set to <code class="highlighter-rouge">AdaptiveBatch</code>. Note that <code class="highlighter-rouge">execution.batch.adaptive.auto-parallelism.max-parallelism</code> will be used if this configuration is not configured. If <code class="highlighter-rouge">execution.batch.adaptive.auto-parallelism.max-parallelism</code> is not set either, then the default parallelism set via <code class="highlighter-rouge">parallelism.default</code> will be used instead.</td>
         </tr>
         <tr>
             <td><h5>execution.batch.adaptive.auto-parallelism.enabled</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/BatchExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/BatchExecutionOptions.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.description.Description;
 import java.time.Duration;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.CoreOptions.DEFAULT_PARALLELISM;
 import static org.apache.flink.configuration.JobManagerOptions.SCHEDULER;
 import static org.apache.flink.configuration.description.TextElement.code;
 
@@ -99,17 +100,22 @@ public class BatchExecutionOptions {
     public static final ConfigOption<Integer> ADAPTIVE_AUTO_PARALLELISM_DEFAULT_SOURCE_PARALLELISM =
             key("execution.batch.adaptive.auto-parallelism.default-source-parallelism")
                     .intType()
-                    .defaultValue(1)
+                    .noDefaultValue()
                     .withDeprecatedKeys(
                             "jobmanager.adaptive-batch-scheduler.default-source-parallelism")
                     .withDescription(
                             Description.builder()
                                     .text(
-                                            "The default parallelism of source vertices if %s has been set to %s",
+                                            "The default parallelism of source vertices or the upper bound of source parallelism "
+                                                    + "to set adaptively if %s has been set to %s. Note that %s will be used if this configuration is not configured. "
+                                                    + "If %s is not set either, then the default parallelism set via %s will be used instead.",
                                             code(SCHEDULER.key()),
                                             code(
                                                     JobManagerOptions.SchedulerType.AdaptiveBatch
-                                                            .name()))
+                                                            .name()),
+                                            code(ADAPTIVE_AUTO_PARALLELISM_MAX_PARALLELISM.key()),
+                                            code(ADAPTIVE_AUTO_PARALLELISM_MAX_PARALLELISM.key()),
+                                            code(DEFAULT_PARALLELISM.key()))
                                     .build());
 
     @Documentation.Section({Documentation.Sections.EXPERT_SCHEDULING})

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDecider.java
@@ -559,7 +559,7 @@ public class DefaultVertexParallelismAndInputInfosDecider
                 configuration.get(
                         BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_AVG_DATA_VOLUME_PER_TASK),
                 configuration.get(
-                        BatchExecutionOptions
-                                .ADAPTIVE_AUTO_PARALLELISM_DEFAULT_SOURCE_PARALLELISM));
+                        BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_DEFAULT_SOURCE_PARALLELISM,
+                        maxParallelism));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, if users do not set the `execution.batch.adaptive.auto-parallelism.default-source-parallelism` configuration option, the AdaptiveBatchScheduler defaults to a parallelism of 1 for source vertices. In [FLIP-379](https://cwiki.apache.org/confluence/display/FLINK/FLIP-379%3A+Dynamic+source+parallelism+inference+for+batch+jobs#FLIP379:Dynamicsourceparallelisminferenceforbatchjobs-IntroduceDynamicParallelismInferenceinterfaceforSource), the value of `execution.batch.adaptive.auto-parallelism.default-source-parallelism` will act as the upper bound for inferring dynamic source parallelism, and continuing with the current policy is no longer appropriate.

We plan to change the effectiveness strategy of `execution.batch.adaptive.auto-parallelism.default-source-parallelism`; when the user does not set this config option, we will use the value of `execution.batch.adaptive.auto-parallelism.max-parallelism` as the upper bound for source parallelism inference. If `execution.batch.adaptive.auto-parallelism.max-parallelism` is also not configured, the value of `parallelism.default` will be used as a fallback.


## Brief change log

  - *Change the logic for determining the default source parallelism value; when `execution.batch.adaptive.auto-parallelism.default-source-parallelism` is not configured, fall back to the global max parallelism.*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added unit test in DefaultVertexParallelismAndInputInfosDeciderTest#testComputeSourceParallelismUpperBound to test  the case where default source parallelism is not configured.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
