### PR TITLE
[FLINK-34196][Connectors][FLIP-389] Annotate SingleThreadFetcherManager as PublicEvolving.

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -74,10 +74,8 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
             RecordEmitter<E, T, SplitStateT> recordEmitter,
             Configuration config,
             SourceReaderContext context) {
-        this(
-                new FutureCompletingBlockingQueue<>(
-                        config.get(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY)),
-                splitReaderSupplier,
+        super(
+                new SingleThreadFetcherManager<>(splitReaderSupplier, config),
                 recordEmitter,
                 config,
                 context);
@@ -87,7 +85,11 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
      * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
      * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
      * FutureCompletingBlockingQueue}.
+     *
+     * @deprecated Please use {@link #SingleThreadMultiplexSourceReaderBase(Supplier, RecordEmitter,
+     *     Configuration, SourceReaderContext)} instead.
      */
+    @Deprecated
     public SingleThreadMultiplexSourceReaderBase(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
@@ -106,7 +108,12 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
      * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
      * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
      * FutureCompletingBlockingQueue} and {@link SingleThreadFetcherManager}.
+     *
+     * @deprecated Please use {@link
+     *     #SingleThreadMultiplexSourceReaderBase(SingleThreadFetcherManager, RecordEmitter,
+     *     Configuration, SourceReaderContext)} instead.
      */
+    @Deprecated
     public SingleThreadMultiplexSourceReaderBase(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             SingleThreadFetcherManager<E, SplitT> splitFetcherManager,
@@ -121,7 +128,12 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
      * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
      * FutureCompletingBlockingQueue}, {@link SingleThreadFetcherManager} and {@link
      * RecordEvaluator}.
+     *
+     * @deprecated Please use {@link
+     *     #SingleThreadMultiplexSourceReaderBase(SingleThreadFetcherManager, RecordEmitter,
+     *     RecordEvaluator, Configuration, SourceReaderContext)} instead.
      */
+    @Deprecated
     public SingleThreadMultiplexSourceReaderBase(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             SingleThreadFetcherManager<E, SplitT> splitFetcherManager,
@@ -136,5 +148,33 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
                 eofRecordEvaluator,
                 config,
                 context);
+    }
+
+    /**
+     * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
+     * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
+     * FutureCompletingBlockingQueue} and {@link SingleThreadFetcherManager}.
+     */
+    public SingleThreadMultiplexSourceReaderBase(
+            SingleThreadFetcherManager<E, SplitT> splitFetcherManager,
+            RecordEmitter<E, T, SplitStateT> recordEmitter,
+            Configuration config,
+            SourceReaderContext context) {
+        super(splitFetcherManager, recordEmitter, config, context);
+    }
+
+    /**
+     * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
+     * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
+     * FutureCompletingBlockingQueue}, {@link SingleThreadFetcherManager} and {@link
+     * RecordEvaluator}.
+     */
+    public SingleThreadMultiplexSourceReaderBase(
+            SingleThreadFetcherManager<E, SplitT> splitFetcherManager,
+            RecordEmitter<E, T, SplitStateT> recordEmitter,
+            @Nullable RecordEvaluator<T> eofRecordEvaluator,
+            Configuration config,
+            SourceReaderContext context) {
+        super(splitFetcherManager, recordEmitter, eofRecordEvaluator, config, context);
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
-import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.configuration.Configuration;
@@ -41,7 +41,7 @@ import java.util.function.Supplier;
  * via the same client. In the example of the file source, there is a single thread that reads the
  * files after another.
  */
-@Internal
+@PublicEvolving
 public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
         extends SplitFetcherManager<E, SplitT> {
 
@@ -53,14 +53,13 @@ public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
      *     the same queue instance that is also passed to the {@link SourceReaderBase}.
      * @param splitReaderSupplier The factory for the split reader that connects to the source
      *     system.
-     * @deprecated Please use {@link #SingleThreadFetcherManager(FutureCompletingBlockingQueue,
-     *     Supplier, Configuration)} instead.
+     * @deprecated Please use {@link #SingleThreadFetcherManager(Supplier, Configuration)} instead.
      */
     @Deprecated
     public SingleThreadFetcherManager(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             Supplier<SplitReader<E, SplitT>> splitReaderSupplier) {
-        this(elementsQueue, splitReaderSupplier, new Configuration());
+        super(elementsQueue, splitReaderSupplier, new Configuration());
     }
 
     /**
@@ -72,7 +71,9 @@ public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
      * @param splitReaderSupplier The factory for the split reader that connects to the source
      *     system.
      * @param configuration The configuration to create the fetcher manager.
+     * @deprecated Please use {@link #SingleThreadFetcherManager(Supplier, Configuration)} instead.
      */
+    @Deprecated
     public SingleThreadFetcherManager(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
@@ -90,14 +91,54 @@ public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
      *     system.
      * @param configuration The configuration to create the fetcher manager.
      * @param splitFinishedHook Hook for handling finished splits in split fetchers
+     * @deprecated Please use {@link #SingleThreadFetcherManager(Supplier, Configuration, Consumer)}
+     *     instead.
      */
     @VisibleForTesting
+    @Deprecated
     public SingleThreadFetcherManager(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
             Configuration configuration,
             Consumer<Collection<String>> splitFinishedHook) {
         super(elementsQueue, splitReaderSupplier, configuration, splitFinishedHook);
+    }
+
+    /**
+     * Creates a new SplitFetcherManager with a single I/O threads.
+     *
+     * @param splitReaderSupplier The factory for the split reader that connects to the source
+     *     system.
+     */
+    public SingleThreadFetcherManager(Supplier<SplitReader<E, SplitT>> splitReaderSupplier) {
+        super(splitReaderSupplier, new Configuration());
+    }
+
+    /**
+     * Creates a new SplitFetcherManager with a single I/O threads.
+     *
+     * @param splitReaderSupplier The factory for the split reader that connects to the source
+     *     system.
+     * @param configuration The configuration to create the fetcher manager.
+     */
+    public SingleThreadFetcherManager(
+            Supplier<SplitReader<E, SplitT>> splitReaderSupplier, Configuration configuration) {
+        super(splitReaderSupplier, configuration);
+    }
+
+    /**
+     * Creates a new SplitFetcherManager with a single I/O threads.
+     *
+     * @param splitReaderSupplier The factory for the split reader that connects to the source
+     *     system.
+     * @param configuration The configuration to create the fetcher manager.
+     * @param splitFinishedHook Hook for handling finished splits in split fetchers
+     */
+    public SingleThreadFetcherManager(
+            Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+            Configuration configuration,
+            Consumer<Collection<String>> splitFinishedHook) {
+        super(splitReaderSupplier, configuration, splitFinishedHook);
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
-import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
@@ -43,7 +43,7 @@ import java.util.function.Consumer;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** The internal fetcher runnable responsible for polling message from the external system. */
-@Internal
+@PublicEvolving
 public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(SplitFetcher.class);
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTask.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
-import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
 
 import java.io.IOException;
 
 /** An interface similar to {@link Runnable} but allows throwing exceptions and wakeup. */
-@Internal
+@PublicEvolving
 public interface SplitFetcherTask {
 
     /**

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
@@ -25,13 +25,11 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
 import org.apache.flink.connector.base.source.reader.mocks.MockBaseSource;
 import org.apache.flink.connector.base.source.reader.mocks.MockSourceReader;
 import org.apache.flink.connector.base.source.reader.mocks.MockSplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
-import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.core.io.InputStatus;
@@ -330,17 +328,13 @@ public class HybridSourceReaderTest {
         private CompletableFuture<Void> availabilityFuture = new CompletableFuture<>();
 
         public MutableFutureSourceReader(
-                FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue,
                 Supplier<SplitReader<int[], MockSourceSplit>> splitFetcherSupplier,
                 Configuration config,
                 SourceReaderContext context) {
-            super(elementsQueue, splitFetcherSupplier, config, context);
+            super(splitFetcherSupplier, config, context);
         }
 
         public static MutableFutureSourceReader createReader(SourceReaderContext readerContext) {
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
-                    new FutureCompletingBlockingQueue<>();
-
             Configuration config = new Configuration();
             config.set(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 2);
             config.set(SourceReaderOptions.SOURCE_READER_CLOSE_TIMEOUT, 30000L);
@@ -348,8 +342,7 @@ public class HybridSourceReaderTest {
                     MockSplitReader.newBuilder()
                             .setNumRecordsPerSplitPerFetch(2)
                             .setBlockingFetch(true);
-            return new MutableFutureSourceReader(
-                    elementsQueue, builder::build, config, readerContext);
+            return new MutableFutureSourceReader(builder::build, config, readerContext);
         }
 
         @Override

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -36,7 +36,6 @@ import org.apache.flink.connector.base.source.reader.mocks.TestingSourceSplit;
 import org.apache.flink.connector.base.source.reader.mocks.TestingSplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
-import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.testutils.source.reader.SourceReaderTestBase;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
@@ -82,13 +81,10 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
                         () -> {
                             final String errMsg = "Testing Exception";
 
-                            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>>
-                                    elementsQueue = new FutureCompletingBlockingQueue<>();
                             // We have to handle split changes first, otherwise fetch will not be
                             // called.
                             try (MockSourceReader reader =
                                     new MockSourceReader(
-                                            elementsQueue,
                                             () ->
                                                     new SplitReader<int[], MockSourceSplit>() {
                                                         @Override
@@ -160,8 +156,6 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 
     @Test
     void testMultipleSplitsWithDifferentFinishingMoments() throws Exception {
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
         MockSplitReader mockSplitReader =
                 MockSplitReader.newBuilder()
                         .setNumRecordsPerSplitPerFetch(2)
@@ -170,10 +164,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
                         .build();
         MockSourceReader reader =
                 new MockSourceReader(
-                        elementsQueue,
-                        () -> mockSplitReader,
-                        getConfig(),
-                        new TestingReaderContext());
+                        () -> mockSplitReader, getConfig(), new TestingReaderContext());
 
         reader.start();
 
@@ -196,8 +187,6 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 
     @Test
     void testMultipleSplitsWithSeparatedFinishedRecord() throws Exception {
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
         MockSplitReader mockSplitReader =
                 MockSplitReader.newBuilder()
                         .setNumRecordsPerSplitPerFetch(2)
@@ -206,10 +195,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
                         .build();
         MockSourceReader reader =
                 new MockSourceReader(
-                        elementsQueue,
-                        () -> mockSplitReader,
-                        getConfig(),
-                        new TestingReaderContext());
+                        () -> mockSplitReader, getConfig(), new TestingReaderContext());
 
         reader.start();
 
@@ -234,22 +220,15 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
     void testPollNextReturnMoreAvailableWhenAllSplitFetcherCloseWithLeftoverElementInQueue()
             throws Exception {
 
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
         MockSplitReader mockSplitReader =
                 MockSplitReader.newBuilder()
                         .setNumRecordsPerSplitPerFetch(1)
                         .setBlockingFetch(true)
                         .build();
         BlockingShutdownSplitFetcherManager<int[], MockSourceSplit> splitFetcherManager =
-                new BlockingShutdownSplitFetcherManager<>(
-                        elementsQueue, () -> mockSplitReader, getConfig());
+                new BlockingShutdownSplitFetcherManager<>(() -> mockSplitReader, getConfig());
         final MockSourceReader sourceReader =
-                new MockSourceReader(
-                        elementsQueue,
-                        splitFetcherManager,
-                        getConfig(),
-                        new TestingReaderContext());
+                new MockSourceReader(splitFetcherManager, getConfig(), new TestingReaderContext());
 
         // Create and add a split that only contains one record
         final MockSourceSplit split = new MockSourceSplit(0, 0, 1);
@@ -273,10 +252,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 
         MockSourceReader reader =
                 new MockSourceReader(
-                        new FutureCompletingBlockingQueue<>(),
-                        () -> mockSplitReader,
-                        new Configuration(),
-                        new TestingReaderContext());
+                        () -> mockSplitReader, new Configuration(), new TestingReaderContext());
 
         SourceOperator<Integer, MockSourceSplit> sourceOperator =
                 createTestOperator(
@@ -343,8 +319,6 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
     void testMultipleSplitsAndFinishedByRecordEvaluator() throws Exception {
         int split0End = 7;
         int split1End = 15;
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
         MockSplitReader mockSplitReader =
                 MockSplitReader.newBuilder()
                         .setNumRecordsPerSplitPerFetch(2)
@@ -353,9 +327,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
                         .build();
         MockSourceReader reader =
                 new MockSourceReader(
-                        elementsQueue,
-                        new SingleThreadFetcherManager<>(
-                                elementsQueue, () -> mockSplitReader, getConfig()),
+                        new SingleThreadFetcherManager<>(() -> mockSplitReader, getConfig()),
                         getConfig(),
                         new TestingReaderContext(),
                         i -> i == split0End || i == split1End);
@@ -392,15 +364,12 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 
     @Override
     protected MockSourceReader createReader() {
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
         MockSplitReader mockSplitReader =
                 MockSplitReader.newBuilder()
                         .setNumRecordsPerSplitPerFetch(2)
                         .setBlockingFetch(true)
                         .build();
-        return new MockSourceReader(
-                elementsQueue, () -> mockSplitReader, getConfig(), new TestingReaderContext());
+        return new MockSourceReader(() -> mockSplitReader, getConfig(), new TestingReaderContext());
     }
 
     @Override
@@ -446,13 +415,9 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
     private static <E> SourceReader<E, ?> createReaderAndAwaitAvailable(
             final String splitId, final RecordsWithSplitIds<E> records) throws Exception {
 
-        final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
-
         final SourceReader<E, TestingSourceSplit> reader =
                 new SingleThreadMultiplexSourceReaderBase<
                         E, E, TestingSourceSplit, TestingSourceSplit>(
-                        elementsQueue,
                         () -> new TestingSplitReader<>(records),
                         new PassThroughRecordEmitter<>(),
                         new Configuration(),
@@ -489,6 +454,7 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
     }
 
     // ------------------ Test helper classes -------------------
+
     /**
      * When maybeShutdownFinishedFetchers is invoke, BlockingShutdownSplitFetcherManager will
      * complete the inShutdownSplitFetcherFuture and ensures that all the split fetchers are
@@ -500,10 +466,8 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
         private final CompletableFuture<Void> inShutdownSplitFetcherFuture;
 
         public BlockingShutdownSplitFetcherManager(
-                FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
-                Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
-                Configuration configuration) {
-            super(elementsQueue, splitReaderSupplier, configuration);
+                Supplier<SplitReader<E, SplitT>> splitReaderSupplier, Configuration configuration) {
+            super(splitReaderSupplier, configuration);
             this.inShutdownSplitFetcherFuture = new CompletableFuture<>();
         }
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockBaseSource.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockBaseSource.java
@@ -27,9 +27,7 @@ import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
-import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -66,8 +64,6 @@ public class MockBaseSource implements Source<Integer, MockSourceSplit, List<Moc
 
     @Override
     public SourceReader<Integer, MockSourceSplit> createReader(SourceReaderContext readerContext) {
-        FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
-                new FutureCompletingBlockingQueue<>();
 
         Configuration config = new Configuration();
         config.set(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 1);
@@ -76,7 +72,7 @@ public class MockBaseSource implements Source<Integer, MockSourceSplit, List<Moc
                 MockSplitReader.newBuilder()
                         .setNumRecordsPerSplitPerFetch(2)
                         .setBlockingFetch(true);
-        return new MockSourceReader(elementsQueue, builder::build, config, readerContext);
+        return new MockSourceReader(builder::build, config, readerContext);
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
@@ -22,11 +22,9 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordEvaluator;
-import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
-import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
 import java.util.Map;
 import java.util.function.Supplier;
@@ -37,25 +35,17 @@ public class MockSourceReader
                 int[], Integer, MockSourceSplit, MockSplitState> {
 
     public MockSourceReader(
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue,
             Supplier<SplitReader<int[], MockSourceSplit>> splitFetcherSupplier,
             Configuration config,
             SourceReaderContext context) {
-        super(
-                elementsQueue,
-                splitFetcherSupplier,
-                new MockRecordEmitter(context.metricGroup()),
-                config,
-                context);
+        super(splitFetcherSupplier, new MockRecordEmitter(context.metricGroup()), config, context);
     }
 
     public MockSourceReader(
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue,
             SingleThreadFetcherManager<int[], MockSourceSplit> splitSplitFetcherManager,
             Configuration config,
             SourceReaderContext context) {
         super(
-                elementsQueue,
                 splitSplitFetcherManager,
                 new MockRecordEmitter(context.metricGroup()),
                 config,
@@ -63,13 +53,11 @@ public class MockSourceReader
     }
 
     public MockSourceReader(
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue,
             SingleThreadFetcherManager<int[], MockSourceSplit> splitSplitFetcherManager,
             Configuration config,
             SourceReaderContext context,
             RecordEvaluator<Integer> recordEvaluator) {
         super(
-                elementsQueue,
                 splitSplitFetcherManager,
                 new MockRecordEmitter(context.metricGroup()),
                 recordEvaluator,


### PR DESCRIPTION
## What is the purpose of the change
As shown in [FLIP-389](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=278465498), this PR has 2 goals:

- To expose the SplitFetcherManager / SingleThreadFetcheManager as Public, allowing connector developers to easily create their own threading models in the SourceReaderBase.

- To hide the element queue from the connector developers and make SplitFetcherManager the only owner class of the queue



## Brief change log

- By exposing the SplitFetcherManager / SingleThreadFetcheManager, connector developers can easily create their own threading models in the SourceReaderBase, by implementing addSplits(), removeSplits() and maybeShutdownFinishedFetchers() functions.
- Note that the SplitFetcher constructor is package private, so users can only create SplitFetchers via SplitFetcherManager.createSplitFetcher(). This ensures each SplitFetcher is always owned by the SplitFetcherManager.

-  This FLIP essentially embedded the element queue (a FutureCompletingBlockingQueue) instance into the SplitFetcherManager. This hides the element queue from the connector developers and simplifies the SourceReaderBase to consist of only SplitFetcherManager and RecordEmitter as major components.

## Verifying this change
This change is already covered by existing tests, such as HybridSourceReaderTest and SplitFetcherManagerTest.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? no
  -  how is the feature documented?https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=278465498