### PR TITLE
[FLINK-34115][table-planner] Fix unstable TableAggregateITCase.testFlagAggregateWithOrWithoutIncrementalUpdate

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
@@ -37,16 +37,13 @@ import org.junit.runners.Parameterized
 @RunWith(classOf[Parameterized])
 class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode) {
 
+  var myTable: Table = _
+
   @Before
   override def before(): Unit = {
     super.before()
     tEnv.getConfig.setIdleStateRetentionTime(Time.hours(1), Time.hours(2))
-  }
-
-  @Test
-  def testFlagAggregateWithOrWithoutIncrementalUpdate(): Unit = {
-    // Create a Table from the array of Rows
-    val table = tEnv.fromValues(
+    myTable = tEnv.fromValues(
       DataTypes.ROW(
         DataTypes.FIELD("id", DataTypes.INT),
         DataTypes.FIELD("name", DataTypes.STRING),
@@ -57,12 +54,12 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       row(4, "Mocha", 8: java.lang.Integer),
       row(5, "Tea", 4: java.lang.Integer)
     )
+  }
 
-    // Register the table aggregate function
+  @Test
+  def testFlatAggregateWithoutIncrementalUpdate(): Unit = {
+    // Register the table aggregate function which does not implement emitUpdateWithRetract
     tEnv.createTemporarySystemFunction("top2", new JavaUserDefinedTableAggFunctions.Top2)
-    tEnv.createTemporarySystemFunction(
-      "incrementalTop2",
-      new JavaUserDefinedTableAggFunctions.IncrementalTop2)
 
     checkRank(
       "top2",
@@ -90,6 +87,13 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
         "(true,6,2)"
       )
     )
+  }
+
+  @Test
+  def testFlatAggregateWithIncrementalUpdate(): Unit = {
+    tEnv.createTemporarySystemFunction(
+      "incrementalTop2",
+      new JavaUserDefinedTableAggFunctions.IncrementalTop2)
     checkRank(
       "incrementalTop2",
       List(
@@ -107,18 +111,18 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
         "(true,6,2)"
       )
     )
+  }
 
-    def checkRank(func: String, expectedResult: List[String]): Unit = {
-      val resultTable =
-        table
-          .flatAggregate(call(func, $("price")).as("top_price", "rank"))
-          .select($("top_price"), $("rank"))
+  def checkRank(func: String, expectedResult: List[String]): Unit = {
+    val resultTable =
+      myTable
+        .flatAggregate(call(func, $("price")).as("top_price", "rank"))
+        .select($("top_price"), $("rank"))
 
-      val sink = new TestingRetractSink()
-      resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
-      env.execute()
-      assertEquals(expectedResult, sink.getRawResults)
-    }
+    val sink = new TestingRetractSink()
+    resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    assertEquals(expectedResult, sink.getRawResults)
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

See  #24172 for more details.

(cherry picked from commit ecd7efc2522b7640ec8d561ee8607c971cd714e7)

## Brief change log
Split test cases and fix typo.

## Verifying this change
The CI should pass and no more unstable cases occur.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializer: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
