### PR TITLE
[FLINK-34209] Migrate FileSink to the new SinkV2 API

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
@@ -26,9 +26,12 @@ import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.api.common.serialization.Encoder;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.Committer;
-import org.apache.flink.api.connector.sink2.StatefulSink;
-import org.apache.flink.api.connector.sink2.StatefulSink.WithCompatibleState;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.CommitterInitContext;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
+import org.apache.flink.api.connector.sink2.SupportsWriterState;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.api.java.typeutils.EitherTypeInfo;
 import org.apache.flink.connector.file.sink.committer.FileCommitter;
 import org.apache.flink.connector.file.sink.compactor.FileCompactStrategy;
@@ -48,7 +51,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
-import org.apache.flink.streaming.api.connector.sink2.WithPreCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreCommitTopology;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
@@ -128,10 +131,11 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @Experimental
 public class FileSink<IN>
-        implements StatefulSink<IN, FileWriterBucketState>,
-                TwoPhaseCommittingSink<IN, FileSinkCommittable>,
-                WithCompatibleState,
-                WithPreCommitTopology<IN, FileSinkCommittable>,
+        implements Sink<IN>,
+                SupportsWriterState<IN, FileWriterBucketState>,
+                SupportsCommitter<FileSinkCommittable>,
+                SupportsWriterState.WithCompatibleState,
+                SupportsPreCommitTopology<FileSinkCommittable, FileSinkCommittable>,
                 SupportsConcurrentExecutionAttempts {
 
     private final BucketsBuilder<IN, ? extends BucketsBuilder<IN, ?>> bucketsBuilder;
@@ -141,13 +145,18 @@ public class FileSink<IN>
     }
 
     @Override
-    public FileWriter<IN> createWriter(InitContext context) throws IOException {
+    public SinkWriter<IN> createWriter(InitContext context) throws IOException {
+        throw new UnsupportedOperationException("Not supported");
+    }
+
+    @Override
+    public FileWriter<IN> createWriter(WriterInitContext context) throws IOException {
         return restoreWriter(context, Collections.emptyList());
     }
 
     @Override
     public FileWriter<IN> restoreWriter(
-            InitContext context, Collection<FileWriterBucketState> recoveredState)
+            WriterInitContext context, Collection<FileWriterBucketState> recoveredState)
             throws IOException {
         FileWriter<IN> writer = bucketsBuilder.createWriter(context);
         writer.initializeState(recoveredState);
@@ -167,7 +176,8 @@ public class FileSink<IN>
     }
 
     @Override
-    public Committer<FileSinkCommittable> createCommitter() throws IOException {
+    public Committer<FileSinkCommittable> createCommitter(CommitterInitContext context)
+            throws IOException {
         return bucketsBuilder.createCommitter();
     }
 
@@ -181,6 +191,11 @@ public class FileSink<IN>
             // IOException.
             throw new FlinkRuntimeException("Could not create committable serializer.", e);
         }
+    }
+
+    @Override
+    public SimpleVersionedSerializer<FileSinkCommittable> getWriteResultSerializer() {
+        return getCommittableSerializer();
     }
 
     @Override
@@ -291,7 +306,7 @@ public class FileSink<IN>
         }
 
         @Internal
-        abstract FileWriter<IN> createWriter(final InitContext context) throws IOException;
+        abstract FileWriter<IN> createWriter(final WriterInitContext context) throws IOException;
 
         @Internal
         abstract FileCommitter createCommitter() throws IOException;
@@ -409,7 +424,7 @@ public class FileSink<IN>
         }
 
         @Override
-        FileWriter<IN> createWriter(InitContext context) throws IOException {
+        FileWriter<IN> createWriter(WriterInitContext context) throws IOException {
             OutputFileConfig writerFileConfig;
             if (compactStrategy == null) {
                 writerFileConfig = outputFileConfig;
@@ -603,7 +618,7 @@ public class FileSink<IN>
         }
 
         @Override
-        FileWriter<IN> createWriter(InitContext context) throws IOException {
+        FileWriter<IN> createWriter(WriterInitContext context) throws IOException {
             OutputFileConfig writerFileConfig;
             if (compactStrategy == null) {
                 writerFileConfig = outputFileConfig;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/FileWriter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/FileWriter.java
@@ -21,9 +21,9 @@ package org.apache.flink.connector.file.sink.writer;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.api.connector.sink2.CommittingSinkWriter;
 import org.apache.flink.api.connector.sink2.SinkWriter;
-import org.apache.flink.api.connector.sink2.StatefulSink.StatefulSinkWriter;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
+import org.apache.flink.api.connector.sink2.StatefulSinkWriter;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.connector.file.sink.FileSinkCommittable;
 import org.apache.flink.core.fs.Path;
@@ -62,7 +62,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 @Internal
 public class FileWriter<IN>
         implements StatefulSinkWriter<IN, FileWriterBucketState>,
-                TwoPhaseCommittingSink.PrecommittingSinkWriter<IN, FileSinkCommittable>,
+                CommittingSinkWriter<IN, FileSinkCommittable>,
                 SinkWriter<IN>,
                 ProcessingTimeService.ProcessingTimeCallback {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -41,7 +41,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.apache.flink.configuration.ConfigOptions.key;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -74,7 +74,7 @@ import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.translators.CacheTransformationTranslator;
 import org.apache.flink.streaming.util.NoOpIntMap;
 import org.apache.flink.streaming.util.TestExpandingSink;
-import org.apache.flink.streaming.util.TestExpandingSinkWithMixin;
+import org.apache.flink.streaming.util.TestExpandingSinkDeprecated;
 import org.apache.flink.util.AbstractID;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
@@ -887,8 +887,12 @@ public class StreamGraphGeneratorTest extends TestLogger {
                                         .isEqualTo(StreamExchangeMode.UNDEFINED));
     }
 
+    /**
+     * Should be removed along {@link org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink}.
+     */
+    @Deprecated
     @Test
-    public void testAutoParallelismForExpandedTransformations() {
+    public void testAutoParallelismForExpandedTransformationsDeprecated() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         env.setParallelism(2);
@@ -896,7 +900,7 @@ public class StreamGraphGeneratorTest extends TestLogger {
         DataStream<Integer> sourceDataStream = env.fromData(1, 2, 3);
         // Parallelism is set to -1 (default parallelism identifier) to imitate the behavior of
         // the table planner. Parallelism should be set automatically after translating.
-        sourceDataStream.sinkTo(new TestExpandingSink()).setParallelism(-1);
+        sourceDataStream.sinkTo(new TestExpandingSinkDeprecated()).setParallelism(-1);
 
         StreamGraph graph = env.getStreamGraph();
 
@@ -910,7 +914,7 @@ public class StreamGraphGeneratorTest extends TestLogger {
     }
 
     @Test
-    public void testAutoParallelismForExpandedTransformationsWithMixin() {
+    public void testAutoParallelismForExpandedTransformations() {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         env.setParallelism(2);
@@ -918,7 +922,7 @@ public class StreamGraphGeneratorTest extends TestLogger {
         DataStream<Integer> sourceDataStream = env.fromData(1, 2, 3);
         // Parallelism is set to -1 (default parallelism identifier) to imitate the behavior of
         // the table planner. Parallelism should be set automatically after translating.
-        sourceDataStream.sinkTo(new TestExpandingSinkWithMixin()).setParallelism(-1);
+        sourceDataStream.sinkTo(new TestExpandingSink()).setParallelism(-1);
 
         StreamGraph graph = env.getStreamGraph();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSink.java
@@ -21,11 +21,14 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.CommitterInitContext;
 import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.SupportsCommitter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
-import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
-import org.apache.flink.streaming.api.connector.sink2.WithPreCommitTopology;
-import org.apache.flink.streaming.api.connector.sink2.WithPreWriteTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 
@@ -34,9 +37,10 @@ import java.io.IOException;
 /** A test sink that expands into a simple subgraph. Do not use in runtime. */
 public class TestExpandingSink
         implements Sink<Integer>,
-                WithPreWriteTopology<Integer>,
-                WithPreCommitTopology<Integer, Integer>,
-                WithPostCommitTopology<Integer, Integer> {
+                SupportsCommitter<Integer>,
+                SupportsPreWriteTopology<Integer>,
+                SupportsPreCommitTopology<Integer, Integer>,
+                SupportsPostCommitTopology<Integer> {
 
     @Override
     public void addPostCommitTopology(DataStream<CommittableMessage<Integer>> committables) {
@@ -55,8 +59,12 @@ public class TestExpandingSink
     }
 
     @Override
-    public PrecommittingSinkWriter<Integer, Integer> createWriter(InitContext context)
-            throws IOException {
+    public SinkWriter<Integer> createWriter(WriterInitContext context) throws IOException {
+        return null;
+    }
+
+    @Override
+    public SinkWriter<Integer> createWriter(InitContext context) throws IOException {
         return null;
     }
 
@@ -67,6 +75,11 @@ public class TestExpandingSink
 
     @Override
     public SimpleVersionedSerializer<Integer> getCommittableSerializer() {
+        return null;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Integer> getWriteResultSerializer() {
         return null;
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSinkDeprecated.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestExpandingSinkDeprecated.java
@@ -21,26 +21,28 @@ package org.apache.flink.streaming.util;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.CommitterInitContext;
 import org.apache.flink.api.connector.sink2.Sink;
-import org.apache.flink.api.connector.sink2.SinkWriter;
-import org.apache.flink.api.connector.sink2.SupportsCommitter;
-import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
-import org.apache.flink.streaming.api.connector.sink2.SupportsPostCommitTopology;
-import org.apache.flink.streaming.api.connector.sink2.SupportsPreCommitTopology;
-import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
+import org.apache.flink.streaming.api.connector.sink2.WithPostCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.WithPreCommitTopology;
+import org.apache.flink.streaming.api.connector.sink2.WithPreWriteTopology;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 
 import java.io.IOException;
 
-/** A test sink that expands into a simple subgraph. Do not use in runtime. */
-public class TestExpandingSinkWithMixin
+/**
+ * A test sink that expands into a simple subgraph. Do not use in runtime.
+ *
+ * <p>Should be removed along with {@link
+ * org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink}
+ */
+@Deprecated
+public class TestExpandingSinkDeprecated
         implements Sink<Integer>,
-                SupportsCommitter<Integer>,
-                SupportsPreWriteTopology<Integer>,
-                SupportsPreCommitTopology<Integer, Integer>,
-                SupportsPostCommitTopology<Integer> {
+                WithPreWriteTopology<Integer>,
+                WithPreCommitTopology<Integer, Integer>,
+                WithPostCommitTopology<Integer, Integer> {
 
     @Override
     public void addPostCommitTopology(DataStream<CommittableMessage<Integer>> committables) {
@@ -59,12 +61,8 @@ public class TestExpandingSinkWithMixin
     }
 
     @Override
-    public SinkWriter<Integer> createWriter(WriterInitContext context) throws IOException {
-        return null;
-    }
-
-    @Override
-    public SinkWriter<Integer> createWriter(InitContext context) throws IOException {
+    public PrecommittingSinkWriter<Integer, Integer> createWriter(InitContext context)
+            throws IOException {
         return null;
     }
 
@@ -75,11 +73,6 @@ public class TestExpandingSinkWithMixin
 
     @Override
     public SimpleVersionedSerializer<Integer> getCommittableSerializer() {
-        return null;
-    }
-
-    @Override
-    public SimpleVersionedSerializer<Integer> getWriteResultSerializer() {
         return null;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently `FileSink` uses `TwoPhaseCommittingSink` and `StatefulSink` from the SinkV2 API. We should migrate it to use the new FLIP-372 SinkV2 API.

There are some additional changes to use the same pattern for the `Deprecated` methods/classes.


## Brief change log

Move to the new API.

## Verifying this change

Tests are updated where needed. The other tests should cover the existing code

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
