### PR TITLE
[FLINK-34145][connector/filesystem] support dynamic source parallelism inference in batch jobs

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/AbstractFileSource.java
@@ -69,7 +69,7 @@ public abstract class AbstractFileSource<T, SplitT extends FileSourceSplit>
 
     private static final long serialVersionUID = 1L;
 
-    private final Path[] inputPaths;
+    final Path[] inputPaths;
 
     private final FileEnumerator.Provider enumeratorFactory;
 
@@ -99,6 +99,10 @@ public abstract class AbstractFileSource<T, SplitT extends FileSourceSplit>
     // ------------------------------------------------------------------------
     //  Getters
     // ------------------------------------------------------------------------
+
+    FileEnumerator.Provider getEnumeratorFactory() {
+        return enumeratorFactory;
+    }
 
     public FileSplitAssigner.Provider getAssignerFactory() {
         return assignerFactory;


### PR DESCRIPTION
## What is the purpose of the change

*[FLIP-379](https://cwiki.apache.org/confluence/display/FLINK/FLIP-379%3A+Dynamic+source+parallelism+inference+for+batch+jobs) has introduced support for dynamic source parallelism inference in batch jobs, and we plan to give priority to enabling this feature for the file source connector.*


## Brief change log
  - *The FileSource implements the DynamicParallelismInference interface.*


## Verifying this change
This change is already covered by existing tests, such as *(FileSourceTextLinesITCase::testBoundedTextFileSource)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
