### PR TITLE
[FLINK-34228] Add long UTF serializer/deserializer

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/DataInputDeserializer.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/DataInputDeserializer.java
@@ -248,7 +248,24 @@ public class DataInputDeserializer implements DataInputView, java.io.Serializabl
     @Nonnull
     @Override
     public String readUTF() throws IOException {
-        int utflen = readUnsignedShort();
+        return readString(readUnsignedShort());
+    }
+
+    /**
+     * Similar to {@link #readUTF()}. The size is stored in the manner of the {@link #readInt()}
+     * method, the character conversion is the same.
+     *
+     * @return a Unicode string.
+     * @throws EOFException – if this stream reaches the end before reading all the bytes.
+     * @throws IOException – if an I/O error occurs.
+     * @throws UTFDataFormatException – if the bytes do not represent a valid modified UTF-8
+     *     encoding of a string.
+     */
+    public String readLongUTF() throws IOException {
+        return readString(readInt());
+    }
+
+    private String readString(int utflen) throws IOException {
         byte[] bytearr = new byte[utflen];
         char[] chararr = new char[utflen];
 

--- a/flink-core/src/test/java/org/apache/flink/core/memory/DataInputOutputSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/memory/DataInputOutputSerializerTest.java
@@ -27,7 +27,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayDeque;
+import java.util.Random;
 
 /** Tests for the combination of {@link DataOutputSerializer} and {@link DataInputDeserializer}. */
 public class DataInputOutputSerializerTest {
@@ -118,5 +120,35 @@ public class DataInputOutputSerializerTest {
         }
 
         reference.clear();
+    }
+
+    @Test
+    public void testLongUTFWriteRead() throws IOException {
+        byte[] array = new byte[1000];
+        new Random(1).nextBytes(array);
+        String expected = new String(array, Charset.forName("UTF-8"));
+
+        DataOutputSerializer serializer = new DataOutputSerializer(1);
+        serializer.writeLongUTF(expected);
+        DataInputDeserializer deserializer =
+                new DataInputDeserializer(serializer.getSharedBuffer());
+
+        String actual = deserializer.readLongUTF();
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testUTFWriteRead() throws IOException {
+        byte[] array = new byte[1000];
+        new Random(1).nextBytes(array);
+        String expected = new String(array, Charset.forName("UTF-8"));
+
+        DataOutputSerializer serializer = new DataOutputSerializer(1);
+        serializer.writeUTF(expected);
+        DataInputDeserializer deserializer =
+                new DataInputDeserializer(serializer.getSharedBuffer());
+
+        String actual = deserializer.readUTF();
+        Assert.assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add a way to serialize UTF8 strings where the resulting byte array is longer than 64k

## Brief change log

  - Added DataOutputSerializer.writeLongUTF
  - Added DataInputDeserializer.readLongUTF

## Verifying this change

  - Added DataInputOutputSerializerTest.testLongUTFWriteRead unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
