### PR TITLE
[FLINK-34117][bugfix][table] Fix CompactCoordinator data loss upon termination

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinator.java
@@ -152,6 +152,10 @@ public class CompactCoordinator extends AbstractStreamOperator<CoordinatorOutput
         for (Map.Entry<Long, Map<String, List<Path>>> entry : headMap.entrySet()) {
             coordinate(entry.getKey(), entry.getValue());
         }
+        if (checkpointId == Long.MAX_VALUE) {
+            coordinate(checkpointId, currentInputFiles);
+            currentInputFiles.clear();
+        }
         headMap.clear();
     }
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/stream/compact/CompactCoordinatorTest.java
@@ -84,10 +84,12 @@ class CompactCoordinatorTest extends AbstractCompactTestBase {
                     harness.open();
 
                     harness.processElement(new EndCheckpoint(2, 0, 1), 0);
-
+                    harness.processElement(new InputFile("p2", newFile("f9", 4)), 0);
+                    // Pipeline terminates
+                    harness.processElement(new EndCheckpoint(Long.MAX_VALUE, 0, 1), 0);
                     List<CoordinatorOutput> outputs = harness.extractOutputValues();
 
-                    assertThat(outputs).hasSize(7);
+                    assertThat(outputs).hasSize(9);
 
                     List<CompactionUnit> cp1Units = new ArrayList<>();
                     for (int i = 0; i < 4; i++) {
@@ -109,6 +111,8 @@ class CompactCoordinatorTest extends AbstractCompactTestBase {
                     assertUnit(outputs.get(5), 0, "p0", Arrays.asList("f7", "f8"));
 
                     assertEndCompaction(outputs.get(6), 2);
+                    assertUnit(outputs.get(7), 0, "p2", Collections.singletonList("f9"));
+                    assertEndCompaction(outputs.get(8), Long.MAX_VALUE);
                 });
     }
 


### PR DESCRIPTION
`CompactCoordinator` accumulates data in `currentInputFiles` and only rolls them into `inputFiles` when `snapshotState()` gets called. At the same time it relies on separately receiving checkpoint indications from the upstream operator via `processElement()` (`EndCheckpoint`). If the job terminates, the final `EndCheckpoint` can arrive before the `snapshotState()` gets called. This leads to data loss (all events in `currentInputFiles` get discarded).

This is a backport from the 1.19 branch: https://github.com/apache/flink/pull/24120