### PR TITLE
[FLINK-34059][docs][table] Add documentation on STATE_TTL hint

### DIFF
--- a/docs/content.zh/docs/dev/table/concepts/overview.md
+++ b/docs/content.zh/docs/dev/table/concepts/overview.md
@@ -124,6 +124,39 @@ SELECT * FROM upsert_kakfa;
 
 通过移除状态的键，连续查询会完全忘记它曾经见过这个键。如果一个状态带有曾被移除状态的键被处理了，这条记录将被认为是对应键的第一条记录。上述例子中意味着 `cnt` 会再次从 `0` 开始计数。
 
+#### 指定状态生命周期的不同方式
+<table class="table table-bordered">
+<thead>
+<tr>
+	<th class="text-left">配置方式</th>
+	<th class="text-left">TableAPI/SQL 支持</th>
+	<th class="text-left">生效范围</th>
+	<th class="text-left">优先级</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+	<td>SET 'table.exec.state.ttl' = '...' </td>
+	<td>{{<label TableAPI>}}{{<label SQL>}}</td>
+	<td>作业粒度，默认情况下所有状态算子都会使用该值控制状态生命周期</td>
+	<td>默认配置，可被覆盖</td>
+</tr>
+<tr>
+	<td>SELECT /*+ STATE_TTL(...) */ ... </td>
+	<td>{{<label SQL>}}</td>
+	<td>有限算子粒度，当前支持连接和分组聚合算子</td>
+	<td>该值将会优先作用于相应算子的状态生命周期。查阅<a href="{{< ref "docs/dev/table/sql/queries/hints" >}}#状态生命周期提示">状态生命周期提示</a>获取更多信息。</td>
+</tr>
+<tr>
+	<td>修改序列化为 JSON 的 CompiledPlan </td>
+	<td>{{<label TableAPI>}}{{<label SQL>}}</td>
+	<td>通用算子粒度, 可修改任一状态算子的生命周期</td>
+	<td>table.exec.state.ttl 和 STATE_TTL 的值将会序列化到 CompiledPlan，如果作业使用 CompiledPlan 提交，则最终生效的生命周期由最后一次修改的状态元数据决定。</td>
+</tr>
+</tbody>
+</table>
+
+
 #### 配置算子粒度的状态 TTL
 --------------------------
 {{< hint warning >}}

--- a/docs/content.zh/docs/dev/table/sql/queries/hints.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/hints.md
@@ -635,7 +635,8 @@ GROUP BY o_orderkey;
   SELECT /*+ STATE_TTL('V' = '1d', 'C' = '3d')*/ * FROM V JOIN C ON ...;
   ```
 - `STATE_TTL` 提示仅作用在当前查询块上。
-- 当 `STATE_TTL` 提示键重复时取最后一个值。举例来说，在出现 `SELECT /*+ STATE_TTL('A' = '1d', 'A' = '2d')*/ * FROM ...` 或  `SELECT /*+ STATE_TTL('A' = '1d'), STATE_TTL('A' = '3d')*/ * FROM ...` 时，TTL 值分别取 2d，3d。
+- 当 `STATE_TTL` 提示键重复时取最后一个值。举例来说，在出现 `SELECT /*+ STATE_TTL('A' = '1d', 'A' = '2d')*/ * FROM ...` 时，输入 A 的 TTL 值将会取 2d。
+- 当出现多个 `STATE_TTL` 且提示键重复时取第一个值。举例来说，在出现 `SELECT /*+ STATE_TTL('A' = '1d', 'B' = '2d'), STATE_TTL('C' = '12h', 'A' = '6h')*/ * FROM ...` 时，输入 A 的 TTL 值将会取 1d。
 {{< /hint >}}
 
 ### 什么是查询块？

--- a/docs/content/docs/dev/table/concepts/overview.md
+++ b/docs/content/docs/dev/table/concepts/overview.md
@@ -134,6 +134,39 @@ before. If a record with a key, whose state has been removed before, is processe
 be treated as if it was the first record with the respective key. For the example above this means
 that the count of a `word` would start again at `0`.
 
+#### Different Ways to Configure State TTL
+<table class="table table-bordered">
+<thead>
+<tr>
+	<th class="text-left">Configuration</th>
+	<th class="text-left">TableAPI/SQL Support</th>
+	<th class="text-left">Granularity</th>
+	<th class="text-left">Priority</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+	<td>SET 'table.exec.state.ttl' = '...' </td>
+	<td>{{<label TableAPI>}}{{<label SQL>}}</td>
+	<td>Pipeline level, all stateful operators will use the value by default.</td>
+	<td>This is the default state TTL configuration and can be overridden by enabling the STATE_TTL hint or modifying the value of the serialized CompiledPlan.</td>
+</tr>
+<tr>
+	<td>SELECT /*+ STATE_TTL(...) */ ... </td>
+	<td>{{<label SQL>}}</td>
+	<td>Operator level with only regular join and group aggregation support.</td>
+	<td>The hint precedes the default table.exec.state.ttl. This value will be serialized to the CompiledPlan during the plan translation phase. See more at <a href="{{< ref "docs/dev/table/sql/queries/hints" >}}#state-ttl-hints">State TTL Hint</a>. </td>
+</tr>
+<tr>
+	<td>Modify serialized JSON content of CompiledPlan </td>
+	<td>{{<label TableAPI>}}{{<label SQL>}}</td>
+	<td>Operator level with a generalized support. The TTL for each stateful operator is explicitly serialized as an entry of the JSON. Modifying the JSON file can change the TTL for any stateful operator.</td>
+	<td>The TTL in CompiledPlan derives from either table.exec.state.ttl or STATE_TTL hint. If the job is submitted via CompiledPlan, 
+the ultimate TTL value is decided by the last modified state metadata.</td>
+</tr>
+</tbody>
+</table>
+
 #### Configure Operator-level State TTL
 --------------------------
 {{< hint warning >}}
@@ -145,15 +178,14 @@ If the pipeline only uses one state, you only need to set [`table.exec.state.ttl
 at pipeline level.
 {{< /hint >}}
 
-From Flink v1.18, Table API & SQL supports configuring fine-grained state TTL at operator-level to improve the state usage. 
+Table API & SQL supports configuring fine-grained state TTL at operator-level to improve the state usage. 
 The configurable granularity is defined as the number of incoming input edges for each state operator. 
 Specifically, `OneInputStreamOperator` can configure the TTL for one state, while `TwoInputStreamOperator` (such as regular join), which has two inputs, can configure the TTL for the left and right states separately. 
 More generally, for `MultipleInputStreamOperator` which has K inputs, K state TTLs can be configured.
 
 Typical use cases are as follows: 
 - Set different TTLs for [regular joins]({{< ref "docs/dev/table/sql/queries/joins" >}}#regular-joins). 
-Regular join generates a `TwoInputStreamOperator` with left state to keep left input and right state to keep right input. From Flink v1.18,
-you can set the different state TTL for left state and right state. 
+Regular join generates a `TwoInputStreamOperator` with left state to keep left input and right state to keep right input. You can set the different state TTL for left state and right state. 
 - Set different TTLs for different transformations within one pipeline.
 For example, there is an ETL pipeline which uses `ROW_NUMBER` to perform [deduplication]({{< ref "docs/dev/table/sql/queries/deduplication" >}}),
 and then use `GROUP BY` to perform [aggregation]({{< ref "docs/dev/table/sql/queries/group-agg" >}}). 

--- a/docs/content/docs/dev/table/sql/queries/hints.md
+++ b/docs/content/docs/dev/table/sql/queries/hints.md
@@ -690,7 +690,8 @@ Note:
   SELECT /*+ STATE_TTL('V' = '1d', 'C' = '3d')*/ * FROM V JOIN C ON ...;
   ```
 - STATE_TTL hint only applies on the underlying query block.
-- When the `STATE_TTL` hint key is duplicated, the last value is applied from the last occurrence. For example, in cases like `SELECT /*+ STATE_TTL('A' = '1d', 'A' = '2d')*/ * FROM ...` or `SELECT /*+ STATE_TTL('A' = '1d'), STATE_TTL('A' = '3d')*/ * FROM ...`, the TTL values should be taken as 2d and 3d, respectively.
+- When the `STATE_TTL` hint key is duplicated, the value is applied from the last occurrence. For example, in cases like `SELECT /*+ STATE_TTL('A' = '1d', 'A' = '2d')*/ * FROM ...`, the TTL for input A will be taken as 2d.
+- When there are multiple `STATE_TTL` hints appear with duplicated hint key, the value is applied from the first occurrence. For example, in cases like `SELECT /*+ STATE_TTL('A' = '1d', 'B' = '2d'), STATE_TTL('C' = '12h', 'A' = '6h')*/ * FROM ...`, the TTL for input A will be taken as 1d.
 {{< /hint >}}
 
 ### What are query blocks ?

--- a/docs/content/docs/dev/table/sql/queries/hints.md
+++ b/docs/content/docs/dev/table/sql/queries/hints.md
@@ -686,41 +686,12 @@ Note:
   If users need to set a specific TTL value for the left state of the second join operator, the query needs to be split into query blocks like 
   ```sql
   CREATE TEMPORARY VIEW V AS 
-  SELECT /*+ STATE_TTL('A' = '${ttl_A}', 'B' = '${ttl_B}')*/ * FROM A JOIN B ON...;
-  SELECT /*+ STATE_TTL('V' = '${ttl_V}', 'C' = '${ttl_C}')*/ * FROM V JOIN C ON ...;
+  SELECT /*+ STATE_TTL('A' = '1d', 'B' = '12h')*/ * FROM A JOIN B ON...;
+  SELECT /*+ STATE_TTL('V' = '1d', 'C' = '3d')*/ * FROM V JOIN C ON ...;
   ```
 - STATE_TTL hint only applies on the underlying query block.
-  {{< /hint >}}
-
-#### Different ways to configure state TTL for SQL pipeline
-<table class="table table-bordered">
-<thead>
-<tr>
-	<th class="text-left">configuration</th>
-	<th class="text-left">granularity</th>
-	<th class="text-left">priority</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-	<td>SET 'table.exec.state.ttl' = '...' </td>
-	<td>The value applies to the whole pipeline, all stateful operators will use the value as state TTL by default. </td>
-	<td>This is the default state TTL configuration and can be overridden by enabling the STATE_TTL hint or modifying the value of the serialized CompiledPlan.</td>
-</tr>
-<tr>
-	<td>SELECT /*+ STATE_TTL(...) */ ... </td>
-	<td>The value only applies to some certain operators (join and group aggregate at present).</td>
-	<td>The hint precedes the default table.exec.state.ttl. This value will be serialized to the CompiledPlan during the plan translation phase.</td>
-</tr>
-<tr>
-	<td>Modify serialized JSON content of CompiledPlan </td>
-	<td>The TTL for each stateful operator is explicitly serialized as an entry of the JSON. Modifying the JSON file can change the TTL for any stateful operator.</td>
-	<td>The TTL in CompiledPlan derives from either table.exec.state.ttl or STATE_TTL hint. If the job is submitted via CompiledPlan, 
-the ultimate TTL value is decided by the last modified state metadata. See more at <a href="{{< ref "docs/dev/table/concepts/overview" >}}#configure-operator-level-state-ttl">Configure Operator-level State TTL</a>. </td>
-</tr>
-</tbody>
-</table>
-
+- When the `STATE_TTL` hint key is duplicated, the last value is applied from the last occurrence. For example, in cases like `SELECT /*+ STATE_TTL('A' = '1d', 'A' = '2d')*/ * FROM ...` or `SELECT /*+ STATE_TTL('A' = '1d'), STATE_TTL('A' = '3d')*/ * FROM ...`, the TTL values should be taken as 2d and 3d, respectively.
+{{< /hint >}}
 
 ### What are query blocks ?
 


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a doc to the `STATE_TTL` hint.


## Brief change log

Add doc.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? Yes
  - If yes, how is the feature documented? docs
