### PR TITLE
[FLINK-34244] Upgrade Confluent Platform Avro Schema Registry

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -32,7 +32,6 @@ under the License.
 	<name>Flink : Formats : Avro confluent registry</name>
 
 	<properties>
-		<kafka.version>3.2.3</kafka.version>
 		<confluent.version>7.5.3</confluent.version>
 	</properties>
 

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
 	<properties>
 		<kafka.version>3.2.3</kafka.version>
-		<confluent.version>7.2.2</confluent.version>
+		<confluent.version>7.5.3</confluent.version>
 	</properties>
 
 	<repositories>

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -9,24 +9,16 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.15.3
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
-- com.google.guava:guava:30.1.1-jre
-- io.confluent:common-config:7.2.2
-- io.confluent:common-utils:7.2.2
-- io.confluent:kafka-schema-registry-client:7.2.2
+- com.google.guava:guava:32.0.1-jre
+- io.confluent:common-utils:7.5.3
+- io.confluent:kafka-schema-registry-client:7.5.3
 - org.apache.avro:avro:1.11.3
 - org.apache.commons:commons-compress:1.24.0
-- org.apache.kafka:kafka-clients:7.2.2-ccs
-- org.glassfish.jersey.core:jersey-common:2.30
+- org.apache.kafka:kafka-clients:7.5.3-ccs
 - org.xerial.snappy:snappy-java:1.1.10.4
-
-The binary distribution of this product bundles these dependencies under the Eclipse Public License - v 2.0 (https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
-
-- jakarta.annotation:jakarta.annotation-api:1.3.5
-- jakarta.ws.rs:jakarta.ws.rs-api:2.1.6
-- org.glassfish.hk2.external:jakarta.inject:2.6.1
-- org.glassfish.hk2:osgi-resource-locator:1.0.3
+- org.yaml:snakeyaml:1.33
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- com.github.luben:zstd-jni:1.5.2-1
+- com.github.luben:zstd-jni:1.5.5-1

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -35,7 +35,6 @@ under the License.
 
 	<properties>
 		<arrow.version>13.0.0</arrow.version>
-		<kafka.version>3.2.3</kafka.version>
 		<surefire.module.config><!--
 			CommonTestUtils#setEnv
 			-->--add-opens=java.base/java.util=ALL-UNNAMED <!--


### PR DESCRIPTION
## What is the purpose of the change

* Decrease tech debt 

## Brief change log

* Update used Confluent Platform version for Avro Schema Registry format

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
