### PR TITLE
[FLINK-34258][docs][table] Fix incorrect retract example for TableAggregateFunction

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -1894,7 +1894,7 @@ tab
 
 下面的例子展示了如何使用 `emitUpdateWithRetract` 方法来只发送更新的数据。为了只发送更新的结果，accumulator 保存了上一次的最大的2个值，也保存了当前最大的2个值。
 {{< hint info >}}
-注意：请不要在 `emitUpdateWithRetract` 方法中更新 accumulator，因为 `GroupTableAggFunction` 在调用过 `function#emitValue` 方法后，不会再次调用 `function#getAccumulators`。
+注意：请不要在 `emitUpdateWithRetract` 方法中更新 accumulator，因为在调用 `function#emitUpdateWithRetract` 之后，`GroupTableAggFunction` 不会重新调用 `function#getAccumulators` 来将最新的 accumulator 更新到状态中。
 {{< /hint >}}
 
 {{< tabs "e0d841fe-8d95-4706-9e19-e76141171966" >}}

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -1779,7 +1779,7 @@ The following example shows how to use the `emitUpdateWithRetract(...)` method t
 updates. In order to do so, the accumulator keeps both the old and new top 2 values.
 
 {{< hint info >}}
-Note: Do not update accumulator within `emitUpdateWithRetract` because `GroupTableAggFunction` will not re-invoke `function#getAccumulators` after `function#emitValue` is invoked.
+Note: Do not update accumulator within `emitUpdateWithRetract` because after `function#emitUpdateWithRetract` is invoked, `GroupTableAggFunction` will not re-invoke `function#getAccumulators` to update the latest accumulator to state.
 {{< /hint >}}
 
 {{< tabs "043e94c6-05b5-4800-9e5f-7d11235f3a11" >}}

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -1778,9 +1778,9 @@ def emitUpdateWithRetract(accumulator: ACC, out: RetractableCollector[T]): Unit
 The following example shows how to use the `emitUpdateWithRetract(...)` method to emit only incremental
 updates. In order to do so, the accumulator keeps both the old and new top 2 values.
 
-If the N of Top N is big, it might be inefficient to keep both the old and new values. One way to
-solve this case is to store only the input record in the accumulator in `accumulate` method and then perform
-a calculation in `emitUpdateWithRetract`.
+{{< hint info >}}
+Note: Do not update accumulator within `emitUpdateWithRetract` because `GroupTableAggFunction` will not re-invoke `function#getAccumulators` after `function#emitValue` is invoked.
+{{< /hint >}}
 
 {{< tabs "043e94c6-05b5-4800-9e5f-7d11235f3a11" >}}
 {{< tab "Java" >}}
@@ -1809,6 +1809,8 @@ public static class Top2WithRetract
   }
 
   public void accumulate(Top2WithRetractAccumulator acc, Integer v) {
+    acc.oldFirst = acc.first;
+    acc.oldSecond = acc.second;
     if (v > acc.first) {
       acc.second = acc.first;
       acc.first = v;
@@ -1826,7 +1828,6 @@ public static class Top2WithRetract
           out.retract(Tuple2.of(acc.oldFirst, 1));
       }
       out.collect(Tuple2.of(acc.first, 1));
-      acc.oldFirst = acc.first;
     }
     if (!acc.second.equals(acc.oldSecond)) {
       // if there is an update, retract the old value then emit a new value
@@ -1834,7 +1835,6 @@ public static class Top2WithRetract
           out.retract(Tuple2.of(acc.oldSecond, 2));
       }
       out.collect(Tuple2.of(acc.second, 2));
-      acc.oldSecond = acc.second;
     }
   }
 }
@@ -1866,6 +1866,8 @@ class Top2WithRetract
   }
 
   def accumulate(acc: Top2WithRetractAccumulator, value: Integer): Unit = {
+    acc.oldFirst = acc.first
+    acc.oldSecond = acc.second
     if (value > acc.first) {
       acc.second = acc.first
       acc.first = value
@@ -1884,7 +1886,6 @@ class Top2WithRetract
           out.retract(Tuple2.of(acc.oldFirst, 1))
       }
       out.collect(Tuple2.of(acc.first, 1))
-      acc.oldFirst = acc.first
     }
     if (!acc.second.equals(acc.oldSecond)) {
       // if there is an update, retract the old value then emit a new value
@@ -1892,7 +1893,6 @@ class Top2WithRetract
           out.retract(Tuple2.of(acc.oldSecond, 2))
       }
       out.collect(Tuple2.of(acc.second, 2))
-      acc.oldSecond = acc.second
     }
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR corrects the Retract Example in [TableAggregateFunction](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/functions/udfs/#retraction-example).

This is because `GroupTableAggFuction` will not reinvoke `getAccumulators` after `emitValue` is called.

See GroupTableAggFuction L#142~ L#146
```java
// get accumulator
accumulators = function.getAccumulators(); // function
if (!recordCounter.recordCountIsZero(accumulators)) {
    function.emitValue(out, currentKey, false); 
    // update the state
    accState.update(accumulators);

}
```

## Brief change log

Update doc


## Verifying this change

The old example cannot generate the expected results. After correcting the example, it works.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
