### PR TITLE
[FLINK-34115][table-planner] Fix TableAggregateITCase unstable test

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -283,6 +283,14 @@ object TestData {
 
   lazy val data3: Seq[Row] = tupleData3.map(d => row(d.productIterator.toList: _*))
 
+  lazy val tupleData4: Seq[Row] = Seq(
+    row(1, "Latte", 6),
+    row(2, "Milk", 3),
+    row(3, "Breve", 5),
+    row(4, "Mocha", 8),
+    row(5, "Tea", 4)
+  )
+
   val nullablesOfData3 = Array(true, true, true)
 
   val nullablesOfData4 = Array(true, true, true)


### PR DESCRIPTION
## What is the purpose of the change

This PR tries to fix the unstable ITCase `TableAggregateITCase`.


## Brief change log

Replace table source.

## Verifying this change

- Plan before fix
```sql
Calc(select=[f0 AS top_price, f1 AS rank], changelogMode=[I,UA,D])
+- GroupTableAggregate(select=[incrementalTop2(price) AS (f0, f1)], changelogMode=[I,UA,D])
   +- Exchange(distribution=[single], changelogMode=[I])
      +- Union(all=[true], union=[id, name, price], changelogMode=[I])
         :- Calc(select=[CAST(1 AS INTEGER) AS id, CAST(_UTF-16LE'Latte':VARCHAR(2147483647) CHARACTER SET "UTF-16LE" AS VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS name, CAST(6 AS INTEGER) AS price], changelogMode=[I])
         :  +- Values(type=[RecordType(INTEGER ZERO)], tuples=[[{ 0 }]], changelogMode=[I])
         :- Calc(select=[CAST(2 AS INTEGER) AS id, CAST(_UTF-16LE'Milk':VARCHAR(2147483647) CHARACTER SET "UTF-16LE" AS VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS name, CAST(3 AS INTEGER) AS price], changelogMode=[I])
         :  +- Values(type=[RecordType(INTEGER ZERO)], tuples=[[{ 0 }]], changelogMode=[I])
         :- Calc(select=[CAST(3 AS INTEGER) AS id, CAST(_UTF-16LE'Breve':VARCHAR(2147483647) CHARACTER SET "UTF-16LE" AS VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS name, CAST(5 AS INTEGER) AS price], changelogMode=[I])
         :  +- Values(type=[RecordType(INTEGER ZERO)], tuples=[[{ 0 }]], changelogMode=[I])
         :- Calc(select=[CAST(4 AS INTEGER) AS id, CAST(_UTF-16LE'Mocha':VARCHAR(2147483647) CHARACTER SET "UTF-16LE" AS VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS name, CAST(8 AS INTEGER) AS price], changelogMode=[I])
         :  +- Values(type=[RecordType(INTEGER ZERO)], tuples=[[{ 0 }]], changelogMode=[I])
         +- Calc(select=[CAST(5 AS INTEGER) AS id, CAST(_UTF-16LE'Tea':VARCHAR(2147483647) CHARACTER SET "UTF-16LE" AS VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS name, CAST(4 AS INTEGER) AS price], changelogMode=[I])
            +- Values(type=[RecordType(INTEGER ZERO)], tuples=[[{ 0 }]], changelogMode=[I])
```

- Plan after fix
```sql
Calc(select=[f0 AS top_price, f1 AS rank])
+- GroupTableAggregate(select=[incrementalTop2(price) AS (f0, f1)])
   +- Exchange(distribution=[single])
      +- TableSourceScan(table=[[default_catalog, default_database, myTable]], fields=[id, name, price])
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable