### PR TITLE
[FLINK-34206][runtime][test] Fix potential job failure with simultaneous global failover and task finish

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexVersioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionVertexVersioner.java
@@ -92,7 +92,7 @@ public class ExecutionVertexVersioner {
                                 ExecutionVertexVersion::getExecutionVertexId, Function.identity()));
     }
 
-    ExecutionVertexVersion getExecutionVertexVersion(ExecutionVertexID executionVertexId) {
+    public ExecutionVertexVersion getExecutionVertexVersion(ExecutionVertexID executionVertexId) {
         final long currentVersion = getCurrentVersion(executionVertexId);
         return new ExecutionVertexVersion(executionVertexId, currentVersion);
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/CacheITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/CacheITCase.java
@@ -48,7 +48,6 @@ import org.apache.flink.util.OutputTag;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -218,7 +217,6 @@ public class CacheITCase extends AbstractTestBase {
     }
 
     @Test
-    @Disabled
     void testRetryOnCorruptedClusterDataset(@TempDir java.nio.file.Path tmpDir) throws Exception {
         File file = prepareTestData(tmpDir);
 


### PR DESCRIPTION
## What is the purpose of the change

*Fix potential job failure with simultaneous global failover and task finish in adaptive batch scheduler.*


## Brief change log

  - *Check execution vertex version is modified or not when executre onTaskFinished() method*
  - *Check job state is `CREATED` in startSchedulingInternal().*
  - *Remove disabled() annotation at CacheITCase#testRetryOnCorruptedClusterDataset.*


## Verifying this change
This change is already covered by existing tests, such as *CacheITCase#testRetryOnCorruptedClusterDataset*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
