### PR TITLE
[FLINK-34286][k8s] Attach cluster config map labels at creation time

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriver.java
@@ -45,7 +45,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.KubernetesUtils.getOnlyConfigMap;
 
 /** {@link LeaderElectionDriver} for Kubernetes. */
@@ -62,9 +61,6 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
     private final LeaderElectionDriver.Listener leaderElectionListener;
 
     private final KubernetesLeaderElector leaderElector;
-
-    // Labels will be used to clean up the ha related ConfigMaps.
-    private final Map<String, String> configMapLabels;
 
     private final KubernetesSharedWatcher.Watch kubernetesWatch;
 
@@ -88,11 +84,6 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
         this.leaderElector =
                 kubeClient.createLeaderElector(
                         leaderElectionConfiguration, new LeaderCallbackHandlerImpl());
-
-        this.configMapLabels =
-                KubernetesUtils.getConfigMapLabels(
-                        leaderElectionConfiguration.getClusterId(),
-                        LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY);
 
         kubernetesWatch =
                 configMapSharedWatcher.watch(
@@ -174,7 +165,6 @@ public class KubernetesLeaderElectionDriver implements LeaderElectionDriver {
                             KubernetesUtils.encodeLeaderInformation(leaderInformation));
                 }
 
-                kubernetesConfigMap.getLabels().putAll(configMapLabels);
                 return Optional.of(kubernetesConfigMap);
             }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/highavailability/KubernetesLeaderElectionDriverTest.java
@@ -29,12 +29,9 @@ import org.apache.flink.runtime.leaderelection.LeaderInformationRegister;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
-import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_KEY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_ADDRESS_KEY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_SESSION_ID_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -249,26 +246,6 @@ class KubernetesLeaderElectionDriverTest extends KubernetesHighAvailabilityTestB
                             assertThat(errorEvent.getError())
                                     .isInstanceOf(LeaderElectionException.class)
                                     .hasMessage(expectedErrorMessage);
-                        });
-            }
-        };
-    }
-
-    @Test
-    void testHighAvailabilityLabelsCorrectlySet() throws Exception {
-        new Context() {
-            {
-                runTest(
-                        () -> {
-                            leaderCallbackGrantLeadership();
-
-                            final Map<String, String> leaderLabels =
-                                    getLeaderConfigMap().getLabels();
-                            assertThat(leaderLabels).hasSize(3);
-                            assertThat(leaderLabels)
-                                    .containsEntry(
-                                            LABEL_CONFIGMAP_TYPE_KEY,
-                                            LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY);
                         });
             }
         };


### PR DESCRIPTION
Move the attachment of config map labels for cluster config maps to the leader elector, which causes them to be set at creation time, instead of when the JM acquires leadership for the first time.