### PR TITLE
[BP-1.18][FLINK-33915][ci] Adds nightly workflow for the releae-1.18 branch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow is meant as an extended CI run that includes certain features that shall be tested
+# and JDK versions that are supported but not considered default.
+
+name: "Nightly (beta)"
+
+on:
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  pre-compile-checks:
+    name: "Pre-compile Checks"
+    uses: ./.github/workflows/template.pre-compile-checks.yml
+
+  java8:
+    name: "Java 8"
+    uses: ./.github/workflows/template.flink-ci.yml
+    with:
+      workflow-caller-id: java8
+      environment: 'PROFILE="-Dinclude_hadoop_aws"'
+      jdk_version: 8
+    secrets:
+      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
+      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
+      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
+  java11:
+    name: "Java 11"
+    uses: ./.github/workflows/template.flink-ci.yml
+    with:
+      workflow-caller-id: java11
+      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk11 -Pjava11-target"'
+      jdk_version: 11
+    secrets:
+      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
+      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
+      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
+  java17:
+    name: "Java 17"
+    uses: ./.github/workflows/template.flink-ci.yml
+    with:
+      workflow-caller-id: java17
+      environment: 'PROFILE="-Dinclude_hadoop_aws -Djdk11 -Djdk17 -Pjava17-target"'
+      jdk_version: 17
+    secrets:
+      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
+      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
+      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
+  hadoop313:
+    name: "Hadoop 3.1.3"
+    uses: ./.github/workflows/template.flink-ci.yml
+    with:
+      workflow-caller-id: hadoop313
+      environment: 'PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3"'
+      jdk_version: 8
+    secrets:
+      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
+      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
+      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
+  adaptive-scheduler:
+    name: "AdaptiveScheduler"
+    uses: ./.github/workflows/template.flink-ci.yml
+    with:
+      workflow-caller-id: adaptive-scheduler
+      environment: 'PROFILE="-Penable-adaptive-scheduler"'
+      jdk_version: 8
+    secrets:
+      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
+      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
+      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}


### PR DESCRIPTION
## What is the purpose of the change

1.18 backport of FLINK-33915 excluding the JDK 21 workflow


## Brief change log

* Cherry-pick of FLINK-33915 excluding the JDK 21 workflow


## Verifying this change

* Azure Pipelines should succeed.
* GHA workflow should succeed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable