### PR TITLE
[FLINK-33396][table-planner] Fix table alias not be cleared in subquery

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
@@ -58,7 +58,8 @@ import java.util.Optional;
  *       </ol>
  *   <li>Validate and modify query hints: The query hints are validated, and table names in the
  *       hints are replaced with LEFT or RIGHT to indicate the join input ordinal.
- *   <li>Clear query block aliases: The query block aliases are cleared from the sink to the source.
+ *   <li>Clear query block aliases: The query block aliases are cleared from the sink to the source
+ *       and within sub-queries.
  *   <li>Consume query hints in applicable scenes. For example, the join hints are consumed in
  *       specific rules where they are relevant.
  * </ol>

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.planner.utils.TableTestBase;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 
 import org.apache.calcite.rel.RelNode;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -100,5 +101,25 @@ class ClearQueryBlockAliasResolverTest extends JoinHintTestBase {
         ClearQueryBlockAliasResolver clearQueryBlockAliasResolver =
                 new ClearQueryBlockAliasResolver();
         return clearQueryBlockAliasResolver.resolve(relNodes);
+    }
+
+    @Test
+    void testNotClearTableHintsWithQueryHintsExist() {
+        // If there are query hints, table alias will be added. And the table hints should not be
+        // cleared.
+        String sql =
+                "select * from (select /*+ BROADCAST(T1) */ T1.* from T1 join T2/*+ OPTIONS('bounded' = 'true') */ on T1.a1 = T2.a2)";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    void testNotClearTableHintsWithQueryHintsNotExist() {
+        // If there are no query hints, table alias is no need to be added. Then the table hints
+        // should not be cleared.
+        String sql =
+                "select * from (select T1.* from T1 join T2/*+ OPTIONS('bounded' = 'true') */ on T1.a1 = T2.a2)";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/BroadcastJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/BroadcastJoinHintTest.xml
@@ -412,7 +412,7 @@ LogicalProject(a2=[$0])
 NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1, a2))], select=[a1, b1], build=[right])
 :- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -435,7 +435,7 @@ LogicalProject(a2=[$0])
 NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1, a2))], select=[a1, b1], build=[right])
 :- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -640,7 +640,7 @@ LogicalProject(EXPR$0=[$1])
       <![CDATA[
 HashJoin(joinType=[LeftSemiJoin], where=[=(a1, EXPR$0)], select=[a1, b1], build=[right], tryDistinctBuildRow=[true])
 :- Exchange(distribution=[hash[a1]])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 +- Exchange(distribution=[hash[EXPR$0]])
    +- LocalHashAggregate(groupBy=[EXPR$0], select=[EXPR$0])
       +- Calc(select=[EXPR$0])
@@ -649,8 +649,9 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, EXPR$0)], select=[a1, b1], build=
                +- LocalHashAggregate(groupBy=[a1], select=[a1, Partial_COUNT(a2) AS count$0])
                   +- HashJoin(joinType=[InnerJoin], where=[=(a2, a1)], select=[a2, a1], isBroadcast=[true], build=[left])
                      :- Exchange(distribution=[broadcast])
-                     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-                     +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+                     +- Calc(select=[a1])
+                        +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
@@ -680,8 +681,8 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
    +- Calc(select=[a2])
       +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], isBroadcast=[true], build=[left])
          :- Exchange(distribution=[broadcast])
-         :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+         :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -717,8 +718,8 @@ Calc(select=[a1, b1])
                         :- Calc(select=[a2])
                         :  +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], isBroadcast=[true], build=[left])
                         :     :- Exchange(distribution=[broadcast])
-                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-                        :     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+                        :     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
                         +- Exchange(distribution=[broadcast])
                            +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
                               +- Exchange(distribution=[hash[a1]])
@@ -770,7 +771,7 @@ LogicalProject(a2=[$0])
     <Resource name="optimized rel plan">
       <![CDATA[
 HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], isBroadcast=[true], build=[right])
-:- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+:- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
    +- Calc(select=[a2])
       +- SortLimit(orderBy=[a1 ASC], offset=[0], fetch=[10], global=[true])
@@ -778,8 +779,9 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], isBroadcas
             +- SortLimit(orderBy=[a1 ASC], offset=[0], fetch=[10], global=[false])
                +- HashJoin(joinType=[InnerJoin], where=[=(a2, a1)], select=[a2, a1], isBroadcast=[true], build=[left])
                   :- Exchange(distribution=[broadcast])
-                  :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-                  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+                  +- Calc(select=[a1])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
@@ -818,13 +820,13 @@ Calc(select=[a1, b1])
                         :- Calc(select=[a2])
                         :  +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], isBroadcast=[true], build=[left])
                         :     :- Exchange(distribution=[broadcast])
-                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :     +- Calc(select=[a3])
                         :        +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
                         :           :- Exchange(distribution=[hash[a2]])
-                        :           :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :           :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :           +- Exchange(distribution=[hash[a3]])
-                        :              +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                        :              +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
                         +- Exchange(distribution=[broadcast])
                            +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
                               +- Exchange(distribution=[hash[a1]])
@@ -859,8 +861,8 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
    +- Calc(select=[a2])
       +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], isBroadcast=[true], build=[left])
          :- Exchange(distribution=[broadcast])
-         :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+         :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1145,7 +1147,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], buil
 :  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
 :     :- Exchange(distribution=[hash[a1]])
 :     :  +- Calc(select=[a1], where=[=(b1, 'abc')])
-:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1], metadata=[]]], fields=[a1, b1])
 :     +- Exchange(distribution=[hash[a2]])
 :        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 +- Exchange(distribution=[broadcast])
@@ -1155,9 +1157,10 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], buil
             +- Calc(select=[0 AS $f0])
                +- HashJoin(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, a3], build=[left])
                   :- Exchange(distribution=[hash[a1]])
-                  :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  :  +- Calc(select=[a1])
+                  :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1], metadata=[]]], fields=[a1, b1])
                   +- Exchange(distribution=[hash[a3]])
-                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1234,7 +1237,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[
          :     +- Exchange(distribution=[single])
          :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
          :           +- Calc(select=[a1], where=[=(a1, 1)])
-         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
          +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
             +- Exchange(distribution=[single])
                +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
@@ -1243,9 +1246,9 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[
                         +- LocalHashAggregate(groupBy=[a3], select=[a3])
                            +- Union(all=[true], union=[a3])
                               :- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a1, 1)])
-                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
                               +- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a3, 1)])
-                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1421,7 +1424,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :- Exchange(distribution=[hash[a1]])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -1509,7 +1512,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :- Exchange(distribution=[hash[a1]])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/NestLoopJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/NestLoopJoinHintTest.xml
@@ -411,7 +411,7 @@ LogicalProject(a2=[$0])
 NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1, a2))], select=[a1, b1], build=[right])
 :- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -434,7 +434,7 @@ LogicalProject(a2=[$0])
 NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1, a2))], select=[a1, b1], build=[right])
 :- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -639,7 +639,7 @@ LogicalProject(EXPR$0=[$1])
       <![CDATA[
 HashJoin(joinType=[LeftSemiJoin], where=[=(a1, EXPR$0)], select=[a1, b1], build=[right], tryDistinctBuildRow=[true])
 :- Exchange(distribution=[hash[a1]])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 +- Exchange(distribution=[hash[EXPR$0]])
    +- LocalHashAggregate(groupBy=[EXPR$0], select=[EXPR$0])
       +- Calc(select=[EXPR$0])
@@ -648,8 +648,9 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, EXPR$0)], select=[a1, b1], build=
                +- LocalHashAggregate(groupBy=[a1], select=[a1, Partial_COUNT(a2) AS count$0])
                   +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a2, a1)], select=[a2, a1], build=[left])
                      :- Exchange(distribution=[broadcast])
-                     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-                     +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+                     +- Calc(select=[a1])
+                        +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
@@ -679,8 +680,8 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
    +- Calc(select=[a2])
       +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
          :- Exchange(distribution=[broadcast])
-         :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+         :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -717,8 +718,8 @@ Calc(select=[a1, b1])
                         :  +- Calc(select=[a2])
                         :     +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
                         :        :- Exchange(distribution=[broadcast])
-                        :        :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-                        :        +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                        :        :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+                        :        +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
                         +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
                            +- Exchange(distribution=[hash[a1]])
                               +- LocalHashAggregate(groupBy=[a1], select=[a1])
@@ -769,7 +770,7 @@ LogicalProject(a2=[$0])
     <Resource name="optimized rel plan">
       <![CDATA[
 HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], isBroadcast=[true], build=[right])
-:- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+:- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
    +- Calc(select=[a2])
       +- SortLimit(orderBy=[a1 ASC], offset=[0], fetch=[10], global=[true])
@@ -777,8 +778,9 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], isBroadcas
             +- SortLimit(orderBy=[a1 ASC], offset=[0], fetch=[10], global=[false])
                +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a2, a1)], select=[a2, a1], build=[left])
                   :- Exchange(distribution=[broadcast])
-                  :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-                  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+                  +- Calc(select=[a1])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
@@ -818,13 +820,13 @@ Calc(select=[a1, b1])
                         :  +- Calc(select=[a2])
                         :     +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
                         :        :- Exchange(distribution=[broadcast])
-                        :        :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :        :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :        +- Calc(select=[a3])
                         :           +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
                         :              :- Exchange(distribution=[hash[a2]])
-                        :              :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :              :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :              +- Exchange(distribution=[hash[a3]])
-                        :                 +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                        :                 +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
                         +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
                            +- Exchange(distribution=[hash[a1]])
                               +- LocalHashAggregate(groupBy=[a1], select=[a1])
@@ -858,8 +860,8 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
    +- Calc(select=[a2])
       +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
          :- Exchange(distribution=[broadcast])
-         :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
-         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+         :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1142,7 +1144,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], buil
 :  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
 :     :- Exchange(distribution=[hash[a1]])
 :     :  +- Calc(select=[a1], where=[=(b1, 'abc')])
-:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1], metadata=[]]], fields=[a1, b1])
 :     +- Exchange(distribution=[hash[a2]])
 :        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 +- Exchange(distribution=[broadcast])
@@ -1152,9 +1154,10 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], buil
             +- Calc(select=[0 AS $f0])
                +- HashJoin(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, a3], build=[left])
                   :- Exchange(distribution=[hash[a1]])
-                  :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  :  +- Calc(select=[a1])
+                  :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1], metadata=[]]], fields=[a1, b1])
                   +- Exchange(distribution=[hash[a3]])
-                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1231,7 +1234,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[
          :     +- Exchange(distribution=[single])
          :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
          :           +- Calc(select=[a1], where=[=(a1, 1)])
-         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
          +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
             +- Exchange(distribution=[single])
                +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
@@ -1240,9 +1243,9 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[
                         +- LocalHashAggregate(groupBy=[a3], select=[a3])
                            +- Union(all=[true], union=[a3])
                               :- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a1, 1)])
-                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
                               +- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a3, 1)])
-                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1418,7 +1421,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :- Exchange(distribution=[hash[a1]])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -1505,7 +1508,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :- Exchange(distribution=[hash[a1]])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleHashJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleHashJoinHintTest.xml
@@ -427,7 +427,7 @@ LogicalProject(a2=[$0])
 NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1, a2))], select=[a1, b1], build=[right])
 :- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -450,7 +450,7 @@ LogicalProject(a2=[$0])
 NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1, a2))], select=[a1, b1], build=[right])
 :- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -660,16 +660,17 @@ LogicalProject(EXPR$0=[$1])
       <![CDATA[
 HashJoin(joinType=[LeftSemiJoin], where=[=(a1, EXPR$0)], select=[a1, b1], build=[right], tryDistinctBuildRow=[true])
 :- Exchange(distribution=[hash[a1]])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 +- Exchange(distribution=[hash[EXPR$0]])
    +- LocalHashAggregate(groupBy=[EXPR$0], select=[EXPR$0])
       +- Calc(select=[EXPR$0])
          +- HashAggregate(isMerge=[false], groupBy=[a1], select=[a1, COUNT(a2) AS EXPR$0])
             +- HashJoin(joinType=[InnerJoin], where=[=(a2, a1)], select=[a2, a1], build=[left])
                :- Exchange(distribution=[hash[a2]])
-               :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+               :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                +- Exchange(distribution=[hash[a1]])
-                  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  +- Calc(select=[a1])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
@@ -698,9 +699,9 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 +- Calc(select=[a2])
    +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
       :- Exchange(distribution=[hash[a2]])
-      :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
       +- Exchange(distribution=[hash[a3]])
-         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -736,9 +737,9 @@ Calc(select=[a1, b1])
                         :- Calc(select=[a2])
                         :  +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
                         :     :- Exchange(distribution=[hash[a2]])
-                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :     +- Exchange(distribution=[hash[a3]])
-                        :        +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                        :        +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
                         +- Exchange(distribution=[broadcast])
                            +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
                               +- Exchange(distribution=[hash[a1]])
@@ -790,7 +791,7 @@ LogicalProject(a2=[$0])
     <Resource name="optimized rel plan">
       <![CDATA[
 HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], isBroadcast=[true], build=[right])
-:- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+:- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
    +- Calc(select=[a2])
       +- SortLimit(orderBy=[a1 ASC], offset=[0], fetch=[10], global=[true])
@@ -798,9 +799,10 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], isBroadcas
             +- SortLimit(orderBy=[a1 ASC], offset=[0], fetch=[10], global=[false])
                +- HashJoin(joinType=[InnerJoin], where=[=(a2, a1)], select=[a2, a1], build=[left])
                   :- Exchange(distribution=[hash[a2]])
-                  :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                  :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                   +- Exchange(distribution=[hash[a1]])
-                     +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                     +- Calc(select=[a1])
+                        +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
@@ -839,13 +841,13 @@ Calc(select=[a1, b1])
                         :- Calc(select=[a2])
                         :  +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
                         :     :- Exchange(distribution=[hash[a2]])
-                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :     +- Calc(select=[a3])
                         :        +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
                         :           :- Exchange(distribution=[hash[a2]])
-                        :           :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :           :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :           +- Exchange(distribution=[hash[a3]])
-                        :              +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                        :              +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
                         +- Exchange(distribution=[broadcast])
                            +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
                               +- Exchange(distribution=[hash[a1]])
@@ -879,9 +881,9 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 +- Calc(select=[a2])
    +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
       :- Exchange(distribution=[hash[a2]])
-      :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
       +- Exchange(distribution=[hash[a3]])
-         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1176,7 +1178,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], buil
 :  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
 :     :- Exchange(distribution=[hash[a1]])
 :     :  +- Calc(select=[a1], where=[=(b1, 'abc')])
-:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1], metadata=[]]], fields=[a1, b1])
 :     +- Exchange(distribution=[hash[a2]])
 :        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 +- Exchange(distribution=[broadcast])
@@ -1186,9 +1188,10 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], buil
             +- Calc(select=[0 AS $f0])
                +- HashJoin(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, a3], build=[left])
                   :- Exchange(distribution=[hash[a1]])
-                  :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  :  +- Calc(select=[a1])
+                  :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1], metadata=[]]], fields=[a1, b1])
                   +- Exchange(distribution=[hash[a3]])
-                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1265,7 +1268,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[
          :     +- Exchange(distribution=[single])
          :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
          :           +- Calc(select=[a1], where=[=(a1, 1)])
-         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
          +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
             +- Exchange(distribution=[single])
                +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
@@ -1274,9 +1277,9 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[
                         +- LocalHashAggregate(groupBy=[a3], select=[a3])
                            +- Union(all=[true], union=[a3])
                               :- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a1, 1)])
-                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
                               +- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a3, 1)])
-                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1453,7 +1456,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :- Exchange(distribution=[hash[a1]])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -1542,7 +1545,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :- Exchange(distribution=[hash[a1]])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleMergeJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleMergeJoinHintTest.xml
@@ -427,7 +427,7 @@ LogicalProject(a2=[$0])
 NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1, a2))], select=[a1, b1], build=[right])
 :- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -450,7 +450,7 @@ LogicalProject(a2=[$0])
 NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1, a2))], select=[a1, b1], build=[right])
 :- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -660,16 +660,17 @@ LogicalProject(EXPR$0=[$1])
       <![CDATA[
 HashJoin(joinType=[LeftSemiJoin], where=[=(a1, EXPR$0)], select=[a1, b1], build=[right], tryDistinctBuildRow=[true])
 :- Exchange(distribution=[hash[a1]])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 +- Exchange(distribution=[hash[EXPR$0]])
    +- LocalHashAggregate(groupBy=[EXPR$0], select=[EXPR$0])
       +- Calc(select=[EXPR$0])
          +- SortAggregate(isMerge=[false], groupBy=[a1], select=[a1, COUNT(a2) AS EXPR$0])
             +- SortMergeJoin(joinType=[InnerJoin], where=[=(a2, a1)], select=[a2, a1])
                :- Exchange(distribution=[hash[a2]])
-               :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+               :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                +- Exchange(distribution=[hash[a1]])
-                  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  +- Calc(select=[a1])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
@@ -698,9 +699,9 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 +- Calc(select=[a2])
    +- SortMergeJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3])
       :- Exchange(distribution=[hash[a2]])
-      :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
       +- Exchange(distribution=[hash[a3]])
-         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -736,9 +737,9 @@ Calc(select=[a1, b1])
                         :- Calc(select=[a2])
                         :  +- SortMergeJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3])
                         :     :- Exchange(distribution=[hash[a2]])
-                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :     +- Exchange(distribution=[hash[a3]])
-                        :        +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                        :        +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
                         +- Exchange(distribution=[broadcast])
                            +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
                               +- Exchange(distribution=[hash[a1]])
@@ -790,7 +791,7 @@ LogicalProject(a2=[$0])
     <Resource name="optimized rel plan">
       <![CDATA[
 HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], isBroadcast=[true], build=[right])
-:- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+:- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 +- Exchange(distribution=[broadcast])
    +- Calc(select=[a2])
       +- SortLimit(orderBy=[a1 ASC], offset=[0], fetch=[10], global=[true])
@@ -798,9 +799,10 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], isBroadcas
             +- SortLimit(orderBy=[a1 ASC], offset=[0], fetch=[10], global=[false])
                +- SortMergeJoin(joinType=[InnerJoin], where=[=(a2, a1)], select=[a2, a1])
                   :- Exchange(distribution=[hash[a2]])
-                  :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                  :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                   +- Exchange(distribution=[hash[a1]])
-                     +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                     +- Calc(select=[a1])
+                        +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1, b1], metadata=[]]], fields=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
@@ -839,13 +841,13 @@ Calc(select=[a1, b1])
                         :- Calc(select=[a2])
                         :  +- SortMergeJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3])
                         :     :- Exchange(distribution=[hash[a2]])
-                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :     :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :     +- Calc(select=[a3])
                         :        +- HashJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3], build=[left])
                         :           :- Exchange(distribution=[hash[a2]])
-                        :           :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+                        :           :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
                         :           +- Exchange(distribution=[hash[a3]])
-                        :              +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                        :              +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
                         +- Exchange(distribution=[broadcast])
                            +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
                               +- Exchange(distribution=[hash[a1]])
@@ -879,9 +881,9 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 +- Calc(select=[a2])
    +- SortMergeJoin(joinType=[InnerJoin], where=[=(a2, a3)], select=[a2, a3])
       :- Exchange(distribution=[hash[a2]])
-      :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
       +- Exchange(distribution=[hash[a3]])
-         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+         +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1176,7 +1178,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], buil
 :  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
 :     :- Exchange(distribution=[hash[a1]])
 :     :  +- Calc(select=[a1], where=[=(b1, 'abc')])
-:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1], metadata=[]]], fields=[a1, b1])
 :     +- Exchange(distribution=[hash[a2]])
 :        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 +- Exchange(distribution=[broadcast])
@@ -1186,9 +1188,10 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], buil
             +- Calc(select=[0 AS $f0])
                +- HashJoin(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, a3], build=[left])
                   :- Exchange(distribution=[hash[a1]])
-                  :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  :  +- Calc(select=[a1])
+                  :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1, b1], metadata=[]]], fields=[a1, b1])
                   +- Exchange(distribution=[hash[a3]])
-                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1265,7 +1268,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[
          :     +- Exchange(distribution=[single])
          :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
          :           +- Calc(select=[a1], where=[=(a1, 1)])
-         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
          +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
             +- Exchange(distribution=[single])
                +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
@@ -1274,9 +1277,9 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[
                         +- LocalHashAggregate(groupBy=[a3], select=[a3])
                            +- Union(all=[true], union=[a3])
                               :- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a1, 1)])
-                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
                               +- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a3, 1)])
-                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3])
 ]]>
     </Resource>
   </TestCase>
@@ -1453,7 +1456,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :- Exchange(distribution=[hash[a1]])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>
@@ -1542,7 +1545,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :- Exchange(distribution=[hash[a1]])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
-   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.xml
@@ -219,7 +219,7 @@ LogicalUnion(all=[false]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[NOT(IN($0, {
 LogicalProject(a2=[$0])
-  LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+  LogicalTableScan(table=[[default_catalog, default_database, T2]])
 }))]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -234,7 +234,7 @@ LogicalProject(a2=[$0])
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[NOT(IN($0, {
 LogicalProject(a2=[$0])
-  LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+  LogicalTableScan(table=[[default_catalog, default_database, T2]])
 }))]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -358,8 +358,8 @@ LogicalProject(EXPR$0=[$1]), rowType=[RecordType(BIGINT EXPR$0)]
 +- LogicalAggregate(group=[{0}], EXPR$0=[COUNT($1)]), rowType=[RecordType(BIGINT a1, BIGINT EXPR$0)]
    +- LogicalProject(a1=[$2], a2=[$0]), rowType=[RecordType(BIGINT a1, BIGINT a2)]
       +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a1, VARCHAR(2147483647) b1)]
-         :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-         +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -376,8 +376,8 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
 +- LogicalFilter(condition=[=($cor0.a1, $0)]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
    +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
-      :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-      +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T3]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })], variablesSet=[[$cor0]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -393,8 +393,8 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 +- LogicalFilter(condition=[IN($0, {
 LogicalProject(EXPR$0=[+($0, $cor0.a1)]), rowType=[RecordType(BIGINT EXPR$0)]
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
-   :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-   +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T3]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })], variablesSet=[[$cor0]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -425,8 +425,8 @@ LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
 +- LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10]), rowType=[RecordType(BIGINT a2, BIGINT a1)]
    +- LogicalProject(a2=[$0], a1=[$2]), rowType=[RecordType(BIGINT a2, BIGINT a1)]
       +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a1, VARCHAR(2147483647) b1)]
-         :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-         +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -442,11 +442,11 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 +- LogicalFilter(condition=[IN($0, {
 LogicalProject(EXPR$0=[+($0, $cor0.a1)]), rowType=[RecordType(BIGINT EXPR$0)]
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
-   :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-   +- LogicalProject(a3=[$2], b3=[$3], hints=[[[ALIAS options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
-      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T3]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
-         :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-         +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalProject(a3=[$2], b3=[$3]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T3]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })], variablesSet=[[$cor0]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -462,8 +462,8 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 +- LogicalFilter(condition=[IN($0, {
 LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
-   :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-   +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T3]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -627,8 +627,8 @@ LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
 LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
 +- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
    +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a3, VARCHAR(2147483647) b3)]
-      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-      +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T3]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
 +- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
@@ -667,12 +667,12 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$
 +- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
    +- LogicalFilter(condition=[=($2, 1)]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a3)]
       +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a3)]
-         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-         +- LogicalUnion(all=[false], hints=[[[ALIAS options:[T3]]]]), rowType=[RecordType(BIGINT a3)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalUnion(all=[false]), rowType=[RecordType(BIGINT a3)]
             :- LogicalProject(a3=[$0]), rowType=[RecordType(BIGINT a3)]
-            :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
             +- LogicalProject(a3=[$0]), rowType=[RecordType(BIGINT a3)]
-               +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
+               +- LogicalTableScan(table=[[default_catalog, default_database, T3]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
 +- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
@@ -777,7 +777,7 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
 LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
-+- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
++- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -831,7 +831,7 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
 LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
-+- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
++- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -942,6 +942,34 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
 +- LogicalJoin(condition=[>($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]][NEST_LOOP options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNotClearTableHintsWithQueryHintsExist">
+    <Resource name="sql">
+      <![CDATA[select * from (select /*+ BROADCAST(T1) */ T1.* from T1 join T2/*+ OPTIONS('bounded' = 'true') */ on T1.a1 = T2.a2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[OPTIONS inheritPath:[] options:{bounded=true}]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNotClearTableHintsWithQueryHintsNotExist">
+    <Resource name="sql">
+      <![CDATA[select * from (select T1.* from T1 join T2/*+ OPTIONS('bounded' = 'true') */ on T1.a1 = T2.a2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[OPTIONS inheritPath:[] options:{bounded=true}]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.xml
@@ -354,12 +354,12 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(EXPR$0=[$1])
-  LogicalAggregate(group=[{0}], EXPR$0=[COUNT($1)])
-    LogicalProject(a1=[$2], a2=[$0])
-      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+LogicalProject(EXPR$0=[$1]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalAggregate(group=[{0}], EXPR$0=[COUNT($1)]), rowType=[RecordType(BIGINT a1, BIGINT EXPR$0)]
+   +- LogicalProject(a1=[$2], a2=[$0]), rowType=[RecordType(BIGINT a1, BIGINT a2)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a1, VARCHAR(2147483647) b1)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -373,11 +373,11 @@ LogicalProject(EXPR$0=[$1])
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalFilter(condition=[=($cor0.a1, $0)])
-    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-      LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalFilter(condition=[=($cor0.a1, $0)]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })], variablesSet=[[$cor0]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -391,10 +391,10 @@ LogicalProject(a2=[$0])
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(EXPR$0=[+($0, $cor0.a1)])
-  LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-    LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalProject(EXPR$0=[+($0, $cor0.a1)]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })], variablesSet=[[$cor0]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -421,12 +421,12 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10])
-    LogicalProject(a2=[$0], a1=[$2])
-      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10]), rowType=[RecordType(BIGINT a2, BIGINT a1)]
+   +- LogicalProject(a2=[$0], a1=[$2]), rowType=[RecordType(BIGINT a2, BIGINT a1)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a1, VARCHAR(2147483647) b1)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -440,13 +440,13 @@ LogicalProject(a2=[$0])
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(EXPR$0=[+($0, $cor0.a1)])
-  LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-    LogicalProject(a3=[$2], b3=[$3])
-      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-        LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalProject(EXPR$0=[+($0, $cor0.a1)]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalProject(a3=[$2], b3=[$3], hints=[[[ALIAS options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T3]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })], variablesSet=[[$cor0]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -460,10 +460,10 @@ LogicalProject(EXPR$0=[+($0, $cor0.a1)])
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-    LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -624,11 +624,11 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
-LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
-  LogicalProject($f0=[0])
-    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-      LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a3, VARCHAR(2147483647) b3)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
 +- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
@@ -663,16 +663,16 @@ LogicalProject(a1=[$0]), rowType=[RecordType(BIGINT a1)]
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
-LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
-  LogicalProject($f0=[0])
-    LogicalFilter(condition=[=($2, 1)])
-      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-        LogicalUnion(all=[false])
-          LogicalProject(a3=[$0])
-            LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-          LogicalProject(a3=[$0])
-            LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalFilter(condition=[=($2, 1)]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a3)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a3)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalUnion(all=[false], hints=[[[ALIAS options:[T3]]]]), rowType=[RecordType(BIGINT a3)]
+            :- LogicalProject(a3=[$0]), rowType=[RecordType(BIGINT a3)]
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+            +- LogicalProject(a3=[$0]), rowType=[RecordType(BIGINT a3)]
+               +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
 +- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
@@ -776,8 +776,8 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -830,8 +830,8 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/QueryHintsResolverTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/QueryHintsResolverTest.xml
@@ -354,12 +354,12 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(EXPR$0=[$1])
-  LogicalAggregate(group=[{0}], EXPR$0=[COUNT($1)])
-    LogicalProject(a1=[$2], a2=[$0])
-      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+LogicalProject(EXPR$0=[$1]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalAggregate(group=[{0}], EXPR$0=[COUNT($1)]), rowType=[RecordType(BIGINT a1, BIGINT EXPR$0)]
+   +- LogicalProject(a1=[$2], a2=[$0]), rowType=[RecordType(BIGINT a1, BIGINT a2)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a1, VARCHAR(2147483647) b1)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -373,11 +373,11 @@ LogicalProject(EXPR$0=[$1])
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalFilter(condition=[=($cor0.a1, $0)])
-    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-      LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalFilter(condition=[=($cor0.a1, $0)]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })], variablesSet=[[$cor0]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -391,10 +391,10 @@ LogicalProject(a2=[$0])
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(EXPR$0=[+($0, $cor0.a1)])
-  LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-    LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalProject(EXPR$0=[+($0, $cor0.a1)]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })], variablesSet=[[$cor0]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -421,12 +421,12 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10])
-    LogicalProject(a2=[$0], a1=[$2])
-      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalSort(sort0=[$1], dir0=[ASC-nulls-first], fetch=[10]), rowType=[RecordType(BIGINT a2, BIGINT a1)]
+   +- LogicalProject(a2=[$0], a1=[$2]), rowType=[RecordType(BIGINT a2, BIGINT a1)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a1, VARCHAR(2147483647) b1)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -440,13 +440,13 @@ LogicalProject(a2=[$0])
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(EXPR$0=[+($0, $cor0.a1)])
-  LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-    LogicalProject(a3=[$2], b3=[$3])
-      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-        LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalProject(EXPR$0=[+($0, $cor0.a1)]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalProject(a3=[$2], b3=[$3], hints=[[[ALIAS options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T3]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })], variablesSet=[[$cor0]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -460,10 +460,10 @@ LogicalProject(EXPR$0=[+($0, $cor0.a1)])
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-    LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-    LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2, BIGINT a3, VARCHAR(2147483647) b3)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -624,11 +624,11 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
-LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
-  LogicalProject($f0=[0])
-    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-      LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a3, VARCHAR(2147483647) b3)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
 +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
@@ -663,16 +663,16 @@ LogicalProject(a1=[$0]), rowType=[RecordType(BIGINT a1)]
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
-LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
-  LogicalProject($f0=[0])
-    LogicalFilter(condition=[=($2, 1)])
-      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
-        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-        LogicalUnion(all=[false])
-          LogicalProject(a3=[$0])
-            LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-          LogicalProject(a3=[$0])
-            LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalFilter(condition=[=($2, 1)]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a3)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a3)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalUnion(all=[false], hints=[[[ALIAS options:[T3]]]]), rowType=[RecordType(BIGINT a3)]
+            :- LogicalProject(a3=[$0]), rowType=[RecordType(BIGINT a3)]
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+            +- LogicalProject(a3=[$0]), rowType=[RecordType(BIGINT a3)]
+               +- LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]]), rowType=[RecordType(BIGINT a3, VARCHAR(2147483647) b3)]
 })]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
 +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
@@ -776,8 +776,8 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>
@@ -830,8 +830,8 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalFilter(condition=[IN($0, {
-LogicalProject(a2=[$0])
-  LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
++- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 ]]>


### PR DESCRIPTION
## What is the purpose of the change

*Clear the table alias in sub-query*


## Brief change log

  - *Clear table alias in `ClearQueryBlockAliasResolver`*
  - *Update existent tests*


## Verifying this change


This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
