### PR TITLE
[FLINK-34336][test] Fix the bug that AutoRescalingITCase may hang sometimes

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AutoRescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AutoRescalingITCase.java
@@ -337,7 +337,7 @@ public class AutoRescalingITCase extends TestLogger {
 
             restClusterClient.updateJobResourceRequirements(jobID, builder.build()).join();
 
-            waitForRunningTasks(restClusterClient, jobID, parallelism2);
+            waitForRunningTasks(restClusterClient, jobID, 2 * parallelism2);
             waitForAvailableSlots(restClusterClient, totalSlots - parallelism2);
 
             StateSourceBase.canFinishLatch.countDown();
@@ -427,7 +427,8 @@ public class AutoRescalingITCase extends TestLogger {
 
             restClusterClient.updateJobResourceRequirements(jobID, builder.build()).join();
 
-            waitForRunningTasks(restClusterClient, jobID, parallelism2);
+            // Source is parallelism, the flatMapper & Sink is parallelism2
+            waitForRunningTasks(restClusterClient, jobID, parallelism + parallelism2);
             waitForAvailableSlots(restClusterClient, totalSlots - parallelism2);
 
             SubtaskIndexSource.SOURCE_LATCH.trigger();


### PR DESCRIPTION
[FLINK-34336][test] Fix the bug that AutoRescalingITCase may hang sometimes

## Purpose

AutoRescalingITCase#testCheckpointRescalingWithKeyedAndNonPartitionedState may hang in waitForRunningTasks(restClusterClient, jobID, parallelism2);

## Reason:

The job has 2 tasks(vertices), after calling updateJobResourceRequirements. The source parallelism isn't changed (It's parallelism) , and the FlatMapper+Sink is changed from  parallelism to parallelism2.

So we expect the task number should be parallelism + parallelism2 instead of parallelism2.

 
## Why it can be passed for now?

Flink 1.19 supports the scaling cooldown, and the cooldown time is 30s by default. It means, flink job will rescale job 30 seconds after updateJobResourceRequirements is called.

So the running tasks are old parallelism when we call waitForRunningTasks(restClusterClient, jobID, parallelism2);.

IIUC, it cannot be guaranteed, and it's unexpected.

 
## How to reproduce this bug?

https://github.com/1996fanrui/flink/commit/ffd713e24d37db2c103e4cd4361d0cd916d0d2f6

1. Disable the cooldown
2. Sleep for a while before waitForRunningTasks

If so, the job running in new parallelism, so `waitForRunningTasks` will hang forever.

