### PR TITLE
[FLINK-34366][table] Add support to group rows by column ordinals

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
@@ -44,7 +44,7 @@ public enum FlinkSqlConformance implements SqlConformance {
 
     @Override
     public boolean isGroupByOrdinal() {
-        return false;
+        return true;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/AggregateQueryOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/AggregateQueryOperation.java
@@ -88,7 +88,7 @@ public class AggregateQueryOperation implements QueryOperation {
 
     private String getGroupingExprs() {
         if (groupingExpressions.isEmpty()) {
-            return "1";
+            return "'1'";
         } else {
             final String groupingExprs =
                     groupingExpressions.stream()

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -21,6 +21,7 @@ import org.apache.flink.sql.parser.ExtendedSqlNode
 import org.apache.flink.sql.parser.ddl.{SqlCompilePlan, SqlReset, SqlSet, SqlUseModules}
 import org.apache.flink.sql.parser.dml._
 import org.apache.flink.sql.parser.dql._
+import org.apache.flink.sql.parser.validate.FlinkSqlConformance
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.planner.hint.FlinkHints
 import org.apache.flink.table.planner.parse.CalciteParser
@@ -102,6 +103,7 @@ class FlinkPlannerImpl(
       catalogReader,
       typeFactory,
       SqlValidator.Config.DEFAULT
+        .withConformance(FlinkSqlConformance.DEFAULT)
         .withIdentifierExpansion(true)
         .withDefaultNullCollation(FlinkPlannerImpl.defaultNullCollation)
         .withTypeCoercionEnabled(false),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
@@ -170,7 +170,7 @@ public class QueryOperationTestPrograms {
                                     + "    SELECT (SUM(`a`)) AS `EXPR$0` FROM (\n"
                                     + "        SELECT `a`, `b` FROM `default_catalog`.`default_database`.`s`\n"
                                     + "    )\n"
-                                    + "    GROUP BY 1\n"
+                                    + "    GROUP BY '1'\n"
                                     + ")")
                     .build();
 

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/AggregateReduceGroupingTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/AggregateReduceGroupingTest.xml
@@ -765,13 +765,13 @@ HashAggregate(isMerge=[false], groupBy=[a1], auxGrouping=[d1], select=[a1, d1, C
   </TestCase>
   <TestCase name="testSingleAggOnlyConstantGroupKey">
     <Resource name="sql">
-      <![CDATA[SELECT count(c1) FROM T1 GROUP BY 1, true]]>
+      <![CDATA[SELECT count(c1) FROM T1 GROUP BY '1', true]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(EXPR$0=[$2])
 +- LogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)])
-   +- LogicalProject($f0=[1], $f1=[true], c1=[$2])
+   +- LogicalProject($f0=[_UTF-16LE'1'], $f1=[true], c1=[$2])
       +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
 ]]>
     </Resource>
@@ -781,7 +781,7 @@ Calc(select=[EXPR$0])
 +- HashAggregate(isMerge=[true], groupBy=[$f0], select=[$f0, Final_COUNT(count$0) AS EXPR$0])
    +- Exchange(distribution=[hash[$f0]])
       +- LocalHashAggregate(groupBy=[$f0], select=[$f0, Partial_COUNT(c1) AS count$0])
-         +- Calc(select=[1 AS $f0, c1])
+         +- Calc(select=['1' AS $f0, c1])
             +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
 ]]>
     </Resource>
@@ -848,13 +848,13 @@ HashAggregate(isMerge=[false], groupBy=[b2], auxGrouping=[c2], select=[b2, c2, A
   </TestCase>
   <TestCase name="testSingleAggWithConstantGroupKey">
     <Resource name="sql">
-      <![CDATA[SELECT a1, b1, count(c1) FROM T1 GROUP BY a1, b1, 1, true]]>
+      <![CDATA[SELECT a1, b1, count(c1) FROM T1 GROUP BY a1, b1, '1', true]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1], EXPR$2=[$4])
 +- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$2=[COUNT($4)])
-   +- LogicalProject(a1=[$0], b1=[$1], $f2=[1], $f3=[true], c1=[$2])
+   +- LogicalProject(a1=[$0], b1=[$1], $f2=[_UTF-16LE'1'], $f3=[true], c1=[$2])
       +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
 ]]>
     </Resource>
@@ -867,7 +867,27 @@ HashAggregate(isMerge=[false], groupBy=[a1], auxGrouping=[b1], select=[a1, b1, C
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSingleDistinctAgg1">
+  <TestCase name="testSingleAggWithOrdinalGroupKey">
+		<Resource name="sql">
+			<![CDATA[SELECT a1, b1, count(c1) FROM T1 GROUP BY 1, 2]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
++- LogicalProject(a1=[$0], b1=[$1], c1=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+HashAggregate(isMerge=[false], groupBy=[a1], auxGrouping=[b1], select=[a1, b1, COUNT(c1) AS EXPR$2])
++- Exchange(distribution=[hash[a1]])
+   +- Calc(select=[a1, b1, c1])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testSingleDistinctAgg1">
     <Resource name="sql">
       <![CDATA[SELECT a1, COUNT(DISTINCT c1) FROM T1 GROUP BY a1]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/GroupingSetsTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/GroupingSetsTest.xml
@@ -45,13 +45,13 @@ Calc(select=[d, c, g])
   </TestCase>
   <TestCase name="testAllowExpressionInCube2">
     <Resource name="sql">
-      <![CDATA[SELECT COUNT(*) AS c FROM emp GROUP BY CUBE(1)]]>
+      <![CDATA[SELECT COUNT(*) AS c FROM emp GROUP BY CUBE('1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(c=[$1])
 +- LogicalAggregate(group=[{0}], groups=[[{0}, {}]], c=[COUNT()])
-   +- LogicalProject($f0=[1])
+   +- LogicalProject($f0=[_UTF-16LE'1'])
       +- LogicalTableScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]])
 ]]>
     </Resource>
@@ -62,7 +62,7 @@ Calc(select=[c])
    +- Exchange(distribution=[hash[$f0, $e]])
       +- LocalHashAggregate(groupBy=[$f0, $e], select=[$f0, $e, Partial_COUNT(*) AS count1$0])
          +- Expand(projects=[{$f0, 0 AS $e}, {null AS $f0, 1 AS $e}])
-            +- Calc(select=[1 AS $f0])
+            +- Calc(select=['1' AS $f0])
                +- LegacyTableSourceScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]], fields=[ename, deptno, gender])
 ]]>
     </Resource>
@@ -121,15 +121,61 @@ Calc(select=[d, c, g])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testAllowExpressionInRollup3">
+  <TestCase name="testAllowOrdinalInCube">
+		<Resource name="sql">
+			<![CDATA[SELECT ename, COUNT(*) AS c FROM emp GROUP BY CUBE(1)]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalAggregate(group=[{0}], groups=[[{0}, {}]], c=[COUNT()])
++- LogicalProject(ename=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[ename, c])
++- HashAggregate(isMerge=[true], groupBy=[ename, $e], select=[ename, $e, Final_COUNT(count1$0) AS c])
+   +- Exchange(distribution=[hash[ename, $e]])
+      +- LocalHashAggregate(groupBy=[ename, $e], select=[ename, $e, Partial_COUNT(*) AS count1$0])
+         +- Expand(projects=[{ename, 0 AS $e}, {null AS ename, 1 AS $e}])
+            +- Calc(select=[ename])
+               +- LegacyTableSourceScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]], fields=[ename, deptno, gender])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testAllowOrdinalInRollup">
+		<Resource name="sql">
+			<![CDATA[SELECT ename, COUNT(*) AS c FROM emp GROUP BY ROLLUP(1)]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalAggregate(group=[{0}], groups=[[{0}, {}]], c=[COUNT()])
++- LogicalProject(ename=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[ename, c])
++- HashAggregate(isMerge=[true], groupBy=[ename, $e], select=[ename, $e, Final_COUNT(count1$0) AS c])
+   +- Exchange(distribution=[hash[ename, $e]])
+      +- LocalHashAggregate(groupBy=[ename, $e], select=[ename, $e, Partial_COUNT(*) AS count1$0])
+         +- Expand(projects=[{ename, 0 AS $e}, {null AS ename, 1 AS $e}])
+            +- Calc(select=[ename])
+               +- LegacyTableSourceScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]], fields=[ename, deptno, gender])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testAllowExpressionInRollup3">
     <Resource name="sql">
-      <![CDATA[SELECT COUNT(*) AS c FROM emp GROUP BY ROLLUP(1)]]>
+      <![CDATA[SELECT COUNT(*) AS c FROM emp GROUP BY ROLLUP('1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(c=[$1])
 +- LogicalAggregate(group=[{0}], groups=[[{0}, {}]], c=[COUNT()])
-   +- LogicalProject($f0=[1])
+   +- LogicalProject($f0=[_UTF-16LE'1'])
       +- LogicalTableScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]])
 ]]>
     </Resource>
@@ -140,7 +186,7 @@ Calc(select=[c])
    +- Exchange(distribution=[hash[$f0, $e]])
       +- LocalHashAggregate(groupBy=[$f0, $e], select=[$f0, $e, Partial_COUNT(*) AS count1$0])
          +- Expand(projects=[{$f0, 0 AS $e}, {null AS $f0, 1 AS $e}])
-            +- Calc(select=[1 AS $f0])
+            +- Calc(select=['1' AS $f0])
                +- LegacyTableSourceScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]], fields=[ename, deptno, gender])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/BroadcastHashSemiAntiJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/BroadcastHashSemiAntiJoinTest.xml
@@ -51,14 +51,14 @@ MultipleInput(readOrder=[0,1,0], members=[\nHashJoin(joinType=[LeftAntiJoin], wh
   </TestCase>
   <TestCase name="testExistsWithCorrelated_AggInSubQuery">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[EXISTS({
 LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[MAX($4)])
-  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[1], e=[$1])
+  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[_UTF-16LE'1'], e=[$1])
     LogicalFilter(condition=[AND(=($cor0.b, $1), <($0, 100), =($cor0.c, $2))])
       LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])
@@ -421,7 +421,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[((b = EXPR$0) AND (c = f))], select=[a,
   </TestCase>
   <TestCase name="testInWithCorrelated_AggInSubQuery2">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -429,7 +429,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, $0, {
 LogicalProject(EXPR$0=[$4], d=[$0])
   LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[COUNT()])
-    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[1])
+    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[_UTF-16LE'1'])
       LogicalFilter(condition=[=($cor0.c, $2)])
         LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/NestedLoopSemiAntiJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/NestedLoopSemiAntiJoinTest.xml
@@ -51,14 +51,14 @@ MultipleInput(readOrder=[0,1,0], members=[\nNestedLoopJoin(joinType=[LeftAntiJoi
   </TestCase>
   <TestCase name="testExistsWithCorrelated_AggInSubQuery">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[EXISTS({
 LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[MAX($4)])
-  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[1], e=[$1])
+  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[_UTF-16LE'1'], e=[$1])
     LogicalFilter(condition=[AND(=($cor0.b, $1), <($0, 100), =($cor0.c, $2))])
       LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])
@@ -562,7 +562,7 @@ NestedLoopJoin(joinType=[LeftSemiJoin], where=[((b = EXPR$0) AND (c = f))], sele
   </TestCase>
   <TestCase name="testInWithCorrelated_AggInSubQuery2">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -570,7 +570,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, $0, {
 LogicalProject(EXPR$0=[$4], d=[$0])
   LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[COUNT()])
-    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[1])
+    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[_UTF-16LE'1'])
       LogicalFilter(condition=[=($cor0.c, $2)])
         LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/SemiAntiJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/SemiAntiJoinTest.xml
@@ -53,14 +53,14 @@ HashJoin(joinType=[LeftAntiJoin], where=[(a = i)], select=[a, b, c], build=[righ
   </TestCase>
   <TestCase name="testExistsWithCorrelated_AggInSubQuery">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[EXISTS({
 LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[MAX($4)])
-  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[1], e=[$1])
+  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[_UTF-16LE'1'], e=[$1])
     LogicalFilter(condition=[AND(=($cor0.b, $1), <($0, 100), =($cor0.c, $2))])
       LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])
@@ -578,7 +578,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[((b = EXPR$0) AND (c = f))], select=[a,
   </TestCase>
   <TestCase name="testInWithCorrelated_AggInSubQuery2">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -586,7 +586,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, $0, {
 LogicalProject(EXPR$0=[$4], d=[$0])
   LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[COUNT()])
-    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[1])
+    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[_UTF-16LE'1'])
       LogicalFilter(condition=[=($cor0.c, $2)])
         LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/ShuffledHashSemiAntiJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/ShuffledHashSemiAntiJoinTest.xml
@@ -53,14 +53,14 @@ HashJoin(joinType=[LeftAntiJoin], where=[(a = i)], select=[a, b, c], build=[righ
   </TestCase>
   <TestCase name="testExistsWithCorrelated_AggInSubQuery">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[EXISTS({
 LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[MAX($4)])
-  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[1], e=[$1])
+  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[_UTF-16LE'1'], e=[$1])
     LogicalFilter(condition=[AND(=($cor0.b, $1), <($0, 100), =($cor0.c, $2))])
       LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])
@@ -472,7 +472,7 @@ HashJoin(joinType=[LeftSemiJoin], where=[((b = EXPR$0) AND (c = f))], select=[a,
   </TestCase>
   <TestCase name="testInWithCorrelated_AggInSubQuery2">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -480,7 +480,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, $0, {
 LogicalProject(EXPR$0=[$4], d=[$0])
   LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[COUNT()])
-    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[1])
+    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[_UTF-16LE'1'])
       LogicalFilter(condition=[=($cor0.c, $2)])
         LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/SortMergeSemiAntiJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/join/SortMergeSemiAntiJoinTest.xml
@@ -53,14 +53,14 @@ SortMergeJoin(joinType=[LeftAntiJoin], where=[(a = i)], select=[a, b, c])
   </TestCase>
   <TestCase name="testExistsWithCorrelated_AggInSubQuery">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[EXISTS({
 LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[MAX($4)])
-  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[1], e=[$1])
+  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[_UTF-16LE'1'], e=[$1])
     LogicalFilter(condition=[AND(=($cor0.b, $1), <($0, 100), =($cor0.c, $2))])
       LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])
@@ -472,7 +472,7 @@ SortMergeJoin(joinType=[LeftSemiJoin], where=[((b = EXPR$0) AND (c = f))], selec
   </TestCase>
   <TestCase name="testInWithCorrelated_AggInSubQuery2">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -480,7 +480,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, $0, {
 LogicalProject(EXPR$0=[$4], d=[$0])
   LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[COUNT()])
-    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[1])
+    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[_UTF-16LE'1'])
       LogicalFilter(condition=[=($cor0.c, $2)])
         LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/AggregateReduceGroupingRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/AggregateReduceGroupingRuleTest.xml
@@ -698,13 +698,13 @@ FlinkLogicalAggregate(group=[{0}], d1=[AUXILIARY_GROUP($2)], EXPR$2=[COUNT($1) F
   </TestCase>
   <TestCase name="testSingleAggOnlyConstantGroupKey">
     <Resource name="sql">
-      <![CDATA[SELECT count(c1) FROM T1 GROUP BY 1, true]]>
+      <![CDATA[SELECT count(c1) FROM T1 GROUP BY '1', true]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(EXPR$0=[$2])
 +- LogicalAggregate(group=[{0, 1}], EXPR$0=[COUNT($2)])
-   +- LogicalProject($f0=[1], $f1=[true], c1=[$2])
+   +- LogicalProject($f0=[_UTF-16LE'1'], $f1=[true], c1=[$2])
       +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
 ]]>
     </Resource>
@@ -712,7 +712,7 @@ LogicalProject(EXPR$0=[$2])
       <![CDATA[
 FlinkLogicalCalc(select=[EXPR$0])
 +- FlinkLogicalAggregate(group=[{0}], EXPR$0=[COUNT($1)])
-   +- FlinkLogicalCalc(select=[1 AS $f0, c1])
+   +- FlinkLogicalCalc(select=['1' AS $f0, c1])
       +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
 ]]>
     </Resource>
@@ -755,6 +755,25 @@ FlinkLogicalAggregate(group=[{0}], b1=[AUXILIARY_GROUP($1)], EXPR$2=[COUNT($2)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSingleAggWithOrdinalGroupKey">
+	<Resource name="sql">
+		<![CDATA[SELECT a1, b1, count(c1) FROM T1 GROUP BY 1, 2]]>
+	</Resource>
+	<Resource name="ast">
+		<![CDATA[
+LogicalAggregate(group=[{0, 1}], EXPR$2=[COUNT($2)])
++- LogicalProject(a1=[$0], b1=[$1], c1=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+]]>
+	</Resource>
+	<Resource name="optimized rel plan">
+		<![CDATA[
+FlinkLogicalAggregate(group=[{0}], b1=[AUXILIARY_GROUP($1)], EXPR$2=[COUNT($2)])
++- FlinkLogicalCalc(select=[a1, b1, c1])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
+]]>
+	</Resource>
+  </TestCase>
   <TestCase name="testSingleAggOnTableWithUniqueKeys">
     <Resource name="sql">
       <![CDATA[SELECT  b2, c2, avg(a2) FROM T2 GROUP BY b2, c2]]>
@@ -775,13 +794,13 @@ FlinkLogicalAggregate(group=[{1}], c2=[AUXILIARY_GROUP($2)], EXPR$2=[AVG($0)])
   </TestCase>
   <TestCase name="testSingleAggWithConstantGroupKey">
     <Resource name="sql">
-      <![CDATA[SELECT a1, b1, count(c1) FROM T1 GROUP BY a1, b1, 1, true]]>
+      <![CDATA[SELECT a1, b1, count(c1) FROM T1 GROUP BY a1, b1, '1', true]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1], EXPR$2=[$4])
 +- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$2=[COUNT($4)])
-   +- LogicalProject(a1=[$0], b1=[$1], $f2=[1], $f3=[true], c1=[$2])
+   +- LogicalProject(a1=[$0], b1=[$1], $f2=[_UTF-16LE'1'], $f3=[true], c1=[$2])
       +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/subquery/SubQuerySemiJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/subquery/SubQuerySemiJoinTest.xml
@@ -282,14 +282,14 @@ LogicalProject(a=[$0], b=[$1])
   </TestCase>
   <TestCase name="testExistsWithCorrelatedOnWhere_Aggregate2">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l1 WHERE EXISTS (SELECT MAX(e) FROM r1 WHERE l1.b = r1.d AND c < 100 AND l1.a = r1.c GROUP BY c, true, f, 1)]]>
+      <![CDATA[SELECT * FROM l1 WHERE EXISTS (SELECT MAX(e) FROM r1 WHERE l1.b = r1.d AND c < 100 AND l1.a = r1.c GROUP BY c, true, f, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
 +- LogicalFilter(condition=[EXISTS({
 LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[MAX($4)])
-  LogicalProject(c=[$0], $f1=[true], f=[$3], $f3=[1], e=[$2])
+  LogicalProject(c=[$0], $f1=[true], f=[$3], $f3=[_UTF-16LE'1'], e=[$2])
     LogicalFilter(condition=[AND(=($cor0.b, $1), <($0, 100), =($cor0.a, $0))])
       LogicalTableScan(table=[[default_catalog, default_database, r1, source: [TestTableSource(c, d, e, f)]]])
 })], variablesSet=[[$cor0]])
@@ -303,7 +303,7 @@ LogicalProject(a=[$0], b=[$1])
    :- LogicalTableScan(table=[[default_catalog, default_database, l1, source: [TestTableSource(a, b)]]])
    +- LogicalProject(c=[$0], d=[$2])
       +- LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($5)])
-         +- LogicalProject(c=[$0], f=[$3], d=[$1], $f1=[true], $f3=[1], e=[$2])
+         +- LogicalProject(c=[$0], f=[$3], d=[$1], $f1=[true], $f3=[_UTF-16LE'1'], e=[$2])
             +- LogicalFilter(condition=[<($0, 100)])
                +- LogicalTableScan(table=[[default_catalog, default_database, r1, source: [TestTableSource(c, d, e, f)]]])
 ]]>
@@ -1681,7 +1681,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
   </TestCase>
   <TestCase name="testInWithCorrelatedOnWhere_Aggregate5">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE b IN (SELECT MAX(e) FROM r WHERE l.c = r.f GROUP BY d, true, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE b IN (SELECT MAX(e) FROM r WHERE l.c = r.f GROUP BY d, true, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -1689,7 +1689,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, {
 LogicalProject(EXPR$0=[$3])
   LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
-    LogicalProject(d=[$0], $f1=[true], $f2=[1], e=[$1])
+    LogicalProject(d=[$0], $f1=[true], $f2=[_UTF-16LE'1'], e=[$1])
       LogicalFilter(condition=[=($cor0.c, $2)])
         LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])
@@ -1703,7 +1703,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
    :- LogicalTableScan(table=[[default_catalog, default_database, l, source: [TestTableSource(a, b, c)]]])
    +- LogicalProject(EXPR$0=[$2], f=[$1])
       +- LogicalAggregate(group=[{0, 1}], EXPR$0=[MAX($4)])
-         +- LogicalProject(d=[$0], f=[$2], $f1=[true], $f2=[1], e=[$1])
+         +- LogicalProject(d=[$0], f=[$2], $f1=[true], $f2=[_UTF-16LE'1'], e=[$1])
             +- LogicalFilter(condition=[true])
                +- LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 ]]>
@@ -1711,7 +1711,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
   </TestCase>
   <TestCase name="testInWithCorrelatedOnWhere_Aggregate6">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -1719,7 +1719,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, $0, {
 LogicalProject(EXPR$0=[$4], d=[$0])
   LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[COUNT()])
-    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[1])
+    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[_UTF-16LE'1'])
       LogicalFilter(condition=[=($cor0.c, $2)])
         LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])
@@ -1733,7 +1733,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
    :- LogicalTableScan(table=[[default_catalog, default_database, l, source: [TestTableSource(a, b, c)]]])
    +- LogicalProject(EXPR$0=[$3], d=[$0], f=[$2])
       +- LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[COUNT()])
-         +- LogicalProject(d=[$0], e=[$1], f=[$2], $f1=[true], $f3=[1])
+         +- LogicalProject(d=[$0], e=[$1], f=[$2], $f1=[true], $f3=[_UTF-16LE'1'])
             +- LogicalFilter(condition=[true])
                +- LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 ]]>
@@ -3199,7 +3199,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
   </TestCase>
   <TestCase name="testInWithUncorrelatedOnWhere_Aggregate5">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE b IN (SELECT MAX(e) FROM r GROUP BY d, true, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE b IN (SELECT MAX(e) FROM r GROUP BY d, true, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -3207,7 +3207,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, {
 LogicalProject(EXPR$0=[$3])
   LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
-    LogicalProject(d=[$0], $f1=[true], $f2=[1], e=[$1])
+    LogicalProject(d=[$0], $f1=[true], $f2=[_UTF-16LE'1'], e=[$1])
       LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })])
    +- LogicalTableScan(table=[[default_catalog, default_database, l, source: [TestTableSource(a, b, c)]]])
@@ -3220,14 +3220,14 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
    :- LogicalTableScan(table=[[default_catalog, default_database, l, source: [TestTableSource(a, b, c)]]])
    +- LogicalProject(EXPR$0=[$3])
       +- LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[MAX($3)])
-         +- LogicalProject(d=[$0], $f1=[true], $f2=[1], e=[$1])
+         +- LogicalProject(d=[$0], $f1=[true], $f2=[_UTF-16LE'1'], e=[$1])
             +- LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 ]]>
     </Resource>
   </TestCase>
   <TestCase name="testInWithUncorrelatedOnWhere_Aggregate6">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r GROUP BY d, true, e, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r GROUP BY d, true, e, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -3235,7 +3235,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, $0, {
 LogicalProject(EXPR$0=[$4], d=[$0])
   LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[COUNT()])
-    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[1])
+    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[_UTF-16LE'1'])
       LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })])
    +- LogicalTableScan(table=[[default_catalog, default_database, l, source: [TestTableSource(a, b, c)]]])
@@ -3248,7 +3248,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
    :- LogicalTableScan(table=[[default_catalog, default_database, l, source: [TestTableSource(a, b, c)]]])
    +- LogicalProject(EXPR$0=[$4], d=[$0])
       +- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[COUNT()])
-         +- LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[1])
+         +- LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[_UTF-16LE'1'])
             +- LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/GroupingSetsTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/GroupingSetsTest.xml
@@ -44,13 +44,13 @@ Calc(select=[d, c, g])
   </TestCase>
   <TestCase name="testAllowExpressionInCube2">
     <Resource name="sql">
-      <![CDATA[SELECT COUNT(*) AS c FROM emp GROUP BY CUBE(1)]]>
+      <![CDATA[SELECT COUNT(*) AS c FROM emp GROUP BY CUBE('1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(c=[$1])
 +- LogicalAggregate(group=[{0}], groups=[[{0}, {}]], c=[COUNT()])
-   +- LogicalProject($f0=[1])
+   +- LogicalProject($f0=[_UTF-16LE'1'])
       +- LogicalTableScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]])
 ]]>
     </Resource>
@@ -60,7 +60,7 @@ Calc(select=[c])
 +- GroupAggregate(groupBy=[$f0, $e], select=[$f0, $e, COUNT(*) AS c])
    +- Exchange(distribution=[hash[$f0, $e]])
       +- Expand(projects=[{$f0, 0 AS $e}, {null AS $f0, 1 AS $e}])
-         +- Calc(select=[1 AS $f0])
+         +- Calc(select=['1' AS $f0])
             +- LegacyTableSourceScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]], fields=[ename, deptno, gender])
 ]]>
     </Resource>
@@ -119,13 +119,13 @@ Calc(select=[d, c, g])
   </TestCase>
   <TestCase name="testAllowExpressionInRollup3">
     <Resource name="sql">
-      <![CDATA[SELECT COUNT(*) AS c FROM emp GROUP BY ROLLUP(1)]]>
+      <![CDATA[SELECT COUNT(*) AS c FROM emp GROUP BY ROLLUP('1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(c=[$1])
 +- LogicalAggregate(group=[{0}], groups=[[{0}, {}]], c=[COUNT()])
-   +- LogicalProject($f0=[1])
+   +- LogicalProject($f0=[_UTF-16LE'1'])
       +- LogicalTableScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]])
 ]]>
     </Resource>
@@ -135,7 +135,7 @@ Calc(select=[c])
 +- GroupAggregate(groupBy=[$f0, $e], select=[$f0, $e, COUNT(*) AS c])
    +- Exchange(distribution=[hash[$f0, $e]])
       +- Expand(projects=[{$f0, 0 AS $e}, {null AS $f0, 1 AS $e}])
-         +- Calc(select=[1 AS $f0])
+         +- Calc(select=['1' AS $f0])
             +- LegacyTableSourceScan(table=[[default_catalog, default_database, emp, source: [TestTableSource(ename, deptno, gender)]]], fields=[ename, deptno, gender])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/SemiAntiJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/SemiAntiJoinTest.xml
@@ -53,14 +53,14 @@ Join(joinType=[LeftAntiJoin], where=[(a = i)], select=[a, b, c], leftInputSpec=[
   </TestCase>
   <TestCase name="testExistsWithCorrelated_AggInSubQuery">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE EXISTS (SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[EXISTS({
 LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[MAX($4)])
-  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[1], e=[$1])
+  LogicalProject(d=[$0], $f1=[true], f=[$2], $f3=[_UTF-16LE'1'], e=[$1])
     LogicalFilter(condition=[AND(=($cor0.b, $1), <($0, 100), =($cor0.c, $2))])
       LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])
@@ -577,7 +577,7 @@ Join(joinType=[LeftSemiJoin], where=[((b = EXPR$0) AND (c = f))], select=[a, b, 
   </TestCase>
   <TestCase name="testInWithCorrelated_AggInSubQuery2">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)]]>
+      <![CDATA[SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -585,7 +585,7 @@ LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalFilter(condition=[IN($1, $0, {
 LogicalProject(EXPR$0=[$4], d=[$0])
   LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$0=[COUNT()])
-    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[1])
+    LogicalProject(d=[$0], $f1=[true], e=[$1], $f3=[_UTF-16LE'1'])
       LogicalFilter(condition=[=($cor0.c, $2)])
         LogicalTableScan(table=[[default_catalog, default_database, r, source: [TestTableSource(d, e, f)]]])
 })], variablesSet=[[$cor0]])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/GroupingSetsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/GroupingSetsTest.scala
@@ -393,12 +393,22 @@ class GroupingSetsTest extends TableTestBase {
 
   @Test
   def testAllowExpressionInCube2(): Unit = {
-    util.verifyExecPlan("SELECT COUNT(*) AS c FROM emp GROUP BY CUBE(1)")
+    util.verifyExecPlan("SELECT COUNT(*) AS c FROM emp GROUP BY CUBE('1')")
   }
 
   @Test
   def testAllowExpressionInRollup3(): Unit = {
-    util.verifyExecPlan("SELECT COUNT(*) AS c FROM emp GROUP BY ROLLUP(1)")
+    util.verifyExecPlan("SELECT COUNT(*) AS c FROM emp GROUP BY ROLLUP('1')")
+  }
+
+  @Test
+  def testAllowOrdinalInCube(): Unit = {
+    util.verifyExecPlan("SELECT ename, COUNT(*) AS c FROM emp GROUP BY CUBE(1)")
+  }
+
+  @Test
+  def testAllowOrdinalInRollup(): Unit = {
+    util.verifyExecPlan("SELECT ename, COUNT(*) AS c FROM emp GROUP BY ROLLUP(1)")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/SemiAntiJoinTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/SemiAntiJoinTestBase.scala
@@ -224,7 +224,7 @@ abstract class SemiAntiJoinTestBase extends TableTestBase {
   @Test
   def testInWithCorrelated_AggInSubQuery2(): Unit = {
     val sqlQuery = "SELECT * FROM l WHERE (b, a) IN " +
-      "(SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)"
+      "(SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')"
     util.verifyExecPlan(sqlQuery)
   }
 
@@ -360,7 +360,7 @@ abstract class SemiAntiJoinTestBase extends TableTestBase {
   @Test
   def testExistsWithCorrelated_AggInSubQuery(): Unit = {
     val sqlQuery = "SELECT * FROM l WHERE EXISTS " +
-      "(SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, 1)"
+      "(SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, '1')"
     util.verifyExecPlan(sqlQuery)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/AggregateReduceGroupingTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/AggregateReduceGroupingTestBase.scala
@@ -108,13 +108,18 @@ abstract class AggregateReduceGroupingTestBase(withExecPlan: Boolean) extends Ta
   }
 
   @Test
+  def testSingleAggWithOrdinalGroupKey(): Unit = {
+    verifyPlan("SELECT a1, b1, count(c1) FROM T1 GROUP BY 1, 2")
+  }
+
+  @Test
   def testSingleAggWithConstantGroupKey(): Unit = {
-    verifyPlan("SELECT a1, b1, count(c1) FROM T1 GROUP BY a1, b1, 1, true")
+    verifyPlan("SELECT a1, b1, count(c1) FROM T1 GROUP BY a1, b1, '1', true")
   }
 
   @Test
   def testSingleAggOnlyConstantGroupKey(): Unit = {
-    verifyPlan("SELECT count(c1) FROM T1 GROUP BY 1, true")
+    verifyPlan("SELECT count(c1) FROM T1 GROUP BY '1', true")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/subquery/SubQuerySemiJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/subquery/SubQuerySemiJoinTest.scala
@@ -286,13 +286,13 @@ class SubQuerySemiJoinTest extends SubQueryTestBase {
 
   @Test
   def testInWithUncorrelatedOnWhere_Aggregate5(): Unit = {
-    util.verifyRelPlan("SELECT * FROM l WHERE b IN (SELECT MAX(e) FROM r GROUP BY d, true, 1)")
+    util.verifyRelPlan("SELECT * FROM l WHERE b IN (SELECT MAX(e) FROM r GROUP BY d, true, '1')")
   }
 
   @Test
   def testInWithUncorrelatedOnWhere_Aggregate6(): Unit = {
     val sqlQuery =
-      "SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r GROUP BY d, true, e, 1)"
+      "SELECT * FROM l WHERE (b, a) IN (SELECT COUNT(*), d FROM r GROUP BY d, true, e, '1')"
     util.verifyRelPlan(sqlQuery)
   }
 
@@ -645,14 +645,14 @@ class SubQuerySemiJoinTest extends SubQueryTestBase {
   @Test
   def testInWithCorrelatedOnWhere_Aggregate5(): Unit = {
     val sqlQuery = "SELECT * FROM l WHERE b IN " +
-      "(SELECT MAX(e) FROM r WHERE l.c = r.f GROUP BY d, true, 1)"
+      "(SELECT MAX(e) FROM r WHERE l.c = r.f GROUP BY d, true, '1')"
     util.verifyRelPlan(sqlQuery)
   }
 
   @Test
   def testInWithCorrelatedOnWhere_Aggregate6(): Unit = {
     val sqlQuery = "SELECT * FROM l WHERE (b, a) IN " +
-      "(SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)"
+      "(SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')"
     util.verifyRelPlan(sqlQuery)
   }
 
@@ -1285,7 +1285,7 @@ class SubQuerySemiJoinTest extends SubQueryTestBase {
     util.addTableSource[(Int, Long, Double, String)]("r1", 'c, 'd, 'e, 'f)
 
     val sqlQuery = "SELECT * FROM l1 WHERE EXISTS " +
-      "(SELECT MAX(e) FROM r1 WHERE l1.b = r1.d AND c < 100 AND l1.a = r1.c GROUP BY c, true, f, 1)"
+      "(SELECT MAX(e) FROM r1 WHERE l1.b = r1.d AND c < 100 AND l1.a = r1.c GROUP BY c, true, f, '1')"
     util.verifyRelPlan(sqlQuery)
   }
 
@@ -1598,7 +1598,7 @@ class SubQuerySemiJoinTest extends SubQueryTestBase {
 
     util.verifyRelPlanNotExpected(sqlQuery1, "joinType=[semi]")
 
-    val sqlQuery2 = "SELECT MAX(a) FROM x GROUP BY 1 HAVING EXISTS (SELECT 1 FROM y WHERE d < b)"
+    val sqlQuery2 = "SELECT MAX(a) FROM x GROUP BY '1' HAVING EXISTS (SELECT 1 FROM y WHERE d < b)"
     util.verifyRelPlanNotExpected(sqlQuery2, "joinType=[semi]")
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/GroupingSetsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/GroupingSetsTest.scala
@@ -393,12 +393,12 @@ class GroupingSetsTest extends TableTestBase {
 
   @Test
   def testAllowExpressionInCube2(): Unit = {
-    util.verifyExecPlan("SELECT COUNT(*) AS c FROM emp GROUP BY CUBE(1)")
+    util.verifyExecPlan("SELECT COUNT(*) AS c FROM emp GROUP BY CUBE('1')")
   }
 
   @Test
   def testAllowExpressionInRollup3(): Unit = {
-    util.verifyExecPlan("SELECT COUNT(*) AS c FROM emp GROUP BY ROLLUP(1)")
+    util.verifyExecPlan("SELECT COUNT(*) AS c FROM emp GROUP BY ROLLUP('1')")
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/SemiAntiJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/SemiAntiJoinTest.scala
@@ -223,7 +223,7 @@ class SemiAntiJoinTest extends TableTestBase {
   @Test
   def testInWithCorrelated_AggInSubQuery2(): Unit = {
     val sqlQuery = "SELECT * FROM l WHERE (b, a) IN " +
-      "(SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, 1)"
+      "(SELECT COUNT(*), d FROM r WHERE l.c = r.f GROUP BY d, true, e, '1')"
     util.verifyExecPlan(sqlQuery)
   }
 
@@ -359,7 +359,7 @@ class SemiAntiJoinTest extends TableTestBase {
   @Test
   def testExistsWithCorrelated_AggInSubQuery(): Unit = {
     val sqlQuery = "SELECT * FROM l WHERE EXISTS " +
-      "(SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, 1)"
+      "(SELECT MAX(e) FROM r WHERE l.b = r.e AND d < 100 AND l.c = r.f GROUP BY d, true, f, '1')"
     util.verifyExecPlan(sqlQuery)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateReduceGroupingITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateReduceGroupingITCase.scala
@@ -213,11 +213,19 @@ class AggregateReduceGroupingITCase extends BatchTestBase {
       "SELECT a2, b2, count(c2) FROM T2 GROUP BY a2, b2",
       Seq(row(1, 1, 1), row(1, 2, 1), row(2, 3, 0), row(2, 4, 1)))
 
+    // group by ordinal fields
+    checkResult(
+      "SELECT a3, b3, count(c3) FROM T3 GROUP BY 1, 2",
+      Seq(row(1, 10, 1), row(2, 20, 2), row(3, 10, 1), row(4, 20, 1), row(4, null, 1)))
+    checkResult(
+      "SELECT a2, b2, count(c2) FROM T2 GROUP BY 1, 2",
+      Seq(row(1, 1, 1), row(1, 2, 1), row(2, 3, 0), row(2, 4, 1)))
+
     // group by constants
     checkResult(
-      "SELECT a1, b1, count(c1) FROM T1 GROUP BY a1, b1, 1, true",
+      "SELECT a1, b1, count(c1) FROM T1 GROUP BY a1, b1, '1', true",
       Seq(row(2, 1, 1), row(3, 2, 1), row(5, 2, 1), row(6, 3, 1)))
-    checkResult("SELECT count(c1) FROM T1 GROUP BY 1, true", Seq(row(4)))
+    checkResult("SELECT count(c1) FROM T1 GROUP BY '1', true", Seq(row(4)))
 
     // large data, for hash agg mode it will fallback
     checkResult(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/GroupingSetsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/GroupingSetsITCase.scala
@@ -602,13 +602,51 @@ class GroupingSetsITCase extends BatchTestBase {
     )
 
     checkResult(
-      "select count(*) as c from emp group by cube(1)",
+      "select mod(deptno, 20) as d, count(*) as c, gender as g " +
+        "from emp group by rollup(1, gender)",
+      Seq(
+        row(0, 1, "F"),
+        row(0, 1, "M"),
+        row(0, 2, null),
+        row(10, 2, "M"),
+        row(10, 4, "F"),
+        row(10, 6, null),
+        row(null, 1, "F"),
+        row(null, 1, null),
+        row(null, 9, null))
+    )
+
+    checkResult(
+      "select count(*) as c from emp group by cube('1')",
       Seq(row(9), row(9))
     )
 
     checkResult(
-      "select count(*) as c from emp group by cube(1)",
+      "select count(*) as c from emp group by cube('1')",
       Seq(row(9), row(9))
+    )
+
+    checkResult(
+      "select deptno + 1, count(*) as c from emp group by cube(1, gender)",
+      Seq(
+        row(11, 1),
+        row(11, 1),
+        row(11, 2),
+        row(21, 1),
+        row(21, 1),
+        row(31, 2),
+        row(31, 2),
+        row(51, 1),
+        row(51, 1),
+        row(51, 2),
+        row(61, 1),
+        row(61, 1),
+        row(null, 1),
+        row(null, 1),
+        row(null, 3),
+        row(null, 6),
+        row(null, 9)
+      )
     )
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -347,6 +347,73 @@ class AggregateITCase(aggMode: AggMode, miniBatch: MiniBatchMode, backend: State
   }
 
   @TestTemplate
+  def testGroupRowsBySingleColumnOrdinals(): Unit = {
+    // this case covers LongArrayValueWithRetractionGenerator and LongValueWithRetractionGenerator
+    val data = new mutable.MutableList[(Int, Long, String)]
+    data.+=((1, 1L, "A"))
+    data.+=((1, 1L, "A"))
+    data.+=((1, 1L, "A"))
+    data.+=((2, 2L, "B"))
+    data.+=((3, 2L, "B"))
+    data.+=((4, 3L, "C"))
+    data.+=((5, 3L, "C"))
+    data.+=((6, 3L, "C"))
+    data.+=((7, 4L, "B"))
+    data.+=((8, 4L, "A"))
+    data.+=((9, 4L, "D"))
+    data.+=((10, 4L, "E"))
+    data.+=((11, 5L, "A"))
+    data.+=((12, 5L, "B"))
+
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.createTemporaryView("T", t)
+
+    val sql =
+      """
+        | SELECT b, sum(a)
+        | FROM T
+        | GROUP BY 1
+      """.stripMargin
+
+    val t1 = tEnv.sqlQuery(sql)
+    val sink = new TestingRetractSink
+    t1.toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = List("1,3", "2,5", "3,15", "4,34", "5,23")
+    assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
+  }
+
+  @TestTemplate
+  def testGroupRowsByMultipleColumnOrdinals(): Unit = {
+    // this case covers LongArrayValueWithRetractionGenerator and LongValueWithRetractionGenerator
+    val data = new mutable.MutableList[(Int, Long, String)]
+    data.+=((1, 1L, "A"))
+    data.+=((1, 1L, "A"))
+    data.+=((1, 1L, "A"))
+    data.+=((2, 2L, "B"))
+    data.+=((3, 2L, "B"))
+
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.createTemporaryView("T", t)
+
+    val sql =
+      """
+        | SELECT b, a, count(c)
+        | FROM T
+        | GROUP BY 2, 1
+      """.stripMargin
+
+    val t1 = tEnv.sqlQuery(sql)
+    val sink = new TestingRetractSink
+    t1.toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = List("1,1,3", "2,2,1", "2,3,1")
+    assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
+  }
+
+  @TestTemplate
   def testDistinctWithRetract(): Unit = {
     // this case covers LongArrayValueWithRetractionGenerator and LongValueWithRetractionGenerator
     val data = new mutable.MutableList[(Int, Long, String)]


### PR DESCRIPTION

## What is the purpose of the change

SImilar to BigQuery add support to group rows by column ordinals


## Brief change log

  - Calcite already supports groupby column ordinals. So, enable it
  - Make sure that the config uses the updated SqlConformance
  - Add tests


## Verifying this change

Added tests to org.apache.flink.table.planner.runtime.stream.sql.AggregateITCase


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
