### PR TITLE
[FLINK-34362][docs] Add argument to skip integrate connector docs in setup_docs.sh to improve build times

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ $ ./build_docs.sh
 
 The shell `./build_docs.sh` will integrate external connector docs, referencing `setup_docs.sh#integrate_connector_docs`.
 This process involves cloning the repo of some external connectors, which can be time-consuming and prone to network issues.
-So, if you wish to skip this step, you can do so by adding the following arg:
+So, if the connector docs have been synced before, and you wish to skip this step, you can do so by adding the following arg:
 
 ```sh
 $ ./build_docs.sh --skip-integrate-connector-docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,14 @@ Then build the docs from source:
 $ ./build_docs.sh
 ```
 
+The shell `./build_docs.sh` will integrate external connector docs, referencing `setup_docs.sh#integrate_connector_docs`.
+This process involves cloning the repo of some external connectors, which can be time-consuming and prone to network issues.
+So, if you wish to skip this step, you can do so by adding the following arg:
+
+```sh
+$ ./build_docs.sh --skip-integrate-connector-docs
+```
+
 The site can be viewed at http://localhost:1313/
 
 ## Include externally hosted documentation

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -24,6 +24,18 @@ then
 	exit 1
 fi
 git submodule update --init --recursive
-./setup_docs.sh
+
+# whether to skip integrate connector docs. If contains arg '--skip-integrate-connector-docs',
+# the external connector docs will not be generated.
+SKIP_INTEGRATE_CONNECTOR_DOCS=""
+for arg in "$@"; do
+  if [ "$arg" == "--skip-integrate-connector-docs" ]; then
+    SKIP_INTEGRATE_CONNECTOR_DOCS="--skip-integrate-connector-docs"
+    break
+  fi
+done
+
+./setup_docs.sh $SKIP_INTEGRATE_CONNECTOR_DOCS
+
 hugo mod get -u
 hugo -b "" serve 

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -25,11 +25,12 @@ then
 fi
 git submodule update --init --recursive
 
-# whether to skip integrate connector docs. If contains arg '--skip-integrate-connector-docs',
-# the external connector docs will not be generated.
+# whether to skip integrate connector docs. If contains arg '--skip-integrate-connector-docs' and
+# the connectors directory is not empty, the external connector docs will not be generated.
+connectors_dir="./themes/connectors"
 SKIP_INTEGRATE_CONNECTOR_DOCS=""
 for arg in "$@"; do
-  if [ "$arg" == "--skip-integrate-connector-docs" ]; then
+  if [ -d "$connectors_dir" ] && [ "$arg" == "--skip-integrate-connector-docs" ]; then
     SKIP_INTEGRATE_CONNECTOR_DOCS="--skip-integrate-connector-docs"
     break
   fi

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -36,24 +36,33 @@ function integrate_connector_docs {
 }
 
 
+SKIP_INTEGRATE_CONNECTOR_DOCS=false
+for arg in "$@"; do
+  if [ "$arg" == "--skip-integrate-connector-docs" ]; then
+    SKIP_INTEGRATE_CONNECTOR_DOCS=true
+    break
+  fi
+done
+
 # Integrate the connector documentation
+if [ "$SKIP_INTEGRATE_CONNECTOR_DOCS" = false ]; then
+  rm -rf themes/connectors/*
+  rm -rf tmp
+  mkdir tmp
+  cd tmp
 
-rm -rf themes/connectors/*
-rm -rf tmp
-mkdir tmp
-cd tmp
+  integrate_connector_docs elasticsearch v3.0
+  integrate_connector_docs aws v4.2
+  integrate_connector_docs cassandra v3.1
+  integrate_connector_docs pulsar v4.0
+  integrate_connector_docs jdbc v3.1
+  integrate_connector_docs rabbitmq v3.0
+  integrate_connector_docs gcp-pubsub v3.0
+  integrate_connector_docs mongodb v1.1
+  integrate_connector_docs opensearch v1.1
+  integrate_connector_docs kafka v3.0
+  integrate_connector_docs hbase v3.0
 
-integrate_connector_docs elasticsearch v3.0
-integrate_connector_docs aws v4.2
-integrate_connector_docs cassandra v3.1
-integrate_connector_docs pulsar v4.0
-integrate_connector_docs jdbc v3.1
-integrate_connector_docs rabbitmq v3.0
-integrate_connector_docs gcp-pubsub v3.0
-integrate_connector_docs mongodb v1.1
-integrate_connector_docs opensearch v1.1
-integrate_connector_docs kafka v3.0
-integrate_connector_docs hbase v3.0
-
-cd ..
-rm -rf tmp
+  cd ..
+  rm -rf tmp
+fi


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The current build process of Flink's documentation involves the `setup_docs.sh` script, which re-clones connector repositories every time the documentation is built. This operation is time-consuming, particularly for developers in regions with slower internet connections or facing network restrictions (like the Great Firewall in China). This results in a build process that can take an excessive amount of time, hindering developer productivity.

So, this pr is aims to add an arg to skip integrate connector docs in setup_docs.sh to improve build times. This arg `--skip-integrate-connector-docs` default is false, which mean we will default to integrate connector docs. If user want to disable integrate connector docs, he/she can run `./build_docs.sh --skip-integrate-connector-docs` in console.


## Brief change log

- Add arg `--skip-integrate-connector-docs` to skip integrate connector docs in setup_docs.sh.


## Verifying this change
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no docs
