### PR TITLE
[FLINK-34371][runtime] Support EndOfStreamTrigger and isOutputOnlyAfterEndOfStream operator attribute to optimize task deployment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -2039,8 +2039,13 @@ public class CheckpointCoordinator {
                     isPeriodicCheckpointingConfigured(),
                     "Can not start checkpoint scheduler, if no periodic checkpointing is configured");
 
-            // make sure all prior timers are cancelled
-            stopCheckpointScheduler();
+            if (isPeriodicCheckpointingStarted()) {
+                // cancel previously scheduled checkpoints and spare savepoints.
+                // TODO: Introduce a more general solution to the race condition
+                //  between different checkpoint scheduling triggers.
+                //  https://issues.apache.org/jira/browse/FLINK-34519
+                stopCheckpointScheduler();
+            }
 
             periodicScheduling = true;
             scheduleTriggerWithDelay(clock.relativeTimeMillis(), getRandomInitDelay());
@@ -2133,14 +2138,15 @@ public class CheckpointCoordinator {
     //  job status listener that schedules / cancels periodic checkpoints
     // ------------------------------------------------------------------------
 
-    public JobStatusListener createActivatorDeactivator() {
+    public JobStatusListener createActivatorDeactivator(boolean allTasksOutputNonBlocking) {
         synchronized (lock) {
             if (shutdown) {
                 throw new IllegalArgumentException("Checkpoint coordinator is shut down");
             }
 
             if (jobStatusListener == null) {
-                jobStatusListener = new CheckpointCoordinatorDeActivator(this);
+                jobStatusListener =
+                        new CheckpointCoordinatorDeActivator(this, allTasksOutputNonBlocking);
             }
 
             return jobStatusListener;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorDeActivator.java
@@ -31,15 +31,18 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class CheckpointCoordinatorDeActivator implements JobStatusListener {
 
     private final CheckpointCoordinator coordinator;
+    private final boolean allTasksOutputNonBlocking;
 
-    public CheckpointCoordinatorDeActivator(CheckpointCoordinator coordinator) {
+    public CheckpointCoordinatorDeActivator(
+            CheckpointCoordinator coordinator, boolean allTasksOutputNonBlocking) {
         this.coordinator = checkNotNull(coordinator);
+        this.allTasksOutputNonBlocking = allTasksOutputNonBlocking;
     }
 
     @Override
     public void jobStatusChanges(JobID jobId, JobStatus newJobStatus, long timestamp) {
-        if (newJobStatus == JobStatus.RUNNING) {
-            // start the checkpoint scheduler
+        if (newJobStatus == JobStatus.RUNNING && allTasksOutputNonBlocking) {
+            // start the checkpoint scheduler if there is no blocking edge
             coordinator.startCheckpointScheduler();
         } else {
             // anything else should stop the trigger for now

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -242,6 +242,7 @@ public class CheckpointFailureManager {
             case UNKNOWN_TASK_CHECKPOINT_NOTIFICATION_FAILURE:
                 // there are some edge cases shouldn't be counted as a failure, e.g. shutdown
             case TRIGGER_CHECKPOINT_FAILURE:
+            case BLOCKING_OUTPUT_EXIST:
                 // ignore
                 break;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureReason.java
@@ -34,6 +34,8 @@ public enum CheckpointFailureReason {
     IO_EXCEPTION(
             true, "An Exception occurred while triggering the checkpoint. IO-problem detected."),
 
+    BLOCKING_OUTPUT_EXIST(true, "Blocking output edge exists in running tasks."),
+
     CHECKPOINT_ASYNC_EXCEPTION(false, "Asynchronous task checkpoint failed."),
 
     CHANNEL_STATE_SHARED_STREAM_EXCEPTION(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -116,6 +116,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphUtils.isAnyOutputBlocking;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -1397,7 +1398,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                 return attempt.switchToInitializing();
 
             case RUNNING:
-                if (!isAnyOutputBlocking()
+                if (!isAnyOutputBlocking(this)
                         && checkpointCoordinator != null
                         && checkpointCoordinator.isPeriodicCheckpointingConfigured()
                         && !checkpointCoordinator.isPeriodicCheckpointingStarted()) {
@@ -1439,11 +1440,6 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                                         + state.getExecutionState()));
                 return false;
         }
-    }
-
-    private boolean isAnyOutputBlocking() {
-        return currentExecutions.values().stream()
-                .anyMatch(x -> x.getVertex().getJobVertex().getJobVertex().isAnyOutputBlocking());
     }
 
     private void maybeReleasePartitionGroupsFor(final Execution attempt) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraphUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+/** Utility methods related to {@link ExecutionGraph}. */
+public class ExecutionGraphUtils {
+    /** @return Whether there is any blocking output edge in the execution graph. */
+    public static boolean isAnyOutputBlocking(ExecutionGraph graph) {
+        return graph.getRegisteredExecutions().values().stream()
+                .anyMatch(x -> x.getVertex().getJobVertex().getJobVertex().isAnyOutputBlocking());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -155,6 +155,8 @@ public class JobVertex implements java.io.Serializable {
      */
     private boolean supportsConcurrentExecutionAttempts = true;
 
+    private boolean anyOutputBlocking = false;
+
     private boolean parallelismConfigured = false;
 
     // --------------------------------------------------------------------------------------------
@@ -496,6 +498,7 @@ public class JobVertex implements java.io.Serializable {
     // --------------------------------------------------------------------------------------------
     public IntermediateDataSet getOrCreateResultDataSet(
             IntermediateDataSetID id, ResultPartitionType partitionType) {
+        anyOutputBlocking |= partitionType.isBlockingOrBlockingPersistentResultPartition();
         return this.results.computeIfAbsent(
                 id, key -> new IntermediateDataSet(id, partitionType, this));
     }
@@ -555,6 +558,10 @@ public class JobVertex implements java.io.Serializable {
 
     public boolean isSupportsConcurrentExecutionAttempts() {
         return supportsConcurrentExecutionAttempts;
+    }
+
+    public boolean isAnyOutputBlocking() {
+        return anyOutputBlocking;
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -26,12 +26,15 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.execution.JobStatusHook;
+import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.failure.FailureEnricher;
 import org.apache.flink.core.failure.TestingFailureEnricher;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.core.testutils.ScheduledTask;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinator;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
@@ -123,6 +126,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -134,6 +138,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
 import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.createSlotOffersForResourceRequirements;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.acknowledgePendingCheckpoint;
@@ -1839,6 +1844,14 @@ public class DefaultSchedulerTest {
         transitionToRunning(scheduler, sourceAttemptId);
         transitionToRunning(scheduler, mapAttemptId);
         assertThat(checkpointCoordinator.isPeriodicCheckpointingStarted()).isFalse();
+        assertThatFuture(scheduler.triggerSavepoint("", false, SavepointFormatType.DEFAULT))
+                .eventuallyFailsWith(ExecutionException.class)
+                .withCauseInstanceOf(CheckpointException.class)
+                .withMessageContaining(CheckpointFailureReason.BLOCKING_OUTPUT_EXIST.message());
+        assertThatFuture(scheduler.stopWithSavepoint("", false, SavepointFormatType.DEFAULT))
+                .eventuallyFailsWith(ExecutionException.class)
+                .withCauseInstanceOf(CheckpointException.class)
+                .withMessageContaining(CheckpointFailureReason.BLOCKING_OUTPUT_EXIST.message());
 
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(sourceAttemptId, ExecutionState.FINISHED));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -486,7 +486,7 @@ public class StreamGraph implements Pipeline {
             @Nullable String slotSharingGroup,
             @Nullable String coLocationGroup,
             Class<? extends TaskInvokable> vertexClass,
-            StreamOperatorFactory<?> operatorFactory,
+            @Nullable StreamOperatorFactory<?> operatorFactory,
             String operatorName) {
 
         if (streamNodes.containsKey(vertexID)) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -893,14 +893,6 @@ public class StreamGraph implements Pipeline {
         return streamNodes.values();
     }
 
-    public Set<Tuple2<Integer, StreamOperatorFactory<?>>> getAllOperatorFactory() {
-        Set<Tuple2<Integer, StreamOperatorFactory<?>>> operatorSet = new HashSet<>();
-        for (StreamNode vertex : streamNodes.values()) {
-            operatorSet.add(new Tuple2<>(vertex.getId(), vertex.getOperatorFactory()));
-        }
-        return operatorSet;
-    }
-
     public String getBrokerID(Integer vertexID) {
         return vertexIDtoBrokerID.get(vertexID);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -443,4 +443,11 @@ public class StreamNode {
             boolean supportsConcurrentExecutionAttempts) {
         this.supportsConcurrentExecutionAttempts = supportsConcurrentExecutionAttempts;
     }
+
+    public boolean isOutputOnlyAfterEndOfStream() {
+        if (operatorFactory == null) {
+            return false;
+        }
+        return operatorFactory.getOperatorAttributes().isOutputOnlyAfterEndOfStream();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -75,7 +75,7 @@ public class StreamNode {
     private KeySelector<?, ?>[] statePartitioners = new KeySelector[0];
     private TypeSerializer<?> stateKeySerializer;
 
-    private StreamOperatorFactory<?> operatorFactory;
+    private @Nullable StreamOperatorFactory<?> operatorFactory;
     private TypeSerializer<?>[] typeSerializersIn = new TypeSerializer[0];
     private TypeSerializer<?> typeSerializerOut;
 
@@ -103,14 +103,14 @@ public class StreamNode {
             Integer id,
             @Nullable String slotSharingGroup,
             @Nullable String coLocationGroup,
-            StreamOperator<?> operator,
+            @Nullable StreamOperator<?> operator,
             String operatorName,
             Class<? extends TaskInvokable> jobVertexClass) {
         this(
                 id,
                 slotSharingGroup,
                 coLocationGroup,
-                SimpleOperatorFactory.of(operator),
+                operator == null ? null : SimpleOperatorFactory.of(operator),
                 operatorName,
                 jobVertexClass);
     }
@@ -119,7 +119,7 @@ public class StreamNode {
             Integer id,
             @Nullable String slotSharingGroup,
             @Nullable String coLocationGroup,
-            StreamOperatorFactory<?> operatorFactory,
+            @Nullable StreamOperatorFactory<?> operatorFactory,
             String operatorName,
             Class<? extends TaskInvokable> jobVertexClass) {
         this.id = id;
@@ -259,10 +259,11 @@ public class StreamNode {
 
     @VisibleForTesting
     public StreamOperator<?> getOperator() {
+        assert operatorFactory != null && operatorFactory instanceof SimpleOperatorFactory;
         return (StreamOperator<?>) ((SimpleOperatorFactory) operatorFactory).getOperator();
     }
 
-    public StreamOperatorFactory<?> getOperatorFactory() {
+    public @Nullable StreamOperatorFactory<?> getOperatorFactory() {
         return operatorFactory;
     }
 
@@ -393,7 +394,7 @@ public class StreamNode {
 
     public Optional<OperatorCoordinator.Provider> getCoordinatorProvider(
             String operatorName, OperatorID operatorID) {
-        if (operatorFactory instanceof CoordinatedOperatorFactory) {
+        if (operatorFactory != null && operatorFactory instanceof CoordinatedOperatorFactory) {
             return Optional.of(
                     ((CoordinatedOperatorFactory) operatorFactory)
                             .getCoordinatorProvider(operatorName, operatorID));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -579,13 +579,15 @@ public class StreamingJobGraphGenerator {
         for (Integer sourceNodeId : streamGraph.getSourceIDs()) {
             final StreamNode sourceNode = streamGraph.getStreamNode(sourceNodeId);
 
-            if (sourceNode.getOperatorFactory() instanceof SourceOperatorFactory
+            if (sourceNode.getOperatorFactory() != null
+                    && sourceNode.getOperatorFactory() instanceof SourceOperatorFactory
                     && sourceNode.getOutEdges().size() == 1) {
                 // as long as only NAry ops support this chaining, we need to skip the other parts
                 final StreamEdge sourceOutEdge = sourceNode.getOutEdges().get(0);
                 final StreamNode target = streamGraph.getStreamNode(sourceOutEdge.getTargetId());
                 final ChainingStrategy targetChainingStrategy =
-                        target.getOperatorFactory().getChainingStrategy();
+                        Preconditions.checkNotNull(target.getOperatorFactory())
+                                .getChainingStrategy();
 
                 if (targetChainingStrategy == ChainingStrategy.HEAD_WITH_SOURCES
                         && isChainableInput(sourceOutEdge, streamGraph)) {
@@ -1630,7 +1632,7 @@ public class StreamingJobGraphGenerator {
             return getHeadOperator(
                     streamGraph.getSourceVertex(upStreamVertex.getInEdges().get(0)), streamGraph);
         }
-        return upStreamVertex.getOperatorFactory();
+        return Preconditions.checkNotNull(upStreamVertex.getOperatorFactory());
     }
 
     private void markSupportingConcurrentExecutionAttempts() {
@@ -1952,7 +1954,8 @@ public class StreamingJobGraphGenerator {
         final ArrayList<MasterTriggerRestoreHook.Factory> hooks = new ArrayList<>();
 
         for (StreamNode node : streamGraph.getStreamNodes()) {
-            if (node.getOperatorFactory() instanceof UdfStreamOperatorFactory) {
+            if (node.getOperatorFactory() != null
+                    && node.getOperatorFactory() instanceof UdfStreamOperatorFactory) {
                 Function f =
                         ((UdfStreamOperatorFactory) node.getOperatorFactory()).getUserFunction();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributes.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributes.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.io.Serializable;
+
+/**
+ * OperatorAttributes element provides Job Manager with information that can be used to optimize job
+ * performance.
+ */
+@Experimental
+public class OperatorAttributes implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final boolean outputOnlyAfterEndOfStream;
+
+    OperatorAttributes(boolean outputOnlyAfterEndOfStream) {
+        this.outputOnlyAfterEndOfStream = outputOnlyAfterEndOfStream;
+    }
+
+    /**
+     * Returns true if and only if the operator only emits records after all its inputs have ended.
+     *
+     * <p>Here are the implications when it is true:
+     *
+     * <ul>
+     *   <li>The results of this operator as well as its chained operators have blocking partition
+     *       type.
+     *   <li>This operator as well as its chained operators will be executed in batch mode.
+     * </ul>
+     */
+    public boolean isOutputOnlyAfterEndOfStream() {
+        return outputOnlyAfterEndOfStream;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributesBuilder.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributesBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Experimental;
+
+/** The builder class for {@link OperatorAttributes}. */
+@Experimental
+public class OperatorAttributesBuilder {
+    private boolean outputOnlyAfterEndOfStream = false;
+
+    /**
+     * Set to true if and only if the operator only emits records after all its inputs have ended.
+     * If it is not set, the default value false is used.
+     */
+    public OperatorAttributesBuilder setOutputOnlyAfterEndOfStream(
+            boolean outputOnlyAfterEndOfStream) {
+        this.outputOnlyAfterEndOfStream = outputOnlyAfterEndOfStream;
+        return this;
+    }
+
+    public OperatorAttributes build() {
+        return new OperatorAttributes(outputOnlyAfterEndOfStream);
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
@@ -132,4 +132,9 @@ public class SimpleOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
     public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
         return operator.getClass();
     }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return operator.getOperatorAttributes();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperator.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
@@ -148,4 +149,15 @@ public interface StreamOperator<OUT> extends CheckpointListener, KeyContext, Ser
     OperatorMetricGroup getMetricGroup();
 
     OperatorID getOperatorID();
+
+    /**
+     * Called to get the OperatorAttributes of the operator. If there is no defined attribute, a
+     * default OperatorAttributes is built.
+     *
+     * @return OperatorAttributes of the operator.
+     */
+    @Experimental
+    default OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder().build();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -87,4 +88,15 @@ public interface StreamOperatorFactory<OUT> extends Serializable {
 
     /** Returns the runtime class of the stream operator. */
     Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader);
+
+    /**
+     * Is called to get the OperatorAttributes of the operator. OperatorAttributes can inform the
+     * frame to optimize the job performance.
+     *
+     * @return OperatorAttributes of the operator.
+     */
+    @Experimental
+    default OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder().build();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
@@ -86,4 +86,8 @@ public abstract class AbstractMultipleInputTransformation<OUT> extends PhysicalT
     public final void setChainingStrategy(ChainingStrategy strategy) {
         operatorFactory.setChainingStrategy(strategy);
     }
+
+    public boolean isOutputOnlyAfterEndOfStream() {
+        return operatorFactory.getOperatorAttributes().isOutputOnlyAfterEndOfStream();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -184,4 +184,8 @@ public class OneInputTransformation<IN, OUT> extends PhysicalTransformation<OUT>
     public final void setChainingStrategy(ChainingStrategy strategy) {
         operatorFactory.setChainingStrategy(strategy);
     }
+
+    public boolean isOutputOnlyAfterEndOfStream() {
+        return operatorFactory.getOperatorAttributes().isOutputOnlyAfterEndOfStream();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
@@ -229,4 +229,8 @@ public class TwoInputTransformation<IN1, IN2, OUT> extends PhysicalTransformatio
     public final void setChainingStrategy(ChainingStrategy strategy) {
         operatorFactory.setChainingStrategy(strategy);
     }
+
+    public boolean isOutputOnlyAfterEndOfStream() {
+        return operatorFactory.getOperatorAttributes().isOutputOnlyAfterEndOfStream();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/assigners/GlobalWindows.java
@@ -27,6 +27,8 @@ import org.apache.flink.streaming.api.windowing.triggers.Trigger;
 import org.apache.flink.streaming.api.windowing.triggers.TriggerResult;
 import org.apache.flink.streaming.api.windowing.windows.GlobalWindow;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.Collections;
 
@@ -39,8 +41,11 @@ import java.util.Collections;
 @PublicEvolving
 public class GlobalWindows extends WindowAssigner<Object, GlobalWindow> {
     private static final long serialVersionUID = 1L;
+    @Nullable private final Trigger<Object, GlobalWindow> defaultTrigger;
 
-    private GlobalWindows() {}
+    private GlobalWindows(Trigger<Object, GlobalWindow> defaultTrigger) {
+        this.defaultTrigger = defaultTrigger;
+    }
 
     @Override
     public Collection<GlobalWindow> assignWindows(
@@ -56,22 +61,29 @@ public class GlobalWindows extends WindowAssigner<Object, GlobalWindow> {
 
     @Override
     public Trigger<Object, GlobalWindow> getDefaultTrigger() {
-        return new NeverTrigger();
+        return defaultTrigger == null ? new NeverTrigger() : defaultTrigger;
     }
 
     @Override
     public String toString() {
-        return "GlobalWindows()";
+        return "GlobalWindows(trigger=" + getDefaultTrigger().getClass().getSimpleName() + ")";
     }
 
     /**
-     * Creates a new {@code GlobalWindows} {@link WindowAssigner} that assigns all elements to the
-     * same {@link GlobalWindow}.
-     *
-     * @return The global window policy.
+     * Creates a {@link WindowAssigner} that assigns all elements to the same {@link GlobalWindow}.
+     * The window is only useful if you also specify a custom trigger. Otherwise, the window will
+     * never be triggered and no computation will be performed.
      */
     public static GlobalWindows create() {
-        return new GlobalWindows();
+        return new GlobalWindows(new NeverTrigger());
+    }
+
+    /**
+     * Creates a {@link WindowAssigner} that assigns all elements to the same {@link GlobalWindow}
+     * and the window is triggered if and only if the input stream is ended.
+     */
+    public static GlobalWindows createWithEndOfStreamTrigger() {
+        return new GlobalWindows(new EndOfStreamTrigger());
     }
 
     /** A trigger that never fires, as default Trigger for GlobalWindows. */
@@ -105,6 +117,35 @@ public class GlobalWindows extends WindowAssigner<Object, GlobalWindow> {
     @Override
     public TypeSerializer<GlobalWindow> getWindowSerializer(ExecutionConfig executionConfig) {
         return new GlobalWindow.Serializer();
+    }
+
+    /** A trigger that fires iff the input stream reaches EndOfStream. */
+    @Internal
+    public static class EndOfStreamTrigger extends Trigger<Object, GlobalWindow> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public TriggerResult onElement(
+                Object element, long timestamp, GlobalWindow window, TriggerContext ctx) {
+            ctx.registerEventTimeTimer(window.maxTimestamp());
+            return TriggerResult.CONTINUE;
+        }
+
+        @Override
+        public TriggerResult onEventTime(long time, GlobalWindow window, TriggerContext ctx) {
+            return time == window.maxTimestamp() ? TriggerResult.FIRE : TriggerResult.CONTINUE;
+        }
+
+        @Override
+        public TriggerResult onProcessingTime(long time, GlobalWindow window, TriggerContext ctx) {
+            return TriggerResult.CONTINUE;
+        }
+
+        @Override
+        public void clear(GlobalWindow window, TriggerContext ctx) throws Exception {}
+
+        @Override
+        public void onMerge(GlobalWindow window, OnMergeContext ctx) {}
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -57,8 +57,11 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.InternalTimer;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
 import org.apache.flink.streaming.api.windowing.assigners.MergingWindowAssigner;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.triggers.Trigger;
@@ -525,6 +528,16 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
             // need to make sure to update the merging state in state
             mergingWindows.persist();
         }
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        boolean isOutputOnlyAfterEndOfStream =
+                windowAssigner instanceof GlobalWindows
+                        && trigger instanceof GlobalWindows.EndOfStreamTrigger;
+        return new OperatorAttributesBuilder()
+                .setOutputOnlyAfterEndOfStream(isOutputOnlyAfterEndOfStream)
+                .build();
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,12 +79,14 @@ public class BatchExecutionUtils {
     private static boolean isInputSelectable(StreamNode node) {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         Class<? extends StreamOperator> operatorClass =
-                node.getOperatorFactory().getStreamOperatorClass(classLoader);
+                Preconditions.checkNotNull(node.getOperatorFactory())
+                        .getStreamOperatorClass(classLoader);
         return InputSelectable.class.isAssignableFrom(operatorClass);
     }
 
     private static void adjustChainingStrategy(StreamNode node) {
-        StreamOperatorFactory<?> operatorFactory = node.getOperatorFactory();
+        StreamOperatorFactory<?> operatorFactory =
+                Preconditions.checkNotNull(node.getOperatorFactory());
         ChainingStrategy currentChainingStrategy = operatorFactory.getChainingStrategy();
         switch (currentChainingStrategy) {
             case ALWAYS:

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
@@ -54,34 +54,22 @@ public class MultiInputTransformationTranslator<OUT>
     protected Collection<Integer> translateForBatchInternal(
             final AbstractMultipleInputTransformation<OUT> transformation, final Context context) {
         Collection<Integer> ids = translateInternal(transformation, context);
-        if (transformation instanceof KeyedMultipleInputTransformation) {
-            KeyedMultipleInputTransformation<OUT> keyedTransformation =
-                    (KeyedMultipleInputTransformation<OUT>) transformation;
-            List<Transformation<?>> inputs = transformation.getInputs();
-            List<KeySelector<?, ?>> keySelectors = keyedTransformation.getStateKeySelectors();
 
-            StreamConfig.InputRequirement[] inputRequirements =
-                    IntStream.range(0, inputs.size())
-                            .mapToObj(
-                                    idx -> {
-                                        if (keySelectors.get(idx) != null) {
-                                            return StreamConfig.InputRequirement.SORTED;
-                                        } else {
-                                            return StreamConfig.InputRequirement.PASS_THROUGH;
-                                        }
-                                    })
-                            .toArray(StreamConfig.InputRequirement[]::new);
+        maybeApplyBatchExecutionSettings(transformation, context);
 
-            BatchExecutionUtils.applyBatchExecutionSettings(
-                    transformation.getId(), context, inputRequirements);
-        }
         return ids;
     }
 
     @Override
     protected Collection<Integer> translateForStreamingInternal(
             final AbstractMultipleInputTransformation<OUT> transformation, final Context context) {
-        return translateInternal(transformation, context);
+        Collection<Integer> ids = translateInternal(transformation, context);
+
+        if (transformation.isOutputOnlyAfterEndOfStream()) {
+            maybeApplyBatchExecutionSettings(transformation, context);
+        }
+
+        return ids;
     }
 
     private Collection<Integer> translateInternal(
@@ -140,5 +128,28 @@ public class MultiInputTransformationTranslator<OUT>
                 transformationId, transformation.isSupportsConcurrentExecutionAttempts());
 
         return Collections.singleton(transformationId);
+    }
+
+    private void maybeApplyBatchExecutionSettings(
+            final AbstractMultipleInputTransformation<OUT> transformation, final Context context) {
+        if (transformation instanceof KeyedMultipleInputTransformation) {
+            KeyedMultipleInputTransformation<OUT> keyedTransformation =
+                    (KeyedMultipleInputTransformation<OUT>) transformation;
+            List<Transformation<?>> inputs = transformation.getInputs();
+            List<KeySelector<?, ?>> keySelectors = keyedTransformation.getStateKeySelectors();
+            StreamConfig.InputRequirement[] inputRequirements =
+                    IntStream.range(0, inputs.size())
+                            .mapToObj(
+                                    idx -> {
+                                        if (keySelectors.get(idx) != null) {
+                                            return StreamConfig.InputRequirement.SORTED;
+                                        } else {
+                                            return StreamConfig.InputRequirement.PASS_THROUGH;
+                                        }
+                                    })
+                            .toArray(StreamConfig.InputRequirement[]::new);
+            BatchExecutionUtils.applyBatchExecutionSettings(
+                    transformation.getId(), context, inputRequirements);
+        }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
@@ -41,20 +41,16 @@ public final class OneInputTransformationTranslator<IN, OUT>
     @Override
     public Collection<Integer> translateForBatchInternal(
             final OneInputTransformation<IN, OUT> transformation, final Context context) {
-        KeySelector<IN, ?> keySelector = transformation.getStateKeySelector();
         Collection<Integer> ids =
                 translateInternal(
                         transformation,
                         transformation.getOperatorFactory(),
                         transformation.getInputType(),
-                        keySelector,
+                        transformation.getStateKeySelector(),
                         transformation.getStateKeyType(),
                         context);
-        boolean isKeyed = keySelector != null;
-        if (isKeyed) {
-            BatchExecutionUtils.applyBatchExecutionSettings(
-                    transformation.getId(), context, StreamConfig.InputRequirement.SORTED);
-        }
+
+        maybeApplyBatchExecutionSettings(transformation, context);
 
         return ids;
     }
@@ -62,12 +58,28 @@ public final class OneInputTransformationTranslator<IN, OUT>
     @Override
     public Collection<Integer> translateForStreamingInternal(
             final OneInputTransformation<IN, OUT> transformation, final Context context) {
-        return translateInternal(
-                transformation,
-                transformation.getOperatorFactory(),
-                transformation.getInputType(),
-                transformation.getStateKeySelector(),
-                transformation.getStateKeyType(),
-                context);
+        Collection<Integer> ids =
+                translateInternal(
+                        transformation,
+                        transformation.getOperatorFactory(),
+                        transformation.getInputType(),
+                        transformation.getStateKeySelector(),
+                        transformation.getStateKeyType(),
+                        context);
+
+        if (transformation.isOutputOnlyAfterEndOfStream()) {
+            maybeApplyBatchExecutionSettings(transformation, context);
+        }
+
+        return ids;
+    }
+
+    private void maybeApplyBatchExecutionSettings(
+            final OneInputTransformation<IN, OUT> transformation, final Context context) {
+        KeySelector<IN, ?> keySelector = transformation.getStateKeySelector();
+        if (keySelector != null) {
+            BatchExecutionUtils.applyBatchExecutionSettings(
+                    transformation.getId(), context, StreamConfig.InputRequirement.SORTED);
+        }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -91,6 +91,7 @@ import org.apache.flink.streaming.api.datastream.IterativeStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.CoProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.PrintSink;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
@@ -112,6 +113,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
+import org.apache.flink.streaming.api.operators.co.CoProcessOperator;
 import org.apache.flink.streaming.api.transformations.CacheTransformation;
 import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
@@ -2311,7 +2313,8 @@ class StreamingJobGraphGeneratorTest {
                 StreamExecutionEnvironment.getExecutionEnvironment(new Configuration());
 
         final DataStream<Integer> source = env.fromData(1, 2, 3).name("source");
-        source.transform(
+        source.keyBy(x -> x)
+                .transform(
                         "transform",
                         Types.INT,
                         new StreamOperatorWithConfigurableOperatorAttributes<>(
@@ -2334,6 +2337,10 @@ class StreamingJobGraphGeneratorTest {
         assertThat(nodeMap.get("transform").isOutputOnlyAfterEndOfStream()).isTrue();
         assertThat(nodeMap.get("Map").isOutputOnlyAfterEndOfStream()).isFalse();
         assertThat(nodeMap.get("sink: Writer").isOutputOnlyAfterEndOfStream()).isFalse();
+        assertManagedMemoryWeightsSize(nodeMap.get("Source: source"), 0);
+        assertManagedMemoryWeightsSize(nodeMap.get("transform"), 1);
+        assertManagedMemoryWeightsSize(nodeMap.get("Map"), 0);
+        assertManagedMemoryWeightsSize(nodeMap.get("sink: Writer"), 0);
 
         JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
         Map<String, JobVertex> vertexMap = new HashMap<>();
@@ -2345,7 +2352,6 @@ class StreamingJobGraphGeneratorTest {
                 vertexMap.get("Source: source"), ResultPartitionType.PIPELINED_BOUNDED);
         assertHasOutputPartitionType(
                 vertexMap.get("transform -> Map"), ResultPartitionType.BLOCKING);
-
         assertThat(vertexMap.get("Source: source").isAnyOutputBlocking()).isFalse();
         assertThat(vertexMap.get("transform -> Map").isAnyOutputBlocking()).isTrue();
         assertThat(vertexMap.get("sink: Writer").isAnyOutputBlocking()).isFalse();
@@ -2361,11 +2367,45 @@ class StreamingJobGraphGeneratorTest {
                 vertexMap.get("Source: source"), ResultPartitionType.PIPELINED_BOUNDED);
         assertHasOutputPartitionType(vertexMap.get("transform"), ResultPartitionType.BLOCKING);
         assertHasOutputPartitionType(vertexMap.get("Map"), ResultPartitionType.PIPELINED_BOUNDED);
-
         assertThat(vertexMap.get("Source: source").isAnyOutputBlocking()).isFalse();
         assertThat(vertexMap.get("transform").isAnyOutputBlocking()).isTrue();
         assertThat(vertexMap.get("Map").isAnyOutputBlocking()).isFalse();
         assertThat(vertexMap.get("sink: Writer").isAnyOutputBlocking()).isFalse();
+    }
+
+    @Test
+    void testApplyBatchExecutionSettingsOnTwoInputOperator() {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(new Configuration());
+
+        final DataStream<Integer> source1 = env.fromData(1, 2, 3).name("source1");
+        final DataStream<Integer> source2 = env.fromData(1, 2, 3).name("source2");
+        source1.keyBy(x -> x)
+                .connect(source2.keyBy(x -> x))
+                .transform(
+                        "transform",
+                        Types.INT,
+                        new TwoInputStreamOperatorWithConfigurableOperatorAttributes<>(
+                                new OperatorAttributesBuilder()
+                                        .setOutputOnlyAfterEndOfStream(true)
+                                        .build()))
+                .sinkTo(new DiscardingSink<>())
+                .name("sink");
+
+        final StreamGraph streamGraph = env.getStreamGraph(false);
+        Map<String, StreamNode> nodeMap = new HashMap<>();
+        for (StreamNode node : streamGraph.getStreamNodes()) {
+            nodeMap.put(node.getOperatorName(), node);
+        }
+        assertThat(nodeMap).hasSize(4);
+        assertManagedMemoryWeightsSize(nodeMap.get("Source: source1"), 0);
+        assertManagedMemoryWeightsSize(nodeMap.get("Source: source2"), 0);
+        assertManagedMemoryWeightsSize(nodeMap.get("transform"), 1);
+        assertManagedMemoryWeightsSize(nodeMap.get("sink: Writer"), 0);
+    }
+
+    private void assertManagedMemoryWeightsSize(StreamNode node, int weightSize) {
+        assertThat(node.getManagedMemoryOperatorScopeUseCaseWeights()).hasSize(weightSize);
     }
 
     private static void testWhetherOutputFormatSupportsConcurrentExecutionAttempts(
@@ -3025,5 +3065,32 @@ class StreamingJobGraphGeneratorTest {
         public OperatorAttributes getOperatorAttributes() {
             return attributes;
         }
+    }
+
+    private static class TwoInputStreamOperatorWithConfigurableOperatorAttributes<IN1, IN2, OUT>
+            extends CoProcessOperator<IN1, IN2, OUT> {
+        private final OperatorAttributes attributes;
+
+        public TwoInputStreamOperatorWithConfigurableOperatorAttributes(
+                OperatorAttributes attributes) {
+            super(new NoOpCoProcessFunction<>());
+            this.attributes = attributes;
+        }
+
+        @Override
+        public OperatorAttributes getOperatorAttributes() {
+            return attributes;
+        }
+    }
+
+    private static class NoOpCoProcessFunction<IN1, IN2, OUT>
+            extends CoProcessFunction<IN1, IN2, OUT> {
+        @Override
+        public void processElement1(
+                IN1 value, CoProcessFunction<IN1, IN2, OUT>.Context ctx, Collector<OUT> out) {}
+
+        @Override
+        public void processElement2(
+                IN2 value, CoProcessFunction<IN1, IN2, OUT>.Context ctx, Collector<OUT> out) {}
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -2346,6 +2346,10 @@ class StreamingJobGraphGeneratorTest {
         assertHasOutputPartitionType(
                 vertexMap.get("transform -> Map"), ResultPartitionType.BLOCKING);
 
+        assertThat(vertexMap.get("Source: source").isAnyOutputBlocking()).isFalse();
+        assertThat(vertexMap.get("transform -> Map").isAnyOutputBlocking()).isTrue();
+        assertThat(vertexMap.get("sink: Writer").isAnyOutputBlocking()).isFalse();
+
         env.disableOperatorChaining();
         jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph(false));
         vertexMap = new HashMap<>();
@@ -2357,6 +2361,11 @@ class StreamingJobGraphGeneratorTest {
                 vertexMap.get("Source: source"), ResultPartitionType.PIPELINED_BOUNDED);
         assertHasOutputPartitionType(vertexMap.get("transform"), ResultPartitionType.BLOCKING);
         assertHasOutputPartitionType(vertexMap.get("Map"), ResultPartitionType.PIPELINED_BOUNDED);
+
+        assertThat(vertexMap.get("Source: source").isAnyOutputBlocking()).isFalse();
+        assertThat(vertexMap.get("transform").isAnyOutputBlocking()).isTrue();
+        assertThat(vertexMap.get("Map").isAnyOutputBlocking()).isFalse();
+        assertThat(vertexMap.get("sink: Writer").isAnyOutputBlocking()).isFalse();
     }
 
     private static void testWhetherOutputFormatSupportsConcurrentExecutionAttempts(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -99,6 +99,7 @@ public class AbstractUdfStreamOperatorLifecycleTest {
                     + "finish[], "
                     + "getCurrentKey[], "
                     + "getMetricGroup[], "
+                    + "getOperatorAttributes[], "
                     + "getOperatorID[], "
                     + "initializeState[interface org.apache.flink.streaming.api.operators.StreamTaskStateInitializer], "
                     + "notifyCheckpointAborted[long], "

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorAttributesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorAttributesTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link OperatorAttributes} and {@link OperatorAttributesBuilder}. */
+class OperatorAttributesTest {
+    @Test
+    public void testDefaultValues() {
+        OperatorAttributes attributes = new OperatorAttributesBuilder().build();
+        assertThat(attributes.isOutputOnlyAfterEndOfStream()).isFalse();
+    }
+
+    @Test
+    public void testSetAndGet() {
+        OperatorAttributes attributes =
+                new OperatorAttributesBuilder().setOutputOnlyAfterEndOfStream(true).build();
+        assertThat(attributes.isOutputOnlyAfterEndOfStream()).isTrue();
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/GlobalWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/GlobalWindowsTest.java
@@ -58,5 +58,8 @@ public class GlobalWindowsTest extends TestLogger {
         assertEquals(
                 new GlobalWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
         assertThat(assigner.getDefaultTrigger(), instanceOf(GlobalWindows.NeverTrigger.class));
+        assigner = GlobalWindows.createWithEndOfStreamTrigger();
+        assertThat(
+                assigner.getDefaultTrigger(), instanceOf(GlobalWindows.EndOfStreamTrigger.class));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperator.java
@@ -26,6 +26,8 @@ import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.binary.BinaryRowData;
@@ -152,5 +154,10 @@ public class StreamSortOperator extends TableStreamOperator<RowData>
                     });
         }
         super.finish();
+    }
+
+    @Override
+    public OperatorAttributes getOperatorAttributes() {
+        return new OperatorAttributesBuilder().setOutputOnlyAfterEndOfStream(true).build();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds support for EndOfStreamTrigger and isOutputOnlyAfterEndOfStream operator attribute to optimize task deployment.


## Brief change log

- Introduces OperatorAttributes with isOutputOnlyAfterEndOfStream attribute
- Schedules operators with isOutputOnlyAfterEndOfStream=true to run in blocking mode
- Make WindowOperator and StreamSortOperator return isOutputOnlyAfterEndOfStream=true in certain cases

## Verifying this change

- This change adds unit tests for OperatorAttributes and the corresponding blocking mode changes.
- The change on WindowOperator and StreamSortOperator is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
