### PR TITLE
[FLINK-34372][table-api] Support DESCRIBE CATALOG

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -2002,6 +2002,11 @@ public class HiveCatalog extends AbstractCatalog {
         return hiveDB;
     }
 
+    @Override
+    protected Map<String, String> extraExplainInfo() {
+        return Collections.singletonMap("hiveVersion", hiveVersion);
+    }
+
     enum CatalogTableType {
         HIVE_TABLE,
         FLINK_MANAGED_TABLE,

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -379,6 +379,15 @@ public class HiveCatalogTest {
         }
     }
 
+    @Test
+    public void testExplainCatalog() {
+        assertThat(hiveCatalog.explainCatalog())
+                .matches(
+                        "default database: default\n"
+                                + "hiveVersion: .*\n"
+                                + "CatalogClass: org.apache.flink.table.catalog.hive.HiveCatalog");
+    }
+
     private static Map<String, String> getLegacyFileSystemConnectorOptions(String path) {
         final Map<String, String> options = new HashMap<>();
         options.put("connector.type", "filesystem");

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.CatalogNotExistException;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.Catalog;
+
+import static org.apache.flink.table.api.internal.TableResultUtils.buildStringArrayResult;
+
+/** Operation to describe a DESCRIBE CATALOG catalogName statement. */
+@Internal
+public class DescribeCatalogOperation implements Operation, ExecutableOperation {
+
+    private final String catalogName;
+
+    public DescribeCatalogOperation(String catalogName) {
+        this.catalogName = catalogName;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "DESCRIBE CATALOG " + catalogName;
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        Catalog catalog =
+                ctx.getCatalogManager()
+                        .getCatalog(catalogName)
+                        .orElseThrow(() -> new CatalogNotExistException(catalogName));
+
+        return buildStringArrayResult("result", new String[] {catalog.explainCatalog()});
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeOperator.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeOperator.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * An {@link Operation} that describes the catalog, database and table, e.g. DESCRIBE CATALOG
+ * catalogName, DESCRIBE DATABASE [catalogName.]dataBaseName and DESCRIBE TABLE [[catalogName.]
+ * dataBaseName.]tableName.
+ */
+@Internal
+public interface DescribeOperator extends Operation, ExecutableOperation {}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeTableOperation.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * statement.
  */
 @Internal
-public class DescribeTableOperation implements Operation, ExecutableOperation {
+public class DescribeTableOperation implements DescribeOperator {
 
     private final ObjectIdentifier sqlIdentifier;
     private final boolean isExtended;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/AbstractCatalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/AbstractCatalog.java
@@ -21,6 +21,10 @@ package org.apache.flink.table.catalog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.StringUtils;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Abstract class for catalogs. */
@@ -46,5 +50,32 @@ public abstract class AbstractCatalog implements Catalog {
     @Override
     public String getDefaultDatabase() {
         return defaultDatabase;
+    }
+
+    @Override
+    public String explainCatalog() {
+        StringBuilder sb = new StringBuilder();
+        Map<String, String> extraExplainInfo = extraExplainInfo();
+        sb.append("default database: ").append(defaultDatabase);
+        if (!extraExplainInfo.isEmpty()) {
+            sb.append("\n");
+            sb.append(
+                    extraExplainInfo.entrySet().stream()
+                            .map(entry -> entry.getKey() + ": " + entry.getValue())
+                            .collect(Collectors.joining("\n")));
+        }
+
+        // put the class name at the end
+        sb.append("\n").append(Catalog.super.explainCatalog());
+        return sb.toString();
+    }
+
+    /**
+     * Extra explain information used to print by DESCRIBE CATALOG catalogName statement.
+     *
+     * <p>Note: The class name and default database name of this catalog are no need to be added.
+     */
+    protected Map<String, String> extraExplainInfo() {
+        return new HashMap<>();
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -781,4 +781,13 @@ public interface Catalog {
             CatalogColumnStatistics columnStatistics,
             boolean ignoreIfNotExists)
             throws PartitionNotExistException, CatalogException;
+
+    /**
+     * Get a user defined catalog description.
+     *
+     * @return a user-implement catalog detailed explanation
+     */
+    default String explainCatalog() {
+        return String.format("CatalogClass: %s", this.getClass().getCanonicalName());
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -60,6 +60,7 @@ import org.apache.flink.sql.parser.dml.SqlEndStatementSet;
 import org.apache.flink.sql.parser.dml.SqlExecute;
 import org.apache.flink.sql.parser.dml.SqlExecutePlan;
 import org.apache.flink.sql.parser.dml.SqlStatementSet;
+import org.apache.flink.sql.parser.dql.SqlDescribeCatalog;
 import org.apache.flink.sql.parser.dql.SqlLoadModule;
 import org.apache.flink.sql.parser.dql.SqlRichDescribeTable;
 import org.apache.flink.sql.parser.dql.SqlRichExplain;
@@ -116,6 +117,7 @@ import org.apache.flink.table.functions.FunctionIdentifier;
 import org.apache.flink.table.operations.BeginStatementSetOperation;
 import org.apache.flink.table.operations.CompileAndExecutePlanOperation;
 import org.apache.flink.table.operations.DeleteFromFilterOperation;
+import org.apache.flink.table.operations.DescribeCatalogOperation;
 import org.apache.flink.table.operations.DescribeTableOperation;
 import org.apache.flink.table.operations.EndStatementSetOperation;
 import org.apache.flink.table.operations.ExplainOperation;
@@ -284,6 +286,8 @@ public class SqlNodeToOperationConversion {
         } else if (validated instanceof SqlShowCurrentCatalog) {
             return Optional.of(
                     converter.convertShowCurrentCatalog((SqlShowCurrentCatalog) validated));
+        } else if (validated instanceof SqlDescribeCatalog) {
+            return Optional.of(converter.convertDescribeCatalog((SqlDescribeCatalog) validated));
         } else if (validated instanceof SqlShowModules) {
             return Optional.of(converter.convertShowModules((SqlShowModules) validated));
         } else if (validated instanceof SqlUnloadModule) {
@@ -890,6 +894,10 @@ public class SqlNodeToOperationConversion {
     /** Convert SHOW CURRENT CATALOG statement. */
     private Operation convertShowCurrentCatalog(SqlShowCurrentCatalog sqlShowCurrentCatalog) {
         return new ShowCurrentCatalogOperation();
+    }
+
+    private Operation convertDescribeCatalog(SqlDescribeCatalog sqlDescribeCatalog) {
+        return new DescribeCatalogOperation(sqlDescribeCatalog.getCatalogName());
     }
 
     /** Convert SHOW CURRENT DATABASE statement. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -19,7 +19,7 @@ package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.sql.parser.ExtendedSqlNode
 import org.apache.flink.sql.parser.ddl.{SqlCompilePlan, SqlReset, SqlSet, SqlUseModules}
-import org.apache.flink.sql.parser.dml.{RichSqlInsert, SqlBeginStatementSet, SqlCompileAndExecutePlan, SqlEndStatementSet, SqlExecute, SqlExecutePlan, SqlStatementSet, SqlTruncateTable}
+import org.apache.flink.sql.parser.dml._
 import org.apache.flink.sql.parser.dql._
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.planner.hint.FlinkHints
@@ -135,6 +135,7 @@ class FlinkPlannerImpl(
         || sqlNode.isInstanceOf[SqlLoadModule]
         || sqlNode.isInstanceOf[SqlShowCatalogs]
         || sqlNode.isInstanceOf[SqlShowCurrentCatalog]
+        || sqlNode.isInstanceOf[SqlDescribeCatalog]
         || sqlNode.isInstanceOf[SqlShowDatabases]
         || sqlNode.isInstanceOf[SqlShowCurrentDatabase]
         || sqlNode.isInstanceOf[SqlShowTables]


### PR DESCRIPTION
## What is the purpose of the change

The work about DESCRIBE CATALOG is not finished yet. This pr aims to support it when converting sql node and executing it. 
See more at https://issues.apache.org/jira/browse/FLINK-34372.

Note: This pr should not be merged into 1.19 as it is a feature.

## Brief change log

  - *Support DESCRIBE CATALOG when converting sql and executing*
  - *Add tests for this pr*

## Verifying this change

Some tests are added to verify it.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? later
