### PR TITLE
[hotfix][web] Correct the hint of options name of rest.profiling.enabled

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/profiler/task-manager-profiler.component.html
@@ -121,7 +121,7 @@
       nzType="warning"
       style="margin-top: 10px"
       nzShowIcon
-      nzMessage="You need to set the config `rest.profiler.enabled: true` to enable this experimental profiler feature."
+      nzMessage="You need to set the config `rest.profiling.enabled: true` to enable this experimental profiler feature."
     ></nz-alert>
   </div>
   <nz-table


### PR DESCRIPTION
## What is the purpose of the change

A hotfix to correct the profilling options name.



## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
