### PR TITLE
[FLINK-34360][ci] Adds cleanup to job_init action

### DIFF
--- a/.github/actions/job_init/action.yml
+++ b/.github/actions/job_init/action.yml
@@ -44,6 +44,31 @@ runs:
         echo "GHA_PIPELINE_START_TIME=${job_start_time}" >> "${GITHUB_ENV}"
         echo "The job's start time is set to ${job_start_time}."
 
+    - name: "Pre-cleanup Disk Info"
+      shell: bash
+      run: df -h
+
+    - name: "Delete unused binaries"
+      shell: bash
+      run: |
+        # inspired by https://github.com/easimon/maximize-build-space
+        for label_with_path in \
+              "Android SDK:/usr/local/lib/android" \
+              "CodeQL:/opt/hostedtoolcache/CodeQL" \
+              ".NET:/usr/share/dotnet"; do
+          dependency_name="$(echo "${label_with_path}" | cut -d: -f1)"
+          dependency_path="$(echo "${label_with_path}" | cut -d: -f2)"
+        
+          if [ -d "${dependency_path}" ]; then
+            echo "[INFO] Deleting binaries of ${dependency_name} in ${dependency_path}."
+            sudo rm -rf "${dependency_path}"
+            df -h
+          else
+            echo "[INFO] The directory '${dependency_path}' doesn't exist. ${dependency_name} won't be removed."
+          fi
+        done
+        android_sdk_path="/usr/local/lib/android"
+
     - name: "Set JDK version to ${{ inputs.jdk_version }}"
       shell: bash
       run: |


### PR DESCRIPTION
## What is the purpose of the change

There was a drop in disk space some time between Feb 2 (see [84G example workflow](https://github.com/apache/flink/actions/runs/7750406652/job/21136823036#step:14:11726)) and Feb 3 (see [73G example workflow](https://github.com/apache/flink/actions/runs/7763815214/job/21176570116#step:14:11074)). Previously, the runners had a disk size of ~84G. That dropped to ~73G. Instead of 24G free space, the e2e tests were only able to use 14G.

This seems to be a GHA runner specific issue. The Azure Pipeline runners have a disk size of 73G as well, but come with less disk being used from the start. That is why we're not seeing the issue in Azure Pipelines.

There are some binaries which we're not really using. Removing those would already free quite some disk space:
* Andoid: ~9G
* CodeQL: ~5G
* .NET: ~1G

Removing these binaries results in another 15G of additional space. There is a risk that GitHub Action requires some of these dependencies, though. But for this change, I got inspired by [easymon/maximize-build-space:action.yml](https://github.com/easimon/maximize-build-space/blob/master/action.yml). That plugin does exactly that (+ some other even more elaborate things like creating a LVM volumes). I didn't use the plugin itself because I wanted to keep the impact on the runner as small as possible. Just removing the files seems to be the easiest way to gain some disk space.

## Brief change log

* Adds step to `job_init` action that deletes the folders for Android, CodeQL and .NET and logs the disk space afterwards

## Verifying this change

* The e2e tests should succeed again (see [GitHub Actions workflow run](https://github.com/XComp/flink/actions/runs/7802016945/job/21278945328))
* No instabilities should appear due to the missing binaries

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable