### PR TITLE
[FLINK-28693][table] Fix janino compile failed because the code generated refers the class in table-planner

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/CompileAndExecuteRemotePlanITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/CompileAndExecuteRemotePlanITCase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.sql.codegen;
+package org.apache.flink.table.sql;
 
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.RemoteIterator;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/CreateTableAsITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/CreateTableAsITCase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.sql.codegen;
+package org.apache.flink.table.sql;
 
 import org.apache.flink.formats.json.debezium.DebeziumJsonDeserializationSchema;
 import org.apache.flink.table.api.DataTypes;
@@ -33,13 +33,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * End-to-End tests for table planner scala-free since 1.15. Due to scala-free of table planner
- * introduced, the class in table planner is not visible in distribution runtime, if we use these
- * class in execution time, ClassNotFound exception will be thrown. ITCase in table planner can not
- * cover it, so we should add E2E test for these case.
- */
-public class PlannerScalaFreeITCase extends SqlITCaseBase {
+/** End-to-End tests for create table as select syntax. */
+public class CreateTableAsITCase extends SqlITCaseBase {
 
     private static final ResolvedSchema SINK_TABLE_SCHEMA =
             new ResolvedSchema(
@@ -52,13 +47,20 @@ public class PlannerScalaFreeITCase extends SqlITCaseBase {
     private static final DebeziumJsonDeserializationSchema DESERIALIZATION_SCHEMA =
             createDebeziumDeserializationSchema(SINK_TABLE_SCHEMA);
 
-    public PlannerScalaFreeITCase(String executionMode) {
+    public CreateTableAsITCase(String executionMode) {
         super(executionMode);
     }
 
     @Test
-    public void testImperativeUdaf() throws Exception {
-        runAndCheckSQL("scala_free_e2e.sql", Arrays.asList("+I[Bob, 2]", "+I[Alice, 1]"));
+    public void testCreateTableAs() throws Exception {
+        runAndCheckSQL("create_table_as_e2e.sql", Arrays.asList("+I[Bob, 2]", "+I[Alice, 1]"));
+    }
+
+    @Test
+    public void testCreateTableAsInStatementSet() throws Exception {
+        runAndCheckSQL(
+                "create_table_as_statementset_e2e.sql",
+                Arrays.asList("+I[Bob, 2]", "+I[Alice, 1]"));
     }
 
     @Override

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/HdfsITCaseBase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/HdfsITCaseBase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.sql.codegen;
+package org.apache.flink.table.sql;
 
 import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/SqlITCaseBase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/SqlITCaseBase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.sql.codegen;
+package org.apache.flink.table.sql;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.time.Deadline;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/UsingRemoteJarITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/UsingRemoteJarITCase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.sql.codegen;
+package org.apache.flink.table.sql;
 
 import org.apache.flink.formats.json.debezium.DebeziumJsonDeserializationSchema;
 import org.apache.flink.table.api.DataTypes;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/resources/watermark_push_down_e2e.sql
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/resources/watermark_push_down_e2e.sql
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+CREATE TABLE SourceTable (
+    user_name STRING,
+    order_cnt BIGINT,
+    order_time TIMESTAMP(3),
+    ts AS COALESCE(`order_time` ,CURRENT_TIMESTAMP),
+    watermark FOR `ts` AS `ts` - INTERVAL '5' SECOND
+) WITH (
+    'connector' = 'test-scan-table-source-with-watermark-push-down'
+);
+
+CREATE TABLE SinkTable (
+    user_name STRING,
+    order_cnt BIGINT
+) WITH (
+    'connector' = 'filesystem',
+    'path' = '$RESULT',
+    'sink.rolling-policy.rollover-interval' = '2s',
+    'sink.rolling-policy.check-interval' = '2s',
+    'format' = 'debezium-json'
+);
+
+SET execution.runtime-mode = $MODE;
+
+INSERT INTO SinkTable
+SELECT user_name, order_cnt
+FROM SourceTable;

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -40,6 +40,13 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-end-to-end-tests-common</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestScanTableSourceWithWatermarkPushDown.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestScanTableSourceWithWatermarkPushDown.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.data.RowData;
  *
  * <p>For simplicity, the deprecated source function method is used to create the source.
  */
-@SuppressWarnings("deprecation")
 public class TestScanTableSourceWithWatermarkPushDown
         implements ScanTableSource, SupportsWatermarkPushDown {
 

--- a/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestScanTableSourceWithWatermarkPushDown.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestScanTableSourceWithWatermarkPushDown.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.toolbox;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * A source used to test {@link SupportsWatermarkPushDown}.
+ *
+ * <p>For simplicity, the deprecated source function method is used to create the source.
+ */
+@SuppressWarnings("deprecation")
+public class TestScanTableSourceWithWatermarkPushDown
+        implements ScanTableSource, SupportsWatermarkPushDown {
+
+    private WatermarkStrategy<RowData> watermarkStrategy;
+
+    @Override
+    public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
+        this.watermarkStrategy = watermarkStrategy;
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        final TestScanTableSourceWithWatermarkPushDown newSource =
+                new TestScanTableSourceWithWatermarkPushDown();
+        newSource.watermarkStrategy = this.watermarkStrategy;
+        return newSource;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "TestScanTableSourceWithWatermarkPushDown";
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+        return SourceFunctionProvider.of(new TestSourceFunction(watermarkStrategy), false);
+    }
+}

--- a/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestScanTableSourceWithWatermarkPushDownFactory.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestScanTableSourceWithWatermarkPushDownFactory.java
@@ -32,7 +32,6 @@ public class TestScanTableSourceWithWatermarkPushDownFactory implements DynamicT
 
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
-
         return new TestScanTableSourceWithWatermarkPushDown();
     }
 

--- a/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestScanTableSourceWithWatermarkPushDownFactory.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestScanTableSourceWithWatermarkPushDownFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.toolbox;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** A factory to create {@link TestScanTableSourceWithWatermarkPushDown}. */
+public class TestScanTableSourceWithWatermarkPushDownFactory implements DynamicTableSourceFactory {
+
+    public static final String IDENTIFIER = "test-scan-table-source-with-watermark-push-down";
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+
+        return new TestScanTableSourceWithWatermarkPushDown();
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Collections.emptySet();
+    }
+}

--- a/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestSourceFunction.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestSourceFunction.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.toolbox;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A source function used to test.
+ *
+ * <p>For simplicity, the deprecated source function method is used to create the source.
+ */
+@SuppressWarnings("deprecation")
+public class TestSourceFunction implements SourceFunction<RowData> {
+
+    public static final List<List<Object>> DATA = new ArrayList<>();
+
+    static {
+        DATA.add(Arrays.asList(StringData.fromString("Bob"), 1L, TimestampData.fromEpochMillis(1)));
+        DATA.add(
+                Arrays.asList(
+                        StringData.fromString("Alice"), 2L, TimestampData.fromEpochMillis(2)));
+    }
+
+    private final WatermarkStrategy<RowData> watermarkStrategy;
+
+    public TestSourceFunction(WatermarkStrategy<RowData> watermarkStrategy) {
+        this.watermarkStrategy = watermarkStrategy;
+    }
+
+    private volatile boolean isRunning = true;
+
+    @Override
+    public void run(SourceContext<RowData> ctx) {
+        WatermarkGenerator<RowData> generator =
+                watermarkStrategy.createWatermarkGenerator(() -> null);
+        WatermarkOutput output = new TestWatermarkOutput(ctx);
+
+        int rowDataSize = DATA.get(0).size();
+        int index = 0;
+        while (index < DATA.size() && isRunning) {
+            List<Object> list = DATA.get(index);
+            GenericRowData row = new GenericRowData(rowDataSize);
+            for (int i = 0; i < rowDataSize; i++) {
+                row.setField(i, list.get(i));
+            }
+            generator.onEvent(row, Long.MIN_VALUE, output);
+            generator.onPeriodicEmit(output);
+
+            ctx.collect(row);
+
+            index++;
+        }
+        ctx.close();
+    }
+
+    @Override
+    public void cancel() {
+        isRunning = false;
+    }
+
+    private static class TestWatermarkOutput implements WatermarkOutput {
+
+        private final SourceFunction.SourceContext<RowData> ctx;
+
+        public TestWatermarkOutput(SourceFunction.SourceContext<RowData> ctx) {
+            this.ctx = ctx;
+        }
+
+        @Override
+        public void emitWatermark(Watermark watermark) {
+            ctx.emitWatermark(
+                    new org.apache.flink.streaming.api.watermark.Watermark(
+                            watermark.getTimestamp()));
+        }
+
+        @Override
+        public void markIdle() {}
+
+        @Override
+        public void markActive() {}
+    }
+}

--- a/flink-end-to-end-tests/flink-sql-client-test/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.toolbox.TestScanTableSourceWithWatermarkPushDownFactory

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenerator.scala
@@ -19,12 +19,11 @@ package org.apache.flink.table.planner.codegen
 
 import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier
 import org.apache.flink.configuration.{Configuration, ReadableConfig}
-import org.apache.flink.metrics.MetricGroup
 import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{newName, ROW_DATA}
 import org.apache.flink.table.planner.codegen.Indenter.toISC
-import org.apache.flink.table.runtime.generated.{GeneratedWatermarkGenerator, WatermarkGenerator}
+import org.apache.flink.table.runtime.generated.{GeneratedWatermarkGenerator, WatermarkGenerator, WatermarkGeneratorCodeGeneratorFunctionContextWrapper}
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.{LogicalTypeRoot, RowType}
 
@@ -135,11 +134,4 @@ class WatermarkGeneratorFunctionContext(
   override def addReusableConverter(dataType: DataType, classLoaderTerm: String = null): String = {
     super.addReusableConverter(dataType, "this.getClass().getClassLoader()")
   }
-}
-
-class WatermarkGeneratorCodeGeneratorFunctionContextWrapper(
-    context: WatermarkGeneratorSupplier.Context)
-  extends FunctionContext(null, null, null) {
-
-  override def getMetricGroup: MetricGroup = context.getMetricGroup
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/WatermarkGeneratorCodeGeneratorFunctionContextWrapper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/generated/WatermarkGeneratorCodeGeneratorFunctionContextWrapper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.generated;
+
+import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.table.functions.FunctionContext;
+
+/**
+ * A function wrapper for {@link FunctionContext} if the source supports {@link
+ * org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown}.
+ *
+ * <p>See more in {@link WatermarkGeneratorFunctionContext}.
+ */
+public class WatermarkGeneratorCodeGeneratorFunctionContextWrapper extends FunctionContext {
+    private final WatermarkGeneratorSupplier.Context context;
+
+    public WatermarkGeneratorCodeGeneratorFunctionContextWrapper(
+            WatermarkGeneratorSupplier.Context context) {
+        super(null, null, null);
+        this.context = context;
+    }
+
+    @Override
+    public MetricGroup getMetricGroup() {
+        return context.getMetricGroup();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The code generated by codegen references the class in the table-planner package, but the class in the table-planner package is hidden by table-planner-loader, so classloader cannot find it. 

This pr moves the referred class `WatermarkGeneratorCodeGeneratorFunctionContextWrapper` from table-planner to table-runtime. 

## Brief change log

  - *Moves the class `WatermarkGeneratorCodeGeneratorFunctionContextWrapper` from table-planner to table-runtime*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

This pr can't be verified by IT cases or UT cases because the bug only can be -reproduced without jar `table-planner`.
So we need to verify this pr manually. The following steps can verify it.

1. run a kafka and prepare some data
You can start docker and run the test in flink-connector-kafka by debugging to do it:
https://github.com/apache/flink-connector-kafka/blob/abf4563e0342abe25dc28bb6b5457bb971381f61/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java#L488C17-L488C58

Note: debug the code after executing preparing data:
https://github.com/apache/flink-connector-kafka/blob/abf4563e0342abe25dc28bb6b5457bb971381f61/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java#L531C9-L531C48 

2. run start-cluster to start flink
3. run sql-client and then execute ddl
Add computed column and watermark column like:
```
ts AS COALESCE(`timestamp` ,CURRENT_TIMESTAMP),
WATERMARK FOR ts AS ts - INTERVAL '5' SECOND
```
4. run `select * from kafka_table`

Before this fix, you will see an exception thrown. After this fix and re-build flink repo, re-run 2-4, then you can see the actual data from sql-client.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 