### PR TITLE
[FLINK-34282][ci] Adds release-1.18 back to GHA nightly trigger workflow

### DIFF
--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -31,6 +31,7 @@ jobs:
         branch:
           - master
           - release-1.19
+          - release-1.18
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Workflow


### PR DESCRIPTION
## What is the purpose of the change

https://github.com/apache/flink/commit/b8b2596a updated the release branch to monitor from `release-1.18` to `release-1.19` because of the 1.19 release branch cut. We still want to monitor `release-1.18` as part of the nightlies, though.

## Brief change log

* Adds `release-1.18` to the branch list for the GHA nightly trigger workflow

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable