### PR TITLE
[FLINK-34410][ci] Disables the nightly trigger workflow for forks

### DIFF
--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   Trigger:
+    if: github.repository == 'apache/flink'
     permissions:
       actions: write
     strategy:


### PR DESCRIPTION
## What is the purpose of the change

Disables the nightly trigger for the forks. The nightly builds can be still triggered manually through the [`workflow_dispatch` trigger of the nightly workflow](https://github.com/apache/flink/blob/master/.github/workflows/nightly.yml#L22)

## Brief change log

* Added repo check to trigger workflow

## Verifying this change

* [Test run](https://github.com/XComp/flink/actions/runs/7826269858) in `XComp/flink` fork

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable