### PR TITLE
[BP-1.19][FLINK-34410] Correct hadoop.tar.gz download url

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
@@ -99,7 +99,7 @@ function start_hadoop_cluster() {
 function build_image() {
     echo "Pre-downloading Hadoop tarball"
     local cache_path
-    cache_path=$(get_artifact "http://archive.apache.org/dist/hadoop/common/hadoop-2.10.2/hadoop-2.10.2.tar.gz")
+    cache_path=$(get_artifact "https://archive.apache.org/dist/hadoop/common/hadoop-2.10.2/hadoop-2.10.2.tar.gz")
     ln "${cache_path}" "${END_TO_END_DIR}/test-scripts/docker-hadoop-secure-cluster/hadoop/hadoop.tar.gz"
 
     echo "Building Hadoop Docker container"


### PR DESCRIPTION
#24293 backport to 1.19.