### PR TITLE
[FLINK-34421] Skip post-compile checks if 'fast' profile is active

### DIFF
--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -79,6 +79,11 @@ if [ $EXIT_CODE != 0 ]; then
     exit $EXIT_CODE
 fi
 
+if [[ ${PROFILE} == *"-Dfast"* || ${PROFILE} == *"-Pfast"* ]]; then
+  echo "Skipping post-compile checks because 'fast' profile is active."
+  exit $EXIT_CODE
+fi
+
 echo "============ Checking Javadocs ============"
 
 javadoc_output=/tmp/javadoc.out


### PR DESCRIPTION
Saves about 7m in the e2e azure builds.