### PR TITLE
[hotfix][build] Wire up spotless.skip property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@ under the License.
 		<orc.version>1.5.6</orc.version>
 		<japicmp.referenceVersion>1.18.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
+		<spotless.skip>false</spotless.skip>
 		<spotless.version>2.27.1</spotless.version>
 		<spotless.scalafmt.version>3.4.3</spotless.scalafmt.version>
 		<spotless.delimiter>package</spotless.delimiter>
@@ -2199,6 +2200,7 @@ under the License.
 					<artifactId>spotless-maven-plugin</artifactId>
 					<version>${spotless.version}</version>
 					<configuration>
+						<skip>${spotless.skip}</skip>
 						<java>
 							<googleJavaFormat>
 								<version>1.7</version>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@ under the License.
 		<orc.version>1.5.6</orc.version>
 		<japicmp.referenceVersion>1.18.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
+		<!-- can be removed with maven-spotless-plugin:2.38+ -->
 		<spotless.skip>false</spotless.skip>
 		<spotless.version>2.27.1</spotless.version>
 		<spotless.scalafmt.version>3.4.3</spotless.scalafmt.version>


### PR DESCRIPTION
Our version of the plugin has a plugin configuration option, but it's not honored when specified on the command-line. Manually wire up a property that takes care of this.

Can be removed once we upgrade post to 2.38+
