### PR TITLE
[FLINK-34418][ci] Adds volume mount to gain more disk space

### DIFF
--- a/.github/actions/job_init/action.yml
+++ b/.github/actions/job_init/action.yml
@@ -67,7 +67,6 @@ runs:
             echo "[INFO] The directory '${dependency_path}' doesn't exist. ${dependency_name} won't be removed."
           fi
         done
-        android_sdk_path="/usr/local/lib/android"
 
     - name: "Set JDK version to ${{ inputs.jdk_version }}"
       shell: bash

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -177,6 +177,9 @@ jobs:
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
       # --privileged allows writing coredumps in docker (FLINK-16973)
       options: --init --privileged
+      # the /mnt folder is a separate disk mounted to the host filesystem with more free disk space that can be utilized
+      volumes:
+        - /mnt:/root
     env:
       # timeout in minutes - this environment variable is required by uploading_watchdog.sh
       GHA_JOB_TIMEOUT: 240
@@ -250,6 +253,17 @@ jobs:
         run: |
           ${{ inputs.environment }} PROFILE="$PROFILE -Pgithub-actions" ./tools/azure-pipelines/uploading_watchdog.sh \
               ./tools/ci/test_controller.sh ${{ matrix.module }}
+
+      - name: "Post-build Disk Info"
+        if: ${{ always() }}
+        shell: bash
+        run: df -h
+
+      - name: "Top 15 biggest directories in terms of used disk space"
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          du -ah --exclude="proc" -t100M . | sort -h -r | head -n 15
 
       - name: "Post-process build artifacts"
         working-directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}


### PR DESCRIPTION
## What is the purpose of the change

* Adds disk space by mounting `/mnt` to the Docker container
* GitHub runners come with an additional disk mounted to `/mnt` which we can utilize (code snippet below was copied from the [e2e1 stage of this build](https://github.com/XComp/flink/actions/runs/7934542890/job/21666101915#step:3:100)):
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   54G   19G  74% /
tmpfs           7.9G  172K  7.9G   1% /dev/shm
tmpfs           3.2G  1.1M  3.2G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb15      105M  6.1M   /boot/efi
/dev/sda1        74G  4.1G   66G   6% /mnt
tmpfs           1.6G   12K  1.6G   1% /run/user/1001
```

## Brief change log

* Adds an additional mount point `/mnt` that points to the container's `/root` folder overwriting the existing one
* I run the CI hourly over the weekend without observing any disk space issues anymore 

## Verifying this change

[Here](https://github.com/XComp/flink/actions/runs/7934542890/job/21666103300#step:4:111)'s a test run (see corresponding commit https://github.com/XComp/flink/commit/62ff288e55f77f8449a54f6d0428244e6deef44d) that simulates how GHA behaves if the host folder doesn't exist (e.g. if we use a GHA runner aside from the default GitHub runners which might not have the `/mnt` point available). The Pipeline runs as expected (and fails probably due to the missing disk space again FLINK-34443).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable