### PR TITLE
[FLINK-34431] Move static BlobWriter methods to separate util

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobWriterUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobWriterUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.types.Either;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedValue;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class BlobWriterUtils {
+    /**
+     * Serializes the given value and offloads it to the BlobServer if its size exceeds the minimum
+     * offloading size of the BlobServer.
+     *
+     * @param value to serialize
+     * @param jobId to which the value belongs.
+     * @param blobWriter to use to offload the serialized value
+     * @param <T> type of the value to serialize
+     * @return Either the serialized value or the stored blob key
+     * @throws IOException if the data cannot be serialized
+     */
+    public static <T> Either<SerializedValue<T>, PermanentBlobKey> serializeAndTryOffload(
+            T value, JobID jobId, BlobWriter blobWriter) throws IOException {
+        Preconditions.checkNotNull(value);
+
+        final SerializedValue<T> serializedValue = new SerializedValue<>(value);
+
+        return tryOffload(serializedValue, jobId, blobWriter);
+    }
+
+    private static <T> Either<SerializedValue<T>, PermanentBlobKey> tryOffload(
+            SerializedValue<T> serializedValue, JobID jobId, BlobWriter blobWriter) {
+        Preconditions.checkNotNull(serializedValue);
+        Preconditions.checkNotNull(jobId);
+        Preconditions.checkNotNull(blobWriter);
+
+        if (serializedValue.getByteArray().length < blobWriter.getMinOffloadingSize()) {
+            return Either.Left(serializedValue);
+        } else {
+            return offloadWithException(serializedValue, jobId, blobWriter)
+                    .map(Either::<SerializedValue<T>, PermanentBlobKey>Right)
+                    .orElse(Either.Left(serializedValue));
+        }
+    }
+
+    /**
+     * Offloads the given value to the BlobServer.
+     *
+     * @param serializedValue to offload
+     * @param jobId to which the value belongs.
+     * @param blobWriter to use to offload the serialized value
+     * @param <T> type of the value to serialize
+     * @return the stored blob key
+     */
+    public static <T> Optional<PermanentBlobKey> offloadWithException(
+            SerializedValue<T> serializedValue, JobID jobId, BlobWriter blobWriter) {
+        Preconditions.checkNotNull(serializedValue);
+        Preconditions.checkNotNull(jobId);
+        Preconditions.checkNotNull(blobWriter);
+        try {
+            final PermanentBlobKey permanentBlobKey =
+                    blobWriter.putPermanent(jobId, serializedValue.getByteArray());
+            return Optional.of(permanentBlobKey);
+        } catch (IOException e) {
+            BlobWriter.LOG.warn("Failed to offload value for job {} to BLOB store.", jobId, e);
+            return Optional.empty();
+        }
+    }
+
+    private BlobWriterUtils() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.blob.BlobWriterUtils;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -507,7 +508,7 @@ public class TaskDeploymentDescriptorFactory {
 
             final Either<ShuffleDescriptorGroup, PermanentBlobKey> rawValueOrBlobKey =
                     shouldOffload(shuffleDescriptorGroup.getShuffleDescriptors(), numConsumer)
-                            ? BlobWriter.offloadWithException(
+                            ? BlobWriterUtils.offloadWithException(
                                             CompressedSerializedValue.fromObject(
                                                     shuffleDescriptorGroup),
                                             jobID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.blob.BlobWriterUtils;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
@@ -128,7 +129,8 @@ public class DefaultExecutionGraphBuilder {
         try {
             taskDeploymentDescriptorFactory =
                     new TaskDeploymentDescriptorFactory(
-                            BlobWriter.serializeAndTryOffload(jobInformation, jobId, blobWriter),
+                            BlobWriterUtils.serializeAndTryOffload(
+                                    jobInformation, jobId, blobWriter),
                             jobId,
                             partitionLocationConstraint,
                             blobWriter,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.blob.BlobWriterUtils;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -443,7 +444,8 @@ public class ExecutionJobVertex
                 final BlobWriter blobWriter = graph.getBlobWriter();
                 final TaskInformation taskInformation = getTaskInformation();
                 taskInformationOrBlobKey =
-                        BlobWriter.serializeAndTryOffload(taskInformation, getJobId(), blobWriter);
+                        BlobWriterUtils.serializeAndTryOffload(
+                                taskInformation, getJobId(), blobWriter);
             }
 
             return taskInformationOrBlobKey;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.blob.BlobServer;
-import org.apache.flink.runtime.blob.BlobWriter;
+import org.apache.flink.runtime.blob.BlobWriterUtils;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
@@ -161,7 +161,7 @@ class TaskDeploymentDescriptorTest {
         try (BlobServer blobServer = setupBlobServer()) {
             // Serialize taskInformation to blobServer and get the permanentBlobKey
             Either<SerializedValue<TaskInformation>, PermanentBlobKey> taskInformationOrBlobKey =
-                    BlobWriter.serializeAndTryOffload(taskInformation, jobID, blobServer);
+                    BlobWriterUtils.serializeAndTryOffload(taskInformation, jobID, blobServer);
             assertThat(taskInformationOrBlobKey.isRight()).isTrue();
             PermanentBlobKey permanentBlobKey = taskInformationOrBlobKey.right();
 


### PR DESCRIPTION
I intend to refactor these methods soon to also support transient blobs, and not being able to designate methods as private isn't great.