### PR TITLE
Chore: Change metric types, "numSplitsProcessed" in metrics.md

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1831,7 +1831,7 @@ Note that the metrics are only available via reporters.
     <tr>
       <td>numSplitsProcessed</td>
       <td>The total number of InputSplits this data source has processed (if the operator is a data source).</td>
-      <td>Gauge</td>
+      <td>Counter</td>
     </tr>
   </tbody>
 </table>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1821,7 +1821,7 @@ Note that the metrics are only available via reporters.
     <tr>
       <td>numSplitsProcessed</td>
       <td>The total number of InputSplits this data source has processed (if the operator is a data source).</td>
-      <td>Gauge</td>
+      <td>Counter</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## What is the purpose of the change

Typo in metics.md.
Modify "numSplitsProcessed" metric type from Gauge to Counter in both english and chinese version.

![image](https://github.com/apache/flink/assets/60968905/f58d0934-b361-4928-88f0-382f9ec0f71b)

