### PR TITLE
[FLINK-34427][runtime] Adds state check to requirementsCheck logic

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/TestingUtils.java
@@ -35,14 +35,18 @@ public class TestingUtils {
     public static final Time TIMEOUT = Time.minutes(1L);
     public static final Duration DEFAULT_ASK_TIMEOUT = Duration.ofSeconds(200);
 
+    /**
+     * {@code Duration} that can be used for mimicking an "infinite" amount of time. It translates
+     * to ~24 days.
+     *
+     * <p>{@code Integer.MAX_VALUE} is used here because Apache Pekko saves its tickCount in integer
+     * which results in a hard limit for Pekko-related scenarios. But the maximum of 24 days is
+     * still a reasonable enough boundary to simulate infinity.
+     */
+    public static final Duration INFINITE = Duration.ofMillis(Integer.MAX_VALUE);
+
     public static Time infiniteTime() {
         return Time.milliseconds(Integer.MAX_VALUE);
-    }
-
-    public static Duration infiniteDuration() {
-        // we cannot use Long.MAX_VALUE because the Duration stores it in nanosecond resolution and
-        // calculations will easily cause overflows --> 1 year should be long enough for "infinity"
-        return Duration.ofDays(365L);
     }
 
     public static TestExecutorExtension<ScheduledExecutorService> defaultExecutorExtension() {

--- a/flink-core/src/test/java/org/apache/flink/util/concurrent/FutureUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/concurrent/FutureUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.util.concurrent;
 
 import org.apache.flink.core.testutils.FlinkAssertions;
+import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
@@ -33,6 +34,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -264,6 +266,91 @@ class FutureUtilsTest {
 
         assertThat(retryFuture).isCancelled();
         assertThat(scheduledFuture.isCancelled()).isTrue();
+    }
+
+    @Test
+    void testRetrySuccessfulOperationWithDelay() {
+        final int expectedFinalRetryCount = 3;
+        final RuntimeException expectedException =
+                new RuntimeException(
+                        "Expected exception to verify that the retry will be stopped.");
+        final AtomicInteger callCounter = new AtomicInteger();
+        final CompletableFuture<Void> loopFuture =
+                FutureUtils.retrySuccessfulOperationWithDelay(
+                        () -> {
+                            if (callCounter.incrementAndGet() > expectedFinalRetryCount) {
+                                throw expectedException;
+                            }
+                        },
+                        Duration.ofMillis(1),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()));
+
+        assertThatFuture(loopFuture)
+                .eventuallyFails()
+                .withThrowableOfType(ExecutionException.class)
+                .withCause(expectedException);
+        assertThat(callCounter.get()).isEqualTo(expectedFinalRetryCount + 1);
+    }
+
+    @Test
+    void testCancellingFutureRetrySuccessfulOperationWithDelay() {
+        final AtomicInteger callCounter = new AtomicInteger();
+        final ManuallyTriggeredScheduledExecutorService executorService =
+                new ManuallyTriggeredScheduledExecutorService();
+        final CompletableFuture<Void> loopFuture =
+                FutureUtils.retrySuccessfulOperationWithDelay(
+                        callCounter::incrementAndGet,
+                        Duration.ofMillis(0),
+                        new ScheduledExecutorServiceAdapter(executorService));
+
+        loopFuture.cancel(false);
+
+        // trigger all tasks multiple times to ensure that no task is subsequently scheduled
+        for (int i = 0; i < 3; i++) {
+            executorService.triggerAll();
+            executorService.triggerScheduledTasks();
+        }
+
+        assertThat(callCounter.get()).isEqualTo(0);
+    }
+
+    @Test
+    void testCancellingFutureAfterFirstOperationCallRetrySuccessfulOperationWithDelay() {
+        final AtomicInteger callCounter = new AtomicInteger();
+        final ManuallyTriggeredScheduledExecutorService executorService =
+                new ManuallyTriggeredScheduledExecutorService();
+        final CompletableFuture<Void> loopFuture =
+                FutureUtils.retrySuccessfulOperationWithDelay(
+                        callCounter::incrementAndGet,
+                        Duration.ofMillis(0),
+                        new ScheduledExecutorServiceAdapter(executorService));
+
+        executorService.trigger();
+        loopFuture.cancel(false);
+
+        // trigger all tasks multiple times to ensure that no task is subsequently scheduled
+        for (int i = 0; i < 3; i++) {
+            executorService.triggerAll();
+            executorService.triggerScheduledTasks();
+        }
+
+        assertThat(callCounter.get()).isEqualTo(1);
+    }
+
+    @Test
+    void testCancellingRetrySuccessfulOperationWithDelayThroughException() {
+        final CompletableFuture<Void> loopFuture =
+                FutureUtils.retrySuccessfulOperationWithDelay(
+                        () -> {
+                            throw new CancellationException();
+                        },
+                        Duration.ofMillis(0),
+                        new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()));
+
+        assertThatFuture(loopFuture)
+                .eventuallyFails()
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(FutureUtils.RetryException.class);
     }
 
     /** Tests that a future is timed out after the specified timeout. */

--- a/flink-core/src/test/java/org/apache/flink/util/concurrent/FutureUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/concurrent/FutureUtilsTest.java
@@ -246,7 +246,7 @@ class FutureUtilsTest {
                         () ->
                                 FutureUtils.completedExceptionally(
                                         new FlinkException("Test exception")),
-                        new FixedRetryStrategy(1, TestingUtils.infiniteDuration()),
+                        new FixedRetryStrategy(1, TestingUtils.INFINITE),
                         scheduledExecutor);
 
         assertThat(retryFuture).isNotDone();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -59,8 +59,7 @@ public class ResourceManagerRuntimeServices {
             ScheduledExecutor scheduledExecutor,
             SlotManagerMetricGroup slotManagerMetricGroup) {
 
-        final SlotManager slotManager =
-                createSlotManager(configuration, scheduledExecutor, slotManagerMetricGroup);
+        final SlotManager slotManager = createSlotManager(configuration, slotManagerMetricGroup);
 
         final JobLeaderIdService jobLeaderIdService =
                 new DefaultJobLeaderIdService(
@@ -71,12 +70,10 @@ public class ResourceManagerRuntimeServices {
 
     private static SlotManager createSlotManager(
             ResourceManagerRuntimeServicesConfiguration configuration,
-            ScheduledExecutor scheduledExecutor,
             SlotManagerMetricGroup slotManagerMetricGroup) {
         final SlotManagerConfiguration slotManagerConfiguration =
                 configuration.getSlotManagerConfiguration();
         return new FineGrainedSlotManager(
-                scheduledExecutor,
                 slotManagerConfiguration,
                 slotManagerMetricGroup,
                 new DefaultResourceTracker(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
@@ -41,7 +42,6 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
-import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,11 +56,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -76,9 +77,6 @@ public class FineGrainedSlotManager implements SlotManager {
     private final ResourceAllocationStrategy resourceAllocationStrategy;
 
     private final SlotStatusSyncer slotStatusSyncer;
-
-    /** Scheduled executor for timeouts. */
-    private final ScheduledExecutor scheduledExecutor;
 
     /** Timeout after which an unused TaskManager is released. */
     private final Time taskManagerTimeout;
@@ -109,7 +107,7 @@ public class FineGrainedSlotManager implements SlotManager {
     @Nullable private ResourceManagerId resourceManagerId;
 
     /** Executor for future callbacks which have to be "synchronized". */
-    @Nullable private Executor mainThreadExecutor;
+    @Nullable private ComponentMainThreadExecutor mainThreadExecutor;
 
     /** Callbacks for resource (de-)allocations. */
     @Nullable private ResourceAllocator resourceAllocator;
@@ -117,11 +115,11 @@ public class FineGrainedSlotManager implements SlotManager {
     /** Callbacks for resource not enough. */
     @Nullable private ResourceEventListener resourceEventListener;
 
-    @Nullable private ScheduledFuture<?> clusterReconciliationCheck;
+    private Future<?> clusterReconciliationCheck;
 
-    @Nullable private CompletableFuture<Void> requirementsCheckFuture;
+    private Future<?> requirementsCheckFuture;
 
-    @Nullable private CompletableFuture<Void> declareNeededResourceFuture;
+    private Future<?> declareNeededResourceFuture;
 
     /** Blocked task manager checker. */
     @Nullable private BlockedTaskManagerChecker blockedTaskManagerChecker;
@@ -130,16 +128,12 @@ public class FineGrainedSlotManager implements SlotManager {
     private boolean started;
 
     public FineGrainedSlotManager(
-            ScheduledExecutor scheduledExecutor,
             SlotManagerConfiguration slotManagerConfiguration,
             SlotManagerMetricGroup slotManagerMetricGroup,
             ResourceTracker resourceTracker,
             TaskManagerTracker taskManagerTracker,
             SlotStatusSyncer slotStatusSyncer,
             ResourceAllocationStrategy resourceAllocationStrategy) {
-
-        this.scheduledExecutor = Preconditions.checkNotNull(scheduledExecutor);
-
         Preconditions.checkNotNull(slotManagerConfiguration);
         this.taskManagerTimeout = slotManagerConfiguration.getTaskManagerTimeout();
         this.waitResultConsumedBeforeRelease =
@@ -164,8 +158,9 @@ public class FineGrainedSlotManager implements SlotManager {
         resourceAllocator = null;
         resourceEventListener = null;
         mainThreadExecutor = null;
-        clusterReconciliationCheck = null;
-        requirementsCheckFuture = null;
+        clusterReconciliationCheck = FutureUtils.completedVoidFuture();
+        declareNeededResourceFuture = FutureUtils.completedVoidFuture();
+        requirementsCheckFuture = FutureUtils.completedVoidFuture();
 
         started = false;
     }
@@ -205,11 +200,18 @@ public class FineGrainedSlotManager implements SlotManager {
     @Override
     public void start(
             ResourceManagerId newResourceManagerId,
-            Executor newMainThreadExecutor,
+            ComponentMainThreadExecutor newMainThreadExecutor,
             ResourceAllocator newResourceAllocator,
             ResourceEventListener newResourceEventListener,
             BlockedTaskManagerChecker newBlockedTaskManagerChecker) {
         LOG.info("Starting the slot manager.");
+
+        Preconditions.checkState(
+                !started, "The %s is already started.", this.getClass().getSimpleName());
+
+        // start needs to be called in the main thread because the FineGrainedSlotManager state
+        // isn't thread safe
+        newMainThreadExecutor.assertRunningInMainThread();
 
         resourceManagerId = Preconditions.checkNotNull(newResourceManagerId);
         mainThreadExecutor = Preconditions.checkNotNull(newMainThreadExecutor);
@@ -223,11 +225,10 @@ public class FineGrainedSlotManager implements SlotManager {
 
         if (resourceAllocator.isSupported()) {
             clusterReconciliationCheck =
-                    scheduledExecutor.scheduleWithFixedDelay(
-                            () -> mainThreadExecutor.execute(this::checkClusterReconciliation),
-                            0L,
-                            taskManagerTimeout.toMilliseconds(),
-                            TimeUnit.MILLISECONDS);
+                    FutureUtils.retrySuccessfulOperationWithDelay(
+                            () -> runIfStarted(this::checkClusterReconciliation),
+                            taskManagerTimeout.toDuration(),
+                            mainThreadExecutor);
         }
 
         registerSlotManagerMetrics();
@@ -243,6 +244,8 @@ public class FineGrainedSlotManager implements SlotManager {
     /** Suspends the component. This clears the internal state of the slot manager. */
     @Override
     public void suspend() {
+        assertRunsInMainThreadExecutor();
+
         if (!started) {
             return;
         }
@@ -252,10 +255,11 @@ public class FineGrainedSlotManager implements SlotManager {
         slotManagerMetricGroup.close();
 
         // stop the timeout checks for the TaskManagers
-        if (clusterReconciliationCheck != null) {
-            clusterReconciliationCheck.cancel(false);
-            clusterReconciliationCheck = null;
-        }
+        clusterReconciliationCheck.cancel(false);
+
+        // cancel any ongoing background tasks
+        declareNeededResourceFuture.cancel(false);
+        requirementsCheckFuture.cancel(false);
 
         slotStatusSyncer.close();
         taskManagerTracker.clear();
@@ -286,6 +290,8 @@ public class FineGrainedSlotManager implements SlotManager {
 
     @Override
     public void clearResourceRequirements(JobID jobId) {
+        assertRunsInMainThreadExecutor();
+
         maybeReclaimInactiveSlots(jobId);
         jobMasterTargetAddresses.remove(jobId);
         resourceTracker.notifyResourceRequirements(jobId, Collections.emptyList());
@@ -401,24 +407,18 @@ public class FineGrainedSlotManager implements SlotManager {
         if (declareNeededResourceDelay.toMillis() <= 0) {
             declareNeededResources();
         } else {
-            if (declareNeededResourceFuture == null || declareNeededResourceFuture.isDone()) {
-                declareNeededResourceFuture = new CompletableFuture<>();
-                scheduledExecutor.schedule(
-                        () ->
-                                mainThreadExecutor.execute(
-                                        () -> {
-                                            declareNeededResources();
-                                            Preconditions.checkNotNull(declareNeededResourceFuture)
-                                                    .complete(null);
-                                        }),
-                        declareNeededResourceDelay.toMillis(),
-                        TimeUnit.MILLISECONDS);
+            if (declareNeededResourceFuture.isDone()) {
+                declareNeededResourceFuture =
+                        scheduleInMainThread(
+                                this::declareNeededResources, declareNeededResourceDelay);
             }
         }
     }
 
     /** DO NOT call this method directly. Use {@link #declareNeededResourcesWithDelay()} instead. */
     private void declareNeededResources() {
+        assertRunsInMainThreadExecutor();
+
         Map<InstanceID, WorkerResourceSpec> unWantedTaskManagers =
                 taskManagerTracker.getUnWantedTaskManager();
         Map<WorkerResourceSpec, Set<InstanceID>> unWantedTaskManagerBySpec =
@@ -591,21 +591,15 @@ public class FineGrainedSlotManager implements SlotManager {
      * are performed with a slight delay.
      */
     private void checkResourceRequirementsWithDelay() {
+        assertRunsInMainThreadExecutor();
+
         if (requirementsCheckDelay.toMillis() <= 0) {
             checkResourceRequirements();
         } else {
-            if (requirementsCheckFuture == null || requirementsCheckFuture.isDone()) {
-                requirementsCheckFuture = new CompletableFuture<>();
-                scheduledExecutor.schedule(
-                        () ->
-                                mainThreadExecutor.execute(
-                                        () -> {
-                                            checkResourceRequirements();
-                                            Preconditions.checkNotNull(requirementsCheckFuture)
-                                                    .complete(null);
-                                        }),
-                        requirementsCheckDelay.toMillis(),
-                        TimeUnit.MILLISECONDS);
+            if (requirementsCheckFuture.isDone()) {
+                requirementsCheckFuture =
+                        scheduleInMainThread(
+                                this::checkResourceRequirements, requirementsCheckDelay);
             }
         }
     }
@@ -614,74 +608,81 @@ public class FineGrainedSlotManager implements SlotManager {
      * DO NOT call this method directly. Use {@link #checkResourceRequirementsWithDelay()} instead.
      */
     private void checkResourceRequirements() {
-        if (!started) {
-            return;
-        }
-        Map<JobID, Collection<ResourceRequirement>> missingResources =
-                resourceTracker.getMissingResources();
-        if (missingResources.isEmpty()) {
-            if (resourceAllocator.isSupported()
-                    && !taskManagerTracker.getPendingTaskManagers().isEmpty()) {
-                taskManagerTracker.replaceAllPendingAllocations(Collections.emptyMap());
-                checkResourcesNeedReconcile();
-                declareNeededResourcesWithDelay();
-            }
-            return;
-        }
+        runIfStarted(
+                () -> {
+                    Map<JobID, Collection<ResourceRequirement>> missingResources =
+                            resourceTracker.getMissingResources();
+                    if (missingResources.isEmpty()) {
+                        if (resourceAllocator.isSupported()
+                                && !taskManagerTracker.getPendingTaskManagers().isEmpty()) {
+                            taskManagerTracker.replaceAllPendingAllocations(Collections.emptyMap());
+                            checkResourcesNeedReconcile();
+                            declareNeededResourcesWithDelay();
+                        }
+                        return;
+                    }
 
-        logMissingAndAvailableResource(missingResources);
+                    logMissingAndAvailableResource(missingResources);
 
-        missingResources =
-                missingResources.entrySet().stream()
-                        .collect(
-                                Collectors.toMap(
-                                        Map.Entry::getKey, e -> new ArrayList<>(e.getValue())));
+                    missingResources =
+                            missingResources.entrySet().stream()
+                                    .collect(
+                                            Collectors.toMap(
+                                                    Map.Entry::getKey,
+                                                    e -> new ArrayList<>(e.getValue())));
 
-        final ResourceAllocationResult result =
-                resourceAllocationStrategy.tryFulfillRequirements(
-                        missingResources, taskManagerTracker, this::isBlockedTaskManager);
+                    final ResourceAllocationResult result =
+                            resourceAllocationStrategy.tryFulfillRequirements(
+                                    missingResources,
+                                    taskManagerTracker,
+                                    this::isBlockedTaskManager);
 
-        // Allocate slots according to the result
-        allocateSlotsAccordingTo(result.getAllocationsOnRegisteredResources());
+                    // Allocate slots according to the result
+                    allocateSlotsAccordingTo(result.getAllocationsOnRegisteredResources());
 
-        final Set<PendingTaskManagerId> failAllocations;
-        if (resourceAllocator.isSupported()) {
-            // Allocate task managers according to the result
-            failAllocations =
-                    allocateTaskManagersAccordingTo(result.getPendingTaskManagersToAllocate());
+                    final Set<PendingTaskManagerId> failAllocations;
+                    if (resourceAllocator.isSupported()) {
+                        // Allocate task managers according to the result
+                        failAllocations =
+                                allocateTaskManagersAccordingTo(
+                                        result.getPendingTaskManagersToAllocate());
 
-            // Record slot allocation of pending task managers
-            final Map<PendingTaskManagerId, Map<JobID, ResourceCounter>>
-                    pendingResourceAllocationResult =
-                            new HashMap<>(result.getAllocationsOnPendingResources());
-            pendingResourceAllocationResult.keySet().removeAll(failAllocations);
-            taskManagerTracker.replaceAllPendingAllocations(pendingResourceAllocationResult);
-        } else {
-            failAllocations =
-                    result.getPendingTaskManagersToAllocate().stream()
-                            .map(PendingTaskManager::getPendingTaskManagerId)
-                            .collect(Collectors.toSet());
-        }
+                        // Record slot allocation of pending task managers
+                        final Map<PendingTaskManagerId, Map<JobID, ResourceCounter>>
+                                pendingResourceAllocationResult =
+                                        new HashMap<>(result.getAllocationsOnPendingResources());
+                        pendingResourceAllocationResult.keySet().removeAll(failAllocations);
+                        taskManagerTracker.replaceAllPendingAllocations(
+                                pendingResourceAllocationResult);
+                    } else {
+                        failAllocations =
+                                result.getPendingTaskManagersToAllocate().stream()
+                                        .map(PendingTaskManager::getPendingTaskManagerId)
+                                        .collect(Collectors.toSet());
+                    }
 
-        unfulfillableJobs.clear();
-        unfulfillableJobs.addAll(result.getUnfulfillableJobs());
-        for (PendingTaskManagerId pendingTaskManagerId : failAllocations) {
-            unfulfillableJobs.addAll(
-                    result.getAllocationsOnPendingResources().get(pendingTaskManagerId).keySet());
-        }
-        // Notify jobs that can not be fulfilled
-        if (sendNotEnoughResourceNotifications) {
-            for (JobID jobId : unfulfillableJobs) {
-                LOG.warn("Could not fulfill resource requirements of job {}.", jobId);
-                resourceEventListener.notEnoughResourceAvailable(
-                        jobId, resourceTracker.getAcquiredResources(jobId));
-            }
-        }
+                    unfulfillableJobs.clear();
+                    unfulfillableJobs.addAll(result.getUnfulfillableJobs());
+                    for (PendingTaskManagerId pendingTaskManagerId : failAllocations) {
+                        unfulfillableJobs.addAll(
+                                result.getAllocationsOnPendingResources()
+                                        .get(pendingTaskManagerId)
+                                        .keySet());
+                    }
+                    // Notify jobs that can not be fulfilled
+                    if (sendNotEnoughResourceNotifications) {
+                        for (JobID jobId : unfulfillableJobs) {
+                            LOG.warn("Could not fulfill resource requirements of job {}.", jobId);
+                            resourceEventListener.notEnoughResourceAvailable(
+                                    jobId, resourceTracker.getAcquiredResources(jobId));
+                        }
+                    }
 
-        if (resourceAllocator.isSupported()) {
-            checkResourcesNeedReconcile();
-            declareNeededResourcesWithDelay();
-        }
+                    if (resourceAllocator.isSupported()) {
+                        checkResourcesNeedReconcile();
+                        declareNeededResourcesWithDelay();
+                    }
+                });
     }
 
     private void logMissingAndAvailableResource(
@@ -733,7 +734,7 @@ public class FineGrainedSlotManager implements SlotManager {
                         (s, t) -> {
                             if (t != null) {
                                 // If there is allocation failure, we need to trigger it again.
-                                checkResourceRequirementsWithDelay();
+                                runIfStarted(this::checkResourceRequirementsWithDelay);
                             }
                         },
                         mainThreadExecutor);
@@ -847,13 +848,17 @@ public class FineGrainedSlotManager implements SlotManager {
                 .getTaskExecutorGateway()
                 .canBeReleased()
                 .thenAcceptAsync(
-                        canBeReleased -> {
-                            boolean stillIdle = idleSince == taskManagerInfo.getIdleSince();
-                            if (stillIdle && canBeReleased) {
-                                releaseIdleTaskExecutor(taskManagerInfo.getInstanceId());
-                                declareNeededResourcesWithDelay();
-                            }
-                        },
+                        canBeReleased ->
+                                runIfStarted(
+                                        () -> {
+                                            boolean stillIdle =
+                                                    idleSince == taskManagerInfo.getIdleSince();
+                                            if (stillIdle && canBeReleased) {
+                                                releaseIdleTaskExecutor(
+                                                        taskManagerInfo.getInstanceId());
+                                                declareNeededResourcesWithDelay();
+                                            }
+                                        }),
                         mainThreadExecutor);
     }
 
@@ -891,10 +896,30 @@ public class FineGrainedSlotManager implements SlotManager {
 
     private void checkInit() {
         Preconditions.checkState(started, "The slot manager has not been started.");
-        Preconditions.checkNotNull(resourceManagerId);
         Preconditions.checkNotNull(mainThreadExecutor);
+        Preconditions.checkNotNull(resourceManagerId);
         Preconditions.checkNotNull(resourceAllocator);
         Preconditions.checkNotNull(resourceEventListener);
+
+        assertRunsInMainThreadExecutor();
+    }
+
+    private void assertRunsInMainThreadExecutor() {
+        if (mainThreadExecutor != null) {
+            mainThreadExecutor.assertRunningInMainThread();
+        }
+    }
+
+    private ScheduledFuture<?> scheduleInMainThread(Runnable operation, Duration delay) {
+        return Objects.requireNonNull(mainThreadExecutor)
+                .schedule(() -> runIfStarted(operation), delay.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    private void runIfStarted(Runnable operation) {
+        assertRunsInMainThreadExecutor();
+        if (started) {
+            operation.run();
+        }
     }
 
     private boolean isMaxTotalResourceExceededAfterAdding(ResourceProfile newResource) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -401,7 +401,8 @@ public class FineGrainedSlotManager implements SlotManager {
         }
     }
 
-    private void declareNeededResourcesWithDelay() {
+    @VisibleForTesting
+    void declareNeededResourcesWithDelay() {
         Preconditions.checkState(resourceAllocator.isSupported());
 
         if (declareNeededResourceDelay.toMillis() <= 0) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -297,6 +297,8 @@ public class FineGrainedSlotManager implements SlotManager {
         resourceTracker.notifyResourceRequirements(jobId, Collections.emptyList());
         if (resourceAllocator.isSupported()) {
             taskManagerTracker.clearPendingAllocationsOfJob(jobId);
+
+            // the return value is ignored because we want to declare needed resources in any case
             checkResourcesNeedReconcile();
             declareNeededResourcesWithDelay();
         }
@@ -617,6 +619,9 @@ public class FineGrainedSlotManager implements SlotManager {
                         if (resourceAllocator.isSupported()
                                 && !taskManagerTracker.getPendingTaskManagers().isEmpty()) {
                             taskManagerTracker.replaceAllPendingAllocations(Collections.emptyMap());
+
+                            // the return value is ignored because we want to declare needed
+                            // resources in any case
                             checkResourcesNeedReconcile();
                             declareNeededResourcesWithDelay();
                         }
@@ -816,7 +821,6 @@ public class FineGrainedSlotManager implements SlotManager {
 
     private void checkClusterReconciliation() {
         if (checkResourcesNeedReconcile()) {
-            // only declare on needed.
             declareNeededResourcesWithDelay();
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
@@ -31,7 +32,6 @@ import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
 import java.util.Collection;
-import java.util.concurrent.Executor;
 
 /**
  * The slot manager is responsible for maintaining a view on all registered task manager slots,
@@ -74,7 +74,7 @@ public interface SlotManager extends AutoCloseable {
      */
     void start(
             ResourceManagerId newResourceManagerId,
-            Executor newMainThreadExecutor,
+            ComponentMainThreadExecutor newMainThreadExecutor,
             ResourceAllocator newResourceAllocator,
             ResourceEventListener resourceEventListener,
             BlockedTaskManagerChecker newBlockedTaskManagerChecker);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/DirectComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/DirectComponentMainThreadExecutor.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.concurrent;
+
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A test implementation of the {@link ComponentMainThreadExecutor} that executes any immediate
+ * tasks right away but collects the scheduled tasks to trigger them from within the test.
+ */
+public class DirectComponentMainThreadExecutor implements ComponentMainThreadExecutor {
+
+    private Map<CompletableFuture<Void>, Future<?>> scheduledTasks = new LinkedHashMap<>();
+
+    private final Thread thread;
+    private final Executor directExecutor = Executors.directExecutor();
+
+    public DirectComponentMainThreadExecutor() {
+        this(Thread.currentThread());
+    }
+
+    public DirectComponentMainThreadExecutor(Thread thread) {
+        this.thread = thread;
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return schedule(
+                () -> {
+                    command.run();
+                    return null;
+                },
+                delay,
+                unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        final CompletableFuture<Void> scheduleTriggerFuture = new CompletableFuture<>();
+        final ScheduledFuture<V> scheduledFuture =
+                new ScheduledFutureAdapter<>(
+                        scheduleTriggerFuture.thenApply(
+                                ignored -> {
+                                    try {
+                                        return callable.call();
+                                    } catch (Exception e) {
+                                        throw new CompletionException(e);
+                                    }
+                                }),
+                        delay,
+                        unit);
+
+        scheduledTasks.put(scheduleTriggerFuture, scheduledFuture);
+        return scheduledFuture;
+    }
+
+    public Collection<Future<?>> getScheduledTasks() {
+        return scheduledTasks.values();
+    }
+
+    public void triggerAllScheduledTasks() {
+        // re-instantiate a new instance that can collect scheduled tasks while the older scheduled
+        // tasks are triggered
+        final Map<CompletableFuture<Void>, Future<?>> tasksToExecute = scheduledTasks;
+        scheduledTasks = new LinkedHashMap<>();
+        tasksToExecute.keySet().forEach(ft -> ft.complete(null));
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(
+            Runnable command, long initialDelay, long period, TimeUnit unit) {
+        throw new UnsupportedOperationException(
+                "This method is not supported analogously to RpcEndpoint#MainThreadExecutor.");
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(
+            Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        throw new UnsupportedOperationException(
+                "This method is not supported analogously to RpcEndpoint#MainThreadExecutor.");
+    }
+
+    @Override
+    public void assertRunningInMainThread() {
+        Preconditions.checkState(Thread.currentThread() == this.thread);
+    }
+
+    @Override
+    public void execute(@NotNull Runnable command) {
+        directExecutor.execute(command);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ManuallyTriggeredComponentMainThreadExecutor.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.concurrent;
 
+import java.time.Duration;
+
 /** Testing ComponentMainThreadExecutor which can be manually triggered. */
 public class ManuallyTriggeredComponentMainThreadExecutor
         extends ManuallyTriggeredScheduledExecutorService implements ComponentMainThreadExecutor {
@@ -34,8 +36,8 @@ public class ManuallyTriggeredComponentMainThreadExecutor
     }
 
     @Override
-    public void trigger() {
+    public void trigger(Duration timeout) {
         assertRunningInMainThread();
-        super.trigger();
+        super.trigger(timeout);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -378,9 +378,7 @@ class ResourceManagerTest {
                         () -> {
                             assertThat(processRequirementsFuture.isDone()).isFalse();
                             readyToServeFuture.complete(null);
-                            return null;
-                        },
-                        TIMEOUT)
+                        })
                 .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
         processRequirementsFuture.get();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -588,7 +588,11 @@ class ResourceManagerTest {
                         .buildAndStart();
 
         registerTaskExecutor(resourceManager, taskExecutorId, taskExecutorGateway.getAddress());
-        resourceManager.disconnectTaskManager(taskExecutorId, new FlinkException("Test exception"));
+
+        resourceManager.runInMainThread(
+                () ->
+                        resourceManager.disconnectTaskManager(
+                                taskExecutorId, new FlinkException("Test exception")));
 
         assertThatFuture(disconnectFuture).eventuallySucceeds().isInstanceOf(FlinkException.class);
         assertThatFuture(stopWorkerFuture).eventuallySucceeds().isEqualTo(taskExecutorId);
@@ -937,9 +941,7 @@ class ResourceManagerTest {
             }
 
             if (slotManager == null) {
-                slotManager =
-                        FineGrainedSlotManagerBuilder.newBuilder(rpcService.getScheduledExecutor())
-                                .build();
+                slotManager = FineGrainedSlotManagerBuilder.newBuilder().build();
             }
 
             if (stopWorkerConsumer == null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -66,8 +66,6 @@ import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.concurrent.FutureUtils;
-import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
-import org.apache.flink.util.concurrent.ScheduledExecutor;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.junit.jupiter.api.AfterAll;
@@ -164,14 +162,6 @@ class ResourceManagerTest {
         }
     }
 
-    private static SlotManager createSlotManager() {
-        return createSlotManager(rpcService.getScheduledExecutor());
-    }
-
-    private static SlotManager createSlotManager(ScheduledExecutor scheduledExecutor) {
-        return FineGrainedSlotManagerBuilder.newBuilder(scheduledExecutor).build();
-    }
-
     /**
      * Tests that we can retrieve the correct {@link TaskManagerInfo} from the {@link
      * ResourceManager}.
@@ -185,8 +175,7 @@ class ResourceManagerTest {
                         .createTestingTaskExecutorGateway();
         rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
 
-        resourceManager =
-                new ResourceManagerBuilder().withSlotManager(createSlotManager()).buildAndStart();
+        resourceManager = new ResourceManagerBuilder().buildAndStart();
         final ResourceManagerGateway resourceManagerGateway =
                 resourceManager.getSelfGateway(ResourceManagerGateway.class);
 
@@ -223,8 +212,7 @@ class ResourceManagerTest {
                         .createTestingTaskExecutorGateway();
         rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
 
-        resourceManager =
-                new ResourceManagerBuilder().withSlotManager(createSlotManager()).buildAndStart();
+        resourceManager = new ResourceManagerBuilder().buildAndStart();
         final ResourceManagerGateway resourceManagerGateway =
                 resourceManager.getSelfGateway(ResourceManagerGateway.class);
 
@@ -597,7 +585,6 @@ class ResourceManagerTest {
         resourceManager =
                 new ResourceManagerBuilder()
                         .withStopWorkerConsumer(stopWorkerFuture::complete)
-                        .withSlotManager(createSlotManager())
                         .buildAndStart();
 
         registerTaskExecutor(resourceManager, taskExecutorId, taskExecutorGateway.getAddress());
@@ -667,7 +654,6 @@ class ResourceManagerTest {
                         .withJobLeaderIdService(jobLeaderIdService)
                         .withBlocklistHandlerFactory(
                                 new DefaultBlocklistHandler.Factory(Duration.ofMillis(100L)))
-                        .withSlotManager(createSlotManager())
                         .buildAndStart();
 
         final ResourceManagerGateway resourceManagerGateway =
@@ -698,10 +684,8 @@ class ResourceManagerTest {
 
     @Test
     void testResourceOverviewWithBlockedSlots() throws Exception {
-        ManuallyTriggeredScheduledExecutor executor = new ManuallyTriggeredScheduledExecutor();
         resourceManager =
                 new ResourceManagerBuilder()
-                        .withSlotManager(createSlotManager(executor))
                         .withBlocklistHandlerFactory(
                                 new DefaultBlocklistHandler.Factory(Duration.ofMillis(100L)))
                         .buildAndStart();
@@ -713,7 +697,6 @@ class ResourceManagerTest {
         ResourceID taskExecutorToBlock = ResourceID.generate();
         registerTaskExecutorAndSlot(resourceManagerGateway, taskExecutor, 3);
         registerTaskExecutorAndSlot(resourceManagerGateway, taskExecutorToBlock, 5);
-        executor.triggerAll();
 
         ResourceOverview overview =
                 resourceManagerGateway.requestResourceOverview(Time.seconds(5)).get();
@@ -831,7 +814,6 @@ class ResourceManagerTest {
         resourceManager =
                 new ResourceManagerBuilder()
                         .withJobLeaderIdService(jobLeaderIdService)
-                        .withSlotManager(createSlotManager())
                         .buildAndStart();
 
         highAvailabilityServices.setJobMasterLeaderRetrieverFunction(
@@ -873,11 +855,7 @@ class ResourceManagerTest {
             throws Exception {
         final ResourceManagerBuilder rmBuilder = new ResourceManagerBuilder();
         prepareResourceManager.accept(rmBuilder);
-        resourceManager =
-                rmBuilder
-                        .withHeartbeatServices(fastHeartbeatServices)
-                        .withSlotManager(createSlotManager())
-                        .buildAndStart();
+        resourceManager = rmBuilder.withHeartbeatServices(fastHeartbeatServices).buildAndStart();
         final ResourceManagerGateway resourceManagerGateway =
                 resourceManager.getSelfGateway(ResourceManagerGateway.class);
 
@@ -893,10 +871,7 @@ class ResourceManagerTest {
         final ResourceManagerBuilder rmBuilder = new ResourceManagerBuilder();
         prepareResourceManager.accept(rmBuilder);
         resourceManager =
-                rmBuilder
-                        .withHeartbeatServices(failedRpcEnabledHeartbeatServices)
-                        .withSlotManager(createSlotManager())
-                        .buildAndStart();
+                rmBuilder.withHeartbeatServices(failedRpcEnabledHeartbeatServices).buildAndStart();
         final ResourceManagerGateway resourceManagerGateway =
                 resourceManager.getSelfGateway(ResourceManagerGateway.class);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.blocklist.BlocklistHandler;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -34,13 +33,12 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
-import org.apache.flink.util.TimeUtils;
+import org.apache.flink.testutils.TestingUtils;
 
 import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Consumer;
@@ -122,7 +120,12 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
         return NonSupportedResourceAllocatorImpl.INSTANCE;
     }
 
-    public <T> CompletableFuture<T> runInMainThread(Callable<T> callable, Time timeout) {
-        return callAsync(callable, TimeUtils.toDuration(timeout));
+    public CompletableFuture<Void> runInMainThread(Runnable runnable) {
+        return callAsync(
+                () -> {
+                    runnable.run();
+                    return null;
+                },
+                TestingUtils.INFINITE);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerBuilder.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 /** Builder for {@link FineGrainedSlotManager}. */
 public class FineGrainedSlotManagerBuilder {
@@ -31,19 +30,16 @@ public class FineGrainedSlotManagerBuilder {
             new DefaultSlotStatusSyncer(TestingUtils.infiniteTime());
     private SlotManagerMetricGroup slotManagerMetricGroup =
             UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
-    private final ScheduledExecutor scheduledExecutor;
     private ResourceAllocationStrategy resourceAllocationStrategy =
             TestingResourceAllocationStrategy.newBuilder().build();
 
     SlotManagerConfiguration slotManagerConfiguration =
             SlotManagerConfigurationBuilder.newBuilder().build();
 
-    private FineGrainedSlotManagerBuilder(ScheduledExecutor scheduledExecutor) {
-        this.scheduledExecutor = scheduledExecutor;
-    }
+    private FineGrainedSlotManagerBuilder() {}
 
-    public static FineGrainedSlotManagerBuilder newBuilder(ScheduledExecutor scheduledExecutor) {
-        return new FineGrainedSlotManagerBuilder(scheduledExecutor);
+    public static FineGrainedSlotManagerBuilder newBuilder() {
+        return new FineGrainedSlotManagerBuilder();
     }
 
     public FineGrainedSlotManagerBuilder setTaskManagerTracker(
@@ -82,7 +78,6 @@ public class FineGrainedSlotManagerBuilder {
 
     public FineGrainedSlotManager build() {
         return new FineGrainedSlotManager(
-                scheduledExecutor,
                 slotManagerConfiguration,
                 slotManagerMetricGroup,
                 resourceTracker,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -88,7 +88,21 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
     void testCloseAfterSuspendDoesNotThrowException() throws Exception {
         new Context() {
             {
-                runTest(() -> getSlotManager().suspend());
+                runTest(() -> runInMainThreadAndWait(getSlotManager()::suspend));
+            }
+        };
+    }
+
+    @Test
+    void testRestartAfterSuspend() throws Exception {
+        new Context() {
+            {
+                runTest(
+                        () -> {
+                            runInMainThreadAndWait(() -> getSlotManager().suspend());
+
+                            startSlotManagerInMainThread();
+                        });
             }
         };
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.concurrent.DirectComponentMainThreadExecutor;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.MetricRegistry;
@@ -50,6 +51,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
@@ -540,6 +542,84 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                         });
             }
         };
+    }
+
+    @Test
+    void testScheduledRequirementCheckBeingCancelled() throws Exception {
+        testScheduledTaskIsCancelledAfterClose(
+                // no side-effects are monitored for now
+                (context, callCounter) -> {},
+                context -> context.getSlotManager().triggerResourceRequirementsCheck(),
+                // no side-effects are monitored
+                0,
+                // the reconciliation check is scheduled in the start method aside from the logic
+                // tested in here
+                2);
+    }
+
+    @Test
+    void testScheduledResourceDeclarationCheckBeingCancelled() throws Exception {
+        testScheduledTaskIsCancelledAfterClose(
+                (context, callCounter) ->
+                        context.resourceAllocatorBuilder
+                                .setDeclareResourceNeededConsumer(
+                                        ignoredDeclarations -> callCounter.incrementAndGet())
+                                .setIsSupportedSupplier(() -> true),
+                context -> context.getSlotManager().declareNeededResourcesWithDelay(),
+                // the task should be triggered but never called before the close call
+                0,
+                // the reconciliation check is scheduled in the start method aside from the logic
+                // tested in here
+                2);
+    }
+
+    @Test
+    void testScheduledClusterReconciliationCheckBeingCancelled() throws Exception {
+        testScheduledTaskIsCancelledAfterClose(
+                (context, callCounter) ->
+                        context.resourceAllocationStrategyBuilder
+                                .setTryReleaseUnusedResourcesFunction(
+                                        taskManagerTracker -> {
+                                            callCounter.incrementAndGet();
+                                            return ResourceReconcileResult.builder().build();
+                                        }),
+                // nothing to do here because the reconciliation is triggered during start
+                context -> {},
+                1,
+                1);
+    }
+
+    private void testScheduledTaskIsCancelledAfterClose(
+            BiConsumer<Context, AtomicInteger> sideEffectMonitoring,
+            Consumer<Context> triggerScheduledTask,
+            int expectedCallCount,
+            int expectedScheduledTaskCount)
+            throws Exception {
+        final DirectComponentMainThreadExecutor testSpecificMainThreadExecutor =
+                new DirectComponentMainThreadExecutor();
+        final AtomicInteger callCount = new AtomicInteger();
+        new Context() {
+            {
+                mainThreadExecutor = testSpecificMainThreadExecutor;
+                sideEffectMonitoring.accept(this, callCount);
+                runTest(() -> triggerScheduledTask.accept(this));
+            }
+        };
+
+        assertThat(testSpecificMainThreadExecutor.getScheduledTasks())
+                .hasSize(expectedScheduledTaskCount);
+        assertThat(testSpecificMainThreadExecutor.getScheduledTasks())
+                .as("Any scheduled task should be cancelled.")
+                .satisfies(
+                        scheduledTasks ->
+                                scheduledTasks.forEach(
+                                        ft -> assertThat(ft.isCancelled()).isTrue()));
+        testSpecificMainThreadExecutor.triggerAllScheduledTasks();
+
+        assertThat(callCount.get())
+                .as(
+                        "No side effects should appear due to hanging scheduled tasks after the SlotManager instance is closed.")
+                .isEqualTo(expectedCallCount);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.executiongraph.TestingComponentMainThreadExecutor;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
@@ -39,8 +41,6 @@ import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.concurrent.FutureUtils;
-import org.apache.flink.util.concurrent.ScheduledExecutor;
-import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.util.function.RunnableWithException;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -49,7 +49,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -61,6 +60,10 @@ abstract class FineGrainedSlotManagerTestBase {
     @RegisterExtension
     static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
             TestingUtils.defaultExecutorExtension();
+
+    @RegisterExtension
+    static final TestingComponentMainThreadExecutor.Extension MAIN_THREAD_EXECUTOR_EXTENSION =
+            new TestingComponentMainThreadExecutor.Extension();
 
     private static final long FUTURE_TIMEOUT_SECOND = 5;
     private static final long FUTURE_EXPECT_TIMEOUT_MS = 50;
@@ -152,9 +155,10 @@ abstract class FineGrainedSlotManagerTestBase {
         private SlotManagerMetricGroup slotManagerMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
         private BlockedTaskManagerChecker blockedTaskManagerChecker = resourceID -> false;
-        private final ScheduledExecutor scheduledExecutor =
-                new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor());
-        private final Executor mainThreadExecutor = EXECUTOR_RESOURCE.getExecutor();
+        private ComponentMainThreadExecutor mainThreadExecutor =
+                MAIN_THREAD_EXECUTOR_EXTENSION
+                        .getComponentMainThreadTestExecutor()
+                        .getMainThreadExecutor();
         private FineGrainedSlotManager slotManager;
 
         final TestingResourceAllocationStrategy.Builder resourceAllocationStrategyBuilder =
@@ -207,10 +211,21 @@ abstract class FineGrainedSlotManagerTestBase {
             latch.await();
         }
 
+        protected final void startSlotManagerInMainThread() throws InterruptedException {
+            runInMainThreadAndWait(
+                    () ->
+                            slotManager.start(
+                                    resourceManagerId,
+                                    mainThreadExecutor,
+                                    resourceAllocatorBuilder.build(),
+                                    resourceEventListenerBuilder.build(),
+                                    blockedTaskManagerChecker));
+        }
+
         protected final void runTest(RunnableWithException testMethod) throws Exception {
             SlotManagerConfiguration configuration = slotManagerConfigurationBuilder.build();
             slotManager =
-                    FineGrainedSlotManagerBuilder.newBuilder(scheduledExecutor)
+                    FineGrainedSlotManagerBuilder.newBuilder()
                             .setSlotManagerConfiguration(configuration)
                             .setSlotManagerMetricGroup(slotManagerMetricGroup)
                             .setResourceTracker(resourceTracker)
@@ -221,14 +236,7 @@ abstract class FineGrainedSlotManagerTestBase {
                                             .orElse(resourceAllocationStrategyBuilder.build()))
                             .build();
 
-            runInMainThreadAndWait(
-                    () ->
-                            slotManager.start(
-                                    resourceManagerId,
-                                    mainThreadExecutor,
-                                    resourceAllocatorBuilder.build(),
-                                    resourceEventListenerBuilder.build(),
-                                    blockedTaskManagerChecker));
+            startSlotManagerInMainThread();
 
             testMethod.run();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -155,7 +155,7 @@ abstract class FineGrainedSlotManagerTestBase {
         private SlotManagerMetricGroup slotManagerMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
         private BlockedTaskManagerChecker blockedTaskManagerChecker = resourceID -> false;
-        private ComponentMainThreadExecutor mainThreadExecutor =
+        ComponentMainThreadExecutor mainThreadExecutor =
                 MAIN_THREAD_EXECUTOR_EXTENSION
                         .getComponentMainThreadTestExecutor()
                         .getMainThreadExecutor();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
@@ -32,7 +33,6 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 /** Implementation of {@link SlotManager} for testing purpose. */
@@ -102,7 +102,7 @@ public class TestingSlotManager implements SlotManager {
     @Override
     public void start(
             ResourceManagerId newResourceManagerId,
-            Executor newMainThreadExecutor,
+            ComponentMainThreadExecutor newMainThreadExecutor,
             ResourceAllocator newResourceAllocator,
             ResourceEventListener resourceEventListener,
             BlockedTaskManagerChecker newBlockedTaskManagerChecker) {}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -710,11 +710,12 @@ public class SavepointITCase extends TestLogger {
             client.cancel(jobId).get();
 
             FutureUtils.retrySuccessfulWithDelay(
-                    () -> client.getJobStatus(jobId),
-                    Duration.ofMillis(50),
-                    Deadline.now().plus(Duration.ofSeconds(30)),
-                    status -> status == JobStatus.CANCELED,
-                    new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()));
+                            () -> client.getJobStatus(jobId),
+                            Duration.ofMillis(50),
+                            Deadline.now().plus(Duration.ofSeconds(30)),
+                            status -> status == JobStatus.CANCELED,
+                            new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))
+                    .get();
 
             postCancelChecks.check(cluster);
         } finally {


### PR DESCRIPTION
## What is the purpose of the change

Quoting @zentol from [FLINK-34427](https://issues.apache.org/jira/browse/FLINK-34427?focusedCommentId=17816969&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17816969) here:
> The problem is the use of scheduled executors in the FineGrainedSlotManager. It periodically tries to schedule actions unconditionally into the main thread, and this periodic action is also never cancelled.
> If the rpc endpoint shuts down during the periodic delay the scheduled action can fire again before the rpc service (and thus scheduled executor) is shut down, running into this error.

> This code is plain broken as tt makes assumptions about the lifecycle of the scheduled executor. The loop should be canceled when the FGSM is shut down, and as a safety rail any scheduled action should validate that the FGSM is not shut down yet before scheduling anything into the main thread.

## Brief change log

* Makes `ManuallyTriggeredScheduledExecutorService` more robust against exceptions
* Removes started field and utilizes mainThreadExecutor instead
* Adds main thread assertion in FineGrainedSlotManager
* Refactors code to allow state check in scheduled tasks

## Verifying this change

* One test per scheduled task was added to `FineGrainedSlotManagerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable