### PR TITLE
[FLINK-34437][SQL Client] Fix typo

### DIFF
--- a/docs/content.zh/docs/dev/table/concepts/overview.md
+++ b/docs/content.zh/docs/dev/table/concepts/overview.md
@@ -239,18 +239,18 @@ compiledPlan.writeToFile("/path/to/plan.json")
 
 ```sql
 Flink SQL> CREATE TABLE orders (order_id BIGINT, order_line_id BIGINT, buyer_id BIGINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE line_orders (order_line_id BIGINT, order_status TINYINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE enriched_orders (order_id BIGINT, order_line_id BIGINT, order_status TINYINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> COMPILE PLAN 'file:///path/to/plan.json' FOR INSERT INTO enriched_orders
 > SELECT a.order_id, a.order_line_id, b.order_status, ...
 > FROM orders a JOIN line_orders b ON a.order_line_id = b.order_line_id;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 ```
 
 {{< /tab >}}
@@ -357,13 +357,13 @@ tableEnv.loadPlan(PlanReference.fromFile("/path/to/plan.json")).execute().await(
 
 ```sql
 Flink SQL> CREATE TABLE orders (order_id BIGINT, order_line_id BIGINT, buyer_id BIGINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE line_orders (order_line_id BIGINT, order_status TINYINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE enriched_orders (order_id BIGINT, order_line_id BIGINT, order_status TINYINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> EXECUTE PLAN 'file:///path/to/plan.json';
 [INFO] Submitting SQL update statement to the cluster...

--- a/docs/content.zh/docs/dev/table/hive-compatibility/hive-dialect/queries/overview.md
+++ b/docs/content.zh/docs/dev/table/hive-compatibility/hive-dialect/queries/overview.md
@@ -109,16 +109,16 @@ Following is an example of using hive dialect to run some queries.
 
 ```bash
 Flink SQL> create catalog myhive with ('type' = 'hive', 'hive-conf-dir' = '/opt/hive-conf');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> use catalog myhive;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> load module hive;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> use modules hive,core;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> set table.sql-dialect=hive;
 [INFO] Session property has been set.
@@ -136,7 +136,7 @@ Flink SQL> select explode(array(1,2,3)); -- call hive udtf
 Received a total of 3 rows
 
 Flink SQL> create table tbl (key int,value string);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> insert into table tbl values (5,'e'),(1,'a'),(1,'a'),(3,'c'),(2,'b'),(3,'c'),(3,'c'),(4,'d');
 [INFO] Submitting SQL update statement to the cluster...

--- a/docs/content.zh/docs/dev/table/sql/alter.md
+++ b/docs/content.zh/docs/dev/table/sql/alter.md
@@ -178,10 +178,10 @@ tables = table_env.list_tables()
 {{< tab "SQL CLI" >}}
 ```sql
 Flink SQL> CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> DESCRIBE Orders;
 +---------+--------+------+-----+--------+-----------+------------------+
@@ -195,7 +195,7 @@ Flink SQL> DESCRIBE Orders;
 4 rows in set
 
 Flink SQL> ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR);
-[INFO] Execute statement succeed. 
+[INFO] Execute statement succeeded. 
 
 Flink SQL> DESCRIBE Orders;
 +----------+------------------------+-------+------------+--------+--------------------------+------------------+
@@ -211,7 +211,7 @@ Flink SQL> DESCRIBE Orders;
 6 rows in set
 
 Flink SQL> ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts);
-[INFO] Execute statement succeed. 
+[INFO] Execute statement succeeded. 
 
 Flink SQL> DESCRIBE Orders;
 +----------+------------------------+-------+------------+--------+-----------+---------------------+
@@ -227,7 +227,7 @@ Flink SQL> DESCRIBE Orders;
 6 rows in set
 
 Flink SQL> ALTER TABLE Orders DROP WATERMARK;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> DESCRIBE Orders;
 +----------+--------------+-------+------------+--------+-----------+---------------------+
@@ -243,7 +243,7 @@ Flink SQL> DESCRIBE Orders;
 6 rows in set
 
 Flink SQL> ALTER TABLE Orders DROP (amount, ts, category);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> DESCRIBE Orders;
 +---------+--------+-------+------------+--------+-----------+------------------+
@@ -256,7 +256,7 @@ Flink SQL> DESCRIBE Orders;
 3 rows in set
 
 Flink SQL> ALTER TABLE Orders RENAME `order` to `order_id`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> DESCRIBE Orders;
 +----------+--------+-------+---------------+--------+-----------+------------------+
@@ -277,7 +277,7 @@ Flink SQL> SHOW TABLES;
 1 row in set
 
 Flink SQL> ALTER TABLE Orders RENAME TO NewOrders;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> SHOW TABLES;
 +------------+

--- a/docs/content.zh/docs/dev/table/sql/analyze.md
+++ b/docs/content.zh/docs/dev/table/sql/analyze.md
@@ -297,40 +297,40 @@ Flink SQL> CREATE TABLE Orders (
 [INFO] Table has been created.
 
 Flink SQL> ANALYZE TABLE Store COMPUTE STATISTICS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Store COMPUTE STATISTICS FOR ALL COLUMNS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ANALYZE TABLE Store COMPUTE STATISTICS FOR COLUMNS location;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day='10') COMPUTE STATISTICS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day) COMPUTE STATISTICS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year, sold_month, sold_day) COMPUTE STATISTICS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day='10') COMPUTE STATISTICS FOR ALL COLUMNS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day) COMPUTE STATISTICS FOR ALL COLUMNS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year, sold_month, sold_day) COMPUTE STATISTICS FOR ALL COLUMNS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day='10') COMPUTE STATISTICS FOR COLUMNS amount;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION (sold_year='2022', sold_month='1', sold_day) COMPUTE STATISTICS FOR COLUMNS amount, product;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year, sold_month, sold_day) COMPUTE STATISTICS FOR COLUMNS amount, product;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content.zh/docs/dev/table/sql/delete.md
+++ b/docs/content.zh/docs/dev/table/sql/delete.md
@@ -175,7 +175,7 @@ Flink SQL> SET 'execution.runtime-mode' = 'batch';
 [INFO] Session property has been set.
 
 Flink SQL> CREATE TABLE Orders (`user` STRING, product STRING, amount INT) with (...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> INSERT INTO Orders VALUES ('Lili', 'Apple', 1), ('Jessica', 'Banana', 1), ('Mr.White', 'Chicken', 3);
 [INFO] Submitting SQL update statement to the cluster...

--- a/docs/content.zh/docs/dev/table/sql/jar.md
+++ b/docs/content.zh/docs/dev/table/sql/jar.md
@@ -51,10 +51,10 @@ JAR 语句用于将用户 jar 添加到 classpath、或将用户 jar 从 classpa
 {{< tab "SQL CLI" >}}
 ```sql
 Flink SQL> ADD JAR '/path/hello.jar';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ADD JAR 'hdfs:///udf/common-udf.jar';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> SHOW JARS;
 +----------------------------+

--- a/docs/content.zh/docs/dev/table/sql/job.md
+++ b/docs/content.zh/docs/dev/table/sql/job.md
@@ -53,7 +53,7 @@ Flink SQL> SHOW JOBS;
 +----------------------------------+----------+---------+-------------------------+
 
 Flink SQL> SET 'state.savepoints.dir'='file:/tmp/';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> STOP JOB '228d70913eab60dda85c5e7f78b5782c' WITH SAVEPOINT;
 +-----------------------------------------+

--- a/docs/content.zh/docs/dev/table/sql/truncate.md
+++ b/docs/content.zh/docs/dev/table/sql/truncate.md
@@ -150,7 +150,7 @@ Flink SQL> SET 'execution.runtime-mode' = 'batch';
 [INFO] Session property has been set.
 
 Flink SQL> CREATE TABLE Orders (`user` STRING, product STRING, amount INT) with (...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> INSERT INTO Orders VALUES ('Lili', 'Apple', 1), ('Jessica', 'Banana', 1), ('Mr.White', 'Chicken', 3);
 [INFO] Submitting SQL update statement to the cluster...
@@ -164,7 +164,7 @@ Flink SQL> SELECT * FROM Orders;
 Mr.White                         Chicken           3
 
 Flink SQL> TRUNCATE TABLE Orders;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> SELECT * FROM Orders;
 // Empty set

--- a/docs/content.zh/docs/dev/table/sql/update.md
+++ b/docs/content.zh/docs/dev/table/sql/update.md
@@ -189,7 +189,7 @@ Flink SQL> SET 'execution.runtime-mode' = 'batch';
 [INFO] Session property has been set.
 
 Flink SQL> CREATE TABLE Orders (`user` STRING, product STRING, amount INT) with (...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> INSERT INTO Orders VALUES ('Lili', 'Apple', 1), ('Jessica', 'Banana', 1);
 [INFO] Submitting SQL update statement to the cluster...

--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -727,7 +727,7 @@ Flink SQL> CREATE TABLE pageviews (
 >   'properties.bootstrap.servers' = '...',
 >   'format' = 'avro'
 > );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE pageview (
 >   page_id BIGINT,
@@ -737,7 +737,7 @@ Flink SQL> CREATE TABLE pageview (
 >   'url' = 'jdbc:mysql://localhost:3306/mydatabase',
 >   'table-name' = 'pageview'
 > );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE uniqueview (
 >   page_id BIGINT,
@@ -747,7 +747,7 @@ Flink SQL> CREATE TABLE uniqueview (
 >   'url' = 'jdbc:mysql://localhost:3306/mydatabase',
 >   'table-name' = 'uniqueview'
 > );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> EXECUTE STATEMENT SET
 > BEGIN

--- a/docs/content/docs/dev/table/concepts/overview.md
+++ b/docs/content/docs/dev/table/concepts/overview.md
@@ -257,18 +257,18 @@ compiledPlan.writeToFile("/path/to/plan.json")
 
 ```sql
 Flink SQL> CREATE TABLE orders (order_id BIGINT, order_line_id BIGINT, buyer_id BIGINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE line_orders (order_line_id BIGINT, order_status TINYINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE enriched_orders (order_id BIGINT, order_line_id BIGINT, order_status TINYINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> COMPILE PLAN 'file:///path/to/plan.json' FOR INSERT INTO enriched_orders
 > SELECT a.order_id, a.order_line_id, b.order_status, ...
 > FROM orders a JOIN line_orders b ON a.order_line_id = b.order_line_id;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 ```
 
 {{< /tab >}}
@@ -376,13 +376,13 @@ tableEnv.loadPlan(PlanReference.fromFile("/path/to/plan.json")).execute().await(
 
 ```sql
 Flink SQL> CREATE TABLE orders (order_id BIGINT, order_line_id BIGINT, buyer_id BIGINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE line_orders (order_line_id BIGINT, order_status TINYINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE enriched_orders (order_id BIGINT, order_line_id BIGINT, order_status TINYINT, ...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> EXECUTE PLAN 'file:///path/to/plan.json';
 [INFO] Submitting SQL update statement to the cluster...

--- a/docs/content/docs/dev/table/hive-compatibility/hive-dialect/queries/overview.md
+++ b/docs/content/docs/dev/table/hive-compatibility/hive-dialect/queries/overview.md
@@ -109,16 +109,16 @@ Following is an example of using hive dialect to run some queries.
 
 ```bash
 Flink SQL> create catalog myhive with ('type' = 'hive', 'hive-conf-dir' = '/opt/hive-conf');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> use catalog myhive;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> load module hive;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> use modules hive,core;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> set table.sql-dialect=hive;
 [INFO] Session property has been set.
@@ -136,7 +136,7 @@ Flink SQL> select explode(array(1,2,3)); -- call hive udtf
 Received a total of 3 rows
 
 Flink SQL> create table tbl (key int,value string);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> insert into table tbl values (5,'e'),(1,'a'),(1,'a'),(3,'c'),(2,'b'),(3,'c'),(3,'c'),(4,'d');
 [INFO] Submitting SQL update statement to the cluster...

--- a/docs/content/docs/dev/table/sql/alter.md
+++ b/docs/content/docs/dev/table/sql/alter.md
@@ -179,10 +179,10 @@ tables = table_env.list_tables()
 {{< tab "SQL CLI" >}}
 ```sql
 Flink SQL> CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> DESCRIBE Orders;
 +---------+--------+------+-----+--------+-----------+------------------+
@@ -196,7 +196,7 @@ Flink SQL> DESCRIBE Orders;
 4 rows in set
 
 Flink SQL> ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR);
-[INFO] Execute statement succeed. 
+[INFO] Execute statement succeeded. 
 
 Flink SQL> DESCRIBE Orders;
 +----------+------------------------+-------+------------+--------+--------------------------+------------------+
@@ -212,7 +212,7 @@ Flink SQL> DESCRIBE Orders;
 6 rows in set
 
 Flink SQL> ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts);
-[INFO] Execute statement succeed. 
+[INFO] Execute statement succeeded. 
 
 Flink SQL> DESCRIBE Orders;
 +----------+------------------------+-------+------------+--------+-----------+---------------------+
@@ -228,7 +228,7 @@ Flink SQL> DESCRIBE Orders;
 6 rows in set
 
 Flink SQL> ALTER TABLE Orders DROP WATERMARK;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> DESCRIBE Orders;
 +----------+--------------+-------+------------+--------+-----------+---------------------+
@@ -244,7 +244,7 @@ Flink SQL> DESCRIBE Orders;
 6 rows in set
 
 Flink SQL> ALTER TABLE Orders DROP (amount, ts, category);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> DESCRIBE Orders;
 +---------+--------+-------+------------+--------+-----------+------------------+
@@ -257,7 +257,7 @@ Flink SQL> DESCRIBE Orders;
 3 rows in set
 
 Flink SQL> ALTER TABLE Orders RENAME `order` to `order_id`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> DESCRIBE Orders;
 +----------+--------+-------+---------------+--------+-----------+------------------+
@@ -278,7 +278,7 @@ Flink SQL> SHOW TABLES;
 1 row in set
 
 Flink SQL> ALTER TABLE Orders RENAME TO NewOrders;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> SHOW TABLES;
 +------------+

--- a/docs/content/docs/dev/table/sql/analyze.md
+++ b/docs/content/docs/dev/table/sql/analyze.md
@@ -295,40 +295,40 @@ Flink SQL> CREATE TABLE Orders (
 [INFO] Table has been created.
 
 Flink SQL> ANALYZE TABLE Store COMPUTE STATISTICS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Store COMPUTE STATISTICS FOR ALL COLUMNS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ANALYZE TABLE Store COMPUTE STATISTICS FOR COLUMNS location;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day='10') COMPUTE STATISTICS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day) COMPUTE STATISTICS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year, sold_month, sold_day) COMPUTE STATISTICS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day='10') COMPUTE STATISTICS FOR ALL COLUMNS;
-[INFO] Execute statement succeed.    
+[INFO] Execute statement succeeded.    
 
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day) COMPUTE STATISTICS FOR ALL COLUMNS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year, sold_month, sold_day) COMPUTE STATISTICS FOR ALL COLUMNS;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year='2022', sold_month='1', sold_day='10') COMPUTE STATISTICS FOR COLUMNS amount;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION (sold_year='2022', sold_month='1', sold_day) COMPUTE STATISTICS FOR COLUMNS amount, product;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
     
 Flink SQL> ANALYZE TABLE Orders PARTITION(sold_year, sold_month, sold_day) COMPUTE STATISTICS FOR COLUMNS amount, product;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/table/sql/delete.md
+++ b/docs/content/docs/dev/table/sql/delete.md
@@ -174,7 +174,7 @@ Flink SQL> SET 'execution.runtime-mode' = 'batch';
 [INFO] Session property has been set.
 
 Flink SQL> CREATE TABLE Orders (`user` STRING, product STRING, amount INT) with (...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> INSERT INTO Orders VALUES ('Lili', 'Apple', 1), ('Jessica', 'Banana', 1), ('Mr.White', 'Chicken', 3);
 [INFO] Submitting SQL update statement to the cluster...

--- a/docs/content/docs/dev/table/sql/jar.md
+++ b/docs/content/docs/dev/table/sql/jar.md
@@ -48,10 +48,10 @@ The following examples show how to run `JAR` statements in [SQL CLI]({{< ref "do
 {{< tab "SQL CLI" >}}
 ```sql
 Flink SQL> ADD JAR '/path/hello.jar';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> ADD JAR 'hdfs:///udf/common-udf.jar';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> SHOW JARS;
 +----------------------------+

--- a/docs/content/docs/dev/table/sql/job.md
+++ b/docs/content/docs/dev/table/sql/job.md
@@ -53,7 +53,7 @@ Flink SQL> SHOW JOBS;
 +----------------------------------+----------+---------+-------------------------+
 
 Flink SQL> SET 'state.savepoints.dir'='file:/tmp/';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> STOP JOB '228d70913eab60dda85c5e7f78b5782c' WITH SAVEPOINT;
 +-----------------------------------------+

--- a/docs/content/docs/dev/table/sql/truncate.md
+++ b/docs/content/docs/dev/table/sql/truncate.md
@@ -146,7 +146,7 @@ Flink SQL> SET 'execution.runtime-mode' = 'batch';
 [INFO] Session property has been set.
 
 Flink SQL> CREATE TABLE Orders (`user` STRING, product STRING, amount INT) with (...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> INSERT INTO Orders VALUES ('Lili', 'Apple', 1), ('Jessica', 'Banana', 1), ('Mr.White', 'Chicken', 3);
 [INFO] Submitting SQL update statement to the cluster...
@@ -160,7 +160,7 @@ Flink SQL> SELECT * FROM Orders;
 Mr.White                         Chicken           3
 
 Flink SQL> TRUNCATE TABLE Orders;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> SELECT * FROM Orders;
 // Empty set

--- a/docs/content/docs/dev/table/sql/update.md
+++ b/docs/content/docs/dev/table/sql/update.md
@@ -188,7 +188,7 @@ Flink SQL> SET 'execution.runtime-mode' = 'batch';
 [INFO] Session property has been set.
 
 Flink SQL> CREATE TABLE Orders (`user` STRING, product STRING, amount INT) with (...);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> INSERT INTO Orders VALUES ('Lili', 'Apple', 1), ('Jessica', 'Banana', 1);
 [INFO] Submitting SQL update statement to the cluster...

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -665,7 +665,7 @@ Flink SQL> CREATE TABLE pageviews (
 >   'properties.bootstrap.servers' = '...',
 >   'format' = 'avro'
 > );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE pageview (
 >   page_id BIGINT,
@@ -675,7 +675,7 @@ Flink SQL> CREATE TABLE pageview (
 >   'url' = 'jdbc:mysql://localhost:3306/mydatabase',
 >   'table-name' = 'pageview'
 > );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> CREATE TABLE uniqueview (
 >   page_id BIGINT,
@@ -685,7 +685,7 @@ Flink SQL> CREATE TABLE uniqueview (
 >   'url' = 'jdbc:mysql://localhost:3306/mydatabase',
 >   'table-name' = 'uniqueview'
 > );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 
 Flink SQL> EXECUTE STATEMENT SET
 > BEGIN

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -211,7 +211,7 @@ public final class CliStrings {
 
     public static final String MESSAGE_EXECUTE_FILE = "Executing SQL from file.";
 
-    public static final String MESSAGE_EXECUTE_STATEMENT = "Execute statement succeed.";
+    public static final String MESSAGE_EXECUTE_STATEMENT = "Execute statement succeeded.";
 
     // --------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-sql-client/src/test/resources/sql/call_procedure.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/call_procedure.q
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 create catalog test_procedure_catalog with ('type'='test_procedure_catalog');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 call `test_procedure_catalog`.`system`.generate_n(2);
@@ -40,12 +40,12 @@ call `test_procedure_catalog`.`system`.generate_n(1);
 
 # switch current catalog to test_procedure_catalog
 use catalog test_procedure_catalog;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # create a database `system` to avoid DatabaseNotExistException in the following `show procedure` statement
 create database `system`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show procedures in `system` ilike 'gEnerate%';

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -48,7 +48,7 @@ org.apache.flink.table.api.ValidationException: Catalog my does not exist
 # ==========================================================================
 
 create catalog c1 with ('type'='generic_in_memory');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show catalogs;
@@ -71,7 +71,7 @@ show current catalog;
 !ok
 
 use catalog c1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show current catalog;
@@ -84,7 +84,7 @@ show current catalog;
 !ok
 
 drop catalog default_catalog;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 drop catalog c1;
@@ -97,7 +97,7 @@ org.apache.flink.table.catalog.exceptions.CatalogException: Cannot drop a catalo
 # ==========================================================================
 
 create database db1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show databases;
@@ -111,7 +111,7 @@ show databases;
 !ok
 
 create database db2;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show databases like 'db%';
@@ -171,7 +171,7 @@ show databases ilike 'db2%';
 !ok
 
 drop database db2;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show current database;
@@ -184,7 +184,7 @@ show current database;
 !ok
 
 use db1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show current database;
@@ -197,11 +197,11 @@ show current database;
 !ok
 
 create database db2 comment 'db2_comment' with ('k1' = 'v1');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 alter database db2 set ('k1' = 'a', 'k2' = 'b');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # TODO: show database properties when we support DESCRIBE DATABSE
@@ -218,15 +218,15 @@ show databases;
 !ok
 
 create catalog `c0` with ('type'='generic_in_memory');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create database c0.db0a;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create database c0.db0b;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show databases from c0;
@@ -304,7 +304,7 @@ org.apache.flink.sql.parser.impl.ParseException: Show databases from/in identifi
 !error
 
 drop catalog `c0`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show databases from c0;
@@ -313,7 +313,7 @@ org.apache.flink.table.api.ValidationException: Catalog c0 does not exist
 !error
 
 drop database if exists db2;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show databases;
@@ -331,15 +331,15 @@ show databases;
 # ==========================================================================
 
 create catalog `mod` with ('type'='generic_in_memory');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use catalog `mod`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use `default`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 drop database `default`;
@@ -353,19 +353,19 @@ org.apache.flink.table.catalog.exceptions.CatalogException: Cannot drop a catalo
 !error
 
 use catalog `c1`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 drop catalog `mod`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'execution.runtime-mode' = 'batch';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -373,19 +373,19 @@ SET 'sql-client.execution.result-mode' = 'tableau';
 # ==========================================================================
 
 create catalog c2 with ('type'='generic_in_memory');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use catalog `c2`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table MyTable1 (a int, b string) with ('connector' = 'values');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table MyTable2 (a int, b string) with ('connector' = 'values');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # hive catalog is case-insensitive
@@ -404,11 +404,11 @@ Empty set
 !ok
 
 create view MyView1 as select 1 + 1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create view MyView2 as select 1 + 1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show views;
@@ -423,27 +423,27 @@ show views;
 
 # test create with full qualified name
 create table c1.db1.MyTable3 (a int, b string) with ('connector' = 'values');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table c1.db1.MyTable4 (a int, b string) with ('connector' = 'values');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create view c1.db1.MyView3 as select 1 + 1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create view c1.db1.MyView4 as select 1 + 1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use catalog c1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use db1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables;
@@ -470,23 +470,23 @@ show views;
 
 # test create with database name
 create table `default`.MyTable5 (a int, b string) with ('connector' = 'values');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table `default`.MyTable6 (a int, b string) with ('connector' = 'values');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create view `default`.MyView5 as select 1 + 1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create view `default`.MyView6 as select 1 + 1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use `default`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables;
@@ -512,15 +512,15 @@ show views;
 !ok
 
 drop table db1.MyTable3;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 drop view db1.MyView3;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use db1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables;
@@ -543,15 +543,15 @@ show views;
 !ok
 
 drop table c1.`default`.MyTable6;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 drop view c1.`default`.MyView6;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use `default`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables;
@@ -578,11 +578,11 @@ show views;
 # ==========================================================================
 
 SET 'sql-client.execution.result-mode' = 'changelog';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table MyTable7 (a int, b string) with ('connector' = 'values');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables;
@@ -597,11 +597,11 @@ show tables;
 !ok
 
 reset;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 drop table MyTable5;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables;
@@ -619,27 +619,27 @@ show tables;
 # ==========================================================================
 
 create catalog catalog1 with ('type'='generic_in_memory');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create database catalog1.db1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table catalog1.db1.person (a int, b string) with ('connector' = 'datagen');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table catalog1.db1.dim (a int, b string) with ('connector' = 'datagen');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table catalog1.db1.address (a int, b string) with ('connector' = 'datagen');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create view catalog1.db1.v_person as select * from catalog1.db1.person;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables from catalog1.db1;
@@ -675,7 +675,7 @@ show tables in catalog1.db1 not like '%person%';
 !ok
 
 use catalog catalog1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables from db1 like 'p_r%';

--- a/flink-table/flink-sql-client/src/test/resources/sql/delete.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/delete.q
@@ -17,15 +17,15 @@
 
 # first set batch mode
 SET 'execution.runtime-mode' = 'batch';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'table.dml-sync' = 'true';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # create a table first
@@ -35,7 +35,7 @@ WITH (
   'data-id' = '$VAR_DELETE_TABLE_DATA_ID',
   'mix-delete' = 'true'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # query the table first

--- a/flink-table/flink-sql-client/src/test/resources/sql/function.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/function.q
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 ADD JAR '$VAR_UDF_JAR_PATH';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW JARS;
@@ -30,7 +30,7 @@ SHOW JARS;
 
 # this also tests user classloader because the LowerUDF is in user jar
 create function func1 as 'LowerUDF' LANGUAGE JAVA;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show user functions;
@@ -61,7 +61,7 @@ show user functions ilike 'func%';
 !ok
 
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # run a query to verify the registered UDF works
@@ -78,7 +78,7 @@ Received a total of 2 rows
 # ====== test temporary function ======
 
 create temporary function if not exists func2 as 'LowerUDF' LANGUAGE JAVA;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show user functions;
@@ -112,27 +112,27 @@ show user functions ilike 'func2%';
 # ====== test function with full qualified name ======
 
 create catalog c1 with ('type'='generic_in_memory');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use catalog c1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create database db;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use catalog default_catalog;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create function c1.db.func3 as 'LowerUDF' LANGUAGE JAVA;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create temporary function if not exists c1.db.func4 as 'LowerUDF' LANGUAGE JAVA;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # no func3 and func4 because we are not under catalog c1
@@ -179,11 +179,11 @@ show user functions in c1.db ilike 'FUNC3%';
 !ok
 
 use catalog c1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use db;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # should show func3 and func4 now
@@ -199,15 +199,15 @@ show user functions;
 
 # test create function with database name
 create function `default`.func5 as 'LowerUDF';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create function `default`.func6 as 'LowerUDF';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use `default`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # should show func5 and func6
@@ -226,27 +226,27 @@ show user functions;
 # ==========================================================================
 
 create function c1.db.func10 as 'LowerUDF';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create function c1.db.func11 as 'LowerUDF';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 drop function if exists c1.db.func10;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use catalog c1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 use db;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 drop function if exists non_func;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # should contain func11, not contain func10
@@ -266,13 +266,13 @@ show user functions;
 # ==========================================================================
 
 alter function func11 as 'org.apache.flink.table.client.gateway.local.ExecutorImplITCase$TestScalaFunction';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # TODO: show func11 when we support DESCRIBE FUNCTION
 
 create temporary function tmp_func as 'LowerUDF';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # should throw unsupported error
@@ -287,7 +287,7 @@ org.apache.flink.table.api.ValidationException: Alter temporary catalog function
 # ==========================================================================
 
 REMOVE JAR '$VAR_UDF_JAR_PATH';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW JARS;
@@ -295,7 +295,7 @@ Empty set
 !ok
 
 create temporary function temp_upperudf AS 'UpperUDF' using jar '$VAR_UDF_JAR_PATH';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW JARS;
@@ -303,7 +303,7 @@ Empty set
 !ok
 
 create function upperudf AS 'UpperUDF' using jar '$VAR_UDF_JAR_PATH';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # `SHOW JARS` does not list the jars being used by function, it only list all the jars added by `ADD JAR`

--- a/flink-table/flink-sql-client/src/test/resources/sql/insert.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/insert.q
@@ -16,11 +16,11 @@
 # limitations under the License.
 
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'table.dml-sync' = 'true';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -28,7 +28,7 @@ SET 'table.dml-sync' = 'true';
 # ==========================================================================
 
 SET 'execution.runtime-mode' = 'streaming';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table StreamingTable (
@@ -39,7 +39,7 @@ create table StreamingTable (
   'path' = '$VAR_STREAMING_PATH',
   'format' = 'csv'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 INSERT INTO StreamingTable SELECT * FROM (VALUES (1, 'Hello World'), (2, 'Hi'), (2, 'Hi'), (3, 'Hello'), (3, 'World'), (4, 'ADD'), (5, 'LINE'));
@@ -66,7 +66,7 @@ Received a total of 7 rows
 # ==========================================================================
 
 SET 'execution.runtime-mode' = 'batch';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table BatchTable (
@@ -77,7 +77,7 @@ create table BatchTable (
   'path' = '$VAR_BATCH_PATH',
   'format' = 'csv'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 INSERT INTO BatchTable SELECT * FROM (VALUES (1, 'Hello World'), (2, 'Hi'), (2, 'Hi'), (3, 'Hello'), (3, 'World'), (4, 'ADD'), (5, 'LINE'));

--- a/flink-table/flink-sql-client/src/test/resources/sql/module.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/module.q
@@ -17,7 +17,7 @@
 
 # set tableau result mode
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -87,7 +87,7 @@ org.apache.flink.table.api.ValidationException: Option 'type' = 'dummy' is not s
 !error
 
 LOAD MODULE dummy;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # show enabled modules
@@ -124,7 +124,7 @@ org.apache.flink.table.api.ValidationException: Module 'dummy' appears more than
 
 # change module resolution order
 USE MODULES dummy, core;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW MODULES;
@@ -149,7 +149,7 @@ SHOW FULL MODULES;
 
 # disable dummy module
 USE MODULES core;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW MODULES;
@@ -176,7 +176,7 @@ SHOW FULL MODULES;
 # ==========================================================================
 
 UNLOAD MODULE core;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW MODULES;

--- a/flink-table/flink-sql-client/src/test/resources/sql/select.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/select.q
@@ -18,11 +18,11 @@
 # set default streaming mode and tableau result mode
 
 SET 'execution.runtime-mode' = 'streaming';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -37,7 +37,7 @@ create table src (
   'data-id' = 'non-exist',
   'failing-source' = 'true'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT UPPER(str), id FROM src;
@@ -72,7 +72,7 @@ Received a total of 4 rows
 # ==========================================================================
 
 SET 'table.local-time-zone' = 'Asia/Shanghai';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT TIME '20:12:11' as time0,
@@ -94,7 +94,7 @@ Received a total of 2 rows
 !ok
 
 SET 'table.local-time-zone' = 'UTC';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT TIME '20:12:11' as time0,
@@ -128,7 +128,7 @@ AS (VALUES
   ('8b012d93-6ece-48ad-a2ea-aa75ef7b1d60', TIMESTAMP '1979-03-15 22:13:11.123', false),
   ('09969d9e-d584-11eb-b8bc-0242ac130003', TIMESTAMP '1985-04-16 23:14:11.123', true)
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -146,7 +146,7 @@ Received a total of 4 rows
 # test fallback config option key
 
 SET 'table.display.max-column-width' = '10';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -162,7 +162,7 @@ Received a total of 4 rows
 !ok
 
 SET 'table.display.max-column-width' = '40';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -180,7 +180,7 @@ Received a total of 4 rows
 # test original config option key
 
 SET 'sql-client.display.max-column-width' = '10';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -197,7 +197,7 @@ Received a total of 4 rows
 
 
 SET 'sql-client.display.max-column-width' = '40';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -214,11 +214,11 @@ Received a total of 4 rows
 
 -- post-test cleanup + setting back default max width value
 DROP TEMPORARY VIEW testUserData;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'sql-client.display.max-column-width' = '30';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -226,7 +226,7 @@ SET 'sql-client.display.max-column-width' = '30';
 # ==========================================================================
 
 SET 'execution.runtime-mode' = 'batch';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT id, COUNT(*) as cnt, COUNT(DISTINCT str) as uv
@@ -272,7 +272,7 @@ AS (VALUES
   ('8b012d93-6ece-48ad-a2ea-aa75ef7b1d60', TIMESTAMP '1979-03-15 22:13:11.123', false),
   ('09969d9e-d584-11eb-b8bc-0242ac130003', TIMESTAMP '1985-04-16 23:14:11.123', true)
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -288,7 +288,7 @@ SELECT * from testUserData;
 !ok
 
 SET 'sql-client.display.max-column-width' = '10';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -304,7 +304,7 @@ SELECT * from testUserData;
 !ok
 
 SET 'sql-client.display.max-column-width' = '40';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -321,11 +321,11 @@ SELECT * from testUserData;
 
 -- post-test cleanup + setting back default max width value
 DROP TEMPORARY VIEW testUserData;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'sql-client.display.max-column-width' = '30';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT INTERVAL '1' DAY as dayInterval, INTERVAL '1' YEAR as yearInterval;

--- a/flink-table/flink-sql-client/src/test/resources/sql/select_batch.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/select_batch.q
@@ -18,11 +18,11 @@
 # set default streaming mode and tableau result mode
 
 SET 'execution.runtime-mode' = 'batch';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT id, COUNT(*) as cnt, COUNT(DISTINCT str) as uv
@@ -38,7 +38,7 @@ GROUP BY id;
 !ok
 
 SET 'table.local-time-zone' = 'UTC';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT TIME '20:12:11' as time0,
@@ -72,7 +72,7 @@ AS (VALUES
   ('8b012d93-6ece-48ad-a2ea-aa75ef7b1d60', TIMESTAMP '1979-03-15 22:13:11.123', false),
   ('09969d9e-d584-11eb-b8bc-0242ac130003', TIMESTAMP '1985-04-16 23:14:11.123', true)
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -88,7 +88,7 @@ SELECT * from testUserData;
 !ok
 
 SET 'sql-client.display.max-column-width' = '10';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -104,7 +104,7 @@ SELECT * from testUserData;
 !ok
 
 SET 'sql-client.display.max-column-width' = '40';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from testUserData;
@@ -121,11 +121,11 @@ SELECT * from testUserData;
 
 -- post-test cleanup + setting back default max width value
 DROP TEMPORARY VIEW testUserData;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'sql-client.display.max-column-width' = '30';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT INTERVAL '1' DAY as dayInterval, INTERVAL '1' YEAR as yearInterval;

--- a/flink-table/flink-sql-client/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/set.q
@@ -17,11 +17,11 @@
 
 # test set a configuration
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'table.dml-sync' = 'true';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # test "ctas"
@@ -34,7 +34,7 @@ CREATE TABLE foo with(
 !info
 
 RESET 'table.dml-sync';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT * from foo;
@@ -48,7 +48,7 @@ Received a total of 1 row
 
 # test add jar
 ADD JAR '$VAR_UDF_JAR_PATH';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW JARS;
@@ -61,7 +61,7 @@ SHOW JARS;
 !ok
 
 REMOVE JAR '$VAR_UDF_JAR_PATH';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW JARS;
@@ -69,7 +69,7 @@ Empty set
 !ok
 
 reset 'table.resources.download-dir';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # list the configured configuration
@@ -95,7 +95,7 @@ set;
 
 # reset the configuration
 reset;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 set;
@@ -136,7 +136,7 @@ Was expecting one of:
 !error
 
 set 'sql-client.verbose' = 'true';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 set;
@@ -158,11 +158,11 @@ set;
 !ok
 
 set 'execution.attached' = 'false';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 reset 'execution.attached';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 set;
@@ -185,7 +185,7 @@ set;
 
 # test reset can work with add jar
 ADD JAR '$VAR_UDF_JAR_PATH';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW JARS;
@@ -216,7 +216,7 @@ set;
 !ok
 
 reset;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW JARS;
@@ -229,15 +229,15 @@ SHOW JARS;
 !ok
 
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'sql-client.display.print-time-cost' = 'false';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create function func1 as 'LowerUDF' LANGUAGE JAVA;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SELECT id, func1(str) FROM (VALUES (1, 'Hello World')) AS T(id, str) ;
@@ -250,7 +250,7 @@ Received a total of 1 row
 !ok
 
 REMOVE JAR '$VAR_UDF_JAR_PATH';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SHOW JARS;

--- a/flink-table/flink-sql-client/src/test/resources/sql/statement_set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/statement_set.q
@@ -16,11 +16,11 @@
 # limitations under the License.
 
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'table.dml-sync' = 'true';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table src (
@@ -29,7 +29,7 @@ create table src (
 ) with (
   'connector' = 'values'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -37,7 +37,7 @@ create table src (
 # ==========================================================================
 
 SET 'execution.runtime-mode' = 'streaming';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table StreamingTable (
@@ -48,11 +48,11 @@ create table StreamingTable (
   'path' = '$VAR_STREAMING_PATH',
   'format' = 'csv'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 BEGIN STATEMENT SET;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 BEGIN STATEMENT SET;
@@ -76,7 +76,7 @@ org.apache.flink.table.gateway.service.utils.SqlExecutionException: Only 'INSERT
 !error
 
 INSERT INTO StreamingTable SELECT * FROM (VALUES (1, 'Hello World'), (2, 'Hi'), (2, 'Hi'), (3, 'Hello'), (3, 'World'), (4, 'ADD'), (5, 'LINE'));
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 END;
@@ -108,7 +108,7 @@ Received a total of 7 rows
 # ==========================================================================
 
 SET 'execution.runtime-mode' = 'batch';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table BatchTable (
@@ -119,11 +119,11 @@ str string
 'path' = '$VAR_BATCH_PATH',
 'format' = 'csv'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 BEGIN STATEMENT SET;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 BEGIN STATEMENT SET;
@@ -132,7 +132,7 @@ org.apache.flink.table.gateway.service.utils.SqlExecutionException: Only 'INSERT
 !error
 
 INSERT INTO BatchTable SELECT * FROM (VALUES (1, 'Hello World'), (2, 'Hi'), (2, 'Hi'), (3, 'Hello'), (3, 'World'), (4, 'ADD'), (5, 'LINE'));
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 END;
@@ -155,9 +155,9 @@ SELECT * FROM BatchTable;
 !ok
 
 BEGIN STATEMENT SET;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 END;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info

--- a/flink-table/flink-sql-client/src/test/resources/sql/table.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/table.q
@@ -45,7 +45,7 @@ org.apache.flink.table.api.ValidationException: Table `default_catalog`.`default
 !error
 
 alter table if exists non_exist rename to non_exist2;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -64,7 +64,7 @@ CREATE TABLE IF NOT EXISTS orders (
 ) with (
  'connector' = 'datagen'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # test SHOW TABLES
@@ -114,7 +114,7 @@ show columns from orders;
 
 # test display max colum width
 SET 'table.display.max-column-width' = '10';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show columns from orders;
@@ -131,7 +131,7 @@ show columns from orders;
 !ok
 
 SET 'table.display.max-column-width' = '100';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show columns from orders;
@@ -148,7 +148,7 @@ show columns from orders;
 !ok
 
 SET 'sql-client.display.max-column-width' = '10';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show columns from orders;
@@ -165,7 +165,7 @@ show columns from orders;
 !ok
 
 SET 'sql-client.display.max-column-width' = '100';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show columns from orders;
@@ -359,7 +359,7 @@ show columns in orders not like 'use_';
 # ==========================================================================
 
 alter table orders rename to orders2;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -368,7 +368,7 @@ alter table orders rename to orders2;
 
 # test alter table properties
 alter table orders2 set ('connector' = 'kafka', 'scan.startup.mode' = 'earliest-offset');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table options using SHOW CREATE TABLE
@@ -395,7 +395,7 @@ show create table orders2;
 
 # change connector to 'datagen' without removing 'scan.startup.mode' for the fix later
 alter table orders2 set ('connector' = 'datagen');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table options are problematic
@@ -464,7 +464,7 @@ scan.parallelism
 
 # test alter table reset to remove invalid key
 alter table orders2 reset ('scan.startup.mode');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table options using SHOW CREATE TABLE
@@ -499,7 +499,7 @@ org.apache.flink.table.api.ValidationException: ALTER TABLE RESET does not suppo
 # ==========================================================================
 
 alter table orders2 rename amount to amount1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table options using SHOW CREATE TABLE
@@ -543,7 +543,7 @@ Referenced column `shipment_info` by 'AFTER' does not exist in the table.
 
 # test alter table add one column
 alter table orders2 add product_id bigint not null after `user`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table schema using SHOW CREATE TABLE
@@ -570,7 +570,7 @@ show create table orders2;
 
 # test alter table add multiple columns
 alter table orders2 add (user_email string not null after `user`, cleaned_product as coalesce(product, 'missing_sku') after product, trade_order_id bigint not null first);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table schema using SHOW CREATE TABLE
@@ -603,7 +603,7 @@ show create table orders2;
 # ==========================================================================
 # test alter table schema modify primary key
 alter table orders2 modify constraint order_constraint primary key (trade_order_id) not enforced;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table schema using SHOW CREATE TABLE
@@ -633,7 +633,7 @@ show create table orders2;
 
 # test alter table schema modify watermark offset, change column position
 alter table orders2 modify (watermark for ts as ts - interval '1' minute, ts timestamp(3) not null after trade_order_id, `user` string);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table schema using SHOW CREATE TABLE
@@ -666,7 +666,7 @@ show create table orders2;
 # ==========================================================================
 
 alter table orders2 drop (amount1, product, cleaned_product);
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table options using SHOW CREATE TABLE
@@ -696,7 +696,7 @@ show create table orders2;
 # ==========================================================================
 
 alter table orders2 drop primary key;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table options using SHOW CREATE TABLE
@@ -725,7 +725,7 @@ show create table orders2;
 # ==========================================================================
 
 alter table orders2 drop watermark;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table options using SHOW CREATE TABLE
@@ -786,7 +786,7 @@ desc orders2;
 # ==========================================================================
 
 drop table orders2;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # verify table is dropped
@@ -805,7 +805,7 @@ create temporary table tbl1 (
 ) with (
  'connector' = 'datagen'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # TODO: warning users the table already exists
@@ -816,7 +816,7 @@ create temporary table if not exists tbl1 (
 ) with (
  'connector' = 'datagen'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # list permanent and temporary tables together
@@ -847,7 +847,7 @@ show create table tbl1;
 !ok
 
 drop temporary table tbl1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -855,7 +855,7 @@ drop temporary table tbl1;
 # ==========================================================================
 
 create table `mod` (`table` string, `database` string) with ('connector' = 'values');
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 describe `mod`;
@@ -879,7 +879,7 @@ desc `mod`;
 !ok
 
 drop table `mod`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables;
@@ -902,7 +902,7 @@ CREATE TABLE `default_catalog`.`default_database`.`orders3` (
   'connector' = 'kafka',
   'scan.startup.mode' = 'earliest-offset'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # test describe
@@ -994,7 +994,7 @@ CREATE TABLE IF NOT EXISTS orders (
 ) with (
  'connector' = 'datagen'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 CREATE TABLE IF NOT EXISTS orders2 (
@@ -1006,7 +1006,7 @@ CREATE TABLE IF NOT EXISTS orders2 (
 ) with (
  'connector' = 'blackhole'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 CREATE TABLE IF NOT EXISTS daily_orders (
@@ -1020,7 +1020,7 @@ CREATE TABLE IF NOT EXISTS daily_orders (
  'path' = '$VAR_BATCH_PATH',
  'format' = 'csv'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # test explain plan for select

--- a/flink-table/flink-sql-client/src/test/resources/sql/truncate.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/truncate.q
@@ -17,15 +17,15 @@
 
 # first set batch mode
 SET 'execution.runtime-mode' = 'batch';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'sql-client.execution.result-mode' = 'tableau';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'table.dml-sync' = 'true';
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # create a table first
@@ -34,7 +34,7 @@ WITH (
   'connector' = 'test-update-delete',
   'data-id' = '$VAR_TRUNCATE_TABLE_DATA_ID'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # query the table first
@@ -53,7 +53,7 @@ SELECT * FROM t;
 
 # truncate the table
 TRUNCATE TABLE t;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # query the table again

--- a/flink-table/flink-sql-client/src/test/resources/sql/view.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/view.q
@@ -27,13 +27,13 @@ CREATE TABLE orders (
 ) with (
  'connector' = 'datagen'
 );
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==== test temporary view =====
 
 create temporary view v1 as select * from orders;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create temporary view v1 as select * from orders;
@@ -43,7 +43,7 @@ org.apache.flink.table.api.ValidationException: Temporary table '`default_catalo
 
 # TODO: warning users the view already exists
 create temporary view if not exists v1 as select * from orders;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # test query a view with hint
@@ -54,7 +54,7 @@ org.apache.flink.table.api.ValidationException: View '`default_catalog`.`default
 
 # test create a view reference another view
 create temporary view if not exists v2 as select * from v1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # test show create a temporary view
@@ -112,7 +112,7 @@ org.apache.flink.table.api.TableException: SHOW CREATE TABLE is only supported f
 
 # register a permanent view with the duplicate name with temporary view
 create view v1 as select * from orders;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # test create duplicate view
@@ -123,7 +123,7 @@ org.apache.flink.table.catalog.exceptions.TableAlreadyExistException: Table (or 
 
 # test show create a permanent view
 create view permanent_v1 as select * from orders;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # test show create a permanent view
@@ -140,7 +140,7 @@ FROM `default_catalog`.`default_database`.`orders` |
 
 # remove permanent_v1 view
 drop view permanent_v1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # we didn't distinguish the temporary v1 and permanent v1 for now
@@ -363,12 +363,12 @@ org.apache.flink.table.api.ValidationException: Temporary view with identifier '
 
 # although temporary v2 needs temporary v1, dropping v1 first does not throw exception
 drop temporary view v1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # now we can drop permanent view v1
 drop view v1;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # test drop invalid table
@@ -380,7 +380,7 @@ org.apache.flink.table.api.ValidationException: View with identifier 'default_ca
 # ===== test playing with keyword identifiers =====
 
 create view `mod` as select * from orders;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 describe `mod`;
@@ -410,7 +410,7 @@ desc `mod`;
 !ok
 
 drop view `mod`;
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 show tables;

--- a/flink-table/flink-sql-client/src/test/resources/sql_multi/statement_set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql_multi/statement_set.q
@@ -17,12 +17,12 @@
 
 SET 'sql-client.execution.result-mode' = 'tableau';
 !output
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 SET 'table.dml-sync' = 'true';
 !output
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table src (
@@ -32,7 +32,7 @@ create table src (
   'connector' = 'values'
 );
 !output
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 # ==========================================================================
@@ -41,7 +41,7 @@ create table src (
 
 SET 'execution.runtime-mode' = 'streaming';
 !output
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table StreamingTable (
@@ -53,7 +53,7 @@ create table StreamingTable (
   'format' = 'csv'
 );
 !output
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table StreamingTable2 (
@@ -65,7 +65,7 @@ create table StreamingTable2 (
   'format' = 'csv'
 );
 !output
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 EXPLAIN STATEMENT SET BEGIN
@@ -171,7 +171,7 @@ Was expecting one of:
 
 SET 'execution.runtime-mode' = 'batch';
 !output
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table BatchTable (
@@ -183,7 +183,7 @@ str string
 'format' = 'csv'
 );
 !output
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 create table BatchTable2 (
@@ -195,7 +195,7 @@ str string
 'format' = 'csv'
 );
 !output
-[INFO] Execute statement succeed.
+[INFO] Execute statement succeeded.
 !info
 
 EXPLAIN STATEMENT SET


### PR DESCRIPTION
## What is the purpose of the change

The SQL Client issues a message when a statement successfully executes. For example:

```sql
Flink SQL> CREATE CATALOG c_new WITH ('type'='generic_in_memory');
[INFO] Execute statement succeed.
```

The use of `succeed` is incorrect, and should read `succeeded`. This PR fixes this.

## Brief change log

* Changed the actual message
* Changed the tests and docs that reference it.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

-> This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
