### PR TITLE
[FLINK-34403][ci] Transforms VeryBigPbRowToProtoTest into an integration test

### DIFF
--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/VeryBigPbRowToProtoITCase.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/VeryBigPbRowToProtoITCase.java
@@ -26,8 +26,11 @@ import org.junit.Test;
 /**
  * Test for very huge proto definition, which may trigger some special optimizations such as code
  * splitting and java constant pool size optimization.
+ *
+ * <p>Implementing this test as an {@code ITCase} enables larger heap size for the test execution.
+ * The current unit test execution configuration would cause {@code OutOfMemoryErrors}.
  */
-public class VeryBigPbRowToProtoTest {
+public class VeryBigPbRowToProtoITCase {
 
     @Test
     public void testSimple() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

Follow-up on https://github.com/apache/flink/pull/24302. I missed renaming one test.

## Brief change log

* Renames `VeryBigPbRowToProtoTest` into `VeryBigPbRowToProtoITCase` to utilize the bigger heap size of the integration test execution

## Verifying this change

* Renames the test
* Verified that the causing PR https://github.com/apache/flink/pull/23937 didn't touch any other tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable