### PR TITLE
[WIP] Extend error labeling to avoid restart loops.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/failure/FailureEnricher.java
+++ b/flink-core/src/main/java/org/apache/flink/core/failure/FailureEnricher.java
@@ -37,6 +37,12 @@ import java.util.concurrent.Executor;
 public interface FailureEnricher {
 
     /**
+     * Special key to label failures that prevents job restart for persistent or terminal errors,
+     * e.g. to avoid restart loops from deserialization errors.
+     */
+    String KEY_JOB_CANNOT_RESTART = "JOB_CANNOT_RESTART";
+
+    /**
      * Method to list all the label Keys the enricher can associate with Values in case of a failure
      * {@code processFailure}. Note that Keys must unique and properly defined per enricher
      * implementation otherwise will be ignored.

--- a/flink-core/src/test/java/org/apache/flink/core/failure/TestingFailureEnricher.java
+++ b/flink-core/src/test/java/org/apache/flink/core/failure/TestingFailureEnricher.java
@@ -28,11 +28,13 @@ import java.util.concurrent.CompletableFuture;
 public class TestingFailureEnricher implements FailureEnricher {
 
     final Set<Throwable> seenThrowables = new HashSet<>();
-    final Map<String, String> failureLabels = Collections.singletonMap("failKey", "failValue");
+    Map<String, String> failureLabels = Collections.singletonMap("failKey", "failValue");
+
+    Set<String> outputKeys = Collections.singleton("failKey");
 
     @Override
     public Set<String> getOutputKeys() {
-        return Collections.singleton("failKey");
+        return outputKeys;
     }
 
     @Override
@@ -47,5 +49,13 @@ public class TestingFailureEnricher implements FailureEnricher {
 
     public Map<String, String> getFailureLabels() {
         return failureLabels;
+    }
+
+    public void setFailureLabels(Map<String, String> failureLabels) {
+        this.failureLabels = failureLabels;
+    }
+
+    public void setOutputKeys(Set<String> outputKeys) {
+        this.outputKeys = outputKeys;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1301,8 +1301,9 @@ public class AdaptiveScheduler
     }
 
     @Override
-    public FailureResult howToHandleFailure(Throwable failure) {
-        if (ExecutionFailureHandler.isUnrecoverableError(failure)) {
+    public FailureResult howToHandleFailure(
+            Throwable failure, CompletableFuture<Map<String, String>> failureLabels) {
+        if (ExecutionFailureHandler.isUnrecoverableError(failure, failureLabels)) {
             return FailureResult.canNotRestart(
                     new JobException("The failure is not recoverable", failure));
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Canceling.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Canceling.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /** State which describes a job which is currently being canceled. */
 class Canceling extends StateWithExecutionGraph {
@@ -66,7 +68,7 @@ class Canceling extends StateWithExecutionGraph {
     }
 
     @Override
-    void onFailure(Throwable failure) {
+    void onFailure(Throwable failure, CompletableFuture<Map<String, String>> failureLabels) {
         // Execution graph is already cancelling, so there is nothing more we can do.
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
@@ -106,8 +107,9 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
     }
 
     @Override
-    void onFailure(Throwable cause) {
-        FailureResultUtil.restartOrFail(context.howToHandleFailure(cause), context, this);
+    void onFailure(Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
+        FailureResultUtil.restartOrFail(
+                context.howToHandleFailure(cause, failureLabels), context, this);
     }
 
     @Override
@@ -255,9 +257,11 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
          * Asks how to handle the failure.
          *
          * @param failure failure describing the failure cause
+         * @param failureLabels future of labels from error classification.
          * @return {@link FailureResult} which describes how to handle the failure
          */
-        FailureResult howToHandleFailure(Throwable failure);
+        FailureResult howToHandleFailure(
+                Throwable failure, CompletableFuture<Map<String, String>> failureLabels);
 
         /**
          * Asks if we should rescale the currently executing job.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Failing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Failing.java
@@ -29,6 +29,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /** State which describes a failing job which is currently being canceled. */
 class Failing extends StateWithExecutionGraph {
@@ -71,7 +73,7 @@ class Failing extends StateWithExecutionGraph {
     }
 
     @Override
-    void onFailure(Throwable failure) {
+    void onFailure(Throwable failure, CompletableFuture<Map<String, String>> failureLabels) {
         // We've already failed the execution graph, so there is noting else we can do.
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
@@ -31,6 +31,8 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 
 /** State which describes a job which is currently being restarted. */
@@ -89,7 +91,7 @@ class Restarting extends StateWithExecutionGraph {
     }
 
     @Override
-    void onFailure(Throwable failure) {
+    void onFailure(Throwable failure, CompletableFuture<Map<String, String>> failureLabels) {
         // We've already cancelled the execution graph, so there is noting else we can do.
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
@@ -362,7 +362,7 @@ abstract class StateWithExecutionGraph implements State {
     }
 
     /** Transition to different state when failure occurs. Stays in the same state by default. */
-    abstract void onFailure(Throwable cause);
+    abstract void onFailure(Throwable cause, CompletableFuture<Map<String, String>> failureLabels);
 
     /**
      * Transition to different state when the execution graph reaches a globally terminal state.
@@ -375,7 +375,7 @@ abstract class StateWithExecutionGraph implements State {
     public void handleGlobalFailure(
             Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         failureCollection.add(ExceptionHistoryEntry.createGlobal(cause, failureLabels));
-        onFailure(cause);
+        onFailure(cause, failureLabels);
     }
 
     /**
@@ -407,7 +407,8 @@ abstract class StateWithExecutionGraph implements State {
                         ExceptionHistoryEntry.create(execution, taskName, failureLabels));
                 onFailure(
                         ErrorInfo.handleMissingThrowable(
-                                taskExecutionStateTransition.getError(userCodeClassLoader)));
+                                taskExecutionStateTransition.getError(userCodeClassLoader)),
+                        failureLabels);
             }
         }
         return successfulUpdate;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 
@@ -209,7 +210,7 @@ class StopWithSavepoint extends StateWithExecutionGraph {
     }
 
     @Override
-    void onFailure(Throwable cause) {
+    void onFailure(Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         if (hasPendingStateTransition) {
             // the error handling remains the same independent of how many tasks have failed
             // we don't want to initiate the same state transition multiple times, so we exit early
@@ -231,7 +232,7 @@ class StopWithSavepoint extends StateWithExecutionGraph {
                                                     savepoint, getJobId(), cause);
                             operationFailureCause = ex;
                             FailureResultUtil.restartOrFail(
-                                    context.howToHandleFailure(ex), context, this);
+                                    context.howToHandleFailure(ex, failureLabels), context, this);
                             return null;
                         }));
     }
@@ -279,9 +280,11 @@ class StopWithSavepoint extends StateWithExecutionGraph {
          * Asks how to handle the failure.
          *
          * @param failure failure describing the failure cause
+         * @param failureLabels TODO
          * @return {@link FailureResult} which describes how to handle the failure
          */
-        FailureResult howToHandleFailure(Throwable failure);
+        FailureResult howToHandleFailure(
+                Throwable failure, CompletableFuture<Map<String, String>> failureLabels);
 
         /**
          * Runs the given action after the specified delay if the state is the expected state at

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandlerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.executiongraph.failover;
 
+import org.apache.flink.core.failure.FailureEnricher;
 import org.apache.flink.core.failure.TestingFailureEnricher;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.SuppressRestartsException;
@@ -36,7 +37,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -117,6 +120,37 @@ class ExecutionFailureHandlerTest {
         assertThat(executionFailureHandler.getNumberOfRestarts()).isOne();
     }
 
+    @Test
+    void testLabeling() throws Exception {
+        final Map<String, String> expectedFailureLabels =
+                Collections.singletonMap(FailureEnricher.KEY_JOB_CANNOT_RESTART, "");
+
+        testingFailureEnricher.setFailureLabels(expectedFailureLabels);
+        testingFailureEnricher.setOutputKeys(expectedFailureLabels.keySet());
+
+        final Set<ExecutionVertexID> tasksToRestart =
+                Collections.singleton(new ExecutionVertexID(new JobVertexID(), 0));
+        failoverStrategy.setTasksToRestart(tasksToRestart);
+
+        Execution execution =
+                FailureHandlingResultTest.createExecution(EXECUTOR_RESOURCE.getExecutor());
+        Exception cause = new Exception("test failure");
+        long timestamp = System.currentTimeMillis();
+        // trigger a task failure
+        final FailureHandlingResult result =
+                executionFailureHandler.getFailureHandlingResult(execution, cause, timestamp);
+
+        // verify results
+        assertThat(result.canRestart()).isFalse();
+        assertThat(result.getFailedExecution()).isPresent();
+        assertThat(result.getFailedExecution().get()).isSameAs(execution);
+        assertThat(result.getError()).hasCause(cause);
+        assertThat(result.getTimestamp()).isEqualTo(timestamp);
+        assertThat(testingFailureEnricher.getSeenThrowables()).containsExactly(cause);
+        assertThat(result.getFailureLabels().get()).isEqualTo(expectedFailureLabels);
+        assertThat(executionFailureHandler.getNumberOfRestarts()).isZero();
+    }
+
     /** Tests the case that task restarting is suppressed. */
     @Test
     void testRestartingSuppressedFailureHandlingResult() throws Exception {
@@ -140,7 +174,11 @@ class ExecutionFailureHandlerTest {
         assertThat(testingFailureEnricher.getSeenThrowables()).containsExactly(error);
         assertThat(result.getFailureLabels().get())
                 .isEqualTo(testingFailureEnricher.getFailureLabels());
-        assertThat(ExecutionFailureHandler.isUnrecoverableError(result.getError())).isFalse();
+        assertThat(
+                        ExecutionFailureHandler.isUnrecoverableError(
+                                result.getError(),
+                                CompletableFuture.completedFuture(Collections.emptyMap())))
+                .isFalse();
 
         assertThatThrownBy(result::getVerticesToRestart)
                 .as("getVerticesToRestart is not allowed when restarting is suppressed")
@@ -173,7 +211,11 @@ class ExecutionFailureHandlerTest {
         assertThat(result.getFailedExecution()).isPresent();
         assertThat(result.getFailedExecution().get()).isSameAs(execution);
         assertThat(result.getError()).isNotNull();
-        assertThat(ExecutionFailureHandler.isUnrecoverableError(result.getError())).isTrue();
+        assertThat(
+                        ExecutionFailureHandler.isUnrecoverableError(
+                                result.getError(),
+                                CompletableFuture.completedFuture(Collections.emptyMap())))
+                .isTrue();
         assertThat(testingFailureEnricher.getSeenThrowables()).containsExactly(error);
         assertThat(result.getFailureLabels().get())
                 .isEqualTo(testingFailureEnricher.getFailureLabels());
@@ -251,18 +293,24 @@ class ExecutionFailureHandlerTest {
     @Test
     void testUnrecoverableErrorCheck() {
         // normal error
-        assertThat(ExecutionFailureHandler.isUnrecoverableError(new Exception())).isFalse();
+        assertThat(
+                        ExecutionFailureHandler.isUnrecoverableError(
+                                new Exception(),
+                                CompletableFuture.completedFuture(Collections.emptyMap())))
+                .isFalse();
 
         // direct unrecoverable error
         assertThat(
                         ExecutionFailureHandler.isUnrecoverableError(
-                                new SuppressRestartsException(new Exception())))
+                                new SuppressRestartsException(new Exception()),
+                                CompletableFuture.completedFuture(Collections.emptyMap())))
                 .isTrue();
 
         // nested unrecoverable error
         assertThat(
                         ExecutionFailureHandler.isUnrecoverableError(
-                                new Exception(new SuppressRestartsException(new Exception()))))
+                                new Exception(new SuppressRestartsException(new Exception())),
+                                CompletableFuture.completedFuture(Collections.emptyMap())))
                 .isTrue();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraphTest.java
@@ -218,7 +218,7 @@ public class StateWithExecutionGraphTest extends TestLogger {
         }
 
         @Override
-        void onFailure(Throwable cause) {}
+        void onFailure(Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {}
 
         @Override
         void onGloballyTerminalState(JobStatus globallyTerminalState) {


### PR DESCRIPTION
This PR draft is a proposal to extend the FailureEnricher mechanism in a way that can be used to avoid restart loops by attaching a certain label to the failure. We pass down the labels into the restart decision and check for the presence of a particular label that this PR introduces. 