### PR TITLE
[typos]The comment for function 'initializeState' of interface 'CheckpointedFunction' has a spelling error.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedFunction.java
@@ -166,7 +166,7 @@ public interface CheckpointedFunction {
      * execution. Functions typically set up their state storing data structures in this method.
      *
      * @param context the context for initializing the operator
-     * @throws Exception Thrown, if state could not be created ot restored.
+     * @throws Exception Thrown, if state could not be created or restored.
      */
     void initializeState(FunctionInitializationContext context) throws Exception;
 }


### PR DESCRIPTION
[typos]The comment for function 'initializeState' of interface 'CheckpointedFunction' has a spelling error.