### PR TITLE
[FLINK-34463] Open catalog in CatalogManager should use proper context classloader

### DIFF
--- a/flink-table/flink-table-api-java/pom.xml
+++ b/flink-table/flink-table-api-java/pom.xml
@@ -84,6 +84,53 @@ under the License.
 					</excludes>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>create-test-dependency</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>test-catalog-jar</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!--Remove the TestCatalog code from the test-classes directory since it musn't be in the
+			classpath when running the tests to actually test whether the user code context classloader
+			is properly used.-->
+			<plugin>
+				<artifactId>maven-clean-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>remove-classloading-test-dependencies</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+						<configuration>
+							<excludeDefaultDirectories>true</excludeDefaultDirectories>
+							<filesets>
+								<fileset>
+									<directory>${project.build.testOutputDirectory}</directory>
+									<includes>
+										<include>**/catalog/classloader/Test*.class</include>
+									</includes>
+								</fileset>
+							</filesets>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -312,7 +312,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         }
 
         Catalog catalog = initCatalog(catalogName, catalogDescriptor);
-        try (TemporaryClassLoaderContext context =
+        try (TemporaryClassLoaderContext ignored =
                 TemporaryClassLoaderContext.of(catalogStoreHolder.classLoader())) {
             catalog.open();
         }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -48,6 +48,7 @@ import org.apache.flink.table.expressions.resolver.ExpressionResolver.Expression
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
+import org.apache.flink.util.TemporaryClassLoaderContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -311,7 +312,10 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
         }
 
         Catalog catalog = initCatalog(catalogName, catalogDescriptor);
-        catalog.open();
+        try (TemporaryClassLoaderContext context =
+                TemporaryClassLoaderContext.of(catalogStoreHolder.classLoader())) {
+            catalog.open();
+        }
         catalogs.put(catalogName, catalog);
 
         catalogStoreHolder.catalogStore().storeCatalog(catalogName, catalogDescriptor);

--- a/flink-table/flink-table-api-java/src/test/assembly/test-assembly.xml
+++ b/flink-table/flink-table-api-java/src/test/assembly/test-assembly.xml
@@ -1,0 +1,42 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<!--modify/add include to match your package(s) -->
+			<includes>
+				<include>org/apache/flink/table/catalog/classloader/*.class</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<!-- declaring the service impl -->
+			<directory>${project.basedir}/src/test/resources/testcatalog</directory>
+			<outputDirectory>/META-INF/services</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerContextClassloaderTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerContextClassloaderTest.java
@@ -1,0 +1,42 @@
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Collections;
+
+/**
+ * Tests for {@link CatalogManager} and {@link Catalog} which requires proper thread context
+ * classloader.
+ */
+public class CatalogManagerContextClassloaderTest {
+    @Test
+    public void testOpenCatalogWithContextClassloader() throws MalformedURLException {
+        final String catalogJarFile = "target/test-catalog-jar-test-jar.jar";
+        CatalogStoreHolder catalogStoreHolder =
+                CatalogStoreHolder.newBuilder()
+                        .catalogStore(new GenericInMemoryCatalogStore())
+                        .config(new Configuration())
+                        .classloader(
+                                new URLClassLoader(
+                                        new URL[] {new File(catalogJarFile).toURI().toURL()},
+                                        Thread.currentThread().getContextClassLoader()))
+                        .build();
+        CatalogManager catalogManager =
+                CatalogManager.newBuilder()
+                        .classLoader(CatalogManagerTest.class.getClassLoader())
+                        .config(new Configuration())
+                        .defaultCatalog("default", new GenericInMemoryCatalog("default"))
+                        .catalogStoreHolder(catalogStoreHolder)
+                        .build();
+        catalogManager.createCatalog(
+                "test",
+                CatalogDescriptor.of(
+                        "test", Configuration.fromMap(Collections.singletonMap("type", "test"))));
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerContextClassloaderTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogManagerContextClassloaderTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.configuration.Configuration;

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/classloader/TestCatalog.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/classloader/TestCatalog.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.classloader;
+
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/** Test catalog which requires a proper context classloader when opening. */
+public class TestCatalog extends GenericInMemoryCatalog {
+
+    public TestCatalog(String name) {
+        super(name);
+    }
+
+    public TestCatalog(String name, String defaultDatabase) {
+        super(name, defaultDatabase);
+    }
+
+    @Override
+    public void open() {
+        List<TestService> serviceList =
+                StreamSupport.stream(ServiceLoader.load(TestService.class).spliterator(), false)
+                        .collect(Collectors.toList());
+        if (serviceList.size() != 1) {
+            throw new RuntimeException("Require exactly one TestService implementation");
+        }
+        serviceList.get(0).connect();
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/classloader/TestCatalogFactory.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/classloader/TestCatalogFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.classloader;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.factories.CatalogFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.flink.table.catalog.GenericInMemoryCatalogFactoryOptions.DEFAULT_DATABASE;
+import static org.apache.flink.table.factories.FactoryUtil.PROPERTY_VERSION;
+
+/** Factory for TestCatalog. */
+public class TestCatalogFactory implements CatalogFactory {
+    @Override
+    public String factoryIdentifier() {
+        return "test";
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(DEFAULT_DATABASE);
+        options.add(PROPERTY_VERSION);
+        return options;
+    }
+
+    @Override
+    public Catalog createCatalog(Context context) {
+        final FactoryUtil.CatalogFactoryHelper helper =
+                FactoryUtil.createCatalogFactoryHelper(this, context);
+        helper.validate();
+
+        return new TestCatalog(context.getName(), helper.getOptions().get(DEFAULT_DATABASE));
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/classloader/TestService.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/classloader/TestService.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.classloader;
+
+/** Test service interface used by TestCatalog. */
+public interface TestService {
+    void connect();
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/classloader/TestServiceImpl.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/classloader/TestServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.classloader;
+
+/** Test service implementation used by TestCatalog. */
+public class TestServiceImpl implements TestService {
+    @Override
+    public void connect() {}
+}

--- a/flink-table/flink-table-api-java/src/test/resources/testcatalog/org.apache.flink.table.catalog.classloader.TestService
+++ b/flink-table/flink-table-api-java/src/test/resources/testcatalog/org.apache.flink.table.catalog.classloader.TestService
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.catalog.classloader.TestServiceImpl

--- a/flink-table/flink-table-api-java/src/test/resources/testcatalog/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-api-java/src/test/resources/testcatalog/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.catalog.classloader.TestCatalogFactory


### PR DESCRIPTION
## What is the purpose of the change

When we try to create a catalog in CatalogManager, if the catalog jar is added using `ADD JAR` and the catalog itself requires SPI mechanism, the operation may fail.

This PR try to fix this issue.


## Brief change log
Wrap `Catalog.open` with a temporary context classloader.


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
