### PR TITLE
[BP-1.19][FLINK-22765][test] Fixes test instability in ExceptionUtilsITCase#testIsMetaspaceOutOfMemoryError

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/ClassLoaderUtils.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/ClassLoaderUtils.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.testutils;
 
+import org.apache.flink.util.Preconditions;
+
 import javax.annotation.Nullable;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
@@ -40,6 +42,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 /** Utilities to create class loaders. */
@@ -142,6 +145,15 @@ public class ClassLoaderUtils {
             return this;
         }
 
+        public ClassLoaderBuilder addClass(String className) {
+            Preconditions.checkState(
+                    new File(root, className + ".java").exists(),
+                    "The class %s was added without any source code being present.",
+                    className);
+
+            return addClass(className, null);
+        }
+
         public ClassLoaderBuilder addClass(String className, String source) {
             String oldValue = classes.putIfAbsent(className, source);
 
@@ -158,7 +170,7 @@ public class ClassLoaderUtils {
             return this;
         }
 
-        public URLClassLoader build() throws IOException {
+        public void generateSourcesAndCompile() throws IOException {
             for (Map.Entry<String, String> classInfo : classes.entrySet()) {
                 writeAndCompile(root, createFileName(classInfo.getKey()), classInfo.getValue());
             }
@@ -171,8 +183,35 @@ public class ClassLoaderUtils {
             for (Map.Entry<String, String> resource : resources.entrySet()) {
                 writeSourceFile(root, resource.getKey(), resource.getValue());
             }
+        }
+
+        public URLClassLoader buildWithoutCompilation() throws MalformedURLException {
+            final int generatedSourceClassesCount =
+                    Objects.requireNonNull(
+                                    root.listFiles(
+                                            (dir, name) -> {
+                                                if (!name.endsWith(".java")) {
+                                                    return false;
+                                                }
+                                                final String derivedClassName =
+                                                        name.substring(0, name.lastIndexOf('.'));
+                                                return classes.containsKey(derivedClassName);
+                                            }))
+                            .length;
+            Preconditions.checkState(
+                    generatedSourceClassesCount == classes.size(),
+                    "The generated Java sources in %s (%s) do not match the classes in this %s (%s).",
+                    root.getAbsolutePath(),
+                    generatedSourceClassesCount,
+                    ClassLoaderBuilder.class.getSimpleName(),
+                    classes.size());
 
             return createClassLoader(root, parent);
+        }
+
+        public URLClassLoader build() throws IOException {
+            generateSourcesAndCompile();
+            return buildWithoutCompilation();
         }
 
         private String createFileName(String className) {

--- a/flink-tests/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-tests/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,21 +1,3 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.


### PR DESCRIPTION
1.19 backport for parent PR #24315 

The hotfix improvement and the JUnit5 migration was not backported.