### PR TITLE
[hotfix] Remove redundant call to remove().

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -600,16 +600,13 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                 keyGroupRange.prettyPrintInterval(),
                 operatorIdentifier);
 
-        // Choose the best state handle for the initial DB
+        // Choose the best state handle for the initial DB and remove it from the list
         final IncrementalLocalKeyedStateHandle selectedInitialHandle =
                 localKeyedStateHandles.remove(
                         RocksDBIncrementalCheckpointUtils.findTheBestStateHandleForInitial(
                                 localKeyedStateHandles, keyGroupRange, overlapFractionThreshold));
 
         Preconditions.checkNotNull(selectedInitialHandle);
-
-        // Remove the selected handle from the list so that we don't restore it twice.
-        localKeyedStateHandles.remove(selectedInitialHandle);
 
         // Init the base DB instance with the initial state
         initBaseDBFromSingleStateHandle(selectedInitialHandle);


### PR DESCRIPTION
Code was removing a handle from a list twice, so the second call to remove has no effect and can be deleted.