### PR TITLE
[FLINK-34331][ci] Adds reusable workflow that is used to load the runner configuration based on the projects owner

### DIFF
--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -68,9 +68,14 @@ env:
   DOCKER_IMAGES_CACHE_FOLDER: /root/.docker-cache
 
 jobs:
+  workflow-init:
+    name: "Initialize Workflow"
+    uses: ./.github/workflows/template.workflow-init.yml
+
   compile:
     name: "Compile"
-    runs-on: ubuntu-22.04
+    needs: workflow-init
+    runs-on: ${{ fromJSON( needs.workflow-init.outputs.runner_config ) }}
     container:
       image: mapohl/flink-ci:FLINK-34194
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
@@ -130,8 +135,8 @@ jobs:
 
   packaging:
     name: "Test packaging/licensing"
-    needs: compile
-    runs-on: ubuntu-22.04
+    needs: [compile, workflow-init]
+    runs-on: ${{ fromJSON( needs.workflow-init.outputs.runner_config ) }}
     container:
       image: mapohl/flink-ci:FLINK-34194
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
@@ -170,8 +175,8 @@ jobs:
 
   test:
     name: "Test (module: ${{ matrix.module }})"
-    needs: compile
-    runs-on: ubuntu-22.04
+    needs: [compile, workflow-init]
+    runs-on: ${{ fromJSON( needs.workflow-init.outputs.runner_config ) }}
     container:
       image: mapohl/flink-ci:FLINK-34194
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown
@@ -283,9 +288,9 @@ jobs:
 
   e2e:
     name: "E2E (group ${{ matrix.group }})"
-    needs: compile
     # the end to end tests are not executed in Flink's CI Docker container due to problems when running Docker-in-Docker
-    runs-on: ubuntu-22.04
+    needs: [compile, workflow-init]
+    runs-on: ${{ fromJSON( needs.workflow-init.outputs.runner_config ) }}
     timeout-minutes: 310
     env:
       # timeout in minutes - this environment variable is required by uploading_watchdog.sh

--- a/.github/workflows/template.pre-compile-checks.yml
+++ b/.github/workflows/template.pre-compile-checks.yml
@@ -39,9 +39,14 @@ permissions: read-all
 # This workflow should only contain steps that do not require the compilation of Flink (and therefore, are
 # independent of the used JDK)
 jobs:
+  workflow-init:
+    name: "Initialize Workflow"
+    uses: ./.github/workflows/template.workflow-init.yml
+
   qa:
     name: "Basic QA"
-    runs-on: ubuntu-22.04
+    needs: workflow-init
+    runs-on: ${{ fromJSON( needs.workflow-init.outputs.runner_config ) }}
     container:
       image: mapohl/flink-ci:FLINK-34194
       # --init makes the process in the container being started as an init process which will clean up any daemon processes during shutdown

--- a/.github/workflows/template.workflow-init.yml
+++ b/.github/workflows/template.workflow-init.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Apache Flink Workflow Initialization"
+
+on:
+  workflow_call:
+    outputs:
+      runner_config:
+        description: "The runs-on configuration that can be used in the runs-on parameter."
+        value: ${{ jobs.workflow_init.outputs.runner_config }}
+
+permissions: read-all
+
+jobs:
+  workflow_init:
+    name: "Initialize Workflow"
+    # no need to fix a specific ubuntu version here because the workflow only
+    # runs shell scripts that do not require dependency stability
+    runs-on: ubuntu-latest
+    outputs:
+      runner_config: ${{ steps.runner_config_provider.outputs.runner_config }}
+    steps:
+      - name: "Determine runner configuration"
+        id: runner_config_provider
+        shell: bash
+        run: |
+          runner_config_value="\"ubuntu-22.04\""
+          if [[ "${GITHUB_REPOSITORY_OWNER}" == "apache" ]]; then
+            runner_config_value='["self-hosted", "asf-runner"]'
+          fi
+          
+          echo "runner_config=${runner_config_value}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## What is the purpose of the change

The goal is to enable Apache-hosted runners for the main repo but allow forks to use the GitHub-hosted runners.

## Brief change log

* Adds reusable workflow for initializing workflows which initializes a parameter for configuring the underlying runner

## Verifying this change

* [Test run in fork](https://github.com/XComp/flink/actions/runs/7972523819/job/21764465706)
* I cannot think of a way to test using the Apache runners without merging this PR.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable