### PR TITLE
[FLINK-34480] support user jar class overwrite flink inner when meet the same.

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -44,7 +44,7 @@ constructFlinkClassPath() {
         exit 1
     fi
 
-    echo "$FLINK_CLASSPATH""$FLINK_DIST"
+    echo "$FLINK_USER_JAR":"$FLINK_CLASSPATH""$FLINK_DIST"
 }
 
 findSqlGatewayJar() {


### PR DESCRIPTION
## What is the purpose of the change
When we use flink on kubernetes, user jar to overwrite flink cluster is convenient for users.
Add option to support user jar class to overwrite flink inner class when meet the same

## Brief change log
Add $FLINK_USER_JAR to config.sh

## Verifying this change
Of course : )

This change added tests and can be verified as follows:
Production, and ut can be added if needed : )

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
