### PR TITLE
[FLINK-34477][table] Support capture groups in REGEXP_REPLACE

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -279,7 +279,7 @@ string:
     description: Returns a string that repeats the base string integer times. E.g., REPEAT('This is a test String.', 2) returns "This is a test String.This is a test String.".
   - sql: REGEXP_REPLACE(string1, string2, string3)
     table: STRING1.regexpReplace(STRING2, STRING3)
-    description: Returns a string from STRING1 with all the substrings that match a regular expression STRING2 consecutively being replaced with STRING3. E.g., 'foobar'.regexpReplace('oo|ar', '') returns "fb".
+    description: Returns a string from STRING1 with all the substrings that match a regular expression STRING2 consecutively being replaced with STRING3. E.g., 'foobar'.regexpReplace('oo|ar', '') returns "fb". Note that, this function treats the dollar sign ('$') as a special character to capture groups.
   - sql: OVERLAY(string1 PLACING string2 FROM integer1 [ FOR integer2 ])
     table: |
       STRING1.overlay(STRING2, INT1)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -517,6 +517,15 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
 
   @Test
   def testRegexpReplace(): Unit = {
+    testAllApis(
+      "Hello World".regexpReplace("(\\w+)", "[$1]"),
+      "regexp_replace('Hello World', '(\\w+)', '[$1]')",
+      "[Hello] [World]")
+
+    testAllApis(
+      "ERR1,ERR2".regexpReplace("([^,]+)", "AA$1AA"),
+      "regexp_replace('ERR1,ERR2', '([^,]+)', 'AA$1AA')",
+      "AAERR1AA,AAERR2AA")
 
     testAllApis(
       "foobar".regexpReplace("oo|ar", "abc"),
@@ -538,8 +547,8 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testAllApis("foobar".regexpReplace("\\w", ""), "regexp_replace('foobar', '\\w', '')", "")
 
     testAllApis(
-      "fooobar".regexpReplace("oo", "$"),
-      "regexp_replace('fooobar', 'oo', '$')",
+      "fooobar".regexpReplace("oo", "\\$"),
+      "regexp_replace('fooobar', 'oo', '\\$')",
       "f$obar")
 
     testAllApis(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -426,7 +426,13 @@ public class SqlFunctionUtils {
             return null;
         }
         try {
-            return str.replaceAll(regex, Matcher.quoteReplacement(replacement));
+            Matcher matcher = Pattern.compile(regex).matcher(str);
+            StringBuffer result = new StringBuffer();
+            while (matcher.find()) {
+                matcher.appendReplacement(result, quoteReplacementSkipDollar(replacement));
+            }
+            matcher.appendTail(result);
+            return result.toString();
         } catch (Exception e) {
             LOG.error(
                     String.format(
@@ -436,6 +442,27 @@ public class SqlFunctionUtils {
             // return null if exception in regex replace
             return null;
         }
+    }
+
+    /**
+     * Similar to the ${@link java.util.regex.Matcher} ${quoteReplacement} method, but dollar signs
+     * ('$') will be given a special meaning.
+     */
+    public static String quoteReplacementSkipDollar(String s) {
+        if ((s.indexOf('\\') == -1)) {
+            return s;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); ++i) {
+            char c = s.charAt(i);
+            if (c == '\\'
+                    && ((i == s.length() - 1)
+                            || ((i + 1) < s.length() && s.charAt(i + 1) != '$'))) {
+                sb.append('\\');
+            }
+            sb.append(c);
+        }
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

Support capture groups in REGEXP_REPLACE

## Brief change log

  - Added support for capture groups by skipping the dollar sign
  - Adjusted some tests and added new ones


## Verifying this change

Tests: `org.apache.flink.table.planner.expressions.ScalarFunctionsTest::testRegexpReplace`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
