### PR TITLE
[FLINK-32706][table] Add built-in SPLIT_STRING function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -690,8 +690,7 @@ collection:
     description: Returns an ARRAY that contains the elements from array1 that are not in array2. If no elements remain after excluding the elements in array2 from array1, the function returns an empty ARRAY. If one or both arguments are NULL, the function returns NULL. The order of the elements from array1 is kept.
   - sql: SPLIT(string, delimiter)
     table: string.split(delimiter)
-    description: Returns an array of substrings by splitting the input string based on the given delimiter. If the delimiter is not found in the string, the original string is returned as the only element in the array. If the delimiter is empty, return entire string. If the string or delimiter is null, a null value is returned. If the delimiter is found at the beginning or end of the string, or there are contiguous delimiters, then an empty string is added to the array.
-
+    description: Returns an array of substrings by splitting the input string based on the given delimiter. If the delimiter is not found in the string, the original string is returned as the only element in the array. If the delimiter is empty, every character in the string is split. If the string or delimiter is null, a null value is returned. If the delimiter is found at the beginning or end of the string, or there are contiguous delimiters, then an empty string is added to the array.
 
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -688,7 +688,11 @@ collection:
   - sql: ARRAY_EXCEPT(array1, array2)
     table: arrayOne.arrayExcept(arrayTwo)
     description: Returns an ARRAY that contains the elements from array1 that are not in array2. If no elements remain after excluding the elements in array2 from array1, the function returns an empty ARRAY. If one or both arguments are NULL, the function returns NULL. The order of the elements from array1 is kept.
-    
+  - sql: SPLIT(string, delimiter)
+    table: string.split(delimiter)
+    description: Returns an array of substrings by splitting the input string based on the given delimiter. If the delimiter is not found in the string, the original string is returned as the only element in the array. If the delimiter is empty, return entire string. If the string or delimiter is null, a null value is returned. If the delimiter is found at the beginning or end of the string, or there are contiguous delimiters, then an empty string is added to the array.
+
+
 json:
   - sql: IS JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ]
     table: STRING.isJson([JsonType type])

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -243,6 +243,7 @@ advanced type helper functions
     Expression.map_union
     Expression.map_values
     Expression.array_except
+    Expression.split
 
 
 time definition functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1620,12 +1620,12 @@ class Expression(Generic[T]):
 
     def split(self, delimiter) -> 'Expression':
         """
-        Splits a string into an array of substrings based on a delimiter. If the delimiter is not
-        found, then the original string is returned as the only element in the array.
-        If the delimiter is empty, return entire string.
-        If either, string or delimiter, are NULL, then a NULL value is returned.
-        If the delimiter is found at the beginning or end of the string,
-        or there are contiguous delimiters, then an empty space is added to the array.
+        Returns an array of substrings by splitting the input string based on the given delimiter.
+        If the delimiter is not found in the string, the original string is returned as the only
+        element in the array. If the delimiter is empty, every character in the string is split.
+        If the string or delimiter is null, a null value is returned. If the delimiter is found a
+        t the beginning or end of the string, or there are contiguous delimiters, then an empty
+        string is added to the array.
         """
         return _binary_op("split")(self, delimiter)
 

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1618,6 +1618,17 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayExcept")(self, array)
 
+    def split(self, delimiter) -> 'Expression':
+        """
+        Splits a string into an array of substrings based on a delimiter. If the delimiter is not
+        found, then the original string is returned as the only element in the array.
+        If the delimiter is empty, return entire string.
+        If either, string or delimiter, are NULL, then a NULL value is returned.
+        If the delimiter is found at the beginning or end of the string,
+        or there are contiguous delimiters, then an empty space is added to the array.
+        """
+        return _binary_op("split")(self, delimiter)
+
     @property
     def map_keys(self) -> 'Expression':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -174,6 +174,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SIGN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SIMILAR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SIN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SINH;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SPLIT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SPLIT_INDEX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SQRT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STDDEV_POP;
@@ -1532,6 +1533,20 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType arrayMin() {
         return toApiSpecificExpression(unresolvedCall(ARRAY_MIN, toExpr()));
+    }
+
+    /**
+     * Returns an array of substrings by splitting the input string based on a given delimiter.
+     *
+     * <p>If the delimiter is not found in the string, the original string is returned as the only
+     * element in the array. If the delimiter is empty, every character in the string is split. If
+     * the string or delimiter is null, a null value is returned. If the delimiter is found at the
+     * beginning or end of the string, or there are contiguous delimiters, then an empty string is
+     * added to the array.
+     */
+    public OutType split(InType delimiter) {
+        return toApiSpecificExpression(
+                unresolvedCall(SPLIT, toExpr(), objectToExpression(delimiter)));
     }
 
     /** Returns the keys of the map as an array. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -420,6 +420,18 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayMinFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition SPLIT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("SPLIT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                    logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.ARRAY(STRING()))))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.SplitFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =
             BuiltInFunctionDefinition.newBuilder()
                     .name("$REPLICATE_ROWS$1")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -1755,7 +1755,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f0").split(""),
                                 "SPLIT(f0, '')",
-                                new String[] {"123,123,23"},
+                                new String[] {"1", "2", "3", ",", "1", "2", "3", ",", "2", "3"},
                                 DataTypes.ARRAY(DataTypes.STRING()).notNull())
                         .testResult(
                                 $("f1").split(","),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -55,7 +55,8 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arraySliceTestCases(),
                         arrayMinTestCases(),
                         arraySortTestCases(),
-                        arrayExceptTestCases())
+                        arrayExceptTestCases(),
+                        splitTestCases())
                 .flatMap(s -> s);
     }
 
@@ -1720,5 +1721,84 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").arrayExcept(new String[] {"hi", "there"}),
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "ARRAY_EXCEPT(<COMMON>, <COMMON>)"));
+    }
+
+    private Stream<TestSetSpec> splitTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.SPLIT)
+                        .onFieldsWithData(
+                                "123,123,23",
+                                null,
+                                ",123,123",
+                                ",123,123,",
+                                123,
+                                "12345",
+                                ",123,,,123,")
+                        .andDataTypes(
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.INT().notNull(),
+                                DataTypes.STRING().notNull(),
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                $("f0").split(","),
+                                "SPLIT(f0, ',')",
+                                new String[] {"123", "123", "23"},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        .testResult(
+                                $("f0").split(null),
+                                "SPLIT(f0, NULL)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f0").split(""),
+                                "SPLIT(f0, '')",
+                                new String[] {"123,123,23"},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        .testResult(
+                                $("f1").split(","),
+                                "SPLIT(f1, ',')",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f1").split(null),
+                                "SPLIT(f1, null)",
+                                null,
+                                DataTypes.ARRAY(DataTypes.STRING()))
+                        .testResult(
+                                $("f2").split(","),
+                                "SPLIT(f2, ',')",
+                                new String[] {"", "123", "123"},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        .testResult(
+                                $("f3").split(","),
+                                "SPLIT(f3, ',')",
+                                new String[] {"", "123", "123", ""},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        .testResult(
+                                $("f5").split(","),
+                                "SPLIT(f5, ',')",
+                                new String[] {"12345"},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        .testResult(
+                                $("f6").split(","),
+                                "SPLIT(f6, ',')",
+                                new String[] {"", "123", "", "", "123", ""},
+                                DataTypes.ARRAY(DataTypes.STRING()).notNull())
+                        .testTableApiValidationError(
+                                $("f4").split(","),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "SPLIT(<CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "SPLIT(f4, ',')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "SPLIT(<CHARACTER_STRING>, <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "SPLIT()", "No match found for function signature SPLIT()")
+                        .testSqlValidationError(
+                                "SPLIT(f1, '1', '2')",
+                                "No match found for function signature SPLIT(<CHARACTER>, <CHARACTER>, <CHARACTER>)"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
@@ -31,6 +31,9 @@ import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /** Implementation of {@link BuiltInFunctionDefinitions#SPLIT}. */
 @Internal
 public class SplitFunction extends BuiltInScalarFunction {
@@ -42,6 +45,13 @@ public class SplitFunction extends BuiltInScalarFunction {
         try {
             if (string == null || delimiter == null) {
                 return null;
+            }
+            if (delimiter.toString().isEmpty()) {
+                List<StringData> res = new ArrayList<>();
+                for (int i = 0; i < string.toString().length(); ++i) {
+                    res.add(StringData.fromString(String.valueOf(string.toString().charAt(i))));
+                }
+                return new GenericArrayData(res.toArray());
             }
             BinaryStringData[] binaryStringData =
                     BinaryStringDataUtil.splitByWholeSeparatorPreserveAllTokens(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
@@ -48,8 +48,8 @@ public class SplitFunction extends BuiltInScalarFunction {
             }
             if (delimiter.toString().isEmpty()) {
                 List<StringData> res = new ArrayList<>();
-                for (int i = 0; i < string.toString().length(); ++i) {
-                    res.add(StringData.fromString(String.valueOf(string.toString().charAt(i))));
+                for (char c : string.toString().toCharArray()) {
+                    res.add(StringData.fromString(String.valueOf(c)));
                 }
                 return new GenericArrayData(res.toArray());
             }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
@@ -47,9 +47,10 @@ public class SplitFunction extends BuiltInScalarFunction {
                 return null;
             }
             if (delimiter.toString().isEmpty()) {
+                String str = string.toString();
                 List<StringData> res = new ArrayList<>();
-                for (char c : string.toString().toCharArray()) {
-                    res.add(StringData.fromString(String.valueOf(c)));
+                for (int i = 0; i < str.length(); i++) {
+                    res.add(StringData.fromString(String.valueOf(str.charAt(i))));
                 }
                 return new GenericArrayData(res.toArray());
             }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SplitFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#SPLIT}. */
+@Internal
+public class SplitFunction extends BuiltInScalarFunction {
+    public SplitFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.SPLIT, context);
+    }
+
+    public @Nullable ArrayData eval(@Nullable StringData string, @Nullable StringData delimiter) {
+        try {
+            if (string == null || delimiter == null) {
+                return null;
+            }
+            BinaryStringData[] binaryStringData =
+                    BinaryStringDataUtil.splitByWholeSeparatorPreserveAllTokens(
+                            (BinaryStringData) string, (BinaryStringData) delimiter);
+            return new GenericArrayData(binaryStringData);
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
This is an implementation of SPLIT


## Brief change log
Splits a string into an array of substrings based on a delimiter. If the delimiter is not found, then the original string is returned as the only element in the array. If the delimiter is empty, then all characters in the string are split. If either, string or delimiter, are NULL, then a NULL value is returned.
If the delimiter is found at the beginning or end of the string, or there are contiguous delimiters, then an empty space is added to the array.

- Syntax
`SPLIT(string, delimiter)`

- Arguments
string: The string need to be split
delimiter: Splits a string into an array of substrings based on a delimiter

- Returns
If the delimiter is not found, then the original string is returned as the only element in the array. If the delimiter is empty, then all characters in the string are split. If either, string or delimiter, are NULL, then a NULL value is returned.

- Examples
```
SELECT SPLIT('abcdefg', 'c');
Result: ['ab', 'defg']
```

- See also
1. ksqlDB Split function
ksqlDB provides a scalar function named SPLIT which splits a string into an array of substrings based on a delimiter.
Syntax: SPLIT(string, delimiter)
For example: SPLIT('a,b,c', ',') will return ['a', 'b', 'c'].
https://docs.ksqldb.io/en/0.8.1-ksqldb/developer-guide/ksqldb-reference/scalar-functions/#split

2. Apache Hive Split function
Hive offers a function named split which splits a string around a specified delimiter and returns an array of strings.
Syntax: array<string> split(string str, string pat)
For example: split('a,b,c', ',') will return ["a", "b", "c"].
https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF

3. Spark SQL Split function
Spark SQL also offers a function named split, similar to the one in Hive.
Syntax: split(str, pattern[, limit])
Here, limit is an optional parameter to specify the maximum length of the returned array.
For example: split('oneAtwoBthreeC', '[ABC]', 2) will return ["one", "twoBthreeC"].
https://spark.apache.org/docs/latest/api/sql/index.html#split

4. Presto Split function
Presto offers a function named split which splits a string around a regular expression and returns an array of strings.
Syntax: array<varchar> split(string str, string regex)
For example: split('a.b.c', '\.') will return ["a", "b", "c"].
https://prestodb.io/docs/current/functions/string.html

## Verifying this change
This change added tests in CollectionFunctionsITCase.

## Does this pull request potentially affect one of the following parts:  
  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
