### PR TITLE
[FLINK-33500][Runtime] Run storing the JobGraph an asynchronous operation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/DefaultJobGraphStore.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.persistence.StateHandleStore;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.concurrent.Executors;
+import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.slf4j.Logger;
@@ -197,7 +199,8 @@ public class DefaultJobGraphStore<R extends ResourceVersion<R>>
     }
 
     @Override
-    public void putJobGraph(JobGraph jobGraph) throws Exception {
+    public CompletableFuture<Void> putJobGraph(JobGraph jobGraph, Executor executor)
+            throws Exception {
         checkNotNull(jobGraph, "Job graph");
 
         final JobID jobID = jobGraph.getJobID();
@@ -206,7 +209,7 @@ public class DefaultJobGraphStore<R extends ResourceVersion<R>>
         LOG.debug("Adding job graph {} to {}.", jobID, jobGraphStateHandleStore);
 
         boolean success = false;
-
+        CompletableFuture<Void> completableFuture = null;
         while (!success) {
             synchronized (lock) {
                 verifyIsRunning();
@@ -214,15 +217,12 @@ public class DefaultJobGraphStore<R extends ResourceVersion<R>>
                 final R currentVersion = jobGraphStateHandleStore.exists(name);
 
                 if (!currentVersion.isExisting()) {
-                    try {
-                        jobGraphStateHandleStore.addAndLock(name, jobGraph);
-
-                        addedJobGraphs.add(jobID);
-
-                        success = true;
-                    } catch (StateHandleStore.AlreadyExistException ignored) {
-                        LOG.warn("{} already exists in {}.", jobGraph, jobGraphStateHandleStore);
-                    }
+                    completableFuture =
+                            FutureUtils.runAsync(
+                                    () -> jobGraphStateHandleStore.addAndLock(name, jobGraph),
+                                    executor);
+                    addedJobGraphs.add(jobID);
+                    success = true;
                 } else if (addedJobGraphs.contains(jobID)) {
                     try {
                         jobGraphStateHandleStore.replace(name, currentVersion, jobGraph);
@@ -241,10 +241,10 @@ public class DefaultJobGraphStore<R extends ResourceVersion<R>>
         }
 
         LOG.info("Added {} to {}.", jobGraph, jobGraphStateHandleStore);
+        return completableFuture;
     }
 
-    @Override
-    public void putJobResourceRequirements(
+    private void putJobResourceRequirements(
             JobID jobId, JobResourceRequirements jobResourceRequirements) throws Exception {
         synchronized (lock) {
             @Nullable final JobGraph jobGraph = recoverJobGraph(jobId);
@@ -255,8 +255,15 @@ public class DefaultJobGraphStore<R extends ResourceVersion<R>>
                                 jobId));
             }
             JobResourceRequirements.writeToJobGraph(jobGraph, jobResourceRequirements);
-            putJobGraph(jobGraph);
+            putJobGraph(jobGraph, Executors.directExecutor());
         }
+    }
+
+    @Override
+    public CompletableFuture<Void> putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements, Executor executor) {
+        return FutureUtils.runAsync(
+                () -> putJobResourceRequirements(jobId, jobResourceRequirements), executor);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobGraphWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobGraphWriter.java
@@ -35,7 +35,10 @@ public interface JobGraphWriter extends LocallyCleanableResource, GloballyCleana
      *
      * <p>If a job graph with the same {@link JobID} exists, it is replaced.
      */
-    void putJobGraph(JobGraph jobGraph) throws Exception;
+    default CompletableFuture<Void> putJobGraph(JobGraph jobGraph, Executor executor)
+            throws Exception {
+        return FutureUtils.completedVoidFuture();
+    }
 
     /**
      * Persist {@link JobResourceRequirements job resource requirements} for the given job.
@@ -44,8 +47,11 @@ public interface JobGraphWriter extends LocallyCleanableResource, GloballyCleana
      * @param jobResourceRequirements requirements to persist
      * @throws Exception in case we're not able to persist the requirements for some reason
      */
-    void putJobResourceRequirements(JobID jobId, JobResourceRequirements jobResourceRequirements)
-            throws Exception;
+    default CompletableFuture<Void> putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements, Executor executor)
+            throws Exception {
+        return FutureUtils.completedVoidFuture();
+    }
 
     @Override
     default CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStore.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.jobmanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -40,17 +39,6 @@ public class StandaloneJobGraphStore implements JobGraphStore {
 
     @Override
     public void stop() {
-        // Nothing to do
-    }
-
-    @Override
-    public void putJobGraph(JobGraph jobGraph) {
-        // Nothing to do
-    }
-
-    @Override
-    public void putJobResourceRequirements(
-            JobID jobId, JobResourceRequirements jobResourceRequirements) {
         // Nothing to do
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ThrowingJobGraphWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/ThrowingJobGraphWriter.java
@@ -22,18 +22,21 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 /** {@link JobGraphWriter} implementation which does not allow to store {@link JobGraph}. */
 public enum ThrowingJobGraphWriter implements JobGraphWriter {
     INSTANCE;
 
     @Override
-    public void putJobGraph(JobGraph jobGraph) {
+    public CompletableFuture<Void> putJobGraph(JobGraph jobGraph, Executor executor) {
         throw new UnsupportedOperationException("Cannot store job graphs.");
     }
 
     @Override
-    public void putJobResourceRequirements(
-            JobID jobId, JobResourceRequirements jobResourceRequirements) {
+    public CompletableFuture<Void> putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements, Executor executor) {
         throw new UnsupportedOperationException("Cannot persist job resource requirements.");
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/NoOpJobGraphWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/NoOpJobGraphWriter.java
@@ -18,23 +18,9 @@
 
 package org.apache.flink.runtime.dispatcher;
 
-import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 
 /** Testing implementation of {@link JobGraphWriter} which does nothing. */
 public enum NoOpJobGraphWriter implements JobGraphWriter {
     INSTANCE;
-
-    @Override
-    public void putJobGraph(JobGraph jobGraph) {
-        // No-op.
-    }
-
-    @Override
-    public void putJobResourceRequirements(
-            JobID jobId, JobResourceRequirements jobResourceRequirements) {
-        // No-op.
-    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerITCase.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.util.BlobServerExtension;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -183,7 +184,7 @@ class DefaultDispatcherRunnerITCase {
                         new TestingDispatcherFactory(
                                 jobManagerRunnerFactory, cleanupRunnerFactory));
         jobGraphStore.start(null);
-        jobGraphStore.putJobGraph(jobGraph);
+        jobGraphStore.putJobGraph(jobGraph, Executors.directExecutor());
 
         try (final DispatcherRunner dispatcherRunner = createDispatcherRunner()) {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -562,7 +562,8 @@ class SessionDispatcherLeaderProcessTest {
             // wait first for the dispatcher service to be created
             dispatcherLeaderProcess.getDispatcherGateway().get();
 
-            jobGraphStore.putJobGraph(JOB_GRAPH);
+            jobGraphStore.putJobGraph(
+                    JOB_GRAPH, org.apache.flink.util.concurrent.Executors.directExecutor());
             dispatcherLeaderProcess.onAddedJobGraph(JOB_GRAPH.getJobID());
 
             final JobGraph submittedJobGraph = submittedJobFuture.get();
@@ -591,7 +592,8 @@ class SessionDispatcherLeaderProcessTest {
             dispatcherLeaderProcess.getDispatcherGateway().get();
 
             // now add the job graph
-            jobGraphStore.putJobGraph(JOB_GRAPH);
+            jobGraphStore.putJobGraph(
+                    JOB_GRAPH, org.apache.flink.util.concurrent.Executors.directExecutor());
 
             dispatcherLeaderProcess.closeAsync();
 
@@ -622,7 +624,8 @@ class SessionDispatcherLeaderProcessTest {
             // wait first for the dispatcher service to be created
             dispatcherLeaderProcess.getDispatcherGateway().get();
 
-            jobGraphStore.putJobGraph(JOB_GRAPH);
+            jobGraphStore.putJobGraph(
+                    JOB_GRAPH, org.apache.flink.util.concurrent.Executors.directExecutor());
             dispatcherLeaderProcess.onAddedJobGraph(JOB_GRAPH.getJobID());
 
             assertThatFuture(fatalErrorHandler.getErrorFuture())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/StandaloneJobGraphStoreTest.java
@@ -39,7 +39,7 @@ public class StandaloneJobGraphStoreTest {
 
         assertEquals(0, jobGraphs.getJobIds().size());
 
-        jobGraphs.putJobGraph(jobGraph);
+        jobGraphs.putJobGraph(jobGraph, Executors.directExecutor());
         assertEquals(0, jobGraphs.getJobIds().size());
 
         jobGraphs.globalCleanupAsync(jobGraph.getJobID(), Executors.directExecutor()).join();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperJobGraphsStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/ZooKeeperJobGraphsStoreITCase.java
@@ -102,7 +102,7 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
             assertThat(jobGraphs.getJobIds()).isEmpty();
 
             // Add initial
-            jobGraphs.putJobGraph(jobGraph);
+            jobGraphs.putJobGraph(jobGraph, Executors.directExecutor());
 
             // Verify initial job graph
             Collection<JobID> jobIds = jobGraphs.getJobIds();
@@ -114,7 +114,7 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
 
             // Update (same ID)
             jobGraph = createJobGraph(jobGraph.getJobID(), "Updated JobName");
-            jobGraphs.putJobGraph(jobGraph);
+            jobGraphs.putJobGraph(jobGraph, Executors.directExecutor());
 
             // Verify updated
             jobIds = jobGraphs.getJobIds();
@@ -177,7 +177,7 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
 
             // Add all
             for (JobGraph jobGraph : expected.values()) {
-                jobGraphs.putJobGraph(jobGraph);
+                jobGraphs.putJobGraph(jobGraph, Executors.directExecutor());
             }
 
             Collection<JobID> actual = jobGraphs.getJobIds();
@@ -241,14 +241,14 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
             jobGraphs.start(listener);
             otherJobGraphs.start(NoOpJobGraphListener.INSTANCE);
 
-            jobGraphs.putJobGraph(jobGraph);
+            jobGraphs.putJobGraph(jobGraph, Executors.directExecutor());
 
             // Everything is cool... not much happening ;)
             verify(listener, never()).onAddedJobGraph(any(JobID.class));
             verify(listener, never()).onRemovedJobGraph(any(JobID.class));
 
             // This bad boy adds the other job graph
-            otherJobGraphs.putJobGraph(otherJobGraph);
+            otherJobGraphs.putJobGraph(otherJobGraph, Executors.directExecutor());
 
             // Wait for the cache to call back
             sync.await();
@@ -281,10 +281,10 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
 
         JobGraph jobGraph = createJobGraph(new JobID());
 
-        jobGraphs.putJobGraph(jobGraph);
+        jobGraphs.putJobGraph(jobGraph, Executors.directExecutor());
 
         assertThatExceptionOfType(IllegalStateException.class)
-                .isThrownBy(() -> otherJobGraphs.putJobGraph(jobGraph));
+                .isThrownBy(() -> otherJobGraphs.putJobGraph(jobGraph, Executors.directExecutor()));
     }
 
     /**
@@ -305,7 +305,7 @@ public class ZooKeeperJobGraphsStoreITCase extends TestLogger {
         otherSubmittedJobGraphStore.start(listener);
 
         final JobGraph jobGraph = JobGraphTestUtils.emptyJobGraph();
-        submittedJobGraphStore.putJobGraph(jobGraph);
+        submittedJobGraphStore.putJobGraph(jobGraph, Executors.directExecutor());
 
         final JobGraph recoveredJobGraph =
                 otherSubmittedJobGraphStore.recoverJobGraph(jobGraph.getJobID());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingJobGraphStore.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/TestingJobGraphStore.java
@@ -115,19 +115,23 @@ public class TestingJobGraphStore implements JobGraphStore {
     }
 
     @Override
-    public synchronized void putJobGraph(JobGraph jobGraph) throws Exception {
+    public synchronized CompletableFuture<Void> putJobGraph(JobGraph jobGraph, Executor executor)
+            throws Exception {
         verifyIsStarted();
         putJobGraphConsumer.accept(jobGraph);
         storedJobs.put(jobGraph.getJobID(), jobGraph);
+        return FutureUtils.completedVoidFuture();
     }
 
     @Override
-    public void putJobResourceRequirements(
-            JobID jobId, JobResourceRequirements jobResourceRequirements) throws Exception {
+    public CompletableFuture<Void> putJobResourceRequirements(
+            JobID jobId, JobResourceRequirements jobResourceRequirements, Executor executor)
+            throws Exception {
         verifyIsStarted();
         final JobGraph jobGraph =
                 Preconditions.checkNotNull(storedJobs.get(jobId), "Job [%s] not found.", jobId);
         putJobResourceRequirementsConsumer.accept(jobGraph, jobResourceRequirements);
+        return FutureUtils.completedVoidFuture();
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

*Currently, submitting a job starts with storing the JobGraph (in HA setups) in the JobGraphStore. This includes writing the file to S3 (or some other remote file system). The job submission is done in the Dispatcher's main thread. If writing the JobGraph is slow, it would block any other operation on the Dispatcher.*


## Brief change log

  - *The dispatcher put JobGraph asynchronously in ioExecutor*
  - *The dispatcher write To ExecutionGraphInfoStore asynchronously in ioExecutor*
  - *The JobGraphWriter interface class adds a putJobGraphAsync method for asynchronous write operations*
  - *Implementation class DefaultJobGraphStore adds the putJobGraphAsync method for asynchronous write operations*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added  the Dispatcher JobSubmission test, use ZooKeeperStateHandleStore as JobGraphStore*
  - *Added  the Dispatcher JobSubmission test, use KubernetesStateHandleStore as JobGraphStore*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
