### PR TITLE
[FLINK-34050][state] Clean up useless files in deleted ranges during rescaling for RocksdbStateBackend

### DIFF
--- a/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
+++ b/docs/layouts/shortcodes/generated/rocksdb_configurable_configuration.html
@@ -105,6 +105,12 @@
             <td>The maximum size of RocksDB's file used for information logging. If the log files becomes larger than this, a new file will be created. If 0, all logs will be written to one log file. The default maximum file size is '25MB'. </td>
         </tr>
         <tr>
+            <td><h5>state.backend.rocksdb.rescaling.use-delete-files-in-range</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If true, during rescaling, the deleteFilesInRange API will be invoked to clean up the useless files so that local disk space can be reclaimed more promptly.</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.rocksdb.restore-overlap-fraction-threshold</h5></td>
             <td style="word-wrap: break-word;">0.0</td>
             <td>Double</td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -324,6 +324,13 @@ public class RocksDBConfigurableOptions implements Serializable {
                     .withDescription(
                             "If true, an async compaction of RocksDB is started after every restore after which we detect keys (including tombstones) in the database that are outside the key-groups range of the backend.");
 
+    public static final ConfigOption<Boolean> USE_DELETE_FILES_IN_RANGE_DURING_RESCALING =
+            key("state.backend.rocksdb.rescaling.use-delete-files-in-range")
+                    .booleanType()
+                    .defaultValue(Boolean.FALSE)
+                    .withDescription(
+                            "If true, during rescaling, the deleteFilesInRange API will be invoked to clean up the useless files so that local disk space can be reclaimed more promptly.");
+
     static final ConfigOption<?>[] CANDIDATE_CONFIGS =
             new ConfigOption<?>[] {
                 // configurable DBOptions

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -153,13 +154,14 @@ public class RocksDBIncrementalCheckpointUtils {
             byte[] beginKeyBytes,
             byte[] endKeyBytes)
             throws RocksDBException {
-
+        List<byte[]> deletedRange = Arrays.asList(beginKeyBytes, endKeyBytes);
         for (ColumnFamilyHandle columnFamilyHandle : columnFamilyHandles) {
             // Using RocksDB's deleteRange will take advantage of delete
             // tombstones, which mark the range as deleted.
             //
             // https://github.com/ververica/frocksdb/blob/FRocksDB-6.20.3/include/rocksdb/db.h#L363-L377
             db.deleteRange(columnFamilyHandle, beginKeyBytes, endKeyBytes);
+            db.deleteFilesInRanges(columnFamilyHandle, deletedRange, false);
         }
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -80,6 +80,7 @@ import java.util.function.Function;
 
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.INCREMENTAL_RESTORE_ASYNC_COMPACT_AFTER_RESCALE;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.RESTORE_OVERLAP_FRACTION_THRESHOLD;
+import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.USE_DELETE_FILES_IN_RANGE_DURING_RESCALING;
 import static org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions.USE_INGEST_DB_RESTORE_MODE;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -130,6 +131,9 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
     private RocksDB injectedTestDB; // for testing
     private boolean incrementalRestoreAsyncCompactAfterRescale =
             INCREMENTAL_RESTORE_ASYNC_COMPACT_AFTER_RESCALE.defaultValue();
+    private boolean rescalingUseDeleteFilesInRange =
+            USE_DELETE_FILES_IN_RANGE_DURING_RESCALING.defaultValue();
+
     private double overlapFractionThreshold = RESTORE_OVERLAP_FRACTION_THRESHOLD.defaultValue();
     private boolean useIngestDbRestoreMode = USE_INGEST_DB_RESTORE_MODE.defaultValue();
     private ColumnFamilyHandle injectedDefaultColumnFamilyHandle; // for testing
@@ -285,6 +289,12 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
 
     RocksDBKeyedStateBackendBuilder<K> setUseIngestDbRestoreMode(boolean useIngestDbRestoreMode) {
         this.useIngestDbRestoreMode = useIngestDbRestoreMode;
+        return this;
+    }
+
+    RocksDBKeyedStateBackendBuilder<K> setRescalingUseDeleteFilesInRange(
+            boolean rescalingUseDeleteFilesInRange) {
+        this.rescalingUseDeleteFilesInRange = rescalingUseDeleteFilesInRange;
         return this;
     }
 
@@ -508,7 +518,8 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                     optionsContainer.getWriteBufferManagerCapacity(),
                     overlapFractionThreshold,
                     useIngestDbRestoreMode,
-                    incrementalRestoreAsyncCompactAfterRescale);
+                    incrementalRestoreAsyncCompactAfterRescale,
+                    rescalingUseDeleteFilesInRange);
         } else if (priorityQueueConfig.getPriorityQueueStateType()
                 == EmbeddedRocksDBStateBackend.PriorityQueueStateType.HEAP) {
             return new RocksDBHeapTimersFullRestoreOperation<>(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -126,6 +126,8 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
 
     private final boolean asyncCompactAfterRescale;
 
+    private final boolean useDeleteFilesInRange;
+
     public RocksDBIncrementalRestoreOperation(
             String operatorIdentifier,
             KeyGroupRange keyGroupRange,
@@ -148,7 +150,8 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
             Long writeBufferManagerCapacity,
             double overlapFractionThreshold,
             boolean useIngestDbRestoreMode,
-            boolean asyncCompactAfterRescale) {
+            boolean asyncCompactAfterRescale,
+            boolean useDeleteFilesInRange) {
         this.rocksHandle =
                 new RocksDBHandle(
                         kvStateInformation,
@@ -178,6 +181,7 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
         //        this.asyncCompactAfterRescale = asyncCompactAfterRescale;
         this.useIngestDbRestoreMode = false;
         this.asyncCompactAfterRescale = false;
+        this.useDeleteFilesInRange = useDeleteFilesInRange;
     }
 
     /**
@@ -371,7 +375,8 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                         this.rocksHandle.getColumnFamilyHandles(),
                         keyGroupRange,
                         stateHandleKeyGroupRange,
-                        keyGroupPrefixBytes);
+                        keyGroupPrefixBytes,
+                        useDeleteFilesInRange);
             } catch (RocksDBException e) {
                 String errMsg = "Failed to clip DB after initialization.";
                 logger.error(errMsg, e);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtilsTest.java
@@ -58,6 +58,8 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
 
         testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(0, 1), new KeyGroupRange(2, 4), 1);
 
+        testClipDBWithKeyGroupRangeHelper(new KeyGroupRange(4, 5), new KeyGroupRange(2, 7), 1);
+
         testClipDBWithKeyGroupRangeHelper(
                 new KeyGroupRange(Byte.MAX_VALUE - 15, Byte.MAX_VALUE),
                 new KeyGroupRange(Byte.MAX_VALUE - 10, Byte.MAX_VALUE),
@@ -179,7 +181,8 @@ public class RocksDBIncrementalCheckpointUtilsTest extends TestLogger {
                     Collections.singletonList(columnFamilyHandle),
                     targetGroupRange,
                     currentGroupRange,
-                    keyGroupPrefixBytes);
+                    keyGroupPrefixBytes,
+                    true);
 
             for (int i = currentGroupRangeStart; i <= currentGroupRangeEnd; ++i) {
                 for (int j = 0; j < 100; ++j) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRecoveryTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBRecoveryTest.java
@@ -289,6 +289,7 @@ public class RocksDBRecoveryTest {
                             .setEnableIncrementalCheckpointing(true)
                             .setUseIngestDbRestoreMode(useIngest)
                             .setIncrementalRestoreAsyncCompactAfterRescale(asyncCompactAfterRescale)
+                            .setRescalingUseDeleteFilesInRange(true)
                             .build();
 
             long instanceTime = System.currentTimeMillis() - tInstance;


### PR DESCRIPTION
## What is the purpose of the change

This pull request cleans up useless sst files within rocksdb during rescaling, which reclaims local disk space, reducing the space amplification problem caused by deleteRange.

## Brief change log

- Invoke Rocksdb.deleteFilesInRanges api to delele useless files during rescaling

## Verifying this change

This change is already covered by existing tests, such as RocksDBIncrementalCheckpointUtilsTest and RocksIncrementalCheckpointRescalingTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
