### PR TITLE
[FLINK-34454] Introduce StateRecoveryOptions in flink-core and Rename options

### DIFF
--- a/docs/content.zh/docs/deployment/cli.md
+++ b/docs/content.zh/docs/deployment/cli.md
@@ -315,7 +315,7 @@ $ ./bin/flink run \
 ```
 This is useful if your program dropped an operator that was part of the savepoint.
 
-You can also select the [restore mode]({{< ref "docs/ops/state/savepoints" >}}#restore-mode)
+You can also select the [claim mode]({{< ref "docs/ops/state/savepoints" >}}#claim-mode)
 which should be used for the savepoint. The mode controls who takes ownership of the files of
 the specified savepoint.
 

--- a/docs/content.zh/docs/deployment/config.md
+++ b/docs/content.zh/docs/deployment/config.md
@@ -417,7 +417,6 @@ Flink can fetch user artifacts stored locally, on remote DFS, or accessible via 
 # Execution
 
 {{< generated/deployment_configuration >}}
-{{< generated/savepoint_config_configuration >}}
 {{< generated/execution_configuration >}}
 
 ### Pipeline
@@ -427,6 +426,10 @@ Flink can fetch user artifacts stored locally, on remote DFS, or accessible via 
 ### Checkpointing
 
 {{< generated/execution_checkpointing_configuration >}}
+
+### Recovery
+
+{{< generated/state_recovery_configuration >}}
 
 ----
 ----

--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -673,7 +673,7 @@ SET 'yarn.application.queue' = 'root';
 SET 'parallelism.default' = '100';
 
 -- restore from the specific savepoint path
-SET 'execution.savepoint.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
+SET 'execution.state-recovery.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
 
 INSERT INTO pageviews_enriched
 SELECT *
@@ -862,7 +862,7 @@ Flink SQL> INSERT INTO MyTableSink SELECT * FROM MyTableSource;
 Flink supports to start the job with specified savepoint. In SQL Client, it's allowed to use `SET` command to specify the path of the savepoint.
 
 ```sql
-Flink SQL> SET 'execution.savepoint.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
+Flink SQL> SET 'execution.state-recovery.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
 [INFO] Session property has been set.
 
 -- all the following DML statements will be restroed from the specified savepoint path
@@ -874,7 +874,7 @@ When the path to savepoint is specified, Flink will try to restore the state fro
 Because the specified savepoint path will affect all the following DML statements, you can use `RESET` command to reset this config option, i.e. disable restoring from savepoint.
 
 ```sql
-Flink SQL> RESET execution.savepoint.path;
+Flink SQL> RESET execution.state-recovery.path;
 [INFO] Session property has been reset.
 ```
 

--- a/docs/content.zh/docs/ops/state/savepoints.md
+++ b/docs/content.zh/docs/ops/state/savepoints.md
@@ -193,7 +193,7 @@ $ bin/flink run -s :savepointPath [:runArgs]
 
 你可以通过如下方式指定 restore 模式：
 ```shell
-$ bin/flink run -s :savepointPath -restoreMode :mode -n [:runArgs]
+$ bin/flink run -s :savepointPath -claimMode :mode -n [:runArgs]
 ```
 
 **NO_CLAIM （默认的）**

--- a/docs/content.zh/docs/ops/state/savepoints.md
+++ b/docs/content.zh/docs/ops/state/savepoints.md
@@ -182,16 +182,16 @@ $ bin/flink run -s :savepointPath [:runArgs]
 
 默认情况下，resume 操作将尝试将 Savepoint 的所有状态映射回你要还原的程序。 如果删除了运算符，则可以通过 `--allowNonRestoredState`（short：`-n`）选项跳过无法映射到新程序的状态：
 
-#### Restore 模式
+#### Claim 模式
 
-`Restore 模式` 决定了在 restore 之后谁拥有Savepoint 或者 [externalized checkpoint]({{< ref "docs/ops/state/checkpoints" >}}/#resuming-from-a-retained-checkpoint)的文件的所有权。在这种语境下 Savepoint 和 externalized checkpoint 的行为相似。
+`Claim 模式` 决定了在 restore 之后谁拥有Savepoint 或者 [externalized checkpoint]({{< ref "docs/ops/state/checkpoints" >}}/#resuming-from-a-retained-checkpoint)的文件的所有权。在这种语境下 Savepoint 和 externalized checkpoint 的行为相似。
 这里我们将它们都称为“快照”，除非另有明确说明。
 
-如前所述，restore 模式决定了谁来接管我们从中恢复的快照文件的所有权。快照可被用户或者 Flink 自身拥有。如果快照归用户所有，Flink 不会删除其中的文件，而且 Flink 不能依赖该快照中文件的存在，因为它可能在 Flink 的控制之外被删除。
+如前所述，claim 模式决定了谁来接管我们从中恢复的快照文件的所有权。快照可被用户或者 Flink 自身拥有。如果快照归用户所有，Flink 不会删除其中的文件，而且 Flink 不能依赖该快照中文件的存在，因为它可能在 Flink 的控制之外被删除。
 
-每种 restore 模式都有特定的用途。尽管如此，我们仍然认为默认的 *NO_CLAIM* 模式在大多数情况下是一个很好的折中方案，因为它在提供明确的所有权归属的同时只给恢复后第一个 checkpoint 带来较小的代价。
+每种 claim 模式都有特定的用途。尽管如此，我们仍然认为默认的 *NO_CLAIM* 模式在大多数情况下是一个很好的折中方案，因为它在提供明确的所有权归属的同时只给恢复后第一个 checkpoint 带来较小的代价。
 
-你可以通过如下方式指定 restore 模式：
+你可以通过如下方式指定 claim 模式：
 ```shell
 $ bin/flink run -s :savepointPath -claimMode :mode -n [:runArgs]
 ```
@@ -205,7 +205,7 @@ $ bin/flink run -s :savepointPath -claimMode :mode -n [:runArgs]
 一旦第一个全量的 checkpoint 完成后，所有后续的 checkpoint 会照常创建。所以，一旦一个 checkpoint 成功制作，就可以删除原快照。在此之前不能删除原快照，因为没有任何完成的 checkpoint，Flink 会在故障时尝试从初始的快照恢复。
 
 <div style="text-align: center">
-  {{< img src="/fig/restore-mode-no_claim.svg" alt="NO_CLAIM restore mode" width="70%" >}}
+  {{< img src="/fig/restore-mode-no_claim.svg" alt="NO_CLAIM mode" width="70%" >}}
 </div>
 
 **CLAIM**
@@ -213,7 +213,7 @@ $ bin/flink run -s :savepointPath -claimMode :mode -n [:runArgs]
 另一个可选的模式是 *CLAIM* 模式。该模式下 Flink 将声称拥有快照的所有权，并且本质上将其作为 checkpoint 对待：控制其生命周期并且可能会在其永远不会被用于恢复的时候删除它。因此，手动删除快照和从同一个快照上启动两个作业都是不安全的。Flink 会保持[配置数量]({{< ref "docs/dev/datastream/fault-tolerance/checkpointing" >}}/#state-checkpoints-num-retained)的 checkpoint。
 
 <div style="text-align: center">
-  {{< img src="/fig/restore-mode-claim.svg" alt="CLAIM restore mode" width="70%" >}}
+  {{< img src="/fig/restore-mode-claim.svg" alt="CLAIM mode" width="70%" >}}
 </div>
 
 {{< hint info >}}
@@ -228,7 +228,7 @@ $ bin/flink run -s :savepointPath -claimMode :mode -n [:runArgs]
 Legacy 模式是 Flink 在 1.15 之前的工作方式。该模式下 Flink 永远不会删除初始恢复的 checkpoint。同时，用户也不清楚是否可以删除它。导致该的问题原因是， Flink 会在用来恢复的 checkpoint 之上创建增量的 checkpoint，因此后续的 checkpoint 都有可能会依赖于用于恢复的那个 checkpoint。总而言之，恢复的 checkpoint 的所有权没有明确的界定。
 
 <div style="text-align: center">
-  {{< img src="/fig/restore-mode-legacy.svg" alt="LEGACY restore mode" width="70%" >}}
+  {{< img src="/fig/restore-mode-legacy.svg" alt="LEGACY claim mode" width="70%" >}}
 </div>
 
 {{< hint warning >}}

--- a/docs/content/docs/deployment/cli.md
+++ b/docs/content/docs/deployment/cli.md
@@ -313,7 +313,7 @@ $ ./bin/flink run \
 ```
 This is useful if your program dropped an operator that was part of the savepoint.
 
-You can also select the [restore mode]({{< ref "docs/ops/state/savepoints" >}}#restore-mode)
+You can also select the [claim mode]({{< ref "docs/ops/state/savepoints" >}}#claim-mode)
 which should be used for the savepoint. The mode controls who takes ownership of the files of
 the specified savepoint.
 

--- a/docs/content/docs/deployment/config.md
+++ b/docs/content/docs/deployment/config.md
@@ -419,7 +419,6 @@ Flink can fetch user artifacts stored locally, on remote DFS, or accessible via 
 # Execution
 
 {{< generated/deployment_configuration >}}
-{{< generated/savepoint_config_configuration >}}
 {{< generated/execution_configuration >}}
 
 ### Pipeline
@@ -429,6 +428,10 @@ Flink can fetch user artifacts stored locally, on remote DFS, or accessible via 
 ### Checkpointing
 
 {{< generated/execution_checkpointing_configuration >}}
+
+### Recovery
+
+{{< generated/state_recovery_configuration >}}
 
 ----
 ----

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -611,7 +611,7 @@ SET 'yarn.application.queue' = 'root';
 SET 'parallelism.default' = '100';
 
 -- restore from the specific savepoint path
-SET 'execution.savepoint.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
+SET 'execution.state-recovery.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
 
 INSERT INTO pageviews_enriched
 SELECT *
@@ -800,7 +800,7 @@ Flink SQL> INSERT INTO MyTableSink SELECT * FROM MyTableSource;
 Flink supports to start the job with specified savepoint. In SQL Client, it's allowed to use `SET` command to specify the path of the savepoint.
 
 ```sql
-Flink SQL> SET 'execution.savepoint.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
+Flink SQL> SET 'execution.state-recovery.path' = '/tmp/flink-savepoints/savepoint-cca7bc-bb1e257f0dab';
 [INFO] Session property has been set.
 
 -- all the following DML statements will be restroed from the specified savepoint path
@@ -812,7 +812,7 @@ When the path to savepoint is specified, Flink will try to restore the state fro
 Because the specified savepoint path will affect all the following DML statements, you can use `RESET` command to reset this config option, i.e. disable restoring from savepoint.
 
 ```sql
-Flink SQL> RESET execution.savepoint.path;
+Flink SQL> RESET execution.state-recovery.path;
 [INFO] Session property has been reset.
 ```
 

--- a/docs/content/docs/ops/state/savepoints.md
+++ b/docs/content/docs/ops/state/savepoints.md
@@ -225,7 +225,7 @@ Still, we believe the default *NO_CLAIM* mode is a good tradeoff in most situati
 
 You can pass the restore mode as:
 ```shell
-$ bin/flink run -s :savepointPath -restoreMode :mode -n [:runArgs]
+$ bin/flink run -s :savepointPath -claimMode :mode -n [:runArgs]
 ```
 
 **NO_CLAIM (default)**

--- a/docs/content/docs/ops/state/savepoints.md
+++ b/docs/content/docs/ops/state/savepoints.md
@@ -210,20 +210,20 @@ This submits a job and specifies a savepoint to resume from. You may give a path
 
 By default, the resume operation will try to map all state of the savepoint back to the program you are restoring with. If you dropped an operator, you can allow to skip state that cannot be mapped to the new program via `--allowNonRestoredState` (short: `-n`) option:
 
-#### Restore mode
+#### Claim mode
 
-The `Restore Mode` determines who takes ownership of the files  that make up a Savepoint or [externalized checkpoints]({{< ref "docs/ops/state/checkpoints" >}}/#resuming-from-a-retained-checkpoint) after restoring it.
+The `Claim Mode` determines who takes ownership of the files that make up a Savepoint or [externalized checkpoints]({{< ref "docs/ops/state/checkpoints" >}}/#resuming-from-a-retained-checkpoint) after restoring it.
 Both savepoints and externalized checkpoints behave similarly in this context. 
-Here, they are just called "snapshots" unless explicitely noted otherwise.
+Here, they are just called "snapshots" unless explicitly noted otherwise.
 
-As mentioned, the restore mode determines who takes over ownership of the files of the snapshots that we are restoring from. 
+As mentioned, the claim mode determines who takes over ownership of the files of the snapshots that we are restoring from. 
 Snapshots can be owned either by a user or Flink itself. 
 If a snapshot is owned by a user,  Flink will not delete its files, moreover, Flink can not depend on the existence of the files from such a snapshot, as it might be deleted outside of Flink's control. 
 
-Each restore mode serves a specific purposes. 
+Each claim mode serves a specific purposes. 
 Still, we believe the default *NO_CLAIM* mode is a good tradeoff in most situations, as it provides clear ownership with a small price for the first checkpoint after the restore.
 
-You can pass the restore mode as:
+You can pass the claim mode as:
 ```shell
 $ bin/flink run -s :savepointPath -claimMode :mode -n [:runArgs]
 ```
@@ -243,7 +243,7 @@ Consequently, once a checkpoint succeeds you can manually delete the original sn
 this earlier, because without any completed checkpoints Flink will - upon failure - try to recover from the initial snapshot.
 
 <div style="text-align: center">
-  {{< img src="/fig/restore-mode-no_claim.svg" alt="NO_CLAIM restore mode" width="70%" >}}
+  {{< img src="/fig/restore-mode-no_claim.svg" alt="NO_CLAIM claim mode" width="70%" >}}
 </div>
 
 **CLAIM**
@@ -256,7 +256,7 @@ a [configured number]({{< ref "docs/dev/datastream/fault-tolerance/checkpointing
 of checkpoints.
 
 <div style="text-align: center">
-  {{< img src="/fig/restore-mode-claim.svg" alt="CLAIM restore mode" width="70%" >}}
+  {{< img src="/fig/restore-mode-claim.svg" alt="CLAIM mode" width="70%" >}}
 </div>
 
 {{< hint info >}}
@@ -279,7 +279,7 @@ is that Flink might immediately build an incremental checkpoint on top of the re
 subsequent checkpoints depend on the restored checkpoint. Overall, the ownership is not well-defined.
 
 <div style="text-align: center">
-  {{< img src="/fig/restore-mode-legacy.svg" alt="LEGACY restore mode" width="70%" >}}
+  {{< img src="/fig/restore-mode-legacy.svg" alt="LEGACY claim mode" width="70%" >}}
 </div>
 
 {{< hint warning >}}

--- a/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_checkpointing_configuration.html
@@ -57,12 +57,6 @@
             <td>The checkpointing mode (exactly-once vs. at-least-once).<br /><br />Possible values:<ul><li>"EXACTLY_ONCE"</li><li>"AT_LEAST_ONCE"</li></ul></td>
         </tr>
         <tr>
-            <td><h5>execution.checkpointing.recover-without-channel-state.checkpoint-id</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Long</td>
-            <td>Checkpoint id for which in-flight data should be ignored in case of the recovery from this checkpoint.<br /><br />It is better to keep this value empty until there is explicit needs to restore from the specific checkpoint without in-flight data.<br /></td>
-        </tr>
-        <tr>
             <td><h5>execution.checkpointing.timeout</h5></td>
             <td style="word-wrap: break-word;">10 min</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -571,6 +571,10 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     "allowNonRestoredState" : {
       "type" : "boolean"
     },
+    "claimMode" : {
+      "type" : "string",
+      "enum" : [ "CLAIM", "NO_CLAIM", "LEGACY" ]
+    },
     "entryClass" : {
       "type" : "string"
     },

--- a/docs/layouts/shortcodes/generated/state_recovery_configuration.html
+++ b/docs/layouts/shortcodes/generated/state_recovery_configuration.html
@@ -9,22 +9,28 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>execution.savepoint-restore-mode</h5></td>
+            <td><h5>execution.state-recovery.claim-mode</h5></td>
             <td style="word-wrap: break-word;">NO_CLAIM</td>
             <td><p>Enum</p></td>
             <td>Describes the mode how Flink should restore from the given savepoint or retained checkpoint.<br /><br />Possible values:<ul><li>"CLAIM": Flink will take ownership of the given snapshot. It will clean the snapshot once it is subsumed by newer ones.</li><li>"NO_CLAIM": Flink will not claim ownership of the snapshot files. However it will make sure it does not depend on any artefacts from the restored snapshot. In order to do that, Flink will take the first checkpoint as a full one, which means it might reupload/duplicate files that are part of the restored checkpoint.</li></ul></td>
         </tr>
         <tr>
-            <td><h5>execution.savepoint.ignore-unclaimed-state</h5></td>
+            <td><h5>execution.state-recovery.ignore-unclaimed-state</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Allow to skip savepoint state that cannot be restored. Allow this if you removed an operator from your pipeline after the savepoint was triggered.</td>
         </tr>
         <tr>
-            <td><h5>execution.savepoint.path</h5></td>
+            <td><h5>execution.state-recovery.path</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).</td>
+        </tr>
+        <tr>
+            <td><h5>execution.state-recovery.without-channel-state.checkpoint-id</h5></td>
+            <td style="word-wrap: break-word;">-1</td>
+            <td>Long</td>
+            <td>Checkpoint id for which in-flight data should be ignored in case of the recovery from this checkpoint.<br /><br />It is better to keep this value empty until there is explicit needs to restore from the specific checkpoint without in-flight data.<br /></td>
         </tr>
     </tbody>
 </table>

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: v1/1.19-SNAPSHOT
+  version: v1/1.20-SNAPSHOT
 paths:
   /cluster:
     delete:

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -2255,6 +2255,8 @@ components:
       properties:
         allowNonRestoredState:
           type: boolean
+        claimMode:
+          $ref: '#/components/schemas/RestoreMode'
         entryClass:
           type: string
         flinkConfiguration:

--- a/docs/static/generated/rest_v1_sql_gateway.yml
+++ b/docs/static/generated/rest_v1_sql_gateway.yml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: v1/1.19-SNAPSHOT
+  version: v1/1.20-SNAPSHOT
 paths:
   /api_versions:
     get:

--- a/docs/static/generated/rest_v2_sql_gateway.yml
+++ b/docs/static/generated/rest_v2_sql_gateway.yml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: v2/1.19-SNAPSHOT
+  version: v2/1.20-SNAPSHOT
 paths:
   /api_versions:
     get:

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -20,8 +20,8 @@ package org.apache.flink.client.cli;
 
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.RestoreMode;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import org.apache.commons.cli.CommandLine;
@@ -690,7 +690,7 @@ public class CliFrontendParser {
                                 commandLine.getOptionValue(SAVEPOINT_RESTORE_MODE),
                                 RestoreMode.class);
             } else {
-                restoreMode = SavepointConfigOptions.RESTORE_MODE.defaultValue();
+                restoreMode = StateRecoveryOptions.RESTORE_MODE.defaultValue();
             }
             return SavepointRestoreSettings.forPath(
                     savepointPath, allowNonRestoredState, restoreMode);

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -147,17 +147,17 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 
     @Test
     void testClaimRestoreModeParsingLongOption() throws Exception {
-        testRestoreMode("--restoreMode", "claim", RestoreMode.CLAIM);
+        testRestoreMode("--claimMode", "claim", RestoreMode.CLAIM);
     }
 
     @Test
     void testLegacyRestoreModeParsingLongOption() throws Exception {
-        testRestoreMode("--restoreMode", "legacy", RestoreMode.LEGACY);
+        testRestoreMode("--claimMode", "legacy", RestoreMode.LEGACY);
     }
 
     @Test
     void testNoClaimRestoreModeParsingLongOption() throws Exception {
-        testRestoreMode("--restoreMode", "no_claim", RestoreMode.NO_CLAIM);
+        testRestoreMode("--claimMode", "no_claim", RestoreMode.NO_CLAIM);
     }
 
     private void testRestoreMode(String flag, String arg, RestoreMode expectedMode)

--- a/flink-clients/src/test/java/org/apache/flink/client/program/StreamContextEnvironmentTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/StreamContextEnvironmentTest.java
@@ -24,9 +24,9 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.PipelineExecutorFactory;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
@@ -56,7 +56,7 @@ class StreamContextEnvironmentTest {
         final Configuration clusterConfig = new Configuration();
         clusterConfig.set(DeploymentOptions.PROGRAM_CONFIG_ENABLED, false);
         clusterConfig.set(DeploymentOptions.TARGET, "local");
-        clusterConfig.set(SavepointConfigOptions.SAVEPOINT_PATH, "/flink/savepoints");
+        clusterConfig.set(StateRecoveryOptions.SAVEPOINT_PATH, "/flink/savepoints");
         clusterConfig.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
 
         final Configuration programConfig = new Configuration();

--- a/flink-clients/src/test/java/org/apache/flink/client/testjar/ForbidConfigurationJob.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/testjar/ForbidConfigurationJob.java
@@ -19,7 +19,7 @@
 package org.apache.flink.client.testjar;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 
@@ -33,7 +33,7 @@ public class ForbidConfigurationJob {
 
     public static void main(String[] args) throws Exception {
         final Configuration config = new Configuration();
-        config.set(SavepointConfigOptions.SAVEPOINT_PATH, SAVEPOINT_PATH);
+        config.set(StateRecoveryOptions.SAVEPOINT_PATH, SAVEPOINT_PATH);
         final StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.getExecutionEnvironment(config);
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceRescaleITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceRescaleITCase.java
@@ -23,8 +23,8 @@ import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
@@ -113,7 +113,7 @@ public class CoordinatedSourceRescaleITCase extends TestLogger {
         conf.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
         conf.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
         if (restoreCheckpoint != null) {
-            conf.set(SavepointConfigOptions.SAVEPOINT_PATH, restoreCheckpoint.toURI().toString());
+            conf.set(StateRecoveryOptions.SAVEPOINT_PATH, restoreCheckpoint.toURI().toString());
         }
         conf.set(TaskManagerOptions.NUM_TASK_SLOTS, p);
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateRecoveryOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateRecoveryOptions.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.core.execution.RestoreMode;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/**
+ * The {@link ConfigOption configuration options} used when restoring state from a savepoint or a
+ * checkpoint.
+ */
+@PublicEvolving
+public class StateRecoveryOptions {
+
+    /** The path to a savepoint that will be used to bootstrap the pipeline's state. */
+    public static final ConfigOption<String> SAVEPOINT_PATH =
+            key("execution.state-recovery.path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDeprecatedKeys("execution.savepoint.path")
+                    .withDescription(
+                            "Path to a savepoint to restore the job from (for example hdfs:///flink/savepoint-1537).");
+
+    /**
+     * A flag indicating if we allow Flink to skip savepoint state that cannot be restored, e.g.
+     * because the corresponding operator has been removed.
+     */
+    public static final ConfigOption<Boolean> SAVEPOINT_IGNORE_UNCLAIMED_STATE =
+            key("execution.state-recovery.ignore-unclaimed-state")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDeprecatedKeys("execution.savepoint.ignore-unclaimed-state")
+                    .withDescription(
+                            "Allow to skip savepoint state that cannot be restored. "
+                                    + "Allow this if you removed an operator from your pipeline after the savepoint was triggered.");
+    /**
+     * Describes the mode how Flink should restore from the given savepoint or retained checkpoint.
+     */
+    public static final ConfigOption<RestoreMode> RESTORE_MODE =
+            key("execution.state-recovery.claim-mode")
+                    .enumType(RestoreMode.class)
+                    .defaultValue(RestoreMode.DEFAULT)
+                    .withDeprecatedKeys("execution.savepoint-restore-mode")
+                    .withDescription(
+                            "Describes the mode how Flink should restore from the given"
+                                    + " savepoint or retained checkpoint.");
+
+    /**
+     * Access to this option is officially only supported via {@link
+     * org.apache.flink.runtime.jobgraph.CheckpointConfig#enableApproximateLocalRecovery(boolean)},
+     * but there is no good reason behind this.
+     */
+    @Internal @Documentation.ExcludeFromDocumentation
+    public static final ConfigOption<Boolean> APPROXIMATE_LOCAL_RECOVERY =
+            key("execution.state-recovery.approximate-local-recovery")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDeprecatedKeys("execution.checkpointing.approximate-local-recovery")
+                    .withDescription("Flag to enable approximate local recovery.");
+
+    public static final ConfigOption<Long> CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA =
+            ConfigOptions.key("execution.state-recovery.without-channel-state.checkpoint-id")
+                    .longType()
+                    .defaultValue(-1L)
+                    .withDeprecatedKeys(
+                            "execution.checkpointing.recover-without-channel-state.checkpoint-id")
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Checkpoint id for which in-flight data should be ignored in case of the recovery from this checkpoint.")
+                                    .linebreak()
+                                    .linebreak()
+                                    .text(
+                                            "It is better to keep this value empty until "
+                                                    + "there is explicit needs to restore from "
+                                                    + "the specific checkpoint without in-flight data.")
+                                    .linebreak()
+                                    .build());
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/RestoreMode.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/RestoreMode.java
@@ -25,7 +25,11 @@ import org.apache.flink.configuration.description.InlineElement;
 
 import static org.apache.flink.configuration.description.TextElement.text;
 
-/** Defines how Flink should restore from a given savepoint or retained checkpoint. */
+/**
+ * Defines state files ownership when Flink restore from a given savepoint or retained checkpoint.
+ * TODO: Rename 'RestoreMode' to 'RecoveryClaimMode' in Flink 2.0. Any related variable names should
+ * be adjusted accordingly.
+ */
 @PublicEvolving
 public enum RestoreMode implements DescribedEnum {
     CLAIM(

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -155,6 +155,9 @@ public class JarRunHandler
                                 () ->
                                         effectiveConfiguration.get(
                                                 StateRecoveryOptions.RESTORE_MODE));
+        if (requestBody.isDeprecatedRestoreModeHasValue()) {
+            log.warn("The option 'restoreMode' is deprecated, please use 'claimMode' instead.");
+        }
         if (restoreMode.equals(RestoreMode.LEGACY)) {
             log.warn(
                     "The {} restore mode is deprecated, please use {} or {} mode instead.",

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -25,9 +25,9 @@ import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.RestoreMode;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
@@ -138,7 +138,7 @@ public class JarRunHandler
                         requestBody.getAllowNonRestoredState(),
                         () -> getQueryParameter(request, AllowNonRestoredStateQueryParameter.class),
                         effectiveConfiguration.get(
-                                SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE),
+                                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE),
                         log);
         final String savepointPath =
                 fromRequestBodyOrQueryParameter(
@@ -147,14 +147,14 @@ public class JarRunHandler
                                 emptyToNull(
                                         getQueryParameter(
                                                 request, SavepointPathQueryParameter.class)),
-                        effectiveConfiguration.get(SavepointConfigOptions.SAVEPOINT_PATH),
+                        effectiveConfiguration.get(StateRecoveryOptions.SAVEPOINT_PATH),
                         log);
         final RestoreMode restoreMode =
                 Optional.ofNullable(requestBody.getRestoreMode())
                         .orElseGet(
                                 () ->
                                         effectiveConfiguration.get(
-                                                SavepointConfigOptions.RESTORE_MODE));
+                                                StateRecoveryOptions.RESTORE_MODE));
         if (restoreMode.equals(RestoreMode.LEGACY)) {
             log.warn(
                     "The {} restore mode is deprecated, please use {} or {} mode instead.",

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBody.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunRequestBody.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.webmonitor.handlers;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.execution.RestoreMode;
 import org.apache.flink.runtime.rest.messages.RequestBody;
@@ -36,8 +38,12 @@ import java.util.Map;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class JarRunRequestBody extends JarRequestBody {
     private static final String FIELD_NAME_ALLOW_NON_RESTORED_STATE = "allowNonRestoredState";
+
     private static final String FIELD_NAME_SAVEPOINT_PATH = "savepointPath";
-    private static final String FIELD_NAME_SAVEPOINT_RESTORE_MODE = "restoreMode";
+
+    @Deprecated private static final String FIELD_NAME_SAVEPOINT_RESTORE_MODE = "restoreMode";
+
+    private static final String FIELD_NAME_SAVEPOINT_CLAIM_MODE = "claimMode";
 
     @JsonProperty(FIELD_NAME_ALLOW_NON_RESTORED_STATE)
     @Nullable
@@ -49,10 +55,41 @@ public class JarRunRequestBody extends JarRequestBody {
 
     @JsonProperty(FIELD_NAME_SAVEPOINT_RESTORE_MODE)
     @Nullable
+    @Deprecated
+    @Documentation.ExcludeFromDocumentation
+    private RestoreMode deprecatedRestoreMode;
+
+    @JsonProperty(FIELD_NAME_SAVEPOINT_CLAIM_MODE)
+    @Nullable
     private RestoreMode restoreMode;
 
     public JarRunRequestBody() {
-        this(null, null, null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, null, null, null);
+    }
+
+    /** Fallback constructor ONLY for tests. */
+    @VisibleForTesting
+    public JarRunRequestBody(
+            @Nullable String entryClassName,
+            @Nullable String programArguments,
+            @Nullable List<String> programArgumentsList,
+            @Nullable Integer parallelism,
+            @Nullable JobID jobId,
+            @Nullable Boolean allowNonRestoredState,
+            @Nullable String savepointPath,
+            @Nullable RestoreMode restoreMode,
+            @Nullable Map<String, String> flinkConfiguration) {
+        this(
+                entryClassName,
+                programArguments,
+                programArgumentsList,
+                parallelism,
+                jobId,
+                allowNonRestoredState,
+                savepointPath,
+                null,
+                restoreMode,
+                flinkConfiguration);
     }
 
     @JsonCreator
@@ -66,7 +103,9 @@ public class JarRunRequestBody extends JarRequestBody {
             @Nullable @JsonProperty(FIELD_NAME_ALLOW_NON_RESTORED_STATE)
                     Boolean allowNonRestoredState,
             @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_PATH) String savepointPath,
-            @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_RESTORE_MODE) RestoreMode restoreMode,
+            @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_RESTORE_MODE)
+                    RestoreMode deprecatedRestoreMode,
+            @Nullable @JsonProperty(FIELD_NAME_SAVEPOINT_CLAIM_MODE) RestoreMode restoreMode,
             @Nullable @JsonProperty(FIELD_NAME_FLINK_CONFIGURATION)
                     Map<String, String> flinkConfiguration) {
         super(
@@ -78,6 +117,7 @@ public class JarRunRequestBody extends JarRequestBody {
                 flinkConfiguration);
         this.allowNonRestoredState = allowNonRestoredState;
         this.savepointPath = savepointPath;
+        this.deprecatedRestoreMode = deprecatedRestoreMode;
         this.restoreMode = restoreMode;
     }
 
@@ -96,6 +136,11 @@ public class JarRunRequestBody extends JarRequestBody {
     @Nullable
     @JsonIgnore
     public RestoreMode getRestoreMode() {
-        return restoreMode;
+        return restoreMode == null ? deprecatedRestoreMode : restoreMode;
+    }
+
+    @JsonIgnore
+    public boolean isDeprecatedRestoreModeHasValue() {
+        return deprecatedRestoreMode != null;
     }
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -29,11 +29,11 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.execution.RestoreMode;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
@@ -87,9 +87,9 @@ class JarRunHandlerParameterTest
             new Configuration()
                     .set(TaskManagerOptions.TASK_CANCELLATION_TIMEOUT, 120000L)
                     .set(CoreOptions.DEFAULT_PARALLELISM, 57)
-                    .set(SavepointConfigOptions.SAVEPOINT_PATH, "/foo/bar/test")
-                    .set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, false)
-                    .set(SavepointConfigOptions.RESTORE_MODE, RESTORE_MODE)
+                    .set(StateRecoveryOptions.SAVEPOINT_PATH, "/foo/bar/test")
+                    .set(StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, false)
+                    .set(StateRecoveryOptions.RESTORE_MODE, RESTORE_MODE)
                     .set(
                             PipelineOptions.PARALLELISM_OVERRIDES,
                             new HashMap<String, String>() {
@@ -336,13 +336,13 @@ class JarRunHandlerParameterTest
         final SavepointRestoreSettings savepointRestoreSettings =
                 jobGraph.getSavepointRestoreSettings();
         assertThat(savepointRestoreSettings.getRestoreMode())
-                .isEqualTo(FLINK_CONFIGURATION.get(SavepointConfigOptions.RESTORE_MODE));
+                .isEqualTo(FLINK_CONFIGURATION.get(StateRecoveryOptions.RESTORE_MODE));
         assertThat(savepointRestoreSettings.getRestorePath())
-                .isEqualTo(FLINK_CONFIGURATION.get(SavepointConfigOptions.SAVEPOINT_PATH));
+                .isEqualTo(FLINK_CONFIGURATION.get(StateRecoveryOptions.SAVEPOINT_PATH));
         assertThat(savepointRestoreSettings.allowNonRestoredState())
                 .isEqualTo(
                         FLINK_CONFIGURATION.get(
-                                SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE));
+                                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE));
     }
 
     private void validateSavepointJarRunMessageParameters(

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -467,7 +467,7 @@
         "savepointPath" : {
           "type" : "string"
         },
-        "restoreMode" : {
+        "claimMode" : {
           "type" : "string",
           "enum" : [ "CLAIM", "NO_CLAIM", "LEGACY" ]
         },
@@ -476,6 +476,10 @@
           "additionalProperties" : {
             "type" : "string"
           }
+        },
+        "restoreMode" : {
+          "type" : "string",
+          "enum" : [ "CLAIM", "NO_CLAIM", "LEGACY" ]
         }
       }
     },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1907,7 +1907,7 @@ public class CheckpointCoordinator {
                 checkpointProperties = CheckpointProperties.forUnclaimedSnapshot();
                 break;
             default:
-                throw new IllegalArgumentException("Unknown snapshot restore mode");
+                throw new IllegalArgumentException("Unknown snapshot claim mode");
         }
 
         // Load the savepoint as a checkpoint into the system

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointRecoveryFactory.java
@@ -38,7 +38,7 @@ public interface CheckpointRecoveryFactory {
      * @param sharedStateRegistryFactory Simple factory to produce {@link SharedStateRegistry}
      *     objects.
      * @param ioExecutor Executor used to run (async) deletes.
-     * @param restoreMode the restore mode with which the job is restoring.
+     * @param restoreMode the claim mode with which the job is restoring.
      * @return {@link CompletedCheckpointStore} instance for the job
      */
     CompletedCheckpointStore createRecoveredCompletedCheckpointStore(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/EmbeddedCompletedCheckpointStore.java
@@ -60,7 +60,7 @@ public class EmbeddedCompletedCheckpointStore extends AbstractCompleteCheckpoint
         this(
                 maxRetainedCheckpoints,
                 Collections.emptyList(),
-                /* Using the default restore mode in tests to detect any breaking changes early. */
+                /* Using the default claim mode in tests to detect any breaking changes early. */
                 RestoreMode.DEFAULT);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StandaloneCompletedCheckpointStore.java
@@ -61,7 +61,7 @@ public class StandaloneCompletedCheckpointStore extends AbstractCompleteCheckpoi
                 maxNumberOfCheckpointsToRetain,
                 SharedStateRegistry.DEFAULT_FACTORY,
                 Executors.directExecutor(),
-                /* Using the default restore mode in tests to detect any breaking changes early. */
+                /* Using the default mode in tests to detect any breaking changes early. */
                 RestoreMode.DEFAULT);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointConfigOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointConfigOptions.java
@@ -19,13 +19,19 @@
 package org.apache.flink.runtime.jobgraph;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.core.execution.RestoreMode;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
-/** The {@link ConfigOption configuration options} used when restoring from a savepoint. */
+/**
+ * The {@link ConfigOption configuration options} used when restoring from a savepoint. @Deprecated
+ * All options are moved into {@link org.apache.flink.configuration.StateRecoveryOptions}.
+ */
 @PublicEvolving
+@Deprecated
+@Documentation.ExcludeFromDocumentation("Hidden for deprecated.")
 public class SavepointConfigOptions {
 
     /** The path to a savepoint that will be used to bootstrap the pipeline's state. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/SavepointRestoreSettings.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.jobgraph;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.RestoreMode;
 
 import javax.annotation.Nonnull;
@@ -146,7 +147,7 @@ public class SavepointRestoreSettings implements Serializable {
     public static SavepointRestoreSettings forPath(String savepointPath) {
         return forPath(
                 savepointPath,
-                SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.defaultValue());
+                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.defaultValue());
     }
 
     public static SavepointRestoreSettings forPath(
@@ -155,7 +156,7 @@ public class SavepointRestoreSettings implements Serializable {
         return new SavepointRestoreSettings(
                 savepointPath,
                 allowNonRestoredState,
-                SavepointConfigOptions.RESTORE_MODE.defaultValue());
+                StateRecoveryOptions.RESTORE_MODE.defaultValue());
     }
 
     public static SavepointRestoreSettings forPath(
@@ -171,21 +172,21 @@ public class SavepointRestoreSettings implements Serializable {
             final SavepointRestoreSettings savepointRestoreSettings,
             final Configuration configuration) {
         configuration.set(
-                SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE,
+                StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE,
                 savepointRestoreSettings.allowNonRestoredState());
         configuration.set(
-                SavepointConfigOptions.RESTORE_MODE, savepointRestoreSettings.getRestoreMode());
+                StateRecoveryOptions.RESTORE_MODE, savepointRestoreSettings.getRestoreMode());
         final String savepointPath = savepointRestoreSettings.getRestorePath();
         if (savepointPath != null) {
-            configuration.set(SavepointConfigOptions.SAVEPOINT_PATH, savepointPath);
+            configuration.set(StateRecoveryOptions.SAVEPOINT_PATH, savepointPath);
         }
     }
 
     public static SavepointRestoreSettings fromConfiguration(final ReadableConfig configuration) {
-        final String savepointPath = configuration.get(SavepointConfigOptions.SAVEPOINT_PATH);
+        final String savepointPath = configuration.get(StateRecoveryOptions.SAVEPOINT_PATH);
         final boolean allowNonRestored =
-                configuration.get(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE);
-        final RestoreMode restoreMode = configuration.get(SavepointConfigOptions.RESTORE_MODE);
+                configuration.get(StateRecoveryOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE);
+        final RestoreMode restoreMode = configuration.get(StateRecoveryOptions.RESTORE_MODE);
         return savepointPath == null
                 ? SavepointRestoreSettings.none()
                 : SavepointRestoreSettings.forPath(savepointPath, allowNonRestored, restoreMode);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -31,6 +31,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.core.execution.RestoreMode;
 import org.apache.flink.core.execution.SavepointFormatType;
@@ -66,7 +67,6 @@ import org.apache.flink.runtime.io.network.partition.ClusterPartitionManager;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -1095,7 +1095,7 @@ public class MiniCluster implements AutoCloseableAsync {
                 && savepointRestoreSettings.getRestoreMode() == RestoreMode.NO_CLAIM) {
             final Configuration conf = new Configuration();
             SavepointRestoreSettings.toConfiguration(savepointRestoreSettings, conf);
-            conf.set(SavepointConfigOptions.RESTORE_MODE, RestoreMode.LEGACY);
+            conf.set(StateRecoveryOptions.RESTORE_MODE, RestoreMode.LEGACY);
             jobGraph.setSavepointRestoreSettings(SavepointRestoreSettings.fromConfiguration(conf));
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SharedStateRegistryImpl.java
@@ -217,10 +217,10 @@ public class SharedStateRegistryImpl implements SharedStateRegistry {
                 checkpoint
                         .getRestoredProperties()
                         .map(props -> props.getCheckpointType().getSharingFilesStrategy()));
-        // In NO_CLAIM and LEGACY restore modes, shared state of the initial checkpoints must be
+        // In NO_CLAIM and LEGACY claim modes, shared state of the initial checkpoints must be
         // preserved. This is achieved by advancing highestRetainCheckpointID here, and then
         // checking entry.createdByCheckpointID against it on checkpoint subsumption.
-        // In CLAIM restore mode, the shared state of the initial checkpoints must be
+        // In CLAIM mode, the shared state of the initial checkpoints must be
         // discarded as soon as it becomes unused - so highestRetainCheckpointID is not updated.
         if (mode != RestoreMode.CLAIM) {
             highestNotClaimedCheckpointID =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.description.InlineElement;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
@@ -113,13 +114,11 @@ public class CheckpointConfig implements java.io.Serializable {
      * Default id of checkpoint for which in-flight data should be ignored on recovery.
      *
      * @deprecated This field is no longer used. Please use {@link
-     *     ExecutionCheckpointingOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA} instead.
+     *     StateRecoveryOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA} instead.
      */
     @Deprecated
     public static final int DEFAULT_CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA =
-            ExecutionCheckpointingOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA
-                    .defaultValue()
-                    .intValue();
+            StateRecoveryOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA.defaultValue().intValue();
 
     // --------------------------------------------------------------------------------------------
 
@@ -700,7 +699,7 @@ public class CheckpointConfig implements java.io.Serializable {
      */
     @Experimental
     public boolean isApproximateLocalRecoveryEnabled() {
-        return configuration.get(ExecutionCheckpointingOptions.APPROXIMATE_LOCAL_RECOVERY);
+        return configuration.get(StateRecoveryOptions.APPROXIMATE_LOCAL_RECOVERY);
     }
 
     /**
@@ -719,7 +718,7 @@ public class CheckpointConfig implements java.io.Serializable {
      */
     @Experimental
     public void enableApproximateLocalRecovery(boolean enabled) {
-        configuration.set(ExecutionCheckpointingOptions.APPROXIMATE_LOCAL_RECOVERY, enabled);
+        configuration.set(StateRecoveryOptions.APPROXIMATE_LOCAL_RECOVERY, enabled);
     }
 
     /**
@@ -892,7 +891,7 @@ public class CheckpointConfig implements java.io.Serializable {
     @PublicEvolving
     public void setCheckpointIdOfIgnoredInFlightData(long checkpointIdOfIgnoredInFlightData) {
         configuration.set(
-                ExecutionCheckpointingOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA,
+                StateRecoveryOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA,
                 checkpointIdOfIgnoredInFlightData);
     }
 
@@ -902,8 +901,7 @@ public class CheckpointConfig implements java.io.Serializable {
      */
     @PublicEvolving
     public long getCheckpointIdOfIgnoredInFlightData() {
-        return configuration.get(
-                ExecutionCheckpointingOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA);
+        return configuration.get(StateRecoveryOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA);
     }
 
     /** Cleanup behaviour for externalized checkpoints when the job is cancelled. */
@@ -1001,7 +999,7 @@ public class CheckpointConfig implements java.io.Serializable {
                 .getOptional(ExecutionCheckpointingOptions.ENABLE_UNALIGNED)
                 .ifPresent(this::enableUnalignedCheckpoints);
         configuration
-                .getOptional(ExecutionCheckpointingOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA)
+                .getOptional(StateRecoveryOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA)
                 .ifPresent(this::setCheckpointIdOfIgnoredInFlightData);
         configuration
                 .getOptional(ExecutionCheckpointingOptions.ALIGNED_CHECKPOINT_TIMEOUT)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -254,7 +254,7 @@ public class ExecutionCheckpointingOptions {
     /**
      * @deprecated Use {@link StateRecoveryOptions#CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA} instead.
      */
-    @Deprecated
+    @Deprecated @Documentation.ExcludeFromDocumentation
     public static final ConfigOption<Long> CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA =
             ConfigOptions.key("execution.checkpointing.recover-without-channel-state.checkpoint-id")
                     .longType()
@@ -306,7 +306,7 @@ public class ExecutionCheckpointingOptions {
      *
      * @deprecated Use {@link StateRecoveryOptions#APPROXIMATE_LOCAL_RECOVERY} instead.
      */
-    @Internal @Documentation.ExcludeFromDocumentation @Deprecated
+    @Internal @Deprecated @Documentation.ExcludeFromDocumentation
     public static final ConfigOption<Boolean> APPROXIMATE_LOCAL_RECOVERY =
             key("execution.checkpointing.approximate-local-recovery")
                     .booleanType()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -24,6 +24,7 @@ import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 import org.apache.flink.streaming.api.CheckpointingMode;
@@ -250,6 +251,10 @@ public class ExecutionCheckpointingOptions {
                                             "Forces unaligned checkpoints, particularly allowing them for iterative jobs.")
                                     .build());
 
+    /**
+     * @deprecated Use {@link StateRecoveryOptions#CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA} instead.
+     */
+    @Deprecated
     public static final ConfigOption<Long> CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA =
             ConfigOptions.key("execution.checkpointing.recover-without-channel-state.checkpoint-id")
                     .longType()
@@ -298,8 +303,10 @@ public class ExecutionCheckpointingOptions {
      * Access to this option is officially only supported via {@link
      * CheckpointConfig#enableApproximateLocalRecovery(boolean)}, but there is no good reason behind
      * this.
+     *
+     * @deprecated Use {@link StateRecoveryOptions#APPROXIMATE_LOCAL_RECOVERY} instead.
      */
-    @Internal @Documentation.ExcludeFromDocumentation
+    @Internal @Documentation.ExcludeFromDocumentation @Deprecated
     public static final ConfigOption<Boolean> APPROXIMATE_LOCAL_RECOVERY =
             key("execution.checkpointing.approximate-local-recovery")
                     .booleanType()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1406,7 +1406,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                     String.format(
                             "Configured state backend (%s) does not support enforcing a full"
                                     + " snapshot. If you are restoring in %s mode, please"
-                                    + " consider choosing %s restore mode.",
+                                    + " consider choosing %s mode.",
                             stateBackend, RestoreMode.NO_CLAIM, RestoreMode.CLAIM));
         } else if (checkpointOptions.getCheckpointType().isSavepoint()) {
             SavepointType savepointType = (SavepointType) checkpointOptions.getCheckpointType();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -29,9 +29,9 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.streaming.api.datastream.BroadcastStream;
 import org.apache.flink.streaming.api.datastream.CachedDataStream;
@@ -747,7 +747,7 @@ public class StreamGraphGeneratorTest extends TestLogger {
     @Test
     public void testSettingSavepointRestoreSettings() {
         Configuration config = new Configuration();
-        config.set(SavepointConfigOptions.SAVEPOINT_PATH, "/tmp/savepoint");
+        config.set(StateRecoveryOptions.SAVEPOINT_PATH, "/tmp/savepoint");
 
         final StreamGraph streamGraph =
                 new StreamGraphGenerator(
@@ -767,7 +767,7 @@ public class StreamGraphGeneratorTest extends TestLogger {
     @Test
     public void testSettingSavepointRestoreSettingsSetterOverrides() {
         Configuration config = new Configuration();
-        config.set(SavepointConfigOptions.SAVEPOINT_PATH, "/tmp/savepoint");
+        config.set(StateRecoveryOptions.SAVEPOINT_PATH, "/tmp/savepoint");
 
         StreamGraphGenerator generator =
                 new StreamGraphGenerator(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -699,7 +699,7 @@ public class StreamTaskTest {
                     .hasMessage(
                             "Configured state backend (OnlyIncrementalStateBackend) does not"
                                     + " support enforcing a full snapshot. If you are restoring in"
-                                    + " NO_CLAIM mode, please consider choosing CLAIM restore mode.");
+                                    + " NO_CLAIM mode, please consider choosing CLAIM mode.");
         }
     }
 

--- a/flink-table/flink-sql-client/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/set.q
@@ -74,22 +74,22 @@ reset 'table.resources.download-dir';
 
 # list the configured configuration
 set;
-+--------------------------------------------+-----------+
-|                                        key |     value |
-+--------------------------------------------+-----------+
-|                         execution.attached |      true |
-|           execution.savepoint-restore-mode |  NO_CLAIM |
-| execution.savepoint.ignore-unclaimed-state |     false |
-|        execution.shutdown-on-attached-exit |     false |
-|                           execution.target |    remote |
-|                     jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                        pipeline.classpaths |        [] |
-|                              pipeline.jars |        [] |
-|                                  rest.port |     $VAR_REST_PORT |
-|         sql-client.display.print-time-cost |     false |
-|           sql-client.execution.result-mode |   tableau |
-|           table.exec.legacy-cast-behaviour |  DISABLED |
-+--------------------------------------------+-----------+
++-------------------------------------------------+-----------+
+|                                             key |     value |
++-------------------------------------------------+-----------+
+|                              execution.attached |      true |
+|             execution.shutdown-on-attached-exit |     false |
+|             execution.state-recovery.claim-mode |  NO_CLAIM |
+| execution.state-recovery.ignore-unclaimed-state |     false |
+|                                execution.target |    remote |
+|                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
+|                             pipeline.classpaths |        [] |
+|                                   pipeline.jars |        [] |
+|                                       rest.port |     $VAR_REST_PORT |
+|              sql-client.display.print-time-cost |     false |
+|                sql-client.execution.result-mode |   tableau |
+|                table.exec.legacy-cast-behaviour |  DISABLED |
++-------------------------------------------------+-----------+
 12 rows in set
 !ok
 
@@ -99,19 +99,19 @@ reset;
 !info
 
 set;
-+--------------------------------------------+-----------+
-|                                        key |     value |
-+--------------------------------------------+-----------+
-|                         execution.attached |      true |
-|           execution.savepoint-restore-mode |  NO_CLAIM |
-| execution.savepoint.ignore-unclaimed-state |     false |
-|        execution.shutdown-on-attached-exit |     false |
-|                           execution.target |    remote |
-|                     jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                        pipeline.classpaths |        [] |
-|                              pipeline.jars |        [] |
-|                                  rest.port |     $VAR_REST_PORT |
-+--------------------------------------------+-----------+
++-------------------------------------------------+-----------+
+|                                             key |     value |
++-------------------------------------------------+-----------+
+|                              execution.attached |      true |
+|             execution.shutdown-on-attached-exit |     false |
+|             execution.state-recovery.claim-mode |  NO_CLAIM |
+| execution.state-recovery.ignore-unclaimed-state |     false |
+|                                execution.target |    remote |
+|                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
+|                             pipeline.classpaths |        [] |
+|                                   pipeline.jars |        [] |
+|                                       rest.port |     $VAR_REST_PORT |
++-------------------------------------------------+-----------+
 9 rows in set
 !ok
 
@@ -140,20 +140,20 @@ set 'sql-client.verbose' = 'true';
 !info
 
 set;
-+--------------------------------------------+-----------+
-|                                        key |     value |
-+--------------------------------------------+-----------+
-|                         execution.attached |      true |
-|           execution.savepoint-restore-mode |  NO_CLAIM |
-| execution.savepoint.ignore-unclaimed-state |     false |
-|        execution.shutdown-on-attached-exit |     false |
-|                           execution.target |    remote |
-|                     jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                        pipeline.classpaths |        [] |
-|                              pipeline.jars |        [] |
-|                                  rest.port |     $VAR_REST_PORT |
-|                         sql-client.verbose |      true |
-+--------------------------------------------+-----------+
++-------------------------------------------------+-----------+
+|                                             key |     value |
++-------------------------------------------------+-----------+
+|                              execution.attached |      true |
+|             execution.shutdown-on-attached-exit |     false |
+|             execution.state-recovery.claim-mode |  NO_CLAIM |
+| execution.state-recovery.ignore-unclaimed-state |     false |
+|                                execution.target |    remote |
+|                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
+|                             pipeline.classpaths |        [] |
+|                                   pipeline.jars |        [] |
+|                                       rest.port |     $VAR_REST_PORT |
+|                              sql-client.verbose |      true |
++-------------------------------------------------+-----------+
 10 rows in set
 !ok
 
@@ -166,20 +166,20 @@ reset 'execution.attached';
 !info
 
 set;
-+--------------------------------------------+-----------+
-|                                        key |     value |
-+--------------------------------------------+-----------+
-|                         execution.attached |      true |
-|           execution.savepoint-restore-mode |  NO_CLAIM |
-| execution.savepoint.ignore-unclaimed-state |     false |
-|        execution.shutdown-on-attached-exit |     false |
-|                           execution.target |    remote |
-|                     jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                        pipeline.classpaths |        [] |
-|                              pipeline.jars |        [] |
-|                                  rest.port |     $VAR_REST_PORT |
-|                         sql-client.verbose |      true |
-+--------------------------------------------+-----------+
++-------------------------------------------------+-----------+
+|                                             key |     value |
++-------------------------------------------------+-----------+
+|                              execution.attached |      true |
+|             execution.shutdown-on-attached-exit |     false |
+|             execution.state-recovery.claim-mode |  NO_CLAIM |
+| execution.state-recovery.ignore-unclaimed-state |     false |
+|                                execution.target |    remote |
+|                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
+|                             pipeline.classpaths |        [] |
+|                                   pipeline.jars |        [] |
+|                                       rest.port |     $VAR_REST_PORT |
+|                              sql-client.verbose |      true |
++-------------------------------------------------+-----------+
 10 rows in set
 !ok
 
@@ -198,20 +198,20 @@ SHOW JARS;
 !ok
 
 set;
-+--------------------------------------------+-----------+
-|                                        key |     value |
-+--------------------------------------------+-----------+
-|                         execution.attached |      true |
-|           execution.savepoint-restore-mode |  NO_CLAIM |
-| execution.savepoint.ignore-unclaimed-state |     false |
-|        execution.shutdown-on-attached-exit |     false |
-|                           execution.target |    remote |
-|                     jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                        pipeline.classpaths |        [] |
-|                              pipeline.jars |        [] |
-|                                  rest.port |     $VAR_REST_PORT |
-|                         sql-client.verbose |      true |
-+--------------------------------------------+-----------+
++-------------------------------------------------+-----------+
+|                                             key |     value |
++-------------------------------------------------+-----------+
+|                              execution.attached |      true |
+|             execution.shutdown-on-attached-exit |     false |
+|             execution.state-recovery.claim-mode |  NO_CLAIM |
+| execution.state-recovery.ignore-unclaimed-state |     false |
+|                                execution.target |    remote |
+|                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
+|                             pipeline.classpaths |        [] |
+|                                   pipeline.jars |        [] |
+|                                       rest.port |     $VAR_REST_PORT |
+|                              sql-client.verbose |      true |
++-------------------------------------------------+-----------+
 10 rows in set
 !ok
 

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/set.q
@@ -27,19 +27,19 @@ reset table.resources.download-dir;
 
 set;
 !output
-+--------------------------------------------+-----------+
-|                                        key |     value |
-+--------------------------------------------+-----------+
-|                         execution.attached |      true |
-|           execution.savepoint-restore-mode |  NO_CLAIM |
-| execution.savepoint.ignore-unclaimed-state |     false |
-|        execution.shutdown-on-attached-exit |     false |
-|                           execution.target |    remote |
-|                     jobmanager.rpc.address | localhost |
-|                        pipeline.classpaths |        [] |
-|                              pipeline.jars |        [] |
-|                                  rest.port |     $VAR_REST_PORT |
-+--------------------------------------------+-----------+
++-------------------------------------------------+-----------+
+|                                             key |     value |
++-------------------------------------------------+-----------+
+|                              execution.attached |      true |
+|             execution.shutdown-on-attached-exit |     false |
+|             execution.state-recovery.claim-mode |  NO_CLAIM |
+| execution.state-recovery.ignore-unclaimed-state |     false |
+|                                execution.target |    remote |
+|                          jobmanager.rpc.address | localhost |
+|                             pipeline.classpaths |        [] |
+|                                   pipeline.jars |        [] |
+|                                       rest.port |     $VAR_REST_PORT |
++-------------------------------------------------+-----------+
 9 rows in set
 !ok
 
@@ -51,18 +51,18 @@ java.lang.IllegalArgumentException: No enum constant org.apache.flink.table.api.
 
 set;
 !output
-+--------------------------------------------+-----------+
-|                                        key |     value |
-+--------------------------------------------+-----------+
-|                         execution.attached |      true |
-|           execution.savepoint-restore-mode |  NO_CLAIM |
-| execution.savepoint.ignore-unclaimed-state |     false |
-|        execution.shutdown-on-attached-exit |     false |
-|                           execution.target |    remote |
-|                     jobmanager.rpc.address | localhost |
-|                        pipeline.classpaths |        [] |
-|                              pipeline.jars |        [] |
-|                                  rest.port |     $VAR_REST_PORT |
-+--------------------------------------------+-----------+
++-------------------------------------------------+-----------+
+|                                             key |     value |
++-------------------------------------------------+-----------+
+|                              execution.attached |      true |
+|             execution.shutdown-on-attached-exit |     false |
+|             execution.state-recovery.claim-mode |  NO_CLAIM |
+| execution.state-recovery.ignore-unclaimed-state |     false |
+|                                execution.target |    remote |
+|                          jobmanager.rpc.address | localhost |
+|                             pipeline.classpaths |        [] |
+|                                   pipeline.jars |        [] |
+|                                       rest.port |     $VAR_REST_PORT |
++-------------------------------------------------+-----------+
 9 rows in set
 !ok

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/environment/MiniClusterTestEnvironment.java
@@ -43,8 +43,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL;
+import static org.apache.flink.configuration.StateRecoveryOptions.SAVEPOINT_PATH;
 import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.METRIC_FETCHER_UPDATE_INTERVAL_MS;
-import static org.apache.flink.runtime.jobgraph.SavepointConfigOptions.SAVEPOINT_PATH;
 
 /** Test environment for running jobs on Flink mini-cluster. */
 @Experimental

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RestoreUpgradedJobITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RestoreUpgradedJobITCase.java
@@ -23,10 +23,10 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -214,7 +214,7 @@ public class RestoreUpgradedJobITCase extends TestLogger {
     private void runUpgradedJob(String snapshotPath) throws Exception {
         StreamExecutionEnvironment env;
         Configuration conf = new Configuration();
-        conf.set(SavepointConfigOptions.SAVEPOINT_PATH, snapshotPath);
+        conf.set(StateRecoveryOptions.SAVEPOINT_PATH, snapshotPath);
         env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
         env.setParallelism(PARALLELISM);
         env.addSource(new StringSource(allDataEmittedLatch))

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -48,10 +48,10 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.RpcOptions;
 import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.shuffle.ShuffleServiceOptions;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -769,9 +769,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
             conf.set(StateBackendOptions.STATE_BACKEND, "filesystem");
             conf.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
             if (restoreCheckpoint != null) {
-                conf.set(
-                        SavepointConfigOptions.SAVEPOINT_PATH,
-                        restoreCheckpoint.toURI().toString());
+                conf.set(StateRecoveryOptions.SAVEPOINT_PATH, restoreCheckpoint.toURI().toString());
             }
 
             conf.set(

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/UnifiedSinkMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/UnifiedSinkMigrationITCase.java
@@ -26,13 +26,13 @@ import org.apache.flink.api.connector.sink.GlobalCommitter;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.api.connector.sink.SinkWriter;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.junit5.MiniClusterExtension;
@@ -126,7 +126,7 @@ class UnifiedSinkMigrationITCase {
     private JobClient executeJob(boolean restore) throws Exception {
         final Configuration conf = new Configuration();
         if (restore) {
-            conf.set(SavepointConfigOptions.SAVEPOINT_PATH, findSavepointPath());
+            conf.set(StateRecoveryOptions.SAVEPOINT_PATH, findSavepointPath());
         }
         final StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.getExecutionEnvironment(conf);


### PR DESCRIPTION
## What is the purpose of the change

As one part of FLIP-406, This PR introduce the `StateRecoveryOptions` in flink-core, and move & rename all state-recovery-related options into.

## Brief change log

 - Introduce `StateRecoveryOptions` in flink-core.
 - Move all options of `SavepointConfigOptions` into `StateRecoveryOptions` and rename them.
 - Deprecate `SavepointConfigOptions`.
 - Move two options from `ExecutionCheckpointingOptions` into `StateRecoveryOptions` and rename them.
 - Re-generate the doc.


## Verifying this change

This change is a trivial rework and is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
