### PR TITLE
[FLINK-34497][REST] Avoid using system classloader in SerializedThrowableDeserializer

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableDeserializer.java
@@ -47,7 +47,7 @@ public class SerializedThrowableDeserializer extends StdDeserializer<SerializedT
         final byte[] serializedException = root.get(FIELD_NAME_SERIALIZED_THROWABLE).binaryValue();
         try {
             return InstantiationUtil.deserializeObject(
-                    serializedException, ClassLoader.getSystemClassLoader());
+                    serializedException, Thread.currentThread().getContextClassLoader());
         } catch (ClassNotFoundException e) {
             throw new IOException(
                     "Failed to deserialize " + SerializedThrowable.class.getCanonicalName(), e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SerializedThrowableDeserializer.java
@@ -47,7 +47,7 @@ public class SerializedThrowableDeserializer extends StdDeserializer<SerializedT
         final byte[] serializedException = root.get(FIELD_NAME_SERIALIZED_THROWABLE).binaryValue();
         try {
             return InstantiationUtil.deserializeObject(
-                    serializedException, Thread.currentThread().getContextClassLoader());
+                    serializedException, getClass().getClassLoader());
         } catch (ClassNotFoundException e) {
             throw new IOException(
                     "Failed to deserialize " + SerializedThrowable.class.getCanonicalName(), e);


### PR DESCRIPTION

## What is the purpose of the change

When using Flink rest client in systems like spring boot, which are using [Executable Jar Format](https://docs.spring.io/spring-boot/docs/current/reference/html/executable-jar.html#appendix.executable-jar.restrictions), `SerializedThrowable` will not be deserialized because system classloader will not be able to find class `SerializedThrowable` which is located in a nested jar.


## Brief change log

Use `Thread.currentThread().getContextClassLoader()` to replace `ClassLoader.getSystemClassLoader()`.


## Verifying this change

This change is a trivial rework without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
