### PR TITLE
[FLINK-34496] Break circular dependency in static initializatio

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/ExecNodeMetadataUtilTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/ExecNodeMetadataUtilTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeMetadata;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.MultipleExecNodeMetadata;
-import org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode;
 import org.apache.flink.table.types.logical.LogicalType;
 
@@ -239,7 +238,7 @@ class ExecNodeMetadataUtilTest {
         List<Class<? extends ExecNode<?>>> classesWithJsonCreatorInUnsupportedList =
                 new ArrayList<>();
         for (Class<? extends ExecNode<?>> clazz : subClasses) {
-            boolean hasJsonCreator = JsonSerdeUtil.hasJsonCreatorAnnotation(clazz);
+            boolean hasJsonCreator = ExecNodeMetadataUtil.hasJsonCreatorAnnotation(clazz);
             if (hasJsonCreator && UNSUPPORTED_JSON_SERDE_CLASSES.contains(clazz)) {
                 classesWithJsonCreatorInUnsupportedList.add(clazz);
             }


### PR DESCRIPTION
`ExecNodeMetadataUtil` and `JsonSerdeUtil` have a circular dependency in their static initialization, which can cause a classloading lockup when 2 threads are running the class initialization of each class at the same time because during class initialization they hold a lock.

Break this dependency by moving `hasJsonCreatorAnnotation` to `ExecNodeMetadataUtil`.