### PR TITLE
[FLINK-34498][filesystem] GSFileSystemFactory should not log full Flink log

### DIFF
--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystemFactory.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystemFactory.java
@@ -78,8 +78,6 @@ public class GSFileSystemFactory implements FileSystemFactory {
 
     @Override
     public void configure(Configuration flinkConfig) {
-        LOGGER.info("Configuring GSFileSystemFactory with Flink configuration {}", flinkConfig);
-
         Preconditions.checkNotNull(flinkConfig);
 
         ConfigUtils.ConfigContext configContext = new RuntimeConfigContext();


### PR DESCRIPTION
## What is the purpose of the change

Avoid GSFileSystemFactory to log sensitive configurations

## Brief change log

  - Hide sensitive values and add test


## Verifying this change

Test: `org.apache.flink.fs.gs.GSFileSystemFactoryTest::testSkipSensitiveConf()`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
