### PR TITLE
[FLINK-34495][e2e] Enable incremental checkpoint for stop-with-savepoint tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -78,6 +78,7 @@ run_resume_savepoint_test() {
     --environment.parallelism $ORIGINAL_DOP \
     --state_backend $STATE_BACKEND_TYPE \
     --state_backend.checkpoint_directory $CHECKPOINT_DIR \
+    --state_backend.rocks.incremental true \
     --state_backend.file.async $STATE_BACKEND_FILE_ASYNC \
     --sequence_generator_source.sleep_time 30 \
     --sequence_generator_source.sleep_after_elements 1 \
@@ -114,6 +115,7 @@ run_resume_savepoint_test() {
     --environment.parallelism $NEW_DOP \
     --state_backend $STATE_BACKEND_TYPE \
     --state_backend.checkpoint_directory $CHECKPOINT_DIR \
+    --state_backend.rocks.incremental true \
     --state_backend.file.async $STATE_BACKEND_FILE_ASYNC \
     --sequence_generator_source.sleep_time 15 \
     --sequence_generator_source.sleep_after_elements 1 \


### PR DESCRIPTION
## What is the purpose of the change

Fix the unstable e2e tests related with stop-with-savepoint. See FLINK-34495.

## Brief change log

 - Enable incremental cp for rocksdb in related e2e scripts.

## Verifying this change

This is a test change covered by itself.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
