### PR TITLE
[hotfix] Fix missing flink-end-to-end-tests-jdbc-driver dependency

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-jdbc-driver/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-jdbc-driver/pom.xml
@@ -37,6 +37,12 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-end-to-end-tests-common</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-jdbc-driver-bundle</artifactId>
 			<version>${project.version}</version>
 		</dependency>


### PR DESCRIPTION
## Brief change log

This PR fixes IntelliJ errors when trying to compile `flink-end-to-end-tests-jdbc-driver` due to not declared dependencies to `flink-core` for example.

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
