### PR TITLE
[FLINK-20090][rest] Expose slot sharing group info in REST API

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -895,6 +895,9 @@
               "id" : {
                 "type" : "any"
               },
+              "slotSharingGroupId" : {
+                "type" : "any"
+              },
               "name" : {
                 "type" : "string"
               },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionJobVertex.java
@@ -21,6 +21,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 
 /**
  * Common interface for the runtime {@link ExecutionJobVertex} and {@link
@@ -47,6 +48,13 @@ public interface AccessExecutionJobVertex {
      * @return max parallelism for this job vertex.
      */
     int getMaxParallelism();
+
+    /**
+     * Returns the slot sharing group for this job vertex.
+     *
+     * @return slot sharing group for this job vertex.
+     */
+    SlotSharingGroup getSlotSharingGroup();
 
     /**
      * Returns the resource profile for this job vertex.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraph.java
@@ -400,6 +400,7 @@ public class ArchivedExecutionGraph implements AccessExecutionGraph, Serializabl
                             jobVertex.getName(),
                             parallelismInfo.getParallelism(),
                             parallelismInfo.getMaxParallelism(),
+                            jobVertex.getSlotSharingGroup(),
                             ResourceProfile.fromResourceSpec(
                                     jobVertex.getMinResources(), MemorySize.ZERO),
                             new StringifiedAccumulatorResult[0]);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionJobVertex.java
@@ -21,6 +21,7 @@ import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 
 import java.io.Serializable;
 
@@ -39,6 +40,8 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
 
     private final int maxParallelism;
 
+    private final SlotSharingGroup slotSharingGroup;
+
     private final ResourceProfile resourceProfile;
 
     private final StringifiedAccumulatorResult[] archivedUserAccumulators;
@@ -55,6 +58,7 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
         this.name = jobVertex.getJobVertex().getName();
         this.parallelism = jobVertex.getParallelism();
         this.maxParallelism = jobVertex.getMaxParallelism();
+        this.slotSharingGroup = jobVertex.getSlotSharingGroup();
         this.resourceProfile = jobVertex.getResourceProfile();
     }
 
@@ -64,6 +68,7 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
             String name,
             int parallelism,
             int maxParallelism,
+            SlotSharingGroup slotSharingGroup,
             ResourceProfile resourceProfile,
             StringifiedAccumulatorResult[] archivedUserAccumulators) {
         this.taskVertices = taskVertices;
@@ -71,6 +76,7 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
         this.name = name;
         this.parallelism = parallelism;
         this.maxParallelism = maxParallelism;
+        this.slotSharingGroup = slotSharingGroup;
         this.resourceProfile = resourceProfile;
         this.archivedUserAccumulators = archivedUserAccumulators;
     }
@@ -92,6 +98,11 @@ public class ArchivedExecutionJobVertex implements AccessExecutionJobVertex, Ser
     @Override
     public int getMaxParallelism() {
         return maxParallelism;
+    }
+
+    @Override
+    public SlotSharingGroup getSlotSharingGroup() {
+        return slotSharingGroup;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -391,6 +391,7 @@ public class ExecutionJobVertex
         return splitAssigner;
     }
 
+    @Override
     public SlotSharingGroup getSlotSharingGroup() {
         return slotSharingGroup;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotSharingGroupId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/instance/SlotSharingGroupId.java
@@ -19,13 +19,24 @@
 package org.apache.flink.runtime.instance;
 
 import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.StringUtils;
 
 public class SlotSharingGroupId extends AbstractID {
     private static final long serialVersionUID = 8837647978345422042L;
+
+    public SlotSharingGroupId() {
+        super();
+    }
 
     public SlotSharingGroupId(long lowerPart, long upperPart) {
         super(lowerPart, upperPart);
     }
 
-    public SlotSharingGroupId() {}
+    public SlotSharingGroupId(byte[] bytes) {
+        super(bytes);
+    }
+
+    public static SlotSharingGroupId fromHexString(String hexString) {
+        return new SlotSharingGroupId(StringUtils.hexStringToByte(hexString));
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -230,6 +230,7 @@ public class JobDetailsHandler
 
         return new JobDetailsInfo.JobVertexDetailsInfo(
                 ejv.getJobVertexId(),
+                ejv.getSlotSharingGroup().getSlotSharingGroupId(),
                 ejv.getName(),
                 ejv.getMaxParallelism(),
                 ejv.getParallelism(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rest.messages.job;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
@@ -29,6 +30,8 @@ import org.apache.flink.runtime.rest.messages.json.JobIDDeserializer;
 import org.apache.flink.runtime.rest.messages.json.JobIDSerializer;
 import org.apache.flink.runtime.rest.messages.json.JobVertexIDDeserializer;
 import org.apache.flink.runtime.rest.messages.json.JobVertexIDSerializer;
+import org.apache.flink.runtime.rest.messages.json.SlotSharingGroupIDDeserializer;
+import org.apache.flink.runtime.rest.messages.json.SlotSharingGroupIDSerializer;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
@@ -263,6 +266,8 @@ public class JobDetailsInfo implements ResponseBody {
 
         public static final String FIELD_NAME_JOB_VERTEX_ID = "id";
 
+        public static final String FIELD_NAME_SLOT_SHARING_GROUP_ID = "slotSharingGroupId";
+
         public static final String FIELD_NAME_JOB_VERTEX_NAME = "name";
 
         public static final String FIELD_NAME_MAX_PARALLELISM = "maxParallelism";
@@ -284,6 +289,10 @@ public class JobDetailsInfo implements ResponseBody {
         @JsonProperty(FIELD_NAME_JOB_VERTEX_ID)
         @JsonSerialize(using = JobVertexIDSerializer.class)
         private final JobVertexID jobVertexID;
+
+        @JsonProperty(FIELD_NAME_SLOT_SHARING_GROUP_ID)
+        @JsonSerialize(using = SlotSharingGroupIDSerializer.class)
+        private final SlotSharingGroupId slotSharingGroupId;
 
         @JsonProperty(FIELD_NAME_JOB_VERTEX_NAME)
         private final String name;
@@ -317,6 +326,9 @@ public class JobDetailsInfo implements ResponseBody {
                 @JsonDeserialize(using = JobVertexIDDeserializer.class)
                         @JsonProperty(FIELD_NAME_JOB_VERTEX_ID)
                         JobVertexID jobVertexID,
+                @JsonDeserialize(using = SlotSharingGroupIDDeserializer.class)
+                        @JsonProperty(FIELD_NAME_SLOT_SHARING_GROUP_ID)
+                        SlotSharingGroupId slotSharingGroupId,
                 @JsonProperty(FIELD_NAME_JOB_VERTEX_NAME) String name,
                 @JsonProperty(FIELD_NAME_MAX_PARALLELISM) int maxParallelism,
                 @JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
@@ -328,6 +340,7 @@ public class JobDetailsInfo implements ResponseBody {
                         Map<ExecutionState, Integer> tasksPerState,
                 @JsonProperty(FIELD_NAME_JOB_VERTEX_METRICS) IOMetricsInfo jobVertexMetrics) {
             this.jobVertexID = Preconditions.checkNotNull(jobVertexID);
+            this.slotSharingGroupId = Preconditions.checkNotNull(slotSharingGroupId);
             this.name = Preconditions.checkNotNull(name);
             this.maxParallelism = maxParallelism;
             this.parallelism = parallelism;
@@ -342,6 +355,11 @@ public class JobDetailsInfo implements ResponseBody {
         @JsonIgnore
         public JobVertexID getJobVertexID() {
             return jobVertexID;
+        }
+
+        @JsonIgnore
+        public SlotSharingGroupId getSlotSharingGroupId() {
+            return slotSharingGroupId;
         }
 
         @JsonIgnore
@@ -404,6 +422,7 @@ public class JobDetailsInfo implements ResponseBody {
                     && endTime == that.endTime
                     && duration == that.duration
                     && Objects.equals(jobVertexID, that.jobVertexID)
+                    && Objects.equals(slotSharingGroupId, that.slotSharingGroupId)
                     && Objects.equals(name, that.name)
                     && executionState == that.executionState
                     && Objects.equals(tasksPerState, that.tasksPerState)
@@ -414,6 +433,7 @@ public class JobDetailsInfo implements ResponseBody {
         public int hashCode() {
             return Objects.hash(
                     jobVertexID,
+                    slotSharingGroupId,
                     name,
                     maxParallelism,
                     parallelism,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SlotSharingGroupIDDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SlotSharingGroupIDDeserializer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonParser;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+/** Jackson deserializer for {@link SlotSharingGroupId}. */
+public class SlotSharingGroupIDDeserializer extends StdDeserializer<SlotSharingGroupId> {
+
+    private static final long serialVersionUID = -2908308366715321301L;
+
+    protected SlotSharingGroupIDDeserializer() {
+        super(JobVertexID.class);
+    }
+
+    @Override
+    public SlotSharingGroupId deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+        return SlotSharingGroupId.fromHexString(p.getValueAsString());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SlotSharingGroupIDSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/json/SlotSharingGroupIDSerializer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.json;
+
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+
+/** Jackson serializer for {@link SlotSharingGroupId}. */
+public class SlotSharingGroupIDSerializer extends StdSerializer<SlotSharingGroupId> {
+
+    private static final long serialVersionUID = -4052148694985726120L;
+
+    public SlotSharingGroupIDSerializer() {
+        super(SlotSharingGroupId.class);
+    }
+
+    @Override
+    public void serialize(SlotSharingGroupId value, JsonGenerator gen, SerializerProvider provider)
+            throws IOException {
+        gen.writeString(value.toString());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionHistory;
 import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.HandlerRequestException;
 import org.apache.flink.runtime.rest.handler.legacy.DefaultExecutionGraphCache;
@@ -476,6 +477,7 @@ class JobExceptionsHandlerTest {
                 jobVertexID.toString(),
                 1,
                 1,
+                new SlotSharingGroup(),
                 ResourceProfile.UNKNOWN,
                 emptyAccumulators);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexFlameGraphHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexFlameGraphHandlerTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionHistory;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.HandlerRequestException;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
@@ -103,6 +104,7 @@ class JobVertexFlameGraphHandlerTest {
                         "test",
                         2,
                         2,
+                        new SlotSharingGroup(),
                         ResourceProfile.UNKNOWN,
                         new StringifiedAccumulatorResult[0]);
 
@@ -139,6 +141,7 @@ class JobVertexFlameGraphHandlerTest {
                         "test",
                         2,
                         2,
+                        new SlotSharingGroup(),
                         ResourceProfile.UNKNOWN,
                         new StringifiedAccumulatorResult[0]);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskExecutionAttemptDetailsHandlerTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionHistory;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
 import org.apache.flink.runtime.rest.handler.legacy.DefaultExecutionGraphCache;
@@ -115,6 +116,7 @@ class SubtaskExecutionAttemptDetailsHandlerTest {
                         "test",
                         1,
                         1,
+                        new SlotSharingGroup(),
                         ResourceProfile.UNKNOWN,
                         emptyAccumulators);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.rest.messages.job;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.JobPlanInfo;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
@@ -108,6 +109,7 @@ class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetailsInfo>
         int parallelism = 1 + (random.nextInt() / 3);
         return new JobDetailsInfo.JobVertexDetailsInfo(
                 new JobVertexID(),
+                new SlotSharingGroupId(),
                 "jobVertex" + random.nextLong(),
                 2 * parallelism,
                 parallelism,


### PR DESCRIPTION
## What is the purpose of the change

At the moment slot sharing group information is not exposed in the REST API. In this PR I've added it.
This feature can be used for example in the operator to introduce resource quotas.

## Brief change log

Exposed slot sharing group information in the REST API.

## Verifying this change

Manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not applicable
