### PR TITLE
[hotfix][runtime] Remove unneeded requestTaskManagerFileUploadByName

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -811,13 +811,6 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     }
 
     @Override
-    public CompletableFuture<TransientBlobKey> requestTaskManagerFileUploadByName(
-            ResourceID taskManagerId, String fileName, Time timeout) {
-        return requestTaskManagerFileUploadByNameAndType(
-                taskManagerId, fileName, FileType.LOG, Duration.ofMillis(timeout.toMilliseconds()));
-    }
-
-    @Override
     public CompletableFuture<TransientBlobKey> requestTaskManagerFileUploadByNameAndType(
             ResourceID taskManagerId, String fileName, FileType fileType, Duration timeout) {
         log.debug(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -228,24 +228,6 @@ public interface ResourceManagerGateway
 
     /**
      * Request the file upload from the given {@link TaskExecutor} to the cluster's {@link
-     * BlobServer}. The corresponding {@link TransientBlobKey} is returned. To support different
-     * type file upload with name, using {@link
-     * ResourceManager#requestTaskManagerFileUploadByNameAndType} as instead.
-     *
-     * @param taskManagerId identifying the {@link TaskExecutor} to upload the specified file
-     * @param fileName name of the file to upload
-     * @param timeout for the asynchronous operation
-     * @return Future which is completed with the {@link TransientBlobKey} after uploading the file
-     *     to the {@link BlobServer}.
-     * @deprecated use {@link #requestTaskManagerFileUploadByNameAndType(ResourceID, String,
-     *     FileType, Duration)} as instead.
-     */
-    @Deprecated
-    CompletableFuture<TransientBlobKey> requestTaskManagerFileUploadByName(
-            ResourceID taskManagerId, String fileName, @RpcTimeout Time timeout);
-
-    /**
-     * Request the file upload from the given {@link TaskExecutor} to the cluster's {@link
      * BlobServer}. The corresponding {@link TransientBlobKey} is returned.
      *
      * @param taskManagerId identifying the {@link TaskExecutor} to upload the specified file

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -459,19 +459,6 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
     }
 
     @Override
-    public CompletableFuture<TransientBlobKey> requestTaskManagerFileUploadByName(
-            ResourceID taskManagerId, String fileName, Time timeout) {
-        final Function<Tuple2<ResourceID, String>, CompletableFuture<TransientBlobKey>> function =
-                requestTaskManagerFileUploadByNameFunction;
-
-        if (function != null) {
-            return function.apply(Tuple2.of(taskManagerId, fileName));
-        } else {
-            return CompletableFuture.completedFuture(new TransientBlobKey());
-        }
-    }
-
-    @Override
     public CompletableFuture<TransientBlobKey> requestTaskManagerFileUploadByNameAndType(
             ResourceID taskManagerId, String fileName, FileType fileType, Duration timeout) {
         final Function<Tuple3<ResourceID, String, FileType>, CompletableFuture<TransientBlobKey>>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -94,9 +94,6 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
     private volatile Function<Tuple2<ResourceID, FileType>, CompletableFuture<TransientBlobKey>>
             requestTaskManagerFileUploadByTypeFunction;
 
-    private volatile Function<Tuple2<ResourceID, String>, CompletableFuture<TransientBlobKey>>
-            requestTaskManagerFileUploadByNameFunction;
-
     private volatile Function<
                     Tuple3<ResourceID, String, FileType>, CompletableFuture<TransientBlobKey>>
             requestTaskManagerFileUploadByNameAndTypeFunction;
@@ -190,13 +187,6 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
                     requestTaskManagerFileUploadByTypeFunction) {
         this.requestTaskManagerFileUploadByTypeFunction =
                 requestTaskManagerFileUploadByTypeFunction;
-    }
-
-    public void setRequestTaskManagerFileUploadByNameFunction(
-            Function<Tuple2<ResourceID, String>, CompletableFuture<TransientBlobKey>>
-                    requestTaskManagerFileUploadByNameFunction) {
-        this.requestTaskManagerFileUploadByNameFunction =
-                requestTaskManagerFileUploadByNameFunction;
     }
 
     public void setRequestTaskManagerFileUploadByNameAndTypeFunction(


### PR DESCRIPTION

## What is the purpose of the change

ResourceManagerGateway is internal class, so the deprecated method can be removed directly.


## Brief change log

[hotfix][runtime] Remove unneeded requestTaskManagerFileUploadByName