### PR TITLE
[DRAFT][BP-1.19][FLINK-34516] Move CheckpointingMode to flink-core

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/execution/CheckpointingMode.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/CheckpointingMode.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.streaming.api;
+package org.apache.flink.core.execution;
 
 import org.apache.flink.annotation.Public;
 
@@ -29,12 +29,8 @@ import org.apache.flink.annotation.Public;
  * whether the system draws checkpoints such that a recovery behaves as if the operators/functions
  * see each record "exactly once" ({@link #EXACTLY_ONCE}), or whether the checkpoints are drawn in a
  * simpler fashion that typically encounters some duplicates upon recovery ({@link #AT_LEAST_ONCE})
- *
- * @deprecated This class has been moved to {@link
- *     org.apache.flink.core.execution.CheckpointingMode}.
  */
 @Public
-@Deprecated
 public enum CheckpointingMode {
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -178,7 +178,9 @@ public class CheckpointConfig implements java.io.Serializable {
      * Gets the checkpointing mode (exactly-once vs. at-least-once).
      *
      * @return The checkpointing mode.
+     * @deprecated Use {@link #getCheckpointMode} instead.
      */
+    @Deprecated
     public CheckpointingMode getCheckpointingMode() {
         return configuration.get(ExecutionCheckpointingOptions.CHECKPOINTING_MODE);
     }
@@ -187,9 +189,30 @@ public class CheckpointConfig implements java.io.Serializable {
      * Sets the checkpointing mode (exactly-once vs. at-least-once).
      *
      * @param checkpointingMode The checkpointing mode.
+     * @deprecated Use {@link #setCheckpointMode} instead.
      */
+    @Deprecated
     public void setCheckpointingMode(CheckpointingMode checkpointingMode) {
         configuration.set(ExecutionCheckpointingOptions.CHECKPOINTING_MODE, checkpointingMode);
+    }
+
+    /**
+     * Gets the checkpointing mode (exactly-once vs. at-least-once).
+     *
+     * @return The checkpointing mode.
+     */
+    public org.apache.flink.core.execution.CheckpointingMode getCheckpointMode() {
+        return configuration.get(ExecutionCheckpointingOptions.CHECKPOINTING_MODE_V2);
+    }
+
+    /**
+     * Sets the checkpointing mode (exactly-once vs. at-least-once).
+     *
+     * @param checkpointingMode The checkpointing mode.
+     */
+    public void setCheckpointMode(
+            org.apache.flink.core.execution.CheckpointingMode checkpointingMode) {
+        configuration.set(ExecutionCheckpointingOptions.CHECKPOINTING_MODE_V2, checkpointingMode);
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -40,11 +40,23 @@ import static org.apache.flink.configuration.description.LinkElement.link;
  */
 @PublicEvolving
 public class ExecutionCheckpointingOptions {
+
+    @Deprecated
+    @Documentation.ExcludeFromDocumentation("Hidden for deprecatd.")
     public static final ConfigOption<CheckpointingMode> CHECKPOINTING_MODE =
             ConfigOptions.key("execution.checkpointing.mode")
                     .enumType(CheckpointingMode.class)
                     .defaultValue(CheckpointingMode.EXACTLY_ONCE)
                     .withDescription("The checkpointing mode (exactly-once vs. at-least-once).");
+
+    public static final ConfigOption<org.apache.flink.core.execution.CheckpointingMode>
+            CHECKPOINTING_MODE_V2 =
+                    ConfigOptions.key("execution.checkpointing.mode")
+                            .enumType(org.apache.flink.core.execution.CheckpointingMode.class)
+                            .defaultValue(
+                                    org.apache.flink.core.execution.CheckpointingMode.EXACTLY_ONCE)
+                            .withDescription(
+                                    "The checkpointing mode (exactly-once vs. at-least-once).");
 
     public static final ConfigOption<Duration> CHECKPOINTING_TIMEOUT =
             ConfigOptions.key("execution.checkpointing.timeout")

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/CheckpointConfigFromConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/CheckpointConfigFromConfigurationTest.java
@@ -48,6 +48,32 @@ public class CheckpointConfigFromConfigurationTest {
                         .viaSetter(CheckpointConfig::setCheckpointingMode)
                         .getterVia(CheckpointConfig::getCheckpointingMode)
                         .nonDefaultValue(CheckpointingMode.AT_LEAST_ONCE),
+                TestSpec.testValue(org.apache.flink.core.execution.CheckpointingMode.AT_LEAST_ONCE)
+                        .whenSetFromFile("execution.checkpointing.mode", "AT_LEAST_ONCE")
+                        .viaSetter(CheckpointConfig::setCheckpointMode)
+                        .getterVia(CheckpointConfig::getCheckpointMode)
+                        .nonDefaultValue(
+                                org.apache.flink.core.execution.CheckpointingMode.AT_LEAST_ONCE),
+                TestSpec.testValue(org.apache.flink.core.execution.CheckpointingMode.AT_LEAST_ONCE)
+                        .whenSetFromFile("execution.checkpointing.mode", "AT_LEAST_ONCE")
+                        .viaSetter(
+                                (config, v) -> {
+                                    config.setCheckpointingMode(
+                                            CheckpointingMode.valueOf(v.name()));
+                                })
+                        .getterVia(CheckpointConfig::getCheckpointMode)
+                        .nonDefaultValue(
+                                org.apache.flink.core.execution.CheckpointingMode.AT_LEAST_ONCE),
+                TestSpec.testValue(CheckpointingMode.AT_LEAST_ONCE)
+                        .whenSetFromFile("execution.checkpointing.mode", "AT_LEAST_ONCE")
+                        .viaSetter(
+                                (config, v) -> {
+                                    config.setCheckpointMode(
+                                            org.apache.flink.core.execution.CheckpointingMode
+                                                    .valueOf(v.name()));
+                                })
+                        .getterVia(CheckpointConfig::getCheckpointingMode)
+                        .nonDefaultValue(CheckpointingMode.AT_LEAST_ONCE),
                 TestSpec.testValue(10000L)
                         .whenSetFromFile("execution.checkpointing.interval", "10 s")
                         .viaSetter(CheckpointConfig::setCheckpointInterval)


### PR DESCRIPTION
# Do not merge this for now
## What is the purpose of the change

In FLIP-406, we want to merge all options in `ExecutionCheckpointingOptions` to `CheckpointingOptions`, which depends on the `CheckpointingMode` being moved to `flink-core` as well. This PR introduce a new `CheckpointingMode` in `flink-core`, and deprecate the old one as well as corresponding user-facing APIs.

## Brief change log

 - introduce a new `CheckpointingMode` in `flink-core`, providing new APIs.
 - deprecate the old `CheckpointingMode` in `flink-streaming-java` as well as the APIs.

## Verifying this change

This change is already covered by new introduced UTs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
