### PR TITLE
[FLINK-34517][table]fix environment configs ignored when calling procedure operation

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerCallProcedureOperation.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerCallProcedureOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.operations;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -126,9 +127,7 @@ public class PlannerCallProcedureOperation implements CallProcedureOperation {
             TableConfig tableConfig, ClassLoader userClassLoader) {
         // should be [ProcedureContext, arg1, arg2, ..]
         Object[] argumentVal = new Object[1 + internalInputArguments.length];
-        StreamExecutionEnvironment env =
-                StreamExecutionEnvironment.getExecutionEnvironment(tableConfig.getConfiguration());
-        argumentVal[0] = new DefaultProcedureContext(env);
+        argumentVal[0] = getProcedureContext(tableConfig);
         for (int i = 0; i < internalInputArguments.length; i++) {
             argumentVal[i + 1] =
                     (internalInputArguments[i] != null)
@@ -136,6 +135,14 @@ public class PlannerCallProcedureOperation implements CallProcedureOperation {
                             : null;
         }
         return argumentVal;
+    }
+
+    private ProcedureContext getProcedureContext(TableConfig tableConfig) {
+        Configuration configuration = tableConfig.getConfiguration();
+        configuration.addAll((Configuration) tableConfig.getRootConfiguration());
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        return new DefaultProcedureContext(env);
     }
 
     /** Convert the value with internal representation to the value with external representation. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerCallProcedureOperation.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerCallProcedureOperation.java
@@ -138,8 +138,9 @@ public class PlannerCallProcedureOperation implements CallProcedureOperation {
     }
 
     private ProcedureContext getProcedureContext(TableConfig tableConfig) {
-        Configuration configuration = tableConfig.getConfiguration();
-        configuration.addAll((Configuration) tableConfig.getRootConfiguration());
+        Configuration configuration =
+                new Configuration((Configuration) tableConfig.getRootConfiguration());
+        configuration.addAll(tableConfig.getConfiguration());
         StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.getExecutionEnvironment(configuration);
         return new DefaultProcedureContext(env);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/ProcedureITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/ProcedureITCase.java
@@ -19,14 +19,18 @@
 package org.apache.flink.table.planner.runtime.stream.sql;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.planner.factories.TestProcedureCatalogFactory;
 import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
 import org.apache.flink.types.Row;
@@ -88,7 +92,7 @@ class ProcedureITCase extends StreamingTestBase {
                         tEnv().executeSql("show procedures in `system`").collect());
         assertThat(rows.toString())
                 .isEqualTo(
-                        "[+I[generate_n], +I[generate_user], +I[get_year], +I[named_args], +I[named_args_optional], +I[named_args_overload], +I[sum_n]]");
+                        "[+I[generate_n], +I[generate_user], +I[get_env_conf], +I[get_year], +I[named_args], +I[named_args_optional], +I[named_args_overload], +I[sum_n]]");
 
         // show procedure with like
         rows =
@@ -116,7 +120,7 @@ class ProcedureITCase extends StreamingTestBase {
                                 .collect());
         assertThat(rows.toString())
                 .isEqualTo(
-                        "[+I[get_year], +I[named_args], +I[named_args_optional], +I[named_args_overload], +I[sum_n]]");
+                        "[+I[get_env_conf], +I[get_year], +I[named_args], +I[named_args_optional], +I[named_args_overload], +I[sum_n]]");
 
         // show procedure with not ilike
         rows =
@@ -125,7 +129,7 @@ class ProcedureITCase extends StreamingTestBase {
                                 .collect());
         assertThat(rows.toString())
                 .isEqualTo(
-                        "[+I[get_year], +I[named_args], +I[named_args_optional], +I[named_args_overload], +I[sum_n]]");
+                        "[+I[get_env_conf], +I[get_year], +I[named_args], +I[named_args_optional], +I[named_args_overload], +I[sum_n]]");
     }
 
     @Test
@@ -208,6 +212,24 @@ class ProcedureITCase extends StreamingTestBase {
                 tableResult,
                 Collections.singletonList(Row.of("null, 19")),
                 ResolvedSchema.of(Column.physical("result", DataTypes.STRING())));
+    }
+
+    @Test
+    void testEnvironmentConf() throws DatabaseAlreadyExistException {
+        Configuration configuration = new Configuration();
+        configuration.setString("key1", "value1");
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env);
+        TestProcedureCatalogFactory.CatalogWithBuiltInProcedure procedureCatalog =
+                new TestProcedureCatalogFactory.CatalogWithBuiltInProcedure("procedure_catalog");
+        procedureCatalog.createDatabase(
+                "system", new CatalogDatabaseImpl(Collections.emptyMap(), null), true);
+        tableEnv.registerCatalog("test_p", procedureCatalog);
+        tableEnv.useCatalog("test_p");
+        TableResult tableResult = tableEnv.executeSql("call `system`.get_env_conf()");
+        List<Row> environmentConf = CollectionUtil.iteratorToList(tableResult.collect());
+        assertThat(environmentConf.contains(Row.of("key1", "value1"))).isTrue();
     }
 
     private void verifyTableResult(


### PR DESCRIPTION
## What is the purpose of the change
fix [FLINK-34517](https://issues.apache.org/jira/browse/FLINK-34517)

## Brief change log

when passing StreamExecutionEnvironment in PlannerCallProcedureOperation.java , the env only contains the application-specific conf,  environment-specific config not included. 
As a result ,  environment-specific config doesn't work when executing procedure operation, which is not expected, the test case illustrates the problem.

## Verifying this change
A new test method was added to ProcedureITCase.

## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @Public(Evolving): no
The serializers: no
The runtime per-record code paths (performance sensitive): no
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
The S3 file system connector: no

## Documentation
Does this pull request introduce a new feature? no
If yes, how is the feature documented?  not applicable