### PR TITLE
[FLINK-34484][state] Split 'state.backend.local-recovery' into two options for checkpointing and recovery

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>execution.checkpointing.local-backup.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>This option configures local backup for the state backend, which indicates whether to make backup checkpoint on local disk.  If not configured, fallback to execution.state-recovery.from-local. By default, local backup is deactivated. Local backup currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -15,12 +15,6 @@
             <td>Option whether the state backend should create incremental checkpoints, if possible. For an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the complete checkpoint state. Once enabled, the state size shown in web UI or fetched from rest API only represents the delta checkpoint size instead of full checkpoint size. Some state backends may not support incremental checkpoints and ignore this option.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.local-recovery</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).</td>
-        </tr>
-        <tr>
             <td><h5>state.checkpoint-storage</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -33,6 +33,12 @@
             <td>The default directory for savepoints. Used by the state backends that write savepoints to file systems (HashMapStateBackend, EmbeddedRocksDBStateBackend).</td>
         </tr>
         <tr>
+            <td><h5>execution.state-recovery.from-local</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>This option configures local recovery for the state backend, which indicates whether to recovery from local snapshot.By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend)."</td>
+        </tr>
+        <tr>
             <td><h5>state.backend.incremental</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -39,12 +39,6 @@
             <td>Option whether the state backend should create incremental checkpoints, if possible. For an incremental checkpoint, only a diff from the previous checkpoint is stored, rather than the complete checkpoint state. Once enabled, the state size shown in web UI or fetched from rest API only represents the delta checkpoint size instead of full checkpoint size. Some state backends may not support incremental checkpoints and ignore this option.</td>
         </tr>
         <tr>
-            <td><h5>state.backend.local-recovery</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).</td>
-        </tr>
-        <tr>
             <td><h5>state.checkpoint.cleaner.parallel-mode</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/state_recovery_configuration.html
+++ b/docs/layouts/shortcodes/generated/state_recovery_configuration.html
@@ -15,6 +15,12 @@
             <td>Describes the mode how Flink should restore from the given savepoint or retained checkpoint.<br /><br />Possible values:<ul><li>"CLAIM": Flink will take ownership of the given snapshot. It will clean the snapshot once it is subsumed by newer ones.</li><li>"NO_CLAIM": Flink will not claim ownership of the snapshot files. However it will make sure it does not depend on any artefacts from the restored snapshot. In order to do that, Flink will take the first checkpoint as a full one, which means it might reupload/duplicate files that are part of the restored checkpoint.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>execution.state-recovery.from-local</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td> This option configures local recovery for the state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend)."</td>
+        </tr>
+        <tr>
             <td><h5>execution.state-recovery.ignore-unclaimed-state</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/state_recovery_configuration.html
+++ b/docs/layouts/shortcodes/generated/state_recovery_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>execution.state-recovery.from-local</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td> This option configures local recovery for the state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend)."</td>
+            <td>This option configures local recovery for the state backend, which indicates whether to recovery from local snapshot.By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend)."</td>
         </tr>
         <tr>
             <td><h5>execution.state-recovery.ignore-unclaimed-state</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -179,7 +179,8 @@ public class CheckpointingOptions {
      * <p>Local recovery currently only covers keyed state backends (including both the
      * EmbeddedRocksDBStateBackend and the HashMapStateBackend).
      *
-     * @Deprecated use {@link StateRecoveryOptions#LOCAL_RECOVERY} instead.
+     * @deprecated use {@link StateRecoveryOptions#LOCAL_RECOVERY} and {@link
+     *     CheckpointingOptions#LOCAL_BACKUP_ENABLED} instead.
      */
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     @Documentation.ExcludeFromDocumentation("Hidden for deprecated")
@@ -309,4 +310,25 @@ public class CheckpointingOptions {
                                             + "The actual write buffer size is determined to be the maximum of the value of this option and option '%s'.",
                                     FS_SMALL_FILE_THRESHOLD.key()))
                     .withDeprecatedKeys("state.backend.fs.write-buffer-size");
+
+    /**
+     * This option configures local backup for the state backend, which indicates whether to make
+     * backup checkpoint on local disk. If not configured, fallback to {@link
+     * StateRecoveryOptions#LOCAL_RECOVERY}. By default, local backup is deactivated. Local backup
+     * currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend
+     * and the HashMapStateBackend).
+     */
+    public static final ConfigOption<Boolean> LOCAL_BACKUP_ENABLED =
+            ConfigOptions.key("execution.checkpointing.local-backup.enabled")
+                    .booleanType()
+                    .defaultValue(StateRecoveryOptions.LOCAL_RECOVERY.defaultValue())
+                    .withFallbackKeys(StateRecoveryOptions.LOCAL_RECOVERY.key())
+                    .withDeprecatedKeys(LOCAL_RECOVERY.key())
+                    .withDescription(
+                            "This option configures local backup for the state backend, "
+                                    + "which indicates whether to make backup checkpoint on local disk.  "
+                                    + "If not configured, fallback to "
+                                    + StateRecoveryOptions.LOCAL_RECOVERY.key()
+                                    + ". By default, local backup is deactivated. Local backup currently only "
+                                    + "covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -178,8 +178,12 @@ public class CheckpointingOptions {
      *
      * <p>Local recovery currently only covers keyed state backends (including both the
      * EmbeddedRocksDBStateBackend and the HashMapStateBackend).
+     *
+     * @Deprecated use {@link StateRecoveryOptions#LOCAL_RECOVERY} instead.
      */
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
+    @Documentation.ExcludeFromDocumentation("Hidden for deprecated")
+    @Deprecated
     public static final ConfigOption<Boolean> LOCAL_RECOVERY =
             ConfigOptions.key("state.backend.local-recovery")
                     .booleanType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateRecoveryOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateRecoveryOptions.java
@@ -97,4 +97,21 @@ public class StateRecoveryOptions {
                                                     + "the specific checkpoint without in-flight data.")
                                     .linebreak()
                                     .build());
+
+    /**
+     * This option configures local recovery for the state backend. By default, local recovery is
+     * deactivated.
+     *
+     * <p>Local recovery currently only covers keyed state backends (including both the
+     * EmbeddedRocksDBStateBackend and the HashMapStateBackend).
+     *
+     */
+    public static final ConfigOption<Boolean> LOCAL_RECOVERY =
+            ConfigOptions.key("execution.state-recovery.from-local")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDeprecatedKeys(CheckpointingOptions.LOCAL_RECOVERY.key())
+                    .withDescription(" This option configures local recovery for the state backend. "
+                            + "By default, local recovery is deactivated. Local recovery currently only "
+                            + "covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).\"");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateRecoveryOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateRecoveryOptions.java
@@ -99,19 +99,21 @@ public class StateRecoveryOptions {
                                     .build());
 
     /**
-     * This option configures local recovery for the state backend. By default, local recovery is
-     * deactivated.
+     * This option configures local recovery for the state backend, which indicates whether to
+     * recovery from local snapshot. By default, local recovery is deactivated.
      *
      * <p>Local recovery currently only covers keyed state backends (including both the
      * EmbeddedRocksDBStateBackend and the HashMapStateBackend).
-     *
      */
+    @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<Boolean> LOCAL_RECOVERY =
             ConfigOptions.key("execution.state-recovery.from-local")
                     .booleanType()
                     .defaultValue(false)
-                    .withDeprecatedKeys(CheckpointingOptions.LOCAL_RECOVERY.key())
-                    .withDescription(" This option configures local recovery for the state backend. "
-                            + "By default, local recovery is deactivated. Local recovery currently only "
-                            + "covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).\"");
+                    .withDeprecatedKeys("state.backend.local-recovery")
+                    .withDescription(
+                            "This option configures local recovery for the state backend, "
+                                    + "which indicates whether to recovery from local snapshot."
+                                    + "By default, local recovery is deactivated. Local recovery currently only "
+                                    + "covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).\"");
 }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/DuplicatingStateChangeFsUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/DuplicatingStateChangeFsUploader.java
@@ -24,7 +24,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.ChangelogTaskLocalStateStore;
-import org.apache.flink.runtime.state.LocalRecoveryDirectoryProvider;
+import org.apache.flink.runtime.state.LocalSnapshotDirectoryProvider;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.changelog.LocalChangelogRegistry;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
@@ -68,7 +68,7 @@ public class DuplicatingStateChangeFsUploader extends AbstractStateChangeFsUploa
 
     private final Path basePath;
     private final FileSystem fileSystem;
-    private final LocalRecoveryDirectoryProvider localRecoveryDirectoryProvider;
+    private final LocalSnapshotDirectoryProvider localSnapshotDirectoryProvider;
     private final JobID jobID;
 
     public DuplicatingStateChangeFsUploader(
@@ -79,12 +79,12 @@ public class DuplicatingStateChangeFsUploader extends AbstractStateChangeFsUploa
             int bufferSize,
             ChangelogStorageMetricGroup metrics,
             TaskChangelogRegistry changelogRegistry,
-            LocalRecoveryDirectoryProvider localRecoveryDirectoryProvider) {
+            LocalSnapshotDirectoryProvider localSnapshotDirectoryProvider) {
         super(compression, bufferSize, metrics, changelogRegistry, FileStateHandle::new);
         this.basePath =
                 new Path(basePath, String.format("%s/%s", jobID.toHexString(), PATH_SUB_DIR));
         this.fileSystem = fileSystem;
-        this.localRecoveryDirectoryProvider = localRecoveryDirectoryProvider;
+        this.localSnapshotDirectoryProvider = localSnapshotDirectoryProvider;
         this.jobID = jobID;
     }
 
@@ -96,7 +96,7 @@ public class DuplicatingStateChangeFsUploader extends AbstractStateChangeFsUploa
         FSDataOutputStream primaryStream = fileSystem.create(path, WriteMode.NO_OVERWRITE);
         Path localPath =
                 new Path(
-                        getLocalTaskOwnedDirectory(localRecoveryDirectoryProvider, jobID),
+                        getLocalTaskOwnedDirectory(localSnapshotDirectoryProvider, jobID),
                         fileName);
         FSDataOutputStream secondaryStream =
                 localPath.getFileSystem().create(localPath, WriteMode.NO_OVERWRITE);

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
@@ -143,7 +143,7 @@ public class FsStateChangelogStorage extends FsStateChangelogStorageForRecovery
         this.changelogRegistry = changelogRegistry;
         this.uploader = uploader;
         this.localRecoveryConfig = localRecoveryConfig;
-        if (localRecoveryConfig.isLocalRecoveryEnabled()) {
+        if (localRecoveryConfig.isLocalBackupEnabled()) {
             this.localChangelogRegistry =
                     new LocalChangelogRegistryImpl(Executors.newSingleThreadExecutor());
         }

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
@@ -421,7 +421,7 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
                         size,
                         incrementalSize,
                         FsStateChangelogStorageFactory.IDENTIFIER);
-        if (localRecoveryConfig.isLocalRecoveryEnabled()) {
+        if (localRecoveryConfig.isLocalBackupEnabled()) {
             size = 0;
             List<Tuple2<StreamStateHandle, Long>> localTuples = new ArrayList<>();
             for (UploadResult uploadResult : results.values()) {

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploadScheduler.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeUploadScheduler.java
@@ -97,7 +97,7 @@ public interface StateChangeUploadScheduler extends AutoCloseable {
         checkArgument(bytes <= Integer.MAX_VALUE);
         int bufferSize = (int) bytes;
         StateChangeUploader store =
-                localRecoveryConfig.isLocalRecoveryEnabled()
+                localRecoveryConfig.isLocalBackupEnabled()
                         ? new DuplicatingStateChangeFsUploader(
                                 jobID,
                                 basePath,

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/test/java/org/apache/flink/streaming/tests/AllroundMiniClusterTest.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/test/java/org/apache/flink/streaming/tests/AllroundMiniClusterTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.streaming.tests;
 
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.TestLogger;
@@ -57,7 +57,7 @@ public class AllroundMiniClusterTest extends TestLogger {
 
     private static Configuration createConfiguration() {
         Configuration configuration = new Configuration();
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
         configuration.setString(EXECUTION_FAILOVER_STRATEGY.key(), "region");
         return configuration;
     }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointTaskStateManager.java
@@ -89,7 +89,7 @@ final class SavepointTaskStateManager implements TaskStateManager {
     @Nonnull
     @Override
     public LocalRecoveryConfig createLocalRecoveryConfig() {
-        return new LocalRecoveryConfig(null);
+        return LocalRecoveryConfig.BACKUP_AND_RECOVERY_DISABLED;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RpcOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.failure.FailureEnricher;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.blocklist.BlocklistOperations;
@@ -265,7 +266,7 @@ public final class DefaultSlotPoolServiceSchedulerFactory
     static RequestSlotMatchingStrategy getRequestSlotMatchingStrategy(
             Configuration configuration, JobType jobType) {
         final boolean isLocalRecoveryEnabled =
-                configuration.get(CheckpointingOptions.LOCAL_RECOVERY);
+                configuration.get(StateRecoveryOptions.LOCAL_RECOVERY);
 
         if (isLocalRecoveryEnabled) {
             if (jobType == JobType.STREAMING) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactory.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.jobmaster;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RpcOptions;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocationContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionSlotAllocationContext.java
@@ -19,7 +19,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
@@ -75,7 +74,7 @@ interface ExecutionSlotAllocationContext extends InputsLocationsRetriever, State
      * Returns all reserved allocations. These allocations/slots were used to run certain vertices
      * and reserving them can prevent other vertices to take these slots and thus help vertices to
      * be deployed into their previous slots again after failover. It is needed if {@link
-     * CheckpointingOptions#LOCAL_RECOVERY} is enabled.
+     * org.apache.flink.configuration.StateRecoveryOptions#LOCAL_RECOVERY} is enabled.
      *
      * @return all reserved allocations
      */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ChangelogTaskLocalStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ChangelogTaskLocalStateStore.java
@@ -101,7 +101,7 @@ public class ChangelogTaskLocalStateStore extends TaskLocalStateStoreImpl {
     }
 
     public static Path getLocalTaskOwnedDirectory(
-            LocalRecoveryDirectoryProvider provider, JobID jobID) {
+            LocalSnapshotDirectoryProvider provider, JobID jobID) {
         File outDir =
                 provider.selectAllocationBaseDirectory(
                         (jobID.hashCode() & Integer.MAX_VALUE)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamWithResultProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamWithResultProvider.java
@@ -164,7 +164,7 @@ public interface CheckpointStreamWithResultProvider extends Closeable {
             @Nonnegative long checkpointId,
             @Nonnull CheckpointedStateScope checkpointedStateScope,
             @Nonnull CheckpointStreamFactory primaryStreamFactory,
-            @Nonnull LocalRecoveryDirectoryProvider secondaryStreamDirProvider)
+            @Nonnull LocalSnapshotDirectoryProvider secondaryStreamDirProvider)
             throws IOException {
 
         CheckpointStateOutputStream primaryOut =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/LocalSnapshotDirectoryProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/LocalSnapshotDirectoryProvider.java
@@ -22,12 +22,12 @@ import java.io.File;
 import java.io.Serializable;
 
 /**
- * Provides directories for local recovery. It offers access to the allocation base directories
- * (i.e. the root directories for all local state that is created under the same allocation id) and
- * the subtask-specific paths, which contain the local state for one subtask. Access by checkpoint
- * id rotates over all root directory indexes, in case that there is more than one. Selection
- * methods are provided to pick the directory under a certain index. Directory structures are of the
- * following shape:
+ * Provides directories for local backup or local recovery. It offers access to the allocation base
+ * directories (i.e. the root directories for all local state that is created under the same
+ * allocation id) and the subtask-specific paths, which contain the local state for one subtask.
+ * Access by checkpoint id rotates over all root directory indexes, in case that there is more than
+ * one. Selection methods are provided to pick the directory under a certain index. Directory
+ * structures are of the following shape:
  *
  * <p>
  *
@@ -48,7 +48,7 @@ import java.io.Serializable;
  *
  * <p>
  */
-public interface LocalRecoveryDirectoryProvider extends Serializable {
+public interface LocalSnapshotDirectoryProvider extends Serializable {
 
     /**
      * Returns the local state allocation base directory for given checkpoint id w.r.t. our rotation

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/LocalSnapshotDirectoryProviderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/LocalSnapshotDirectoryProviderImpl.java
@@ -33,15 +33,15 @@ import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-/** Implementation of {@link LocalRecoveryDirectoryProvider}. */
-public class LocalRecoveryDirectoryProviderImpl implements LocalRecoveryDirectoryProvider {
+/** Implementation of {@link LocalSnapshotDirectoryProvider}. */
+public class LocalSnapshotDirectoryProviderImpl implements LocalSnapshotDirectoryProvider {
 
     /** Serial version. */
     private static final long serialVersionUID = 1L;
 
     /** Logger for this class. */
     private static final Logger LOG =
-            LoggerFactory.getLogger(LocalRecoveryDirectoryProviderImpl.class);
+            LoggerFactory.getLogger(LocalSnapshotDirectoryProviderImpl.class);
 
     /** All available root directories that this can potentially deliver. */
     @Nonnull private final File[] allocationBaseDirs;
@@ -55,7 +55,7 @@ public class LocalRecoveryDirectoryProviderImpl implements LocalRecoveryDirector
     /** Index of the owning subtask. */
     @Nonnegative private final int subtaskIndex;
 
-    public LocalRecoveryDirectoryProviderImpl(
+    public LocalSnapshotDirectoryProviderImpl(
             File allocationBaseDir,
             @Nonnull JobID jobID,
             @Nonnull JobVertexID jobVertexID,
@@ -63,7 +63,7 @@ public class LocalRecoveryDirectoryProviderImpl implements LocalRecoveryDirector
         this(new File[] {allocationBaseDir}, jobID, jobVertexID, subtaskIndex);
     }
 
-    public LocalRecoveryDirectoryProviderImpl(
+    public LocalSnapshotDirectoryProviderImpl(
             @Nonnull File[] allocationBaseDirs,
             @Nonnull JobID jobID,
             @Nonnull JobVertexID jobVertexID,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
@@ -67,8 +67,11 @@ public class TaskExecutorLocalStateStoresManager {
     private final Map<AllocationID, Map<JobVertexSubtaskKey, OwnedTaskLocalStateStore>>
             taskStateStoresByAllocationID;
 
-    /** The configured mode for local recovery on this task manager. */
+    /** Whether to recover from the local snapshot. */
     private final boolean localRecoveryEnabled;
+
+    /** Whether to do backup checkpoint on local disk. */
+    private final boolean localBackupEnabled;
 
     /** This is the root directory for all local state of this task manager / executor. */
     private final Reference<File[]> localStateRootDirectories;
@@ -86,6 +89,7 @@ public class TaskExecutorLocalStateStoresManager {
 
     public TaskExecutorLocalStateStoresManager(
             boolean localRecoveryEnabled,
+            boolean localBackupEnabled,
             @Nonnull Reference<File[]> localStateRootDirectories,
             @Nonnull Executor discardExecutor)
             throws IOException {
@@ -97,6 +101,7 @@ public class TaskExecutorLocalStateStoresManager {
 
         this.taskStateStoresByAllocationID = new HashMap<>();
         this.localRecoveryEnabled = localRecoveryEnabled;
+        this.localBackupEnabled = localBackupEnabled;
         this.localStateRootDirectories = localStateRootDirectories;
         this.discardExecutor = discardExecutor;
         this.lock = new Object();
@@ -157,17 +162,17 @@ public class TaskExecutorLocalStateStoresManager {
 
             if (taskLocalStateStore == null) {
 
-                LocalRecoveryDirectoryProviderImpl directoryProvider = null;
-                if (localRecoveryEnabled) {
+                LocalSnapshotDirectoryProviderImpl directoryProvider = null;
+                if (localRecoveryEnabled || localBackupEnabled) {
                     // create the allocation base dirs, one inside each root dir.
                     File[] allocationBaseDirectories = allocationBaseDirectories(allocationID);
                     directoryProvider =
-                            new LocalRecoveryDirectoryProviderImpl(
+                            new LocalSnapshotDirectoryProviderImpl(
                                     allocationBaseDirectories, jobId, jobVertexID, subtaskIndex);
                 }
-
                 LocalRecoveryConfig localRecoveryConfig =
-                        new LocalRecoveryConfig(directoryProvider);
+                        new LocalRecoveryConfig(
+                                localRecoveryEnabled, localBackupEnabled, directoryProvider);
 
                 boolean changelogEnabled =
                         jobConfiguration
@@ -176,7 +181,7 @@ public class TaskExecutorLocalStateStoresManager {
                                         clusterConfiguration.get(
                                                 StateChangelogOptions.ENABLE_STATE_CHANGE_LOG));
 
-                if (localRecoveryConfig.isLocalRecoveryEnabled() && changelogEnabled) {
+                if (localRecoveryConfig.isLocalRecoveryOrLocalBackupEnabled() && changelogEnabled) {
                     taskLocalStateStore =
                             new ChangelogTaskLocalStateStore(
                                     jobId,
@@ -185,7 +190,7 @@ public class TaskExecutorLocalStateStoresManager {
                                     subtaskIndex,
                                     localRecoveryConfig,
                                     discardExecutor);
-                } else if (localRecoveryConfig.isLocalRecoveryEnabled()) {
+                } else if (localRecoveryConfig.isLocalRecoveryOrLocalBackupEnabled()) {
                     taskLocalStateStore =
                             new TaskLocalStateStoreImpl(
                                     jobId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
@@ -119,7 +119,7 @@ class HeapSnapshotStrategy<K>
 
         final SupplierWithException<CheckpointStreamWithResultProvider, Exception>
                 checkpointStreamSupplier =
-                        localRecoveryConfig.isLocalRecoveryEnabled()
+                        localRecoveryConfig.isLocalBackupEnabled()
                                         && !checkpointOptions.getCheckpointType().isSavepoint()
                                 ? () ->
                                         createDuplicatingStream(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -389,6 +389,7 @@ public class TaskManagerServices {
         final TaskExecutorLocalStateStoresManager taskStateManager =
                 new TaskExecutorLocalStateStoresManager(
                         taskManagerServicesConfiguration.isLocalRecoveryEnabled(),
+                        taskManagerServicesConfiguration.isLocalBackupEnabled(),
                         taskManagerServicesConfiguration.getLocalRecoveryStateDirectories(),
                         ioExecutor);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -83,6 +83,8 @@ public class TaskManagerServicesConfiguration {
 
     private final boolean localRecoveryEnabled;
 
+    private final boolean localBackupEnabled;
+
     private final RetryingRegistrationConfiguration retryingRegistrationConfiguration;
 
     private Optional<Time> systemResourceMetricsProbingInterval;
@@ -105,6 +107,7 @@ public class TaskManagerServicesConfiguration {
             String[] tmpDirPaths,
             Reference<File[]> localRecoveryStateDirectories,
             boolean localRecoveryEnabled,
+            boolean localBackupEnabled,
             @Nullable QueryableStateConfiguration queryableStateConfig,
             int numberOfSlots,
             int pageSize,
@@ -126,6 +129,7 @@ public class TaskManagerServicesConfiguration {
         this.tmpDirPaths = checkNotNull(tmpDirPaths);
         this.localRecoveryStateDirectories = checkNotNull(localRecoveryStateDirectories);
         this.localRecoveryEnabled = localRecoveryEnabled;
+        this.localBackupEnabled = localBackupEnabled;
         this.queryableStateConfig = queryableStateConfig;
         this.numberOfSlots = numberOfSlots;
 
@@ -186,6 +190,10 @@ public class TaskManagerServicesConfiguration {
 
     boolean isLocalRecoveryEnabled() {
         return localRecoveryEnabled;
+    }
+
+    boolean isLocalBackupEnabled() {
+        return localBackupEnabled;
     }
 
     @Nullable
@@ -284,7 +292,8 @@ public class TaskManagerServicesConfiguration {
             localStateDirs = Reference.owned(createdLocalStateDirs);
         }
 
-        boolean localRecoveryMode = configuration.get(StateRecoveryOptions.LOCAL_RECOVERY);
+        boolean localRecoveryEnabled = configuration.get(StateRecoveryOptions.LOCAL_RECOVERY);
+        boolean localBackupEnabled = configuration.get(CheckpointingOptions.LOCAL_BACKUP_ENABLED);
 
         final QueryableStateConfiguration queryableStateConfig =
                 QueryableStateConfiguration.fromConfiguration(configuration);
@@ -327,7 +336,8 @@ public class TaskManagerServicesConfiguration {
                 localCommunicationOnly,
                 tmpDirs,
                 localStateDirs,
-                localRecoveryMode,
+                localRecoveryEnabled,
+                localBackupEnabled,
                 queryableStateConfig,
                 ConfigurationParserUtils.getSlot(configuration),
                 ConfigurationParserUtils.getPageSize(configuration),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.RpcOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptionsInternal;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -283,7 +284,7 @@ public class TaskManagerServicesConfiguration {
             localStateDirs = Reference.owned(createdLocalStateDirs);
         }
 
-        boolean localRecoveryMode = configuration.get(CheckpointingOptions.LOCAL_RECOVERY);
+        boolean localRecoveryMode = configuration.get(StateRecoveryOptions.LOCAL_RECOVERY);
 
         final QueryableStateConfiguration queryableStateConfig =
                 QueryableStateConfiguration.fromConfiguration(configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/SlotSelectionStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/SlotSelectionStrategyUtils.java
@@ -19,8 +19,8 @@
 
 package org.apache.flink.runtime.util;
 
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
@@ -50,7 +50,7 @@ public class SlotSelectionStrategyUtils {
                         : LocationPreferenceSlotSelectionStrategy.createDefault();
 
         final boolean isLocalRecoveryEnabled =
-                configuration.get(CheckpointingOptions.LOCAL_RECOVERY);
+                configuration.get(StateRecoveryOptions.LOCAL_RECOVERY);
         if (isLocalRecoveryEnabled) {
             if (jobType == JobType.STREAMING) {
                 return PreviousAllocationSlotSelectionStrategy.create(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/DefaultSlotPoolServiceSchedulerFactoryTest.java
@@ -18,10 +18,10 @@
 
 package org.apache.flink.runtime.jobmaster;
 
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobmaster.slotpool.PreferredAllocationRequestSlotMatchingStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.RequestSlotMatchingStrategy;
@@ -132,7 +132,7 @@ public class DefaultSlotPoolServiceSchedulerFactoryTest {
     public void testGetRequestSlotMatchingStrategy(
             boolean isLocalRecoveryEnabled, JobType jobType, RequestSlotMatchingStrategy expected) {
         final Configuration configuration = new Configuration();
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, isLocalRecoveryEnabled);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, isLocalRecoveryEnabled);
         assertThat(
                         DefaultSlotPoolServiceSchedulerFactory.getRequestSlotMatchingStrategy(
                                 configuration, jobType))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChangelogTaskLocalStateStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChangelogTaskLocalStateStoreTest.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Test for {@link ChangelogTaskLocalStateStore}. */
 class ChangelogTaskLocalStateStoreTest extends TaskLocalStateStoreImplTest {
 
-    private LocalRecoveryDirectoryProvider localRecoveryDirectoryProvider;
+    private LocalSnapshotDirectoryProvider localSnapshotDirectoryProvider;
 
     @BeforeEach
     @Override
@@ -62,12 +62,13 @@ class ChangelogTaskLocalStateStoreTest extends TaskLocalStateStoreImplTest {
             AllocationID allocationID,
             JobVertexID jobVertexID,
             int subtaskIdx) {
-        LocalRecoveryDirectoryProviderImpl directoryProvider =
-                new LocalRecoveryDirectoryProviderImpl(
+        LocalSnapshotDirectoryProviderImpl directoryProvider =
+                new LocalSnapshotDirectoryProviderImpl(
                         allocationBaseDirs, jobID, jobVertexID, subtaskIdx);
-        this.localRecoveryDirectoryProvider = directoryProvider;
+        this.localSnapshotDirectoryProvider = directoryProvider;
 
-        LocalRecoveryConfig localRecoveryConfig = new LocalRecoveryConfig(directoryProvider);
+        LocalRecoveryConfig localRecoveryConfig =
+                LocalRecoveryConfig.backupAndRecoveryEnabled(directoryProvider);
         return new ChangelogTaskLocalStateStore(
                 jobID,
                 allocationID,
@@ -173,14 +174,14 @@ class ChangelogTaskLocalStateStoreTest extends TaskLocalStateStoreImplTest {
 
     private boolean checkMaterializedDirExists(long materializationID) {
         File materializedDir =
-                localRecoveryDirectoryProvider.subtaskSpecificCheckpointDirectory(
+                localSnapshotDirectoryProvider.subtaskSpecificCheckpointDirectory(
                         materializationID);
         return materializedDir.exists();
     }
 
     private void writeToMaterializedDir(long materializationID) {
         File materializedDir =
-                localRecoveryDirectoryProvider.subtaskSpecificCheckpointDirectory(
+                localSnapshotDirectoryProvider.subtaskSpecificCheckpointDirectory(
                         materializationID);
         if (!materializedDir.exists() && !materializedDir.mkdirs()) {
             throw new FlinkRuntimeException(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStreamWithResultProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/CheckpointStreamWithResultProviderTest.java
@@ -53,7 +53,7 @@ class CheckpointStreamWithResultProviderTest {
                     .isInstanceOf(CheckpointStreamWithResultProvider.PrimaryStreamOnly.class);
         }
 
-        LocalRecoveryDirectoryProvider directoryProvider = createLocalRecoveryDirectoryProvider();
+        LocalSnapshotDirectoryProvider directoryProvider = createLocalRecoveryDirectoryProvider();
         try (CheckpointStreamWithResultProvider primaryAndSecondary =
                 CheckpointStreamWithResultProvider.createDuplicatingStream(
                         42L, CheckpointedStateScope.EXCLUSIVE, primaryFactory, directoryProvider)) {
@@ -87,7 +87,7 @@ class CheckpointStreamWithResultProviderTest {
     @Test
     void testCloseAndFinalizeCheckpointStreamResultPrimaryAndSecondary() throws Exception {
         CheckpointStreamFactory primaryFactory = createCheckpointStreamFactory();
-        LocalRecoveryDirectoryProvider directoryProvider = createLocalRecoveryDirectoryProvider();
+        LocalSnapshotDirectoryProvider directoryProvider = createLocalRecoveryDirectoryProvider();
 
         CheckpointStreamWithResultProvider resultProvider =
                 CheckpointStreamWithResultProvider.createDuplicatingStream(
@@ -201,13 +201,13 @@ class CheckpointStreamWithResultProviderTest {
         resultProvider.close();
     }
 
-    private LocalRecoveryDirectoryProvider createLocalRecoveryDirectoryProvider()
+    private LocalSnapshotDirectoryProvider createLocalRecoveryDirectoryProvider()
             throws IOException {
         File localStateDir = TempDirUtils.newFolder(temporaryFolder);
         JobID jobID = new JobID();
         JobVertexID jobVertexID = new JobVertexID();
         int subtaskIdx = 0;
-        return new LocalRecoveryDirectoryProviderImpl(
+        return new LocalSnapshotDirectoryProviderImpl(
                 localStateDir, jobID, jobVertexID, subtaskIdx);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/LocalSnapshotDirectoryProviderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/LocalSnapshotDirectoryProviderImplTest.java
@@ -33,8 +33,8 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Tests for {@link LocalRecoveryDirectoryProvider}. */
-class LocalRecoveryDirectoryProviderImplTest {
+/** Tests for {@link LocalSnapshotDirectoryProvider}. */
+class LocalSnapshotDirectoryProviderImplTest {
 
     private static final JobID JOB_ID = new JobID();
     private static final JobVertexID JOB_VERTEX_ID = new JobVertexID();
@@ -42,7 +42,7 @@ class LocalRecoveryDirectoryProviderImplTest {
 
     @TempDir private java.nio.file.Path tmpFolder;
 
-    private LocalRecoveryDirectoryProviderImpl directoryProvider;
+    private LocalSnapshotDirectoryProviderImpl directoryProvider;
     private File[] allocBaseFolders;
 
     @BeforeEach
@@ -54,7 +54,7 @@ class LocalRecoveryDirectoryProviderImplTest {
                     TempDirUtils.newFolder(tmpFolder)
                 };
         this.directoryProvider =
-                new LocalRecoveryDirectoryProviderImpl(
+                new LocalSnapshotDirectoryProviderImpl(
                         allocBaseFolders, JOB_ID, JOB_VERTEX_ID, SUBTASK_INDEX);
     }
 
@@ -123,7 +123,7 @@ class LocalRecoveryDirectoryProviderImplTest {
     void testPreconditionsNotNullFiles() {
         assertThatThrownBy(
                         () ->
-                                new LocalRecoveryDirectoryProviderImpl(
+                                new LocalSnapshotDirectoryProviderImpl(
                                         new File[] {null}, JOB_ID, JOB_VERTEX_ID, SUBTASK_INDEX))
                 .isInstanceOf(NullPointerException.class);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -152,7 +152,7 @@ class TaskExecutorLocalStateStoresManagerTest {
     }
 
     @Test
-    void testLocalStateNoCreateDirWhenDisabledLocalRecovery() throws Exception {
+    void testLocalStateNoCreateDirWhenDisabledLocalBackupAndRecovery() throws Exception {
         JobID jobID = new JobID();
         JobVertexID jobVertexID = new JobVertexID();
         AllocationID allocationID = new AllocationID();
@@ -165,9 +165,11 @@ class TaskExecutorLocalStateStoresManagerTest {
         };
 
         boolean localRecoveryEnabled = false;
+        boolean localBackupEnabled = false;
         TaskExecutorLocalStateStoresManager storesManager =
                 new TaskExecutorLocalStateStoresManager(
                         localRecoveryEnabled,
+                        localBackupEnabled,
                         Reference.owned(rootDirs),
                         Executors.directExecutor());
 
@@ -196,6 +198,21 @@ class TaskExecutorLocalStateStoresManagerTest {
      */
     @Test
     void testSubtaskStateStoreDirectoryCreateAndDelete() throws Exception {
+        testSubtaskStateStoreDirectoryCreateAndDelete(true, true);
+    }
+
+    @Test
+    void testStateStoreDirectoryCreateAndDeleteWithLocalRecoveryEnabled() throws Exception {
+        testSubtaskStateStoreDirectoryCreateAndDelete(true, false);
+    }
+
+    @Test
+    void testStateStoreDirectoryCreateAndDeleteWithLocalBackupEnabled() throws Exception {
+        testSubtaskStateStoreDirectoryCreateAndDelete(false, true);
+    }
+
+    private void testSubtaskStateStoreDirectoryCreateAndDelete(
+            boolean localRecoveryEnabled, boolean localBackupEnabled) throws Exception {
 
         JobID jobID = new JobID();
         JobVertexID jobVertexID = new JobVertexID();
@@ -209,7 +226,10 @@ class TaskExecutorLocalStateStoresManagerTest {
         };
         TaskExecutorLocalStateStoresManager storesManager =
                 new TaskExecutorLocalStateStoresManager(
-                        true, Reference.owned(rootDirs), Executors.directExecutor());
+                        localRecoveryEnabled,
+                        localBackupEnabled,
+                        Reference.owned(rootDirs),
+                        Executors.directExecutor());
 
         TaskLocalStateStore taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
@@ -305,7 +325,10 @@ class TaskExecutorLocalStateStoresManagerTest {
 
         final TaskExecutorLocalStateStoresManager taskExecutorLocalStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
-                        true, Reference.owned(localStateDirectories), Executors.directExecutor());
+                        true,
+                        true,
+                        Reference.owned(localStateDirectories),
+                        Executors.directExecutor());
 
         for (File localStateDirectory : localStateDirectories) {
             assertThat(localStateDirectory).exists();
@@ -328,6 +351,7 @@ class TaskExecutorLocalStateStoresManagerTest {
         final TaskExecutorLocalStateStoresManager taskExecutorLocalStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
                         true,
+                        true,
                         Reference.borrowed(localStateDirectories),
                         Executors.directExecutor());
 
@@ -348,6 +372,7 @@ class TaskExecutorLocalStateStoresManagerTest {
         final File localStateStore = TempDirUtils.newFolder(temporaryFolder.toPath());
         final TaskExecutorLocalStateStoresManager taskExecutorLocalStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
+                        true,
                         true,
                         Reference.owned(new File[] {localStateStore}),
                         Executors.directExecutor());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.testutils.AllCallbackWrapper;
 import org.apache.flink.runtime.blob.VoidPermanentBlobService;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -81,7 +82,7 @@ class TaskExecutorLocalStateStoresManagerTest {
         config.set(CheckpointingOptions.LOCAL_RECOVERY_TASK_MANAGER_STATE_ROOT_DIRS, rootDirString);
 
         // test configuration of the local state mode
-        config.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        config.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
 
         final WorkingDirectory workingDirectory =
                 WORKING_DIRECTORY_EXTENSION_WRAPPER

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -220,7 +220,7 @@ class TaskExecutorLocalStateStoresManagerTest {
                         new Configuration(),
                         new Configuration());
 
-        LocalRecoveryDirectoryProvider directoryProvider =
+        LocalSnapshotDirectoryProvider directoryProvider =
                 taskLocalStateStore
                         .getLocalRecoveryConfig()
                         .getLocalStateDirectoryProvider()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
@@ -196,6 +196,28 @@ class TaskLocalStateStoreImplTest {
     }
 
     @Test
+    void retrieveNullIfDisableLocalRecovery() {
+        LocalSnapshotDirectoryProvider directoryProvider =
+                new LocalSnapshotDirectoryProviderImpl(
+                        allocationBaseDirs, jobID, jobVertexID, subtaskIdx);
+        LocalRecoveryConfig localRecoveryConfig =
+                new LocalRecoveryConfig(false, true, directoryProvider);
+        TaskLocalStateStoreImpl localStateStore =
+                new TaskLocalStateStoreImpl(
+                        jobID,
+                        allocationID,
+                        jobVertexID,
+                        subtaskIdx,
+                        localRecoveryConfig,
+                        Executors.directExecutor());
+
+        final TaskStateSnapshot taskStateSnapshot = createTaskStateSnapshot();
+        final long checkpointId = 1L;
+        localStateStore.storeLocalState(checkpointId, taskStateSnapshot);
+        assertThat(localStateStore.retrieveLocalState(checkpointId)).isNull();
+    }
+
+    @Test
     void retrievePersistedLocalStateFromDisc() {
         final TaskStateSnapshot taskStateSnapshot = createTaskStateSnapshot();
         final long checkpointId = 0L;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskLocalStateStoreImplTest.java
@@ -79,11 +79,12 @@ class TaskLocalStateStoreImplTest {
             AllocationID allocationID,
             JobVertexID jobVertexID,
             int subtaskIdx) {
-        LocalRecoveryDirectoryProviderImpl directoryProvider =
-                new LocalRecoveryDirectoryProviderImpl(
+        LocalSnapshotDirectoryProviderImpl directoryProvider =
+                new LocalSnapshotDirectoryProviderImpl(
                         allocationBaseDirs, jobID, jobVertexID, subtaskIdx);
 
-        LocalRecoveryConfig localRecoveryConfig = new LocalRecoveryConfig(directoryProvider);
+        LocalRecoveryConfig localRecoveryConfig =
+                LocalRecoveryConfig.backupAndRecoveryEnabled(directoryProvider);
         return new TaskLocalStateStoreImpl(
                 jobID,
                 allocationID,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
@@ -214,10 +214,11 @@ class TaskStateManagerImplTest {
                     TempDirUtils.newFolder(tmpFolder)
                 };
 
-        LocalRecoveryDirectoryProviderImpl directoryProvider =
-                new LocalRecoveryDirectoryProviderImpl(allocBaseDirs, jobID, jobVertexID, 0);
+        LocalSnapshotDirectoryProviderImpl directoryProvider =
+                new LocalSnapshotDirectoryProviderImpl(allocBaseDirs, jobID, jobVertexID, 0);
 
-        LocalRecoveryConfig localRecoveryConfig = new LocalRecoveryConfig(directoryProvider);
+        LocalRecoveryConfig localRecoveryConfig =
+                LocalRecoveryConfig.backupAndRecoveryEnabled(directoryProvider);
 
         TaskLocalStateStore taskLocalStateStore =
                 new TaskLocalStateStoreImpl(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestLocalRecoveryConfig.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestLocalRecoveryConfig.java
@@ -24,14 +24,14 @@ import java.io.File;
 public class TestLocalRecoveryConfig {
 
     public static LocalRecoveryConfig disabled() {
-        return new LocalRecoveryConfig(null);
+        return LocalRecoveryConfig.BACKUP_AND_RECOVERY_DISABLED;
     }
 
     public static LocalRecoveryConfig enabledForTest() {
-        return new LocalRecoveryConfig(new TestDummyLocalDirectoryProvider());
+        return LocalRecoveryConfig.backupAndRecoveryEnabled(new TestDummyLocalDirectoryProvider());
     }
 
-    public static class TestDummyLocalDirectoryProvider implements LocalRecoveryDirectoryProvider {
+    public static class TestDummyLocalDirectoryProvider implements LocalSnapshotDirectoryProvider {
 
         private TestDummyLocalDirectoryProvider() {}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
@@ -145,6 +145,7 @@ class TaskExecutorExecutionDeploymentReconciliationTest {
         final TaskExecutorLocalStateStoresManager localStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
                         false,
+                        false,
                         Reference.owned(new File[] {TempDirUtils.newFolder(tempDir)}),
                         Executors.directExecutor());
         final TaskManagerServices taskManagerServices =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -427,6 +427,7 @@ class TaskExecutorPartitionLifecycleTest {
         final TaskExecutorLocalStateStoresManager localStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
                         false,
+                        false,
                         Reference.owned(new File[] {TempDirUtils.newFolder(tempDir)}),
                         Executors.directExecutor());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRecoveryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorRecoveryTest.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.EachCallbackWrapper;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
@@ -69,7 +69,7 @@ class TaskExecutorRecoveryTest {
 
         final Configuration configuration = new Configuration();
         configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 2);
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
 
         final TestingResourceManagerGateway testingResourceManagerGateway =
                 new TestingResourceManagerGateway();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
@@ -246,6 +246,7 @@ class TaskExecutorSlotLifetimeTest {
             throws IOException {
         return new TaskExecutorLocalStateStoresManager(
                 false,
+                false,
                 Reference.owned(new File[] {TempDirUtils.newFolder(tempDir)}),
                 Executors.directExecutor());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -275,6 +275,7 @@ class TaskExecutorTest {
         final TaskExecutorLocalStateStoresManager localStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
                         false,
+                        false,
                         Reference.borrowed(ioManager.getSpillingDirectories()),
                         Executors.directExecutor());
 
@@ -2740,6 +2741,7 @@ class TaskExecutorTest {
     private TaskExecutorLocalStateStoresManager createTaskExecutorLocalStateStoresManager()
             throws IOException {
         return new TaskExecutorLocalStateStoresManager(
+                false,
                 false,
                 Reference.owned(new File[] {TempDirUtils.newFolder(tempDir)}),
                 Executors.directExecutor());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -158,6 +158,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
         TaskExecutorLocalStateStoresManager localStateStoresManager =
                 new TaskExecutorLocalStateStoresManager(
                         false,
+                        false,
                         Reference.owned(new File[] {temporaryFolder.newFolder()}),
                         Executors.directExecutor());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/SlotSelectionStrategyUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/SlotSelectionStrategyUtilsTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.runtime.util;
 
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
 import org.apache.flink.runtime.jobmaster.slotpool.PreviousAllocationSlotSelectionStrategy;
@@ -35,7 +35,7 @@ class SlotSelectionStrategyUtilsTest {
     @Test
     void testCreatePreviousAllocationSlotSelectionStrategyForLocalRecoveryStreamingJob() {
         final Configuration configuration = new Configuration();
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
 
         final SlotSelectionStrategy slotSelectionStrategy =
                 SlotSelectionStrategyUtils.selectSlotSelectionStrategy(
@@ -48,7 +48,7 @@ class SlotSelectionStrategyUtilsTest {
     @Test
     void testCreateLocationPreferenceSlotSelectionStrategyForLocalRecoveryBatchJob() {
         final Configuration configuration = new Configuration();
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
 
         final SlotSelectionStrategy slotSelectionStrategy =
                 SlotSelectionStrategyUtils.selectSlotSelectionStrategy(

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateDiscardTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateDiscardTest.java
@@ -274,7 +274,7 @@ public class ChangelogStateDiscardTest {
                                 LatencyTrackingStateConfig.disabled(),
                                 emptyList(),
                                 UncompressedStreamCompressionDecorator.INSTANCE,
-                                new LocalRecoveryConfig(null),
+                                LocalRecoveryConfig.BACKUP_AND_RECOVERY_DISABLED,
                                 new HeapPriorityQueueSetFactory(
                                         kgRange, kgRange.getNumberOfKeyGroups(), 128),
                                 true,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBSnapshotStrategyBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBSnapshotStrategyBase.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
-import org.apache.flink.runtime.state.LocalRecoveryDirectoryProvider;
+import org.apache.flink.runtime.state.LocalSnapshotDirectoryProvider;
 import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
 import org.apache.flink.runtime.state.SnapshotDirectory;
 import org.apache.flink.runtime.state.SnapshotResources;
@@ -184,9 +184,9 @@ public abstract class RocksDBSnapshotStrategyBase<K, R extends SnapshotResources
     protected SnapshotDirectory prepareLocalSnapshotDirectory(long checkpointId)
             throws IOException {
 
-        if (localRecoveryConfig.isLocalRecoveryEnabled()) {
+        if (localRecoveryConfig.isLocalBackupEnabled()) {
             // create a "permanent" snapshot directory for local recovery.
-            LocalRecoveryDirectoryProvider directoryProvider =
+            LocalSnapshotDirectoryProvider directoryProvider =
                     localRecoveryConfig
                             .getLocalStateDirectoryProvider()
                             .orElseThrow(LocalRecoveryConfig.localRecoveryNotEnabled());
@@ -260,7 +260,7 @@ public abstract class RocksDBSnapshotStrategyBase<K, R extends SnapshotResources
             throws Exception {
 
         CheckpointStreamWithResultProvider streamWithResultProvider =
-                localRecoveryConfig.isLocalRecoveryEnabled()
+                localRecoveryConfig.isLocalBackupEnabled()
                         ? CheckpointStreamWithResultProvider.createDuplicatingStream(
                                 checkpointId,
                                 CheckpointedStateScope.EXCLUSIVE,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.state.DoneFuture;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
-import org.apache.flink.runtime.state.LocalRecoveryDirectoryProviderImpl;
+import org.apache.flink.runtime.state.LocalSnapshotDirectoryProviderImpl;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
@@ -220,11 +220,12 @@ public class LocalStateForwardingTest extends TestLogger {
 
         Executor executor = Executors.directExecutor();
 
-        LocalRecoveryDirectoryProviderImpl directoryProvider =
-                new LocalRecoveryDirectoryProviderImpl(
+        LocalSnapshotDirectoryProviderImpl directoryProvider =
+                new LocalSnapshotDirectoryProviderImpl(
                         temporaryFolder.newFolder(), jobID, jobVertexID, subtaskIdx);
 
-        LocalRecoveryConfig localRecoveryConfig = new LocalRecoveryConfig(directoryProvider);
+        LocalRecoveryConfig localRecoveryConfig =
+                LocalRecoveryConfig.backupAndRecoveryEnabled(directoryProvider);
 
         TaskLocalStateStore taskLocalStateStore =
                 new TaskLocalStateStoreImpl(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -46,7 +46,7 @@ import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
-import org.apache.flink.runtime.state.LocalRecoveryDirectoryProviderImpl;
+import org.apache.flink.runtime.state.LocalSnapshotDirectoryProviderImpl;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
@@ -153,8 +153,8 @@ public class StreamTaskTestHarness<OUT> {
         this(
                 taskFactory,
                 outputType,
-                new LocalRecoveryConfig(
-                        new LocalRecoveryDirectoryProviderImpl(
+                LocalRecoveryConfig.backupAndRecoveryEnabled(
+                        new LocalSnapshotDirectoryProviderImpl(
                                 localRootDir, new JobID(), new JobVertexID(), 0)));
     }
 

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
@@ -187,7 +187,7 @@ public class StateBackendBenchmarkUtils {
                         2,
                         new KeyGroupRange(0, 1),
                         executionConfig,
-                        new LocalRecoveryConfig(null),
+                        LocalRecoveryConfig.BACKUP_AND_RECOVERY_DISABLED,
                         RocksDBPriorityQueueConfig.buildWithPriorityQueueType(
                                 EmbeddedRocksDBStateBackend.PriorityQueueStateType.ROCKSDB),
                         ttlTimeProvider,
@@ -225,7 +225,7 @@ public class StateBackendBenchmarkUtils {
                         LatencyTrackingStateConfig.disabled(),
                         Collections.emptyList(),
                         AbstractStateBackend.getCompressionDecorator(executionConfig),
-                        new LocalRecoveryConfig(null),
+                        LocalRecoveryConfig.BACKUP_AND_RECOVERY_DISABLED,
                         priorityQueueSetFactory,
                         false,
                         new CloseableRegistry());

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AutoRescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AutoRescalingITCase.java
@@ -38,6 +38,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.StateChangelogOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBConfigurableOptions;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -166,7 +167,7 @@ public class AutoRescalingITCase extends TestLogger {
             config.set(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true);
             // todo: local rescaling is not supported by changelog.
             config.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, false);
-            config.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+            config.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
             config.set(
                     CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
             config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogLocalRecoveryITCase.java
@@ -54,10 +54,10 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.flink.configuration.CheckpointingOptions.LOCAL_RECOVERY;
 import static org.apache.flink.configuration.ClusterOptions.JOB_MANAGER_PROCESS_WORKING_DIR_BASE;
 import static org.apache.flink.configuration.ClusterOptions.PROCESS_WORKING_DIR_BASE;
 import static org.apache.flink.configuration.ClusterOptions.TASK_MANAGER_PROCESS_WORKING_DIR_BASE;
+import static org.apache.flink.configuration.StateRecoveryOptions.LOCAL_RECOVERY;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitUntilCondition;
 import static org.apache.flink.test.checkpointing.ChangelogRecoveryITCaseBase.getAllStateHandleId;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.test.checkpointing;
 
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Ignore;
@@ -116,7 +116,7 @@ public class LocalRecoveryITCase extends TestLogger {
         protected Configuration createClusterConfig() throws IOException {
             Configuration config = super.createClusterConfig();
 
-            config.set(CheckpointingOptions.LOCAL_RECOVERY, localRecoveryEnabled);
+            config.set(StateRecoveryOptions.LOCAL_RECOVERY, localRecoveryEnabled);
 
             return config;
         }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.test.checkpointing;
 
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.util.TestLogger;
@@ -30,8 +32,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingITCase.StateBackendEnum;
 import static org.apache.flink.test.checkpointing.EventTimeWindowCheckpointingITCase.StateBackendEnum.FILE;
@@ -52,16 +56,40 @@ public class LocalRecoveryITCase extends TestLogger {
 
     @Parameterized.Parameter public StateBackendEnum backendEnum;
 
-    @Parameterized.Parameters(name = "statebackend type ={0}")
-    public static Collection<StateBackendEnum> parameter() {
-        return Arrays.asList(ROCKSDB_FULL, ROCKSDB_INCREMENTAL_ZK, FILE);
+    @Parameterized.Parameter(1)
+    public boolean localRecoveryEnabled;
+
+    @Parameterized.Parameter(2)
+    public boolean localBackupEnabled;
+
+    private static final List<StateBackendEnum> STATE_BACKEND_ENUMS =
+            Arrays.asList(ROCKSDB_FULL, ROCKSDB_INCREMENTAL_ZK, FILE);
+
+    private static final List<Tuple2<Boolean, Boolean>> LOCAL_BACKUP_AND_RECOVERY_CONFIGS =
+            Arrays.asList(Tuple2.of(true, true), Tuple2.of(true, false), Tuple2.of(false, true));
+
+    @Parameterized.Parameters(
+            name = "stateBackendType = {0}, localBackupEnabled = {1}, localRecoveryEnabled = {2}")
+    public static Collection<Object[]> parameter() {
+        List<Object[]> parameterList = new ArrayList<>();
+        for (StateBackendEnum stateBackend : STATE_BACKEND_ENUMS) {
+            for (Tuple2<Boolean, Boolean> backupAndRecoveryConfig :
+                    LOCAL_BACKUP_AND_RECOVERY_CONFIGS) {
+                parameterList.add(
+                        new Object[] {
+                            stateBackend, backupAndRecoveryConfig.f0, backupAndRecoveryConfig.f1
+                        });
+            }
+        }
+        return parameterList;
     }
 
     @Test
     public final void executeTest() throws Exception {
         EventTimeWindowCheckpointingITCase.tempFolder.create();
         EventTimeWindowCheckpointingITCase windowChkITCase =
-                new EventTimeWindowCheckpointingITCaseInstance(backendEnum, true);
+                new EventTimeWindowCheckpointingITCaseInstance(
+                        backendEnum, localBackupEnabled, localRecoveryEnabled);
 
         executeTest(windowChkITCase);
     }
@@ -97,13 +125,16 @@ public class LocalRecoveryITCase extends TestLogger {
             extends EventTimeWindowCheckpointingITCase {
 
         private final StateBackendEnum backendEnum;
+        private final boolean localBackupEnable;
         private final boolean localRecoveryEnabled;
 
         public EventTimeWindowCheckpointingITCaseInstance(
-                StateBackendEnum backendEnum, boolean localRecoveryEnabled) {
+                StateBackendEnum backendEnum,
+                boolean localBackupEnable,
+                boolean localRecoveryEnabled) {
             super(backendEnum, 2);
-
             this.backendEnum = backendEnum;
+            this.localBackupEnable = localBackupEnable;
             this.localRecoveryEnabled = localRecoveryEnabled;
         }
 
@@ -115,9 +146,8 @@ public class LocalRecoveryITCase extends TestLogger {
         @Override
         protected Configuration createClusterConfig() throws IOException {
             Configuration config = super.createClusterConfig();
-
             config.set(StateRecoveryOptions.LOCAL_RECOVERY, localRecoveryEnabled);
-
+            config.set(CheckpointingOptions.LOCAL_BACKUP_ENABLED, localBackupEnable);
             return config;
         }
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/NotifyCheckpointAbortedITCase.java
@@ -27,10 +27,10 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.ClusterClient;
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.OneShotLatch;
@@ -114,7 +114,7 @@ public class NotifyCheckpointAbortedITCase extends TestLogger {
     @Before
     public void setup() throws Exception {
         Configuration configuration = new Configuration();
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
         configuration.set(HighAvailabilityOptions.HA_MODE, TestingHAFactory.class.getName());
 
         checkpointPath = new Path(TEMPORARY_FOLDER.newFolder().toURI());

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -30,6 +30,7 @@ import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.core.execution.RestoreMode;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -340,7 +341,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 
         config.set(CheckpointingOptions.CHECKPOINTS_DIRECTORY, checkpointDir.toURI().toString());
         config.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
-        config.set(CheckpointingOptions.LOCAL_RECOVERY, localRecovery);
+        config.set(StateRecoveryOptions.LOCAL_RECOVERY, localRecovery);
 
         // Configure DFS DSTL for this test as it might produce too much GC pressure if
         // ChangelogStateBackend is used.

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/LocalRecoveryITCase.java
@@ -22,12 +22,12 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.accumulators.ListAccumulator;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint;
@@ -88,7 +88,7 @@ class LocalRecoveryITCase {
         configuration.set(HeartbeatManagerOptions.HEARTBEAT_INTERVAL, 1000L);
         configuration.set(HeartbeatManagerOptions.HEARTBEAT_RPC_FAILURE_THRESHOLD, 1);
         configuration.set(ClusterOptions.PROCESS_WORKING_DIR_BASE, tmpDirectory.getAbsolutePath());
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
         configuration.set(TaskManagerOptions.SLOT_TIMEOUT, Duration.ofSeconds(30L));
 
         final int parallelism = 3;

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/DefaultSchedulerLocalRecoveryITCase.java
@@ -22,10 +22,10 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.client.program.MiniClusterClient;
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
@@ -73,7 +73,7 @@ public class DefaultSchedulerLocalRecoveryITCase extends TestLogger {
 
     private void testLocalRecoveryInternal(String failoverStrategyValue) throws Exception {
         final Configuration configuration = new Configuration();
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
         configuration.setString(EXECUTION_FAILOVER_STRATEGY.key(), failoverStrategyValue);
 
         final int parallelism = 10;

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/SchedulingITCase.java
@@ -22,10 +22,10 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.client.program.MiniClusterClient;
-import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
@@ -62,7 +62,7 @@ public class SchedulingITCase extends TestLogger {
     @Test
     public void testDisablingLocalRecovery() throws Exception {
         final Configuration configuration = new Configuration();
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, false);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, false);
 
         executeSchedulingTest(configuration);
     }
@@ -87,7 +87,7 @@ public class SchedulingITCase extends TestLogger {
 
     private void testLocalRecoveryInternal(String failoverStrategyValue) throws Exception {
         final Configuration configuration = new Configuration();
-        configuration.set(CheckpointingOptions.LOCAL_RECOVERY, true);
+        configuration.set(StateRecoveryOptions.LOCAL_RECOVERY, true);
         configuration.setString(EXECUTION_FAILOVER_STRATEGY.key(), failoverStrategyValue);
 
         executeSchedulingTest(configuration);

--- a/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRecoveryCachingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRecoveryCachingITCase.java
@@ -62,12 +62,12 @@ import static org.apache.flink.changelog.fs.FsStateChangelogOptions.CACHE_IDLE_T
 import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PREEMPTIVE_PERSIST_THRESHOLD;
 import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINTS_DIRECTORY;
 import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINT_STORAGE;
-import static org.apache.flink.configuration.CheckpointingOptions.LOCAL_RECOVERY;
 import static org.apache.flink.configuration.CoreOptions.DEFAULT_PARALLELISM;
 import static org.apache.flink.configuration.RestartStrategyOptions.RESTART_STRATEGY;
 import static org.apache.flink.configuration.StateBackendOptions.STATE_BACKEND;
 import static org.apache.flink.configuration.StateChangelogOptions.ENABLE_STATE_CHANGE_LOG;
 import static org.apache.flink.configuration.StateChangelogOptions.PERIODIC_MATERIALIZATION_ENABLED;
+import static org.apache.flink.configuration.StateRecoveryOptions.LOCAL_RECOVERY;
 import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_ENABLED;
 import static org.apache.flink.runtime.jobgraph.SavepointRestoreSettings.forPath;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;

--- a/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRescalingITCase.java
@@ -71,13 +71,13 @@ import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PREEMPTIVE_P
 import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINTS_DIRECTORY;
 import static org.apache.flink.configuration.CheckpointingOptions.CHECKPOINT_STORAGE;
 import static org.apache.flink.configuration.CheckpointingOptions.FS_SMALL_FILE_THRESHOLD;
-import static org.apache.flink.configuration.CheckpointingOptions.LOCAL_RECOVERY;
 import static org.apache.flink.configuration.CoreOptions.DEFAULT_PARALLELISM;
 import static org.apache.flink.configuration.PipelineOptions.OBJECT_REUSE;
 import static org.apache.flink.configuration.RestartStrategyOptions.RESTART_STRATEGY;
 import static org.apache.flink.configuration.StateBackendOptions.STATE_BACKEND;
 import static org.apache.flink.configuration.StateChangelogOptions.ENABLE_STATE_CHANGE_LOG;
 import static org.apache.flink.configuration.StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL;
+import static org.apache.flink.configuration.StateRecoveryOptions.LOCAL_RECOVERY;
 import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_ENABLED;
 import static org.apache.flink.runtime.jobgraph.SavepointRestoreSettings.forPath;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -40,8 +40,8 @@ import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
-import org.apache.flink.runtime.state.LocalRecoveryDirectoryProvider;
-import org.apache.flink.runtime.state.LocalRecoveryDirectoryProviderImpl;
+import org.apache.flink.runtime.state.LocalSnapshotDirectoryProvider;
+import org.apache.flink.runtime.state.LocalSnapshotDirectoryProviderImpl;
 import org.apache.flink.runtime.state.OperatorStateCheckpointOutputStream;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -177,13 +177,16 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
         JobVertexID jobVertexID = new JobVertexID();
         int subtaskIdx = 0;
 
-        LocalRecoveryDirectoryProvider directoryProvider =
+        LocalSnapshotDirectoryProvider directoryProvider =
                 mode == ONLY_JM_RECOVERY
                         ? null
-                        : new LocalRecoveryDirectoryProviderImpl(
+                        : new LocalSnapshotDirectoryProviderImpl(
                                 temporaryFolder.newFolder(), jobID, jobVertexID, subtaskIdx);
 
-        LocalRecoveryConfig localRecoveryConfig = new LocalRecoveryConfig(directoryProvider);
+        LocalRecoveryConfig localRecoveryConfig =
+                (directoryProvider == null)
+                        ? LocalRecoveryConfig.BACKUP_AND_RECOVERY_DISABLED
+                        : LocalRecoveryConfig.backupAndRecoveryEnabled(directoryProvider);
 
         MockEnvironment mockEnvironment =
                 new MockEnvironmentBuilder()


### PR DESCRIPTION
## What is the purpose of the change

This pull request split 'state.backend.local-recovery' into two options: "execution.checkpointing.local-backup.enabled" and "execution.state-recovery.from-local".  The "execution.checkpointing.local-backup.enabled" indicates whether to do checkpoint on local disk; while "execution.state-recovery.from-local" option specifies whether to recover from local.

## Brief change log
- Move LOCAL_RECOVERY config from CheckpointingOptions to StateRecoveryOptions
- Split 'state.backend.local-recovery' into two options for checkpointing and recovery
- Add UT/IT tests to verify localBackup and localRecovery configs

## Verifying this change

The added tests and existing tests can cover this change, which can be verified as follows:
- TaskExecutorLocalStateStoresManagerTest#testStateStoreDirectoryCreateAndDeleteWithLocalRecoveryEnabled and testStateStoreDirectoryCreateAndDeleteWithLocalBackupEnabled   (added tests)
- TaskLocalStateStoreImplTest#TaskLocalStateStoreImplTest  (added tests)
- LocalRecoveryITCase & TaskExecutorLocalStateStoresManagerTest &  TaskLocalStateStoreImplTest (existing tests )

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
