### PR TITLE
[BP-1.17][FLINK-34499] Configuration#toString hides sensitive values

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.configuration.ConfigurationUtils.canBePrefixMap;
 import static org.apache.flink.configuration.ConfigurationUtils.containsPrefixMap;
@@ -1005,6 +1006,12 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
 
     @Override
     public String toString() {
-        return this.confData.toString();
+        return ConfigurationUtils.hideSensitiveValues(
+                        this.confData.entrySet().stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                Map.Entry::getKey,
+                                                entry -> entry.getValue().toString())))
+                .toString();
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -494,6 +495,19 @@ public class ConfigurationTest extends TestLogger {
                         e ->
                                 Assertions.assertThat(ExceptionUtils.stringifyException(e))
                                         .doesNotContain("secret_value"));
+    }
+
+    @Test
+    public void testToStringDoesNotLeakSensitiveData() {
+        ConfigOption<Map<String, String>> secret =
+                ConfigOptions.key("secret").mapType().noDefaultValue();
+
+        assertTrue(GlobalConfiguration.isSensitive(secret.key()));
+
+        final Configuration cfg = new Configuration();
+        cfg.setString(secret.key(), "secret_value");
+
+        assertThat(cfg.toString(), not(containsString("secret_value")));
     }
 
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
1.17 backport for parent PR #24370 