### PR TITLE
[BP-1.19][FLINK-34498] GSFileSystemFactory should not log full Flink config

### DIFF
--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystemFactory.java
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/java/org/apache/flink/fs/gs/GSFileSystemFactory.java
@@ -78,8 +78,6 @@ public class GSFileSystemFactory implements FileSystemFactory {
 
     @Override
     public void configure(Configuration flinkConfig) {
-        LOGGER.info("Configuring GSFileSystemFactory with Flink configuration {}", flinkConfig);
-
         Preconditions.checkNotNull(flinkConfig);
 
         ConfigUtils.ConfigContext configContext = new RuntimeConfigContext();


### PR DESCRIPTION
This is 1.19 backport for parent PR https://github.com/apache/flink/pull/24372