### PR TITLE
 [hotfix][doc] Update the Kafka DDL example in the hive catalog page to the new parameter style

### DIFF
--- a/docs/content.zh/docs/connectors/table/hive/hive_catalog.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_catalog.md
@@ -183,12 +183,12 @@ Create a simple Kafka table with Flink SQL DDL, and verify its schema.
 Flink SQL> USE CATALOG myhive;
 
 Flink SQL> CREATE TABLE mykafka (name String, age Int) WITH (
-   'connector.type' = 'kafka',
-   'connector.version' = 'universal',
-   'connector.topic' = 'test',
-   'connector.properties.bootstrap.servers' = 'localhost:9092',
-   'format.type' = 'csv',
-   'update-mode' = 'append'
+   'connector' = 'kafka',
+   'topic' = 'test',
+   'properties.bootstrap.servers' = 'localhost:9092',
+   'properties.group.id' = 'testGroup',
+   'scan.startup.mode' = 'earliest-offset',
+   'format' = 'csv'
 );
 [INFO] Table has been created.
 

--- a/docs/content/docs/connectors/table/hive/hive_catalog.md
+++ b/docs/content/docs/connectors/table/hive/hive_catalog.md
@@ -183,12 +183,12 @@ Create a simple Kafka table with Flink SQL DDL, and verify its schema.
 Flink SQL> USE CATALOG myhive;
 
 Flink SQL> CREATE TABLE mykafka (name String, age Int) WITH (
-   'connector.type' = 'kafka',
-   'connector.version' = 'universal',
-   'connector.topic' = 'test',
-   'connector.properties.bootstrap.servers' = 'localhost:9092',
-   'format.type' = 'csv',
-   'update-mode' = 'append'
+   'connector' = 'kafka',
+   'topic' = 'test',
+   'properties.bootstrap.servers' = 'localhost:9092',
+   'properties.group.id' = 'testGroup',
+   'scan.startup.mode' = 'earliest-offset',
+   'format' = 'csv'
 );
 [INFO] Table has been created.
 


### PR DESCRIPTION
## What is the purpose of the change

*The example of Kafka DDL used in the current Hive catalog page is using deprecated-style parameters. We should update it to the new style as this type of parameter is no longer supported.*


## Brief change log
-  Update the ddl example in the hive catalog page.


## Verifying this change
Optimization of the document, no need for verification.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
