### PR TITLE
[FLINK-34535] Support JobPlanInfo for the explain result

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ExplainDetail.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ExplainDetail.java
@@ -41,5 +41,8 @@ public enum ExplainDetail {
     /**
      * The potential risk warnings and SQL optimizer tuning advice analyzed from the physical plan.
      */
-    PLAN_ADVICE
+    PLAN_ADVICE,
+
+    /** The job plan in json format of the program. */
+    JSON_JOB_PLAN;
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -985,7 +985,8 @@ public interface TableEnvironment {
      *
      * @param statement The statement for which the AST and execution plan will be returned.
      * @param extraDetails The extra explain details which the explain result should include, e.g.
-     *     estimated cost, changelog mode for streaming, displaying execution plan in json format
+     *     estimated cost, changelog mode for streaming, displaying execution plan in json format,
+     *     displaying job plan in json
      * @return AST and the execution plan.
      */
     default String explainSql(String statement, ExplainDetail... extraDetails) {
@@ -999,7 +1000,8 @@ public interface TableEnvironment {
      * @param statement The statement for which the AST and execution plan will be returned.
      * @param format The output format of explained plan.
      * @param extraDetails The extra explain details which the explain result should include, e.g.
-     *     estimated cost, changelog mode for streaming, displaying execution plan in json format
+     *     estimated cost, changelog mode for streaming, displaying execution plan in json format,
+     *     displaying job plan in json
      * @return AST and the execution plan.
      */
     String explainSql(String statement, ExplainFormat format, ExplainDetail... extraDetails);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -87,7 +87,8 @@ public interface Planner {
      * @param format The output format of explained statement. See more details at {@link
      *     ExplainFormat}.
      * @param extraDetails The extra explain details which the explain result should include, e.g.
-     *     estimated cost, changelog mode for streaming, displaying execution plan in json format
+     *     estimated cost, changelog mode for streaming, displaying execution plan in json format,
+     *     displaying job plan in json
      */
     String explain(List<Operation> operations, ExplainFormat format, ExplainDetail... extraDetails);
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.delegation
 import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ExecutionOptions
+import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator
 import org.apache.flink.table.api.{ExplainDetail, ExplainFormat, PlanReference, TableConfig, TableException}
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
@@ -146,6 +147,13 @@ class BatchPlanner(
       sb.append("== Physical Execution Plan ==")
       sb.append(System.lineSeparator)
       sb.append(streamGraph.getStreamingPlanAsJSON)
+    }
+
+    if (extraDetails.contains(ExplainDetail.JSON_JOB_PLAN)) {
+      sb.append(System.lineSeparator)
+      sb.append("== Job Execution Plan ==")
+      sb.append(System.lineSeparator)
+      sb.append(JsonPlanGenerator.generatePlan(streamGraph.getJobGraph))
     }
 
     sb.toString()

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.delegation
 import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ExecutionOptions
+import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectReader
 import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.table.api._
@@ -154,6 +155,13 @@ class StreamPlanner(
       sb.append(streamGraph.getStreamingPlanAsJSON)
     }
 
+    if (extraDetails.contains(ExplainDetail.JSON_JOB_PLAN)) {
+      sb.append(System.lineSeparator)
+      sb.append("== Job Execution Plan ==")
+      sb.append(System.lineSeparator)
+      sb.append(JsonPlanGenerator.generatePlan(streamGraph.getJobGraph))
+    }
+
     sb.toString()
   }
 
@@ -243,6 +251,13 @@ class StreamPlanner(
       sb.append("== Physical Execution Plan ==")
       sb.append(System.lineSeparator)
       sb.append(streamGraph.getStreamingPlanAsJSON)
+    }
+
+    if (extraDetails.contains(ExplainDetail.JSON_JOB_PLAN)) {
+      sb.append(System.lineSeparator)
+      sb.append("== Job Execution Plan ==")
+      sb.append(System.lineSeparator)
+      sb.append(JsonPlanGenerator.generatePlan(streamGraph.getJobGraph))
     }
 
     sb.toString()

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
@@ -360,9 +360,12 @@ class CompiledPlanITCase extends JsonPlanTestBase {
 
         String actual =
                 tableEnv.loadPlan(PlanReference.fromJsonString(planFromResources))
-                        .explain(ExplainDetail.JSON_EXECUTION_PLAN);
+                        .explain(ExplainDetail.JSON_EXECUTION_PLAN, ExplainDetail.JSON_JOB_PLAN);
         String expected = TableTestUtil.readFromResource("/explain/testExplainJsonPlan.out");
-        assertThat(TableTestUtil.replaceNodeIdInOperator(TableTestUtil.replaceStreamNodeId(actual)))
+        assertThat(
+                        TableTestUtil.replaceNodeIdInOperator(
+                                TableTestUtil.replaceJobId(
+                                        TableTestUtil.replaceStreamNodeId(actual))))
                 .isEqualTo(expected);
     }
 

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExplainJsonPlan.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExplainJsonPlan.out
@@ -23,3 +23,5 @@ Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])
     } ]
   } ]
 }
+== Job Execution Plan ==
+{"jid":"","name":"Flink Exec Table Job","type":"STREAMING","nodes":[{"id":"d3f21cabc6fe0fdf76c8be915bdb22a2","parallelism":1,"operator":"","operator_strategy":"","description":"[]:TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])<br/>+- [2]:Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])<br/>","optimizer_properties":{}}]}

--- a/flink-table/flink-table-planner/src/test/resources/explain/testStatementSetJobJsonExplain.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testStatementSetJobJsonExplain.out
@@ -1,0 +1,25 @@
+== Abstract Syntax Tree ==
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
++- LogicalProject(last=[$3])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first, id, score, last)]]])
+
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
++- LogicalProject(first=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first, id, score, last)]]])
+
+== Optimized Physical Plan ==
+LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: last)]]], fields=[last])
+
+LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first])
+
+== Optimized Execution Plan ==
+LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: last)]]], fields=[last])
+
+LegacySink(name=[`default_catalog`.`default_database`.`MySink`], fields=[first])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first])
+
+== Job Execution Plan ==
+{"jid":"","name":"Flink Exec Table Job","type":"STREAMING","nodes":[{"id":"51397532e2d9c7a21097a30d590b3114","parallelism":1,"operator":"","operator_strategy":"","description":"CsvTableSource(read fields: last)<br/>+- [1]:SourceConversion(table=[default_catalog.default_database.MyTable, source: [CsvTableSource(read fields: last)]], fields=[last])<br/>   +- [2]:SinkConversion To Row<br/>      +- Map<br/>         +- Sink: CsvTableSink(first)<br/>","inputs":[{"num":0,"id":"bc764cd8ddf7a0cff126f51c16239658","ship_strategy":"FORWARD","exchange":"pipelined_bounded"}],"optimizer_properties":{}},{"id":"bc764cd8ddf7a0cff126f51c16239658","parallelism":1,"operator":"","operator_strategy":"","description":"Source: Custom File source<br/>","optimizer_properties":{}},{"id":"8b9f3e513101bcc5d198aee685286d98","parallelism":1,"operator":"","operator_strategy":"","description":"CsvTableSource(read fields: first)<br/>+- [3]:SourceConversion(table=[default_catalog.default_database.MyTable, source: [CsvTableSource(read fields: first)]], fields=[first])<br/>   +- [4]:SinkConversion To Row<br/>      +- Map<br/>         +- Sink: CsvTableSink(first)<br/>","inputs":[{"num":0,"id":"feca28aff5a3958840bee985ee7de4d3","ship_strategy":"FORWARD","exchange":"pipelined_bounded"}],"optimizer_properties":{}},{"id":"feca28aff5a3958840bee985ee7de4d3","parallelism":1,"operator":"","operator_strategy":"","description":"Source: Custom File source<br/>","optimizer_properties":{}}]}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -59,7 +59,7 @@ import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 import org.apache.flink.table.planner.runtime.utils.{TestingAppendTableSink, TestingRetractTableSink, TestingUpsertTableSink}
 import org.apache.flink.table.planner.sinks.CollectRowTableSink
 import org.apache.flink.table.planner.utils.PlanKind.PlanKind
-import org.apache.flink.table.planner.utils.TableTestUtil.{replaceNodeIdInOperator, replaceStageId, replaceStreamNodeId}
+import org.apache.flink.table.planner.utils.TableTestUtil.{replaceJobId, replaceNodeIdInOperator, replaceStageId, replaceStreamNodeId}
 import org.apache.flink.table.resource.ResourceManager
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromLogicalTypeToTypeInfo
 import org.apache.flink.table.sinks._
@@ -1093,6 +1093,8 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
         case ExplainDetail.ESTIMATED_COST => replaceEstimatedCost(result)
         case ExplainDetail.JSON_EXECUTION_PLAN =>
           replaceNodeIdInOperator(replaceStreamNodeId(replaceStageId(result)))
+        case ExplainDetail.JSON_JOB_PLAN =>
+          replaceJobId(result)
         case _ => result
       }
       replaced
@@ -1822,6 +1824,11 @@ object TableTestUtil {
    */
   def replaceStreamNodeId(s: String): String = {
     s.replaceAll("\"id\"\\s*:\\s*\\d+", "\"id\" : ").trim
+  }
+
+  /** JobJson {jid} is ignored. */
+  def replaceJobId(s: String): String = {
+    s.replaceAll("\"jid\"\\s*:\\s*\"[\\w.-]*\"", "\"jid\":\"\"").trim
   }
 
   /** ExecNode {id} is ignored, because id keeps incrementing in test class. */


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR is used to display the job json plan information of the task when flinksql explain is supported

## Brief change log

*(for example:)*
  - Add an enum JSON_JOB_PLAN to ExplainDetail
  - Update all implementations of Planner#explain including streaming and batch
  - Append the job plan in json format to the result when Planner#explain execute with parameter ExplainDetail.JSON_JOB_PLAN.
 

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
