### PR TITLE
[FLINK-32076][checkpoint] Introduce file pool to reuse files

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/BlockingPhysicalFilePool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/BlockingPhysicalFilePool.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.filemerging;
+
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A Blocking {@link PhysicalFilePool} which may block when polling physical files. This class try
+ * best to reuse a physical file until its size > maxFileSize.
+ */
+public class BlockingPhysicalFilePool extends PhysicalFilePool {
+
+    private final AtomicBoolean exclusivePhysicalFilePoolInitialized;
+
+    public BlockingPhysicalFilePool(
+            long maxFileSize, PhysicalFile.PhysicalFileCreator physicalFileCreator) {
+        super(maxFileSize, physicalFileCreator);
+        this.exclusivePhysicalFilePoolInitialized = new AtomicBoolean(false);
+    }
+
+    @Override
+    public boolean tryPutFile(
+            FileMergingSnapshotManager.SubtaskKey subtaskKey, PhysicalFile physicalFile)
+            throws IOException {
+        if (physicalFile.getSize() < maxFileSize) {
+            return getFileQueue(subtaskKey, physicalFile.getScope()).offer(physicalFile);
+        } else {
+            getFileQueue(subtaskKey, physicalFile.getScope())
+                    .offer(physicalFileCreator.perform(subtaskKey, physicalFile.getScope()));
+            return false;
+        }
+    }
+
+    @Override
+    @Nonnull
+    public PhysicalFile pollFile(
+            FileMergingSnapshotManager.SubtaskKey subtaskKey, CheckpointedStateScope scope)
+            throws IOException {
+        initialize(subtaskKey, scope);
+        try {
+            return ((BlockingQueue<PhysicalFile>) getFileQueue(subtaskKey, scope)).take();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void initialize(
+            FileMergingSnapshotManager.SubtaskKey subtaskKey, CheckpointedStateScope scope)
+            throws IOException {
+        if (scope.equals(CheckpointedStateScope.SHARED)) {
+            AtomicBoolean init = new AtomicBoolean(false);
+            Queue<PhysicalFile> fileQueue =
+                    sharedPhysicalFilePoolBySubtask.computeIfAbsent(
+                            subtaskKey,
+                            key -> {
+                                init.set(true);
+                                return createFileQueue();
+                            });
+            if (init.get()) {
+                fileQueue.offer(physicalFileCreator.perform(subtaskKey, scope));
+            }
+        } else if (scope.equals(CheckpointedStateScope.EXCLUSIVE)
+                && exclusivePhysicalFilePoolInitialized.compareAndSet(false, true)) {
+            getFileQueue(subtaskKey, scope).offer(physicalFileCreator.perform(subtaskKey, scope));
+        }
+    }
+
+    @Override
+    protected Queue<PhysicalFile> createFileQueue() {
+        return new LinkedBlockingQueue<>();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
@@ -351,6 +351,8 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
             case NON_BLOCKING:
                 return new NonBlockingPhysicalFilePool(
                         maxPhysicalFileSize, this::createPhysicalFile);
+            case BLOCKING:
+                return new BlockingPhysicalFilePool(maxPhysicalFileSize, this::createPhysicalFile);
             default:
                 throw new UnsupportedOperationException(
                         "Unsupported type of physical file pool: " + filePoolType);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBuilder.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.runtime.checkpoint.filemerging;
 
+import org.apache.flink.util.Preconditions;
+
 import javax.annotation.Nullable;
 
 import java.util.concurrent.Executor;
@@ -27,6 +29,12 @@ public class FileMergingSnapshotManagerBuilder {
     /** The id for identifying a {@link FileMergingSnapshotManager}. */
     private final String id;
 
+    /** Max size for a file. TODO: Make it configurable. */
+    private long maxFileSize = 32 * 1024 * 1024;
+
+    /** Type of physical file pool. TODO: Make it configurable. */
+    private PhysicalFilePool.Type filePoolType = PhysicalFilePool.Type.NON_BLOCKING;
+
     @Nullable private Executor ioExecutor = null;
 
     /**
@@ -36,6 +44,19 @@ public class FileMergingSnapshotManagerBuilder {
      */
     public FileMergingSnapshotManagerBuilder(String id) {
         this.id = id;
+    }
+
+    /** Set the max file size. */
+    public FileMergingSnapshotManagerBuilder setMaxFileSize(long maxFileSize) {
+        Preconditions.checkArgument(maxFileSize > 0);
+        this.maxFileSize = maxFileSize;
+        return this;
+    }
+
+    /** Set the type of physical file pool. */
+    public FileMergingSnapshotManagerBuilder setFilePoolType(PhysicalFilePool.Type filePoolType) {
+        this.filePoolType = filePoolType;
+        return this;
     }
 
     /**
@@ -57,6 +78,6 @@ public class FileMergingSnapshotManagerBuilder {
      */
     public FileMergingSnapshotManager build() {
         return new WithinCheckpointFileMergingSnapshotManager(
-                id, ioExecutor == null ? Runnable::run : ioExecutor);
+                id, maxFileSize, filePoolType, ioExecutor == null ? Runnable::run : ioExecutor);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/NonBlockingPhysicalFilePool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/NonBlockingPhysicalFilePool.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.filemerging;
+
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * A Non-Blocking {@link PhysicalFilePool} which will always provide usable physical file without
+ * blocking. It may create many physical files if {@link
+ * NonBlockingPhysicalFilePool#pollFile(FileMergingSnapshotManager.SubtaskKey,
+ * CheckpointedStateScope)} frequently.
+ */
+public class NonBlockingPhysicalFilePool extends PhysicalFilePool {
+
+    public NonBlockingPhysicalFilePool(
+            long maxFileSize, PhysicalFile.PhysicalFileCreator physicalFileCreator) {
+        super(maxFileSize, physicalFileCreator);
+    }
+
+    @Override
+    public boolean tryPutFile(
+            FileMergingSnapshotManager.SubtaskKey subtaskKey, PhysicalFile physicalFile) {
+        return physicalFile.getSize() < maxFileSize
+                && getFileQueue(subtaskKey, physicalFile.getScope()).offer(physicalFile);
+    }
+
+    @Override
+    @Nonnull
+    public PhysicalFile pollFile(
+            FileMergingSnapshotManager.SubtaskKey subtaskKey, CheckpointedStateScope scope)
+            throws IOException {
+        PhysicalFile physicalFile = getFileQueue(subtaskKey, scope).poll();
+        return physicalFile == null ? physicalFileCreator.perform(subtaskKey, scope) : physicalFile;
+    }
+
+    @Override
+    protected Queue<PhysicalFile> createFileQueue() {
+        return new ConcurrentLinkedQueue<>();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/PhysicalFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/PhysicalFile.java
@@ -45,6 +45,15 @@ public class PhysicalFile {
         void perform(Path filePath) throws IOException;
     }
 
+    /** Functional interface to create the physical file. */
+    @FunctionalInterface
+    public interface PhysicalFileCreator {
+        /** Create the file. */
+        PhysicalFile perform(
+                FileMergingSnapshotManager.SubtaskKey subtaskKey, CheckpointedStateScope scope)
+                throws IOException;
+    }
+
     /**
      * Output stream to the file, which keeps open for writing. It can be null if the file is
      * closed.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/PhysicalFilePool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/PhysicalFilePool.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.filemerging;
+
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+
+import javax.annotation.Nonnull;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** A pool for reusing {@link PhysicalFile}. This implementation should be thread-safe. */
+public abstract class PhysicalFilePool implements Closeable {
+
+    /** Types of supported physical file pool. */
+    public enum Type {
+        BLOCKING,
+        NON_BLOCKING
+    }
+
+    /** creator to create a physical file. */
+    protected final PhysicalFile.PhysicalFileCreator physicalFileCreator;
+
+    /** Max size for a physical file. */
+    protected final long maxFileSize;
+
+    /** Map maintaining queues of different subtasks for reusing shared physical files. */
+    protected final Map<FileMergingSnapshotManager.SubtaskKey, Queue<PhysicalFile>>
+            sharedPhysicalFilePoolBySubtask;
+
+    /** Queue maintaining exclusive physical files for reusing. */
+    protected final Queue<PhysicalFile> exclusivePhysicalFilePool;
+
+    public PhysicalFilePool(
+            long maxFileSize, PhysicalFile.PhysicalFileCreator physicalFileCreator) {
+        this.physicalFileCreator = physicalFileCreator;
+        this.maxFileSize = maxFileSize;
+        this.sharedPhysicalFilePoolBySubtask = new ConcurrentHashMap<>();
+        this.exclusivePhysicalFilePool = createFileQueue();
+    }
+
+    /**
+     * Try to put a physical file into file pool.
+     *
+     * @param subtaskKey the key of current subtask.
+     * @param physicalFile target physical file.
+     * @return true if file is in the pool, false otherwise.
+     */
+    public abstract boolean tryPutFile(
+            FileMergingSnapshotManager.SubtaskKey subtaskKey, PhysicalFile physicalFile)
+            throws IOException;
+
+    /**
+     * Poll a physical file from the pool.
+     *
+     * @param subtaskKey the key of current subtask.
+     * @param scope the scope of the checkpoint.
+     * @return a physical file.
+     */
+    @Nonnull
+    public abstract PhysicalFile pollFile(
+            FileMergingSnapshotManager.SubtaskKey subtaskKey, CheckpointedStateScope scope)
+            throws IOException;
+
+    /**
+     * Create and return a file queue.
+     *
+     * @return a created file queue.
+     */
+    protected abstract Queue<PhysicalFile> createFileQueue();
+
+    /**
+     * Get or create a file queue for specific subtaskKey and checkpoint scope.
+     *
+     * @param subtaskKey the key of current subtask.
+     * @param scope the scope of the checkpoint.
+     * @return an existing or created file queue.
+     */
+    protected Queue<PhysicalFile> getFileQueue(
+            FileMergingSnapshotManager.SubtaskKey subtaskKey, CheckpointedStateScope scope) {
+        return CheckpointedStateScope.SHARED.equals(scope)
+                ? sharedPhysicalFilePoolBySubtask.computeIfAbsent(
+                        subtaskKey, key -> createFileQueue())
+                : exclusivePhysicalFilePool;
+    }
+
+    /**
+     * Return whether the pool is empty or not.
+     *
+     * @return whether the pool is empty or not.
+     */
+    public boolean isEmpty() {
+        return sharedPhysicalFilePoolBySubtask.isEmpty() && exclusivePhysicalFilePool.isEmpty();
+    }
+
+    /**
+     * Close files in shared file pool by subtaskKey and close all files in exclusive file pool.
+     *
+     * @param subtaskKey the key of current subtask.
+     * @throws IOException if anything goes wrong when closing files.
+     */
+    public void close(FileMergingSnapshotManager.SubtaskKey subtaskKey) throws IOException {
+        if (sharedPhysicalFilePoolBySubtask.containsKey(subtaskKey)) {
+            closeFilesInQueue(sharedPhysicalFilePoolBySubtask.remove(subtaskKey));
+        }
+        closeFilesInQueue(exclusivePhysicalFilePool);
+    }
+
+    @Override
+    public void close() throws IOException {
+        closeFilesInQueue(exclusivePhysicalFilePool);
+        for (Queue<PhysicalFile> queue : sharedPhysicalFilePoolBySubtask.values()) {
+            closeFilesInQueue(queue);
+        }
+        sharedPhysicalFilePoolBySubtask.clear();
+    }
+
+    private void closeFilesInQueue(Queue<PhysicalFile> queue) throws IOException {
+        while (!queue.isEmpty()) {
+            PhysicalFile physicalFile = queue.poll();
+            if (physicalFile != null) {
+                physicalFile.close();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManager.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.checkpoint.filemerging;
 
-import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 
@@ -32,21 +31,17 @@ import java.util.concurrent.Executor;
 /** A {@link FileMergingSnapshotManager} that merging files within a checkpoint. */
 public class WithinCheckpointFileMergingSnapshotManager extends FileMergingSnapshotManagerBase {
 
-    /** A dummy subtask key to reuse files among subtasks for private states. */
-    private static final SubtaskKey DUMMY_SUBTASK_KEY = new SubtaskKey("dummy", -1, -1);
-
     /**
      * For WITHIN_BOUNDARY mode, physical files are NOT shared among multiple checkpoints. This map
      * contains all physical files that are still writable and not occupied by a writer. The key of
-     * this map consist of checkpoint id, subtask key, and checkpoint scope, which collectively
-     * determine the physical file to be reused.
+     * this map is checkpoint id, which collectively determine the physical file pool to be reused.
      */
-    private final Map<Tuple3<Long, SubtaskKey, CheckpointedStateScope>, PhysicalFile>
-            writablePhysicalFilePool;
+    private final Map<Long, PhysicalFilePool> writablePhysicalFilePool;
 
-    public WithinCheckpointFileMergingSnapshotManager(String id, Executor ioExecutor) {
+    public WithinCheckpointFileMergingSnapshotManager(
+            String id, long maxFileSize, PhysicalFilePool.Type filePoolType, Executor ioExecutor) {
         // currently there is no file size limit For WITHIN_BOUNDARY mode
-        super(id, ioExecutor);
+        super(id, maxFileSize, filePoolType, ioExecutor);
         writablePhysicalFilePool = new HashMap<>();
     }
 
@@ -69,25 +64,20 @@ public class WithinCheckpointFileMergingSnapshotManager extends FileMergingSnaps
 
     /**
      * Remove files that belongs to specific subtask and checkpoint from the reuse pool. And close
-     * these files. TODO: Refactor this in FLINK-32076.
+     * these files.
      */
     private void removeAndCloseFiles(SubtaskKey subtaskKey, long checkpointId) throws Exception {
-        Tuple3<Long, SubtaskKey, CheckpointedStateScope> fileKey =
-                Tuple3.of(checkpointId, subtaskKey, CheckpointedStateScope.SHARED);
-        PhysicalFile file;
+        PhysicalFilePool filePool;
         synchronized (writablePhysicalFilePool) {
-            file = writablePhysicalFilePool.remove(fileKey);
+            filePool = writablePhysicalFilePool.get(checkpointId);
         }
-        if (file != null) {
-            file.close();
-        }
-
-        fileKey = Tuple3.of(checkpointId, DUMMY_SUBTASK_KEY, CheckpointedStateScope.EXCLUSIVE);
-        synchronized (writablePhysicalFilePool) {
-            file = writablePhysicalFilePool.remove(fileKey);
-        }
-        if (file != null) {
-            file.close();
+        if (filePool != null) {
+            filePool.close(subtaskKey);
+            if (filePool.isEmpty()) {
+                synchronized (writablePhysicalFilePool) {
+                    writablePhysicalFilePool.remove(checkpointId);
+                }
+            }
         }
     }
 
@@ -96,52 +86,55 @@ public class WithinCheckpointFileMergingSnapshotManager extends FileMergingSnaps
     protected PhysicalFile getOrCreatePhysicalFileForCheckpoint(
             SubtaskKey subtaskKey, long checkpointId, CheckpointedStateScope scope)
             throws IOException {
-        // TODO: FLINK-32076 will add a file pool for each subtask key.
-        Tuple3<Long, SubtaskKey, CheckpointedStateScope> fileKey =
-                Tuple3.of(
-                        checkpointId,
-                        scope == CheckpointedStateScope.SHARED ? subtaskKey : DUMMY_SUBTASK_KEY,
-                        scope);
-        PhysicalFile file;
-        synchronized (writablePhysicalFilePool) {
-            file = writablePhysicalFilePool.remove(fileKey);
-            if (file == null) {
-                file = createPhysicalFile(subtaskKey, scope);
-            }
-        }
-        return file;
+        PhysicalFilePool filePool = getOrCreateFilePool(checkpointId);
+        return filePool.pollFile(subtaskKey, scope);
     }
 
     @Override
     protected void returnPhysicalFileForNextReuse(
             SubtaskKey subtaskKey, long checkpointId, PhysicalFile physicalFile)
             throws IOException {
-        // TODO: FLINK-32076 will add a file pool for reusing.
-        CheckpointedStateScope scope = physicalFile.getScope();
-        Tuple3<Long, SubtaskKey, CheckpointedStateScope> fileKey =
-                Tuple3.of(
-                        checkpointId,
-                        scope == CheckpointedStateScope.SHARED ? subtaskKey : DUMMY_SUBTASK_KEY,
-                        scope);
-        PhysicalFile current;
-        synchronized (writablePhysicalFilePool) {
-            current = writablePhysicalFilePool.putIfAbsent(fileKey, physicalFile);
-        }
-        // TODO: We sync the file when return to the reuse pool for safety. Actually it could be
-        // optimized after FLINK-32075.
         if (shouldSyncAfterClosingLogicalFile) {
             FSDataOutputStream os = physicalFile.getOutputStream();
             if (os != null) {
                 os.sync();
             }
         }
-        if (current != null && current != physicalFile) {
+
+        PhysicalFilePool physicalFilePool = getOrCreateFilePool(checkpointId);
+        if (!physicalFilePool.tryPutFile(subtaskKey, physicalFile)) {
             physicalFile.close();
         }
     }
 
     @Override
     protected void discardCheckpoint(long checkpointId) throws IOException {
-        // TODO: Discard the whole file pool for checkpoint id (When there is one after FLINK-32076)
+        PhysicalFilePool filePool;
+        synchronized (writablePhysicalFilePool) {
+            filePool = writablePhysicalFilePool.get(checkpointId);
+        }
+        if (filePool != null) {
+            filePool.close();
+        }
+    }
+
+    private PhysicalFilePool getOrCreateFilePool(long checkpointId) {
+        synchronized (writablePhysicalFilePool) {
+            PhysicalFilePool filePool = writablePhysicalFilePool.get(checkpointId);
+            if (filePool == null) {
+                filePool = createPhysicalPool();
+                writablePhysicalFilePool.put(checkpointId, filePool);
+            }
+            return filePool;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        for (PhysicalFilePool filePool : writablePhysicalFilePool.values()) {
+            filePool.close();
+        }
+        writablePhysicalFilePool.clear();
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add file pool for concurrent file reusing


## Brief change log

  - Introduce PhysicalFilePool and use it in FileMergingSnapshotManager
  - Support different type of PhysicalFilePool

## Verifying this change

This change added tests and can be verified as follows:

  - *Added testConcurrentFileReusingWithNonBlockingPool and testConcurrentFileReusingWithBlockingPool* 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), **Checkpointing**, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
