### PR TITLE
[FLINK-34565] Enhance flink kubernetes configMap to accommodate additional configuration files

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -320,6 +320,14 @@ public class KubernetesConfigOptions {
                     .withDescription(
                             "Specify the name of an existing ConfigMap that contains custom Hadoop configuration "
                                     + "to be mounted on the JobManager(s) and TaskManagers.");
+    public static final ConfigOption<List<String>> FLINK_CONFIGMAP_ADDITIONAL_RESOURCES =
+            key("kubernetes.flink.configmap.additional.resources")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "A semicolon-separated list of the local file in the client Flink config directory that needs to"
+                                    + " be attached in the Flink ConfigMap for JM and TM pod deployment.");
 
     public static final ConfigOption<Map<String, String>> JOB_MANAGER_ANNOTATIONS =
             key("kubernetes.jobmanager.annotations")

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -205,4 +205,10 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
     public boolean isHostNetworkEnabled() {
         return flinkConfig.get(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED);
     }
+
+    public List<String> getAdditionalLocalFiles() {
+        return flinkConfig
+                .getOptional(KubernetesConfigOptions.FLINK_CONFIGMAP_ADDITIONAL_RESOURCES)
+                .orElse(Collections.emptyList());
+    }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The purpose of this change is to empower users to effortlessly add additional files to the Flink ConfigMap, essential for running jobs in app mode on Kubernetes. Currently, the Flink Kubernetes client supports only a fixed set of files (flink-conf.yaml, logback-console.xml, log4j-console.properties) in the ConfigMap for JobManager and TaskManager Pods. However, in certain scenarios, users may need to include extra configuration files, such as user-defined job properties. Without this change, users are forced to employ workarounds, like manually creating and mounting ConfigMaps or Secrets, to incorporate dynamic configuration files into the JobManager and TaskManager Pods.

In my case, I aim to include log4j-cli.properties (for running specific Flink commands on each pod) and hive-site.xml (for metastore). A similar use case was discussed on the user mailing list: [link to the mailing list thread](https://lists.apache.org/thread/md2zq0dbvt2dxytdfxw16jbfh02yq0w9)

## Brief change log

The method FlinkConfMountDecorator#getLocalLogConfFiles() provides a fixed set of files that need to be included in the ConfigMap. I have modified this method to incorporate an additional set of files, which is configured through the new property 'kubernetes.flink.configmap.additional.resources'. This property allows users to specify a semicolon-separated list of local files in the client Flink config directory that should be included in the Flink ConfigMap.

## Verifying this change

This change added tests and can be verified as follows:
- Added FlinkConfMountDecoratorTest#testConfigMapAdditionalResource() which will create two dummy extra files and configure the same files in 'kubernetes.flink.configmap.additional.resources'.
- The test will verify if flinkConfMountDecorator is able to get the additional files as part of the ConfigMap or not.
- The case when this property is not configured is already covered by an existing test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable