### PR TITLE
[FLINK-34579][metrics] Introduce metric for time since last competed checkpoint

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1297,7 +1297,7 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
   </thead>
   <tbody>
     <tr>
-      <th rowspan="10"><strong>Job (only available on JobManager)</strong></th>
+      <th rowspan="11"><strong>Job (only available on JobManager)</strong></th>
       <td>lastCheckpointDuration</td>
       <td>The time it took to complete the last checkpoint (in milliseconds).</td>
       <td>Gauge</td>
@@ -1310,6 +1310,11 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
     <tr>
       <td>lastCompletedCheckpointId</td>
       <td>The identifier of the last completed checkpoint.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>lastCompletedCheckpointTimeSinceMillis</td>
+      <td>The time that has passed since the last completed checkpoint in milliseconds. If no checkpoint has been completed, this measures the time since the start of the job. After restore and before another checkpoint completes, this measures the time from the completion timestamp of the restored checkpoint.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1287,7 +1287,7 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
   </thead>
   <tbody>
     <tr>
-      <th rowspan="10"><strong>Job (only available on JobManager)</strong></th>
+      <th rowspan="11"><strong>Job (only available on JobManager)</strong></th>
       <td>lastCheckpointDuration</td>
       <td>The time it took to complete the last checkpoint (in milliseconds).</td>
       <td>Gauge</td>
@@ -1300,6 +1300,11 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
     <tr>
       <td>lastCompletedCheckpointId</td>
       <td>The identifier of the last completed checkpoint.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>lastCompletedCheckpointTimeSinceMillis</td>
+      <td>The time that has passed since the last completed checkpoint in milliseconds. If no checkpoint has been completed, this measures the time since the start of the job. After restore and before another checkpoint completes, this measures the time from the completion timestamp of the restored checkpoint.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStats.java
@@ -56,6 +56,9 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
     /** The external pointer of the checkpoint. */
     private final String externalPointer;
 
+    /** Timestamp of when the checkpoint was completed. */
+    private final long completedTimestamp;
+
     /** Flag indicating whether the checkpoint was discarded. */
     private volatile boolean discarded;
 
@@ -71,7 +74,8 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
             long persistedData,
             boolean unalignedCheckpoint,
             SubtaskStateStats latestAcknowledgedSubtask,
-            String externalPointer) {
+            String externalPointer,
+            long completedTimestamp) {
         this(
                 checkpointId,
                 triggerTimestamp,
@@ -85,7 +89,8 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
                 persistedData,
                 unalignedCheckpoint,
                 latestAcknowledgedSubtask,
-                externalPointer);
+                externalPointer,
+                completedTimestamp);
     }
 
     /**
@@ -105,6 +110,7 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
      * @param unalignedCheckpoint Whether the checkpoint is unaligned.
      * @param latestAcknowledgedSubtask The latest acknowledged subtask stats.
      * @param externalPointer Optional external path if persisted externally.
+     * @param completedTimestamp Timestamp of when the checkpoint was completed.
      */
     CompletedCheckpointStats(
             long checkpointId,
@@ -119,7 +125,8 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
             long persistedData,
             boolean unalignedCheckpoint,
             SubtaskStateStats latestAcknowledgedSubtask,
-            String externalPointer) {
+            String externalPointer,
+            long completedTimestamp) {
 
         super(checkpointId, triggerTimestamp, props, totalSubtaskCount, taskStats);
         checkArgument(
@@ -133,6 +140,7 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
         this.unalignedCheckpoint = unalignedCheckpoint;
         this.latestAcknowledgedSubtask = checkNotNull(latestAcknowledgedSubtask);
         this.externalPointer = externalPointer;
+        this.completedTimestamp = completedTimestamp;
     }
 
     @Override
@@ -174,6 +182,10 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
     @Nullable
     public SubtaskStateStats getLatestAcknowledgedSubtaskStats() {
         return latestAcknowledgedSubtask;
+    }
+
+    public long getCompletedTimestamp() {
+        return completedTimestamp;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.clock.Clock;
 
 import javax.annotation.Nullable;
 
@@ -221,7 +222,7 @@ public class PendingCheckpointStats extends AbstractCheckpointStats {
         }
     }
 
-    CompletedCheckpointStats toCompletedCheckpointStats(String externalPointer) {
+    CompletedCheckpointStats toCompletedCheckpointStats(String externalPointer, Clock clock) {
         return new CompletedCheckpointStats(
                 checkpointId,
                 triggerTimestamp,
@@ -235,7 +236,8 @@ public class PendingCheckpointStats extends AbstractCheckpointStats {
                 currentPersistedData,
                 unalignedCheckpoint,
                 latestAcknowledgedSubtask,
-                externalPointer);
+                externalPointer,
+                clock.absoluteTimeMillis());
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummaryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummaryTest.java
@@ -118,7 +118,8 @@ public class CompletedCheckpointStatsSummaryTest {
                 persistedData,
                 unalignedCheckpoint,
                 latest,
-                null);
+                null,
+                -1L);
     }
 
     /** Simply test that quantiles can be computed and fields are not permuted. */
@@ -145,7 +146,8 @@ public class CompletedCheckpointStatsSummaryTest {
                         persistedData,
                         unalignedCheckpoint,
                         new SubtaskStateStats(0, lastAck),
-                        ""));
+                        "",
+                        -1L));
         CompletedCheckpointStatsSummarySnapshot snapshot = summary.createSnapshot();
         assertThat(snapshot.getStateSizeStats().getQuantile(1)).isCloseTo(stateSize, offset(0d));
         assertThat(snapshot.getProcessedDataStats().getQuantile(1))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
@@ -370,7 +370,8 @@ public class CompletedCheckpointTest {
                         1,
                         true,
                         mock(SubtaskStateStats.class),
-                        null);
+                        null,
+                        System.currentTimeMillis());
         CompletedCheckpoint completed =
                 new CompletedCheckpoint(
                         new JobID(),
@@ -412,7 +413,8 @@ public class CompletedCheckpointTest {
                         true,
                         new SubtaskStateStats(
                                 123, 213123, 123123, 123123, 0, 0, 0, 0, 0, 0, false, true),
-                        null);
+                        null,
+                        -1L);
 
         CompletedCheckpointStats copy = CommonTestUtils.createCopySerializable(completed);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -146,7 +147,8 @@ public class PendingCheckpointStatsTest {
         // Report completed
         String externalPath = "asdjkasdjkasd";
 
-        callback.reportCompletedCheckpoint(pending.toCompletedCheckpointStats(externalPath));
+        callback.reportCompletedCheckpoint(
+                pending.toCompletedCheckpointStats(externalPath, SystemClock.getInstance()));
 
         ArgumentCaptor<CompletedCheckpointStats> args =
                 ArgumentCaptor.forClass(CompletedCheckpointStats.class);


### PR DESCRIPTION
## What is the purpose of the change

Introduces metric for time since last competed checkpoint. This metric will help us to identify jobs with checkpointing problems without first requiring to complete or fail the checkpoint first before the problem surfaces.


## Brief change log

Added metric in CheckpointStatsTracker.


## Verifying this change

CheckpointStatsTrackerTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
