### PR TITLE
[FLINK-34580][rest] Do not erase "pipeline.classpaths" config during REST job deploy

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.client.program;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ProgramDescription;
 import org.apache.flink.client.ClientUtils;
 import org.apache.flink.configuration.Configuration;
@@ -681,6 +682,11 @@ public class PackagedProgram implements AutoCloseable {
                 SavepointRestoreSettings savepointRestoreSettings) {
             this.savepointRestoreSettings = savepointRestoreSettings;
             return this;
+        }
+
+        @VisibleForTesting
+        public List<URL> getUserClassPaths() {
+            return userClassPaths;
         }
 
         public PackagedProgram build() throws ProgramInvocationException {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -182,15 +183,20 @@ public class JarHandlerUtils {
             }
 
             try {
-                return PackagedProgram.newBuilder()
-                        .setJarFile(jarFile.toFile())
-                        .setEntryPointClassName(entryClass)
-                        .setConfiguration(configuration)
-                        .setArguments(programArgs.toArray(new String[0]))
-                        .build();
+                return initPackagedProgramBuilder(configuration).build();
             } catch (final ProgramInvocationException e) {
                 throw new CompletionException(e);
             }
+        }
+
+        @VisibleForTesting
+        PackagedProgram.Builder initPackagedProgramBuilder(Configuration configuration) {
+            return PackagedProgram.newBuilder()
+                    .setJarFile(jarFile.toFile())
+                    .setEntryPointClassName(entryClass)
+                    .setConfiguration(configuration)
+                    .setUserClassPaths(getClasspaths(configuration))
+                    .setArguments(programArgs.toArray(new String[0]));
         }
 
         @VisibleForTesting
@@ -211,6 +217,21 @@ public class JarHandlerUtils {
         @VisibleForTesting
         JobID getJobId() {
             return jobId;
+        }
+    }
+
+    private static List<URL> getClasspaths(Configuration configuration) {
+        try {
+            return ConfigUtils.decodeListFromConfig(
+                    configuration, PipelineOptions.CLASSPATHS, URL::new);
+        } catch (MalformedURLException e) {
+            throw new CompletionException(
+                    new RestHandlerException(
+                            String.format(
+                                    "Failed to extract '%s' as URLs. Provided value: %s",
+                                    PipelineOptions.CLASSPATHS.key(),
+                                    configuration.get(PipelineOptions.CLASSPATHS)),
+                            HttpResponseStatus.BAD_REQUEST));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes a bug when during REST job deploy the `pipeline.classpaths` config value gets erased.

## Brief change log

- Write back the original `pipeline.classpaths` value during `applyToConfiguration`.
- Add a getter for the classpath field in `PackagedProgram.Builder` to make changes testable with a reasonable effort.

## Verifying this change

Added unit tests to cover the changed logic.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
