### PR TITLE
[WIP][FLINK-34442][table] Support optimizations for pre-partitioned data sources

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSource.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.DynamicParallelismInference;
 import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
 import org.apache.flink.connector.file.src.assigners.LocalityAwareSplitAssigner;
+import org.apache.flink.connector.file.src.assigners.PartitionAwareSplitAssigner;
 import org.apache.flink.connector.file.src.enumerate.BlockSplittingRecursiveEnumerator;
 import org.apache.flink.connector.file.src.enumerate.FileEnumerator;
 import org.apache.flink.connector.file.src.enumerate.NonSplittingRecursiveEnumerator;
@@ -40,6 +41,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -240,6 +242,12 @@ public final class FileSource<T> extends AbstractFileSource<T, FileSourceSplit>
                             ? DEFAULT_SPLITTABLE_FILE_ENUMERATOR
                             : DEFAULT_NON_SPLITTABLE_FILE_ENUMERATOR,
                     DEFAULT_SPLIT_ASSIGNER);
+        }
+
+        public FileSourceBuilder<T> withPartitionedAssigner(List<Path> partitionPaths) {
+            this.splitAssigner =
+                    initialSplits -> new PartitionAwareSplitAssigner(initialSplits, partitionPaths);
+            return this;
         }
 
         @Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/FileSplitAssigner.java
@@ -43,6 +43,17 @@ public interface FileSplitAssigner {
     Optional<FileSourceSplit> getNext(@Nullable String hostname);
 
     /**
+     * Gets the next split with the context information of the calling subtaskID and overall
+     * registered source tasks. These extra information might be useful for the split assigners to
+     * send splits to specific partitions.
+     *
+     * <p>When this method returns an empty {@code Optional}, then the set of splits is assumed to
+     * be done and the source will finish once the readers finished their current splits.
+     */
+    Optional<FileSourceSplit> getNext(
+            @Nullable String hostname, int subtaskID, int registeredTasks);
+
+    /**
      * Adds a set of splits to this assigner. This happens for example when some split processing
      * failed and the splits need to be re-added, or when new splits got discovered.
      */

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/LocalityAwareSplitAssigner.java
@@ -124,6 +124,12 @@ public class LocalityAwareSplitAssigner implements FileSplitAssigner {
     }
 
     @Override
+    public Optional<FileSourceSplit> getNext(
+            @Nullable String hostname, int subtaskID, int registeredTasks) {
+        return getNext(hostname);
+    }
+
+    @Override
     public void addSplits(Collection<FileSourceSplit> splits) {
         for (FileSourceSplit split : splits) {
             SplitWithInfo sc = new SplitWithInfo(split);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/PartitionAwareSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/PartitionAwareSplitAssigner.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.assigners;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.core.fs.Path;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link FileSplitAssigner} that assigns splits in a partitioned way. Splits belonging to
+ * specific partition can be consumed only by one source task
+ */
+@PublicEvolving
+public class PartitionAwareSplitAssigner implements FileSplitAssigner {
+
+    private final Map<Integer, List<FileSourceSplit>> partitionedSplits;
+    private final List<Path> partitionPaths;
+
+    private Map<Integer, Set<Integer>> subtaskToPartitionAssignment;
+
+    public PartitionAwareSplitAssigner(
+            Collection<FileSourceSplit> splits, List<Path> partitionPaths) {
+        this.partitionPaths = partitionPaths;
+        partitionedSplits =
+                splits.stream()
+                        .collect(
+                                Collectors.groupingBy(
+                                        split -> deriveParentIdx(split.path(), partitionPaths)));
+    }
+
+    private int deriveParentIdx(Path path, List<Path> possibleParents) {
+        for (int i = 0; i < possibleParents.size(); ++i) {
+            if (isParentPath(possibleParents.get(i), path)) {
+                return i;
+            }
+        }
+        throw new RuntimeException("Unexpected path error happened");
+    }
+
+    private boolean isParentPath(Path maybeParent, Path path) {
+        Path pathParent = path.getParent();
+        while (pathParent != null) {
+            if (pathParent.getPath().equals(maybeParent.getPath())) {
+                return true;
+            }
+            pathParent = pathParent.getParent();
+        }
+        return false;
+    }
+
+    private void initializePartitionAssignment(int registeredTasks) {
+        this.subtaskToPartitionAssignment = new HashMap<>();
+        int length = partitionedSplits.size();
+        if (length < registeredTasks) {
+            throw new IllegalArgumentException(
+                    "Number of pieces cannot be greater than the length of the list");
+        }
+
+        int quotient = length / registeredTasks;
+        int remainder = length % registeredTasks;
+
+        //        List<List<Integer>> pieces = new ArrayList<>();
+        int start = 0;
+        for (int i = 0; i < registeredTasks; i++) {
+            int end = start + quotient + (i < remainder ? 1 : 0);
+            Set<Integer> partitions = new HashSet<>();
+            for (int p = start; p < end; ++p) {
+                partitions.add(p);
+            }
+            subtaskToPartitionAssignment.put(i, partitions);
+            start = end;
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public Optional<FileSourceSplit> getNext(String hostname) {
+        throw new RuntimeException(
+                "PartitionAwareSplitAssigner only supports getNext(@Nullable String hostname, int subtaskID)");
+    }
+
+    @Override
+    public Optional<FileSourceSplit> getNext(
+            @Nullable String hostname, int subtaskID, int registeredTasks) {
+        if (subtaskToPartitionAssignment == null || subtaskToPartitionAssignment.isEmpty()) {
+            initializePartitionAssignment(registeredTasks);
+        }
+        Set<Integer> partitions =
+                subtaskToPartitionAssignment.getOrDefault(subtaskID, Collections.emptySet());
+        for (Integer p : partitions) {
+            List<FileSourceSplit> partition =
+                    partitionedSplits.getOrDefault(p, Collections.emptyList());
+            final int size = partition.size();
+            if (size != 0) {
+                return Optional.of(partition.remove(size - 1));
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void addSplits(Collection<FileSourceSplit> newSplits) {
+        for (FileSourceSplit split : newSplits) {
+            final int idx = deriveParentIdx(split.path(), partitionPaths);
+            partitionedSplits.computeIfAbsent(idx, v -> new ArrayList<>()).add(split);
+        }
+    }
+
+    @Override
+    public Collection<FileSourceSplit> remainingSplits() {
+        List<FileSourceSplit> remainingSplits = new ArrayList<>();
+        partitionedSplits.values().forEach(remainingSplits::addAll);
+        return remainingSplits;
+    }
+
+    // ------------------------------------------------------------------------
+
+    @Override
+    public String toString() {
+        return "PartitionAwareSplitAssigner " + partitionedSplits;
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/SimpleSplitAssigner.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/assigners/SimpleSplitAssigner.java
@@ -21,6 +21,8 @@ package org.apache.flink.connector.file.src.assigners;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
@@ -44,6 +46,12 @@ public class SimpleSplitAssigner implements FileSplitAssigner {
     public Optional<FileSourceSplit> getNext(String hostname) {
         final int size = splits.size();
         return size == 0 ? Optional.empty() : Optional.of(splits.remove(size - 1));
+    }
+
+    @Override
+    public Optional<FileSourceSplit> getNext(
+            @Nullable String hostname, int subtaskID, int registeredTasks) {
+        return getNext(hostname);
     }
 
     @Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
@@ -167,7 +167,8 @@ public class ContinuousFileSplitEnumerator
 
             final String hostname = nextAwaiting.getValue();
             final int awaitingSubtask = nextAwaiting.getKey();
-            final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname);
+            final Optional<FileSourceSplit> nextSplit =
+                    splitAssigner.getNext(hostname, awaitingSubtask, context.currentParallelism());
             if (nextSplit.isPresent()) {
                 context.assignSplit(nextSplit.get(), awaitingSubtask);
                 awaitingReader.remove();

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumerator.java
@@ -95,7 +95,8 @@ public class StaticFileSplitEnumerator
             LOG.info("Subtask {} {} is requesting a file source split", subtask, hostInfo);
         }
 
-        final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostname);
+        final Optional<FileSourceSplit> nextSplit =
+                splitAssigner.getNext(hostname, subtask, context.currentParallelism());
         if (nextSplit.isPresent()) {
             final FileSourceSplit split = nextSplit.get();
             context.assignSplit(split, subtask);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.file.table;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
@@ -38,6 +39,13 @@ public class FileSystemConnectorOptions {
 
     public static final ConfigOption<String> PATH =
             key("path").stringType().noDefaultValue().withDescription("The path of a directory");
+
+    public static final ConfigOption<Boolean> PARTITIONED_READ =
+            ConfigOptions.key("partitioned-read")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "The configuration option for forcing the source to read input in a partitioned manner.");
 
     public static final ConfigOption<String> PARTITION_DEFAULT_NAME =
             key("partition.default-name")

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemConnectorOptions.java
@@ -47,6 +47,13 @@ public class FileSystemConnectorOptions {
                     .withDescription(
                             "The configuration option for forcing the source to read input in a partitioned manner.");
 
+    public static final ConfigOption<String> SOURCE_PARTITIONING =
+            ConfigOptions.key("source-partitioning")
+                    .stringType()
+                    .defaultValue("hash")
+                    .withDescription(
+                            "The configuration option to indicate partitioning type of the source.");
+
     public static final ConfigOption<String> PARTITION_DEFAULT_NAME =
             key("partition.default-name")
                     .stringType()

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -104,6 +104,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(FileSystemConnectorOptions.PARTITIONED_READ);
         options.add(FileSystemConnectorOptions.PARTITION_DEFAULT_NAME);
         options.add(FileSystemConnectorOptions.SOURCE_MONITOR_INTERVAL);
         options.add(FileSystemConnectorOptions.SOURCE_REPORT_STATISTICS);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -105,6 +105,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(FileSystemConnectorOptions.PARTITIONED_READ);
+        options.add(FileSystemConnectorOptions.SOURCE_PARTITIONING);
         options.add(FileSystemConnectorOptions.PARTITION_DEFAULT_NAME);
         options.add(FileSystemConnectorOptions.SOURCE_MONITOR_INTERVAL);
         options.add(FileSystemConnectorOptions.SOURCE_REPORT_STATISTICS);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -281,7 +281,8 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
                     @Override
                     public void sendSplitRequest() {
                         operatorEventGateway.sendEventToCoordinator(
-                                new RequestSplitEvent(getLocalHostName()));
+                                new RequestSplitEvent(
+                                        String.format("%s:%s", getLocalHostName(), this)));
                     }
 
                     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsPartitioning.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsPartitioning.java
@@ -20,9 +20,7 @@ package org.apache.flink.table.connector.source.abilities;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.connector.source.ScanTableSource;
-
-import java.util.List;
-import java.util.Optional;
+import org.apache.flink.table.connector.source.partitioning.Partitioning;
 
 /**
  * Enables {@link ScanTableSource} to discover source partitions and inform the optimizer
@@ -48,14 +46,12 @@ import java.util.Optional;
  * this pre-partitioned data source to eliminate possible shuffle operation. For example, for a
  * query SELECT region, month, AVG(age) from MyTable GROUP BY region, month the optimizer takes the
  * advantage of pre-partitioned source and avoids partitioning the data w.r.t. [region,month]
- *
- * @param <T> The type of data each partition.
  */
 @PublicEvolving
-public interface SupportsPartitioning<T> {
+public interface SupportsPartitioning {
 
-    /** Returns a list of data units in each partition. */
-    Optional<List<T>> sourcePartitions();
+    /** Returns the output data partitioning that this reader guarantees. */
+    Partitioning outputPartitioning();
 
     /** Applies partitioned reading to the source operator. */
     void applyPartitionedRead();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsPartitioning.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsPartitioning.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.ScanTableSource;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Enables {@link ScanTableSource} to discover source partitions and inform the optimizer
+ * accordingly.
+ *
+ * <p>Partitions split the data stored in an external system into smaller portions that are
+ * identified by one or more string-based partition keys.
+ *
+ * <p>For example, data can be partitioned by region and within a region partitioned by month. The
+ * order of the partition keys (in the example: first by region then by month) is defined by the
+ * catalog table. A list of partitions could be:
+ *
+ * <pre>
+ *   List(
+ *     ['region'='europe', 'month'='2020-01'],
+ *     ['region'='europe', 'month'='2020-02'],
+ *     ['region'='asia', 'month'='2020-01'],
+ *     ['region'='asia', 'month'='2020-02']
+ *   )
+ * </pre>
+ *
+ * <p>In the above case (data is partitioned w.r.t. region and month) the optimizer might utilize
+ * this pre-partitioned data source to eliminate possible shuffle operation. For example, for a
+ * query SELECT region, month, AVG(age) from MyTable GROUP BY region, month the optimizer takes the
+ * advantage of pre-partitioned source and avoids partitioning the data w.r.t. [region,month]
+ *
+ * @param <T> The type of data each partition.
+ */
+@PublicEvolving
+public interface SupportsPartitioning<T> {
+
+    /** Returns a list of data units in each partition. */
+    Optional<List<T>> sourcePartitions();
+
+    /** Applies partitioned reading to the source operator. */
+    void applyPartitionedRead();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/partitioning/AnyPartitioning.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/partitioning/AnyPartitioning.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.partitioning;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.abilities.SupportsPartitioning;
+
+import java.util.Optional;
+
+/**
+ * An interface to represent the {@link Distribution#ANY} data partitioning for a data source, which
+ * is returned by {@link SupportsPartitioning#outputPartitioning()}.
+ */
+@PublicEvolving
+public class AnyPartitioning implements Partitioning {
+    @Override
+    public Optional<Integer> numPartitions() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Distribution getDistribution() {
+        return Distribution.ANY;
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/partitioning/HashPartitioning.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/partitioning/HashPartitioning.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.partitioning;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.abilities.SupportsPartitioning;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * An interface to represent the {@link Distribution#HASH} data partitioning for a data source,
+ * which is returned by {@link SupportsPartitioning#outputPartitioning()}.
+ */
+@PublicEvolving
+public interface HashPartitioning extends Partitioning {
+    default Distribution getDistribution() {
+        return Distribution.HASH;
+    }
+
+    /**
+     * Returns the partitioned columns. If the source provider does not expose this information,
+     * then {@link Optional#empty()} is returned. In this case, the the partitioned columns are
+     * derived from PARTITIONED BY clause. If the result of {@link HashPartitioning#getColumns()} is
+     * non-empty, it overrides the columns given in PARTITIONED BY clause.
+     */
+    Optional<List<Integer>> getColumns();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/partitioning/Partitioning.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/partitioning/Partitioning.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.partitioning;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.abilities.SupportsPartitioning;
+
+import java.util.Optional;
+
+/**
+ * An interface to represent the output data partitioning for a data source, which is returned by
+ * {@link SupportsPartitioning#outputPartitioning()}. Note: implementors <b>should NOT</b> directly
+ * implement this interface. Instead, they should use its subinterfaces or subclasses:
+ *
+ * <ul>
+ *   <li>{@link HashPartitioning}
+ * </ul>
+ */
+@PublicEvolving
+public interface Partitioning {
+    /**
+     * Returns the number of partitions that the data is split across. If the source provider does
+     * not expose the partition count information, then {@link Optional#empty()} is returned.
+     */
+    Optional<Integer> numPartitions();
+
+    /** Returns the distribution information of the source. */
+    Distribution getDistribution();
+
+    @PublicEvolving
+    enum Distribution {
+        ANY,
+        SINGLETON,
+        BROADCAST_DISTRIBUTED,
+        RANDOM_DISTRIBUTED,
+        ROUND_ROBIN_DISTRIBUTED,
+        HASH,
+        RANGE
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitioningSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitioningSpec.java
@@ -36,7 +36,7 @@ public final class PartitioningSpec extends SourceAbilitySpecBase {
     @Override
     public void apply(DynamicTableSource tableSource, SourceAbilityContext context) {
         if (tableSource instanceof SupportsPartitioning) {
-            ((SupportsPartitioning<?>) tableSource).applyPartitionedRead();
+            ((SupportsPartitioning) tableSource).applyPartitionedRead();
         } else {
             throw new TableException(
                     String.format(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitioningSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/PartitioningSpec.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.abilities.source;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsPartitioning;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.Objects;
+
+/**
+ * A sub-class of {@link SourceAbilitySpec} that can not only serialize/deserialize the limit value
+ * to/from JSON, but also can push the limit value into a {@link LimitPushDownSpec}.
+ */
+@JsonTypeName("Partitioning")
+public final class PartitioningSpec extends SourceAbilitySpecBase {
+
+    @Override
+    public void apply(DynamicTableSource tableSource, SourceAbilityContext context) {
+        if (tableSource instanceof SupportsPartitioning) {
+            ((SupportsPartitioning<?>) tableSource).applyPartitionedRead();
+        } else {
+            throw new TableException(
+                    String.format(
+                            "%s does not support SupportsPartitioning.",
+                            tableSource.getClass().getName()));
+        }
+    }
+
+    @Override
+    public boolean needAdjustFieldReferenceAfterProjection() {
+        return false;
+    }
+
+    @Override
+    public String getDigests(SourceAbilityContext context) {
+        return "partitionedReading";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode());
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilitySpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/source/SourceAbilitySpec.java
@@ -43,7 +43,8 @@ import java.util.Optional;
     @JsonSubTypes.Type(value = ReadingMetadataSpec.class),
     @JsonSubTypes.Type(value = WatermarkPushDownSpec.class),
     @JsonSubTypes.Type(value = SourceWatermarkSpec.class),
-    @JsonSubTypes.Type(value = AggregatePushDownSpec.class)
+    @JsonSubTypes.Type(value = AggregatePushDownSpec.class),
+    @JsonSubTypes.Type(value = PartitioningSpec.class)
 })
 @Internal
 public interface SourceAbilitySpec {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/RemoveSourceDistributionRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/RemoveSourceDistributionRule.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.batch;
+
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.abilities.SupportsPartitioning;
+import org.apache.flink.table.planner.plan.abilities.source.PartitioningSpec;
+import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalTableSourceScan;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.utils.ScanUtil;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttleImpl;
+import org.apache.calcite.rel.type.RelDataTypeField;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import scala.Option;
+
+/**
+ * Planner rule that removes ${BatchPhysicalTableSourceScan} distribution trait if it is not used by
+ * ${BatchPhysicalExchange}.
+ */
+public class RemoveSourceDistributionRule extends PushLocalAggIntoScanRuleBase {
+    public static final RemoveSourceDistributionRule INSTANCE = new RemoveSourceDistributionRule();
+
+    public RemoveSourceDistributionRule() {
+        super(operand(BatchPhysicalExchange.class, any()), "RemoveSourceDistributionRule");
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        BatchPhysicalExchange exchange = call.rel(0);
+        TableSourceFinder finder = new TableSourceFinder();
+        exchange.getInput().accept(finder);
+        Optional<BatchPhysicalTableSourceScan> scanOptional = finder.getScan();
+        if (scanOptional.isPresent()) {
+            BatchPhysicalTableSourceScan scanOp = scanOptional.get();
+
+            final TableSourceTable sourceTable = scanOp.getTable().unwrap(TableSourceTable.class);
+            if (sourceTable == null) {
+                return false;
+            }
+            return supportsSourcePartitioning(sourceTable, derivePartitioningColumns(exchange));
+        } else {
+            return false;
+        }
+    }
+
+    private List<String> derivePartitioningColumns(BatchPhysicalExchange exchange) {
+        List<Integer> partitionKeyIdx = exchange.getDistribution().getKeys();
+        return exchange.getInput().getRowType().getFieldList().stream()
+                .filter(f -> partitionKeyIdx.contains(f.getIndex()))
+                .map(RelDataTypeField::getName)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+        BatchPhysicalExchange exchange = call.rel(0);
+
+        TableSourceFinder finder = new TableSourceFinder();
+        exchange.getInput().accept(finder);
+        Optional<BatchPhysicalTableSourceScan> scanOptional = finder.getScan();
+        if (!(scanOptional.isPresent())) {
+            return;
+        }
+
+        BatchPhysicalTableSourceScan scan = scanOptional.get();
+
+        TableSourceTable newTableSourceTable = removePartitioning(scan);
+        BatchPhysicalTableSourceScan newScan =
+                new BatchPhysicalTableSourceScan(
+                        scan.getCluster(),
+                        scan.getTraitSet(),
+                        scan.getHints(),
+                        newTableSourceTable);
+
+        RelNode newTopWithNewScan = replaceScan(scan, newScan, exchange);
+
+        call.transformTo(newTopWithNewScan);
+    }
+
+    private RelNode replaceScan(
+            BatchPhysicalTableSourceScan oldScan,
+            BatchPhysicalTableSourceScan newScan,
+            RelNode node) {
+        RelNode curNode = getNode(node);
+        for (int i = 0; i < curNode.getInputs().size(); ++i) {
+            RelNode curChild = getNode(curNode.getInput(i));
+            if (curChild.equals(oldScan)) {
+                curNode.replaceInput(i, newScan);
+            } else {
+                replaceScan(oldScan, newScan, curChild);
+            }
+        }
+        return curNode;
+    }
+
+    private TableSourceTable removePartitioning(BatchPhysicalTableSourceScan scan) {
+        TableSourceTable relOptTable = scan.getTable().unwrap(TableSourceTable.class);
+        TableSourceTable oldTableSourceTable = relOptTable.unwrap(TableSourceTable.class);
+        DynamicTableSource newTableSource = oldTableSourceTable.tableSource().copy();
+
+        List<SourceAbilitySpec> newSpecs = new ArrayList<>();
+        for (SourceAbilitySpec spec : oldTableSourceTable.abilitySpecs()) {
+            if (!(spec instanceof PartitioningSpec)) {
+                newSpecs.add(spec);
+            }
+        }
+
+        return oldTableSourceTable.replace(
+                newTableSource,
+                oldTableSourceTable.getRowType(),
+                newSpecs.toArray(new SourceAbilitySpec[0]));
+    }
+
+    private boolean supportsSourcePartitioning(
+            TableSourceTable tableSourceTable, List<String> exchangeKeys) {
+        DynamicTableSource tableSource = tableSourceTable.tableSource();
+        if (!(tableSource instanceof SupportsPartitioning)) {
+            return false;
+        }
+        Option<List<String>> maybeSourcePartitionKeys = ScanUtil.getPartitionCols(tableSourceTable);
+        if (maybeSourcePartitionKeys.isEmpty()) {
+            return false;
+        }
+        List<String> sourcePartitionKeys = maybeSourcePartitionKeys.get();
+
+        // if exchange keys and source partition keys are not the same, then we need to remove
+        // partitioned read ability from the source
+        return !sourcePartitionKeys.equals(exchangeKeys);
+    }
+
+    private static RelNode getNode(RelNode node) {
+        return node instanceof HepRelVertex ? ((HepRelVertex) node).getCurrentRel() : node;
+    }
+
+    private static class TableSourceFinder extends RelShuttleImpl {
+        private boolean anotherExchangeExists = false;
+        private BatchPhysicalTableSourceScan tableSourceScan;
+
+        // Override the visit method for SingleRel
+        @Override
+        public RelNode visit(RelNode node) {
+            RelNode relNode = getNode(node);
+            if ((relNode instanceof BatchPhysicalExchange) || anotherExchangeExists) {
+                anotherExchangeExists = true;
+                return node;
+            }
+
+            if (relNode instanceof BatchPhysicalTableSourceScan) {
+                this.tableSourceScan = (BatchPhysicalTableSourceScan) relNode;
+                return relNode;
+            } else {
+                return visitChildren(relNode);
+            }
+        }
+
+        public Optional<BatchPhysicalTableSourceScan> getScan() {
+            if (anotherExchangeExists || tableSourceScan == null) {
+                return Optional.empty();
+            } else {
+                return Optional.of(tableSourceScan);
+            }
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -440,6 +440,7 @@ object FlinkBatchRuleSets {
     PushLocalSortAggIntoScanRule.INSTANCE,
     PushLocalSortAggWithSortIntoScanRule.INSTANCE,
     PushLocalSortAggWithCalcIntoScanRule.INSTANCE,
-    PushLocalSortAggWithSortAndCalcIntoScanRule.INSTANCE
+    PushLocalSortAggWithSortAndCalcIntoScanRule.INSTANCE,
+    RemoveSourceDistributionRule.INSTANCE
   )
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
@@ -19,11 +19,15 @@ package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.table.api.TableException
+import org.apache.flink.table.catalog.ResolvedCatalogTable
+import org.apache.flink.table.connector.source.abilities.SupportsPartitioning
 import org.apache.flink.table.data.{GenericRowData, RowData}
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenUtils, ExprCodeGenerator, OperatorCodeGenerator}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{DEFAULT_INPUT1_TERM, GENERIC_ROW}
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator.generateCollect
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil
+import org.apache.flink.table.planner.plan.schema.TableSourceTable
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
@@ -159,5 +163,40 @@ object ScanUtil {
         }
         index
     }.toArray
+  }
+
+  def getPartitionKeys(tableSourceTable: TableSourceTable): Option[Array[Int]] = {
+    val catalogTable =
+      tableSourceTable.contextResolvedTable.getResolvedTable[ResolvedCatalogTable]
+    val maybePartitionStrKeys = ScanUtil.getPartitionCols(tableSourceTable)
+    if (maybePartitionStrKeys.isEmpty) {
+      return None
+    }
+    val partitionStrKeys = maybePartitionStrKeys.get
+    // derive partition key indexes
+    val strCols = JavaScalaConversionUtil
+      .toScala(catalogTable.getUnresolvedSchema.getColumns)
+      .map(col => col.getName)
+
+    val partitionKeyIdxs =
+      JavaScalaConversionUtil.toScala(partitionStrKeys).map(c => strCols.indexOf(c))
+    Some(partitionKeyIdxs.toArray)
+  }
+
+  def getPartitionCols(tableSourceTable: TableSourceTable): Option[util.List[String]] = {
+    val tableSource = tableSourceTable.tableSource
+    if (!tableSource.isInstanceOf[SupportsPartitioning[_]]) {
+      return None
+    }
+
+    val sourcePartitions = tableSource.asInstanceOf[SupportsPartitioning[_]].sourcePartitions()
+    if (!sourcePartitions.isPresent) {
+      return None
+    }
+
+    val catalogTable =
+      tableSourceTable.contextResolvedTable.getResolvedTable[ResolvedCatalogTable]
+    val partitionStrKeys = catalogTable.getPartitionKeys
+    Some(partitionStrKeys)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
@@ -21,6 +21,7 @@ import org.apache.flink.api.dag.Transformation
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.catalog.ResolvedCatalogTable
 import org.apache.flink.table.connector.source.abilities.SupportsPartitioning
+import org.apache.flink.table.connector.source.partitioning.Partitioning
 import org.apache.flink.table.data.{GenericRowData, RowData}
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenUtils, ExprCodeGenerator, OperatorCodeGenerator}
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{DEFAULT_INPUT1_TERM, GENERIC_ROW}
@@ -185,12 +186,13 @@ object ScanUtil {
 
   def getPartitionCols(tableSourceTable: TableSourceTable): Option[util.List[String]] = {
     val tableSource = tableSourceTable.tableSource
-    if (!tableSource.isInstanceOf[SupportsPartitioning[_]]) {
+    if (!tableSource.isInstanceOf[SupportsPartitioning]) {
       return None
     }
 
-    val sourcePartitions = tableSource.asInstanceOf[SupportsPartitioning[_]].sourcePartitions()
-    if (!sourcePartitions.isPresent) {
+    val distribution =
+      tableSource.asInstanceOf[SupportsPartitioning].outputPartitioning().getDistribution
+    if (distribution == Partitioning.Distribution.ANY) {
       return None
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/BatchFileSystemTableSourceTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/BatchFileSystemTableSourceTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.planner.plan.utils.OperatorType;
+import org.apache.flink.table.planner.utils.BatchTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
+
+/** Test for {@link FileSystemTableSource}. */
+class BatchFileSystemTableSourceTest extends TableTestBase {
+
+    private BatchTableTestUtil util;
+
+    @TempDir protected Path fileTempFolder;
+    protected String resultPath;
+
+    @BeforeEach
+    void setup() throws IOException, ExecutionException, InterruptedException {
+        resultPath = TempDirUtils.newFolder(fileTempFolder).toURI().getPath();
+        util = batchTestUtil(TableConfig.getDefault());
+        TableEnvironment tEnv = util.getTableEnv();
+
+        String srcTableDdl =
+                "CREATE TABLE MyTable (\n"
+                        + "  a bigint,\n"
+                        + "  b int,\n"
+                        + "  c varchar\n"
+                        + ") with (\n"
+                        + " 'connector' = 'filesystem',"
+                        + " 'format' = 'testcsv',"
+                        + " 'path' = '"
+                        + resultPath
+                        + "/no-partition')";
+        tEnv.executeSql(srcTableDdl).await();
+
+        String srcTableWithPartitionsDdl =
+                "CREATE TABLE MyTableP (\n"
+                        + "  a bigint,\n"
+                        + "  b int,\n"
+                        + "  c varchar\n"
+                        + ") PARTITIONED BY (a, b) with (\n"
+                        + " 'connector' = 'filesystem',"
+                        + " 'format' = 'testcsv',"
+                        + " 'path' = '"
+                        + resultPath
+                        + "/partitioned', "
+                        + " 'partitioned-read' = 'true')";
+        tEnv.executeSql(srcTableWithPartitionsDdl).await();
+
+        tEnv.executeSql(
+                        "insert into MyTable values (1, 2, 'a'), (3, 4, 'b'), (5, 6, 'c'), (7, 8, 'd')")
+                .await();
+
+        tEnv.executeSql("insert into MyTableP partition(a='1', b='1') values ('a')").await();
+        tEnv.executeSql("insert into MyTableP partition(a='1', b='2') values ('b')").await();
+        tEnv.executeSql("insert into MyTableP partition(a='2', b='1') values ('c')").await();
+        tEnv.executeSql("insert into MyTableP partition(a='2', b='2') values ('d')").await();
+    }
+
+    @Test
+    void testShouldNotEliminatePartitioning1() {
+        setHashAgg();
+        util.verifyExecPlan("select a, b, count (c) from MyTable group by a, b");
+    }
+
+    @Test
+    void testShouldNotEliminatePartitioning2() {
+        setSortAgg();
+        util.verifyExecPlan("select a, b, count (c) from MyTable group by a, b");
+    }
+
+    @Test
+    void testShouldNotEliminatePartitioning3() {
+        setHashAgg();
+        util.verifyExecPlan("select c, b, count (a) from MyTableP group by c, b");
+    }
+
+    @Test
+    void testShouldNotEliminatePartitioning4() {
+        setHashAgg();
+        util.verifyExecPlan("select a, count (c) from MyTableP group by a");
+    }
+
+    @Test
+    void testShouldEliminatePartitioning1() {
+        setHashAgg();
+        util.verifyExecPlan("select a, b, count (c) from MyTableP group by a, b");
+    }
+
+    @Test
+    void testShouldEliminatePartitioning2() {
+        setHashAgg();
+        util.verifyExecPlan("select b, a, count (c) from MyTableP group by b, a");
+    }
+
+    @Test
+    void testShouldEliminatePartitioning3() {
+        util.verifyExecPlan("select a, b, count (c) from MyTableP group by a, b");
+    }
+
+    @Test
+    void testShouldEliminatePartitioning4() {
+        setHashAgg();
+        util.verifyExecPlan("select a, count (c) from MyTableP group by a, b");
+    }
+
+    void setSortAgg() {
+        util.tableEnv()
+                .getConfig()
+                .set(
+                        ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS,
+                        OperatorType.HashAgg.toString());
+    }
+
+    void setHashAgg() {
+        util.tableEnv()
+                .getConfig()
+                .set(
+                        ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS,
+                        OperatorType.SortAgg.toString());
+    }
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/connector/file/table/BatchFileSystemTableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/connector/file/table/BatchFileSystemTableSourceTest.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+	<TestCase name="testShouldNotEliminatePartitioning4">
+		<Resource name="sql">
+			<![CDATA[select a, count (c) from MyTableP group by a]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+HashAggregate(isMerge=[true], groupBy=[a], select=[a, Final_COUNT(count$0) AS EXPR$1])
++- Exchange(distribution=[hash[a]])
+   +- LocalHashAggregate(groupBy=[a], select=[a, Partial_COUNT(c) AS count$0])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTableP, project=[a, c], metadata=[]]], fields=[a, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testShouldNotEliminatePartitioning3">
+		<Resource name="sql">
+			<![CDATA[select c, b, count (a) from MyTableP group by c, b]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[c, b, EXPR$2])
++- HashAggregate(isMerge=[true], groupBy=[b, c], select=[b, c, Final_COUNT(count$0) AS EXPR$2])
+   +- Exchange(distribution=[hash[b, c]])
+      +- LocalHashAggregate(groupBy=[b, c], select=[b, c, Partial_COUNT(a) AS count$0])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTableP]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testShouldNotEliminatePartitioning2">
+		<Resource name="sql">
+			<![CDATA[select a, b, count (c) from MyTable group by a, b]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+SortAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_COUNT(count$0) AS EXPR$2])
++- Exchange(distribution=[forward])
+   +- Sort(orderBy=[a ASC, b ASC])
+      +- Exchange(distribution=[hash[a, b]])
+         +- LocalSortAggregate(groupBy=[a, b], select=[a, b, Partial_COUNT(c) AS count$0])
+            +- Exchange(distribution=[forward])
+               +- Sort(orderBy=[a ASC, b ASC])
+                  +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testShouldNotEliminatePartitioning1">
+		<Resource name="sql">
+			<![CDATA[select a, b, count (c) from MyTable group by a, b]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+HashAggregate(isMerge=[true], groupBy=[a, b], select=[a, b, Final_COUNT(count$0) AS EXPR$2])
++- Exchange(distribution=[hash[a, b]])
+   +- LocalHashAggregate(groupBy=[a, b], select=[a, b, Partial_COUNT(c) AS count$0])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testShouldEliminatePartitioning4">
+		<Resource name="sql">
+			<![CDATA[select a, count (c) from MyTableP group by a, b]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[a, EXPR$1])
++- HashAggregate(isMerge=[false], groupBy=[a, b], select=[a, b, COUNT(c) AS EXPR$1])
+   +- Exchange(distribution=[keep_input_as_is[hash[a, b]]])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTableP, partitionedReading]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testShouldEliminatePartitioning3">
+		<Resource name="sql">
+			<![CDATA[select a, b, count (c) from MyTableP group by a, b]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+SortAggregate(isMerge=[false], groupBy=[a, b], select=[a, b, COUNT(c) AS EXPR$2])
++- Exchange(distribution=[forward])
+   +- Sort(orderBy=[a ASC, b ASC])
+      +- Exchange(distribution=[keep_input_as_is[hash[a, b]]])
+         +- TableSourceScan(table=[[default_catalog, default_database, MyTableP, partitionedReading]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testShouldEliminatePartitioning2">
+		<Resource name="sql">
+			<![CDATA[select b, a, count (c) from MyTableP group by b, a]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[b, a, EXPR$2])
++- HashAggregate(isMerge=[false], groupBy=[a, b], select=[a, b, COUNT(c) AS EXPR$2])
+   +- Exchange(distribution=[keep_input_as_is[hash[a, b]]])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTableP, partitionedReading]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testShouldEliminatePartitioning1">
+		<Resource name="sql">
+			<![CDATA[select a, b, count (c) from MyTableP group by a, b]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+HashAggregate(isMerge=[false], groupBy=[a, b], select=[a, b, COUNT(c) AS EXPR$2])
++- Exchange(distribution=[keep_input_as_is[hash[a, b]]])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTableP, partitionedReading]], fields=[a, b, c])
+]]>
+		</Resource>
+	</TestCase>
+</Root>


### PR DESCRIPTION
## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
