### PR TITLE
[FLINK-34582][realse][python] Updates cibuildwheel to support cpython 3.11 wheel package

### DIFF
--- a/tools/azure-pipelines/build-python-wheels.yml
+++ b/tools/azure-pipelines/build-python-wheels.yml
@@ -33,11 +33,11 @@ jobs:
     steps:
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: '3.9'
+          versionSpec: '3.11'
       - script: |
           cd flink-python
           python -m pip install --upgrade pip
-          pip install cibuildwheel==2.8.0
+          pip install cibuildwheel==2.16.5
           cibuildwheel --platform macos --output-dir dist .
       - task: PublishPipelineArtifact@0
         inputs:


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will update cibuildwheel to support cpython 3.11 wheel package*


## Brief change log

  - *Updates cibuildwheel to support cpython 3.11 wheel package*


## Verifying this change

  - *Trigger build wheel mannually*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
