### PR TITLE
[FLINK-34617][docs] Correct the Javadoc of org.apache.flink.api.common.time.Time

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/time/Time.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/time/Time.java
@@ -32,9 +32,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * The definition of a time interval. Similar to a simpler version of {@link java.time.Duration}.
  *
- * <p>Note: This class will fully replace org.apache.flink.streaming.api.windowing.time.Time in
- * Flink 2.0
- *
  * @deprecated Use {@link Duration}
  */
 @Deprecated


### PR DESCRIPTION
## What is the purpose of the change

Correct the Javadoc of `org.apache.flink.api.common.time.Time`

## Brief change log

Correct the Javadoc of `org.apache.flink.api.common.time.Time`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


This change added tests and can be verified as follows:


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
