### PR TITLE
[FLINK-34620][formats][protobuf] add support of recursive schemas to PbToRowTypeUtil

### DIFF
--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/ProtobufTestHelper.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/ProtobufTestHelper.java
@@ -77,15 +77,39 @@ public class ProtobufTestHelper {
                 row,
                 messageClass,
                 new PbFormatConfig(messageClass.getName(), false, false, ""),
-                enumAsInt);
+                enumAsInt,
+                0);
+    }
+
+    public static byte[] rowToPbBytes(
+            RowData row, Class messageClass, boolean enumAsInt, int recursiveFieldMaxDepth)
+            throws Exception {
+        return rowToPbBytes(
+                row,
+                messageClass,
+                new PbFormatConfig(messageClass.getName(), false, false, ""),
+                enumAsInt,
+                recursiveFieldMaxDepth);
     }
 
     public static byte[] rowToPbBytes(
             RowData row, Class messageClass, PbFormatConfig formatConfig, boolean enumAsInt)
             throws Exception {
+        return rowToPbBytes(row, messageClass, formatConfig, enumAsInt, 0);
+    }
+
+    public static byte[] rowToPbBytes(
+            RowData row,
+            Class messageClass,
+            PbFormatConfig formatConfig,
+            boolean enumAsInt,
+            int recursiveFieldMaxDepth)
+            throws Exception {
         RowType rowType =
                 PbToRowTypeUtil.generateRowType(
-                        PbFormatUtils.getDescriptor(messageClass.getName()), enumAsInt);
+                        PbFormatUtils.getDescriptor(messageClass.getName()),
+                        enumAsInt,
+                        recursiveFieldMaxDepth);
         row = validateRow(row, rowType);
         PbRowDataSerializationSchema serializationSchema =
                 new PbRowDataSerializationSchema(rowType, formatConfig);
@@ -95,7 +119,7 @@ public class ProtobufTestHelper {
     }
 
     public static RowData pbBytesToRow(Class messageClass, byte[] bytes) throws Exception {
-        return pbBytesToRow(messageClass, bytes, false);
+        return pbBytesToRow(messageClass, bytes, false, 0);
     }
 
     public static RowData pbBytesToRow(Class messageClass, byte[] bytes, boolean enumAsInt)
@@ -104,15 +128,39 @@ public class ProtobufTestHelper {
                 messageClass,
                 bytes,
                 new PbFormatConfig(messageClass.getName(), false, false, ""),
-                enumAsInt);
+                enumAsInt,
+                0);
+    }
+
+    public static RowData pbBytesToRow(
+            Class messageClass, byte[] bytes, boolean enumAsInt, int recursiveFieldMaxDepth)
+            throws Exception {
+        return pbBytesToRow(
+                messageClass,
+                bytes,
+                new PbFormatConfig(messageClass.getName(), false, false, ""),
+                enumAsInt,
+                recursiveFieldMaxDepth);
     }
 
     public static RowData pbBytesToRow(
             Class messageClass, byte[] bytes, PbFormatConfig formatConfig, boolean enumAsInt)
             throws Exception {
+        return pbBytesToRow(messageClass, bytes, formatConfig, enumAsInt, 0);
+    }
+
+    public static RowData pbBytesToRow(
+            Class messageClass,
+            byte[] bytes,
+            PbFormatConfig formatConfig,
+            boolean enumAsInt,
+            int recursiveFieldMaxDepth)
+            throws Exception {
         RowType rowType =
                 PbToRowTypeUtil.generateRowType(
-                        PbFormatUtils.getDescriptor(messageClass.getName()), enumAsInt);
+                        PbFormatUtils.getDescriptor(messageClass.getName()),
+                        enumAsInt,
+                        recursiveFieldMaxDepth);
         PbRowDataDeserializationSchema deserializationSchema =
                 new PbRowDataDeserializationSchema(
                         rowType, InternalTypeInfo.of(rowType), formatConfig);

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveProtoToRowTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveProtoToRowTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.formats.protobuf.testproto.RecursiveMessageClass;
+import org.apache.flink.formats.protobuf.util.PbToRowTypeUtil;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/** Test conversion of proto message data with recursive schema to flink internal data. */
+public class RecursiveProtoToRowTest {
+    @Test
+    public void testRecursiveMessage() throws Exception {
+        RecursiveMessageClass.RecursiveMessage message =
+                RecursiveMessageClass.RecursiveMessage.newBuilder()
+                        .setId(0)
+                        .setMessage(
+                                RecursiveMessageClass.RecursiveMessage.newBuilder()
+                                        .setId(1)
+                                        .setMessage(
+                                                RecursiveMessageClass.RecursiveMessage.newBuilder()
+                                                        .setId(2)
+                                                        .setMessage(
+                                                                RecursiveMessageClass
+                                                                        .RecursiveMessage
+                                                                        .newBuilder()
+                                                                        .setId(3)
+                                                                        .build())
+                                                        .build())
+                                        .build())
+                        .build();
+
+        int recursiveFieldMaxDepth = 2;
+        RowData row =
+                ProtobufTestHelper.pbBytesToRow(
+                        RecursiveMessageClass.RecursiveMessage.class,
+                        message.toByteArray(),
+                        false,
+                        recursiveFieldMaxDepth);
+
+        RowType schema =
+                PbToRowTypeUtil.generateRowType(
+                        RecursiveMessageClass.RecursiveMessage.getDescriptor(), 2);
+        assertEquals(0, row.getInt(0));
+        assertEquals(1, row.getRow(1, 2).getInt(0));
+        assertEquals(2, row.getRow(1, 2).getRow(1, 2).getInt(0));
+
+        //       recursive field on level 2 will be removed from the schema
+        assertThrows(
+                ArrayIndexOutOfBoundsException.class,
+                () -> row.getRow(1, 2).getRow(1, 2).getRow(1, 2));
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveRowToProtoTest.java
+++ b/flink-formats/flink-protobuf/src/test/java/org/apache/flink/formats/protobuf/RecursiveRowToProtoTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf;
+
+import org.apache.flink.formats.protobuf.testproto.RecursiveMessageClass;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test conversion of folded flink internal rows to proto data. */
+public class RecursiveRowToProtoTest {
+    @Test
+    public void testRecursiveMessage() throws Exception {
+
+        RowData subRowLevel4 = GenericRowData.of(4);
+        RowData subRowLevel3 = GenericRowData.of(3, subRowLevel4);
+        RowData subRowLevel2 = GenericRowData.of(2, subRowLevel3);
+        RowData subRowLevel1 = GenericRowData.of(1, subRowLevel2);
+        RowData row = GenericRowData.of(99, subRowLevel1);
+        int recursiveFieldMaxDepth = 2;
+
+        byte[] bytes =
+                ProtobufTestHelper.rowToPbBytes(
+                        row,
+                        RecursiveMessageClass.RecursiveMessage.class,
+                        false,
+                        recursiveFieldMaxDepth);
+        RecursiveMessageClass.RecursiveMessage recursiveMessageTest =
+                RecursiveMessageClass.RecursiveMessage.parseFrom(bytes);
+
+        assertEquals(99, recursiveMessageTest.getId());
+        assertEquals(1, recursiveMessageTest.getMessage().getId());
+        assertEquals(2, recursiveMessageTest.getMessage().getMessage().getId());
+
+        // recursive schema is trimmed on the level=`recursiveFieldMaxDepth+1`.
+        // so on the next this will return a default value - 0
+        assertEquals(0, recursiveMessageTest.getMessage().getMessage().getMessage().getId());
+    }
+}

--- a/flink-formats/flink-protobuf/src/test/proto/test_recursive_schema.proto
+++ b/flink-formats/flink-protobuf/src/test/proto/test_recursive_schema.proto
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ syntax = "proto3";
+
+ package org.apache.flink.formats.protobuf.testproto;
+
+ option java_package = "org.apache.flink.formats.protobuf.testproto";
+ option java_outer_classname = "RecursiveMessageClass";
+
+ message RecursiveMessage {
+   int32 id = 1;
+   RecursiveMessage message = 2;
+ }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The current version of `PbToRowTypeUtil.generateRowType` doesn't support recursive protobuf schemas like
```
message RecursiveMessage {
int32 id = 1;
RecursiveMessage message = 2;
} 
```
It throws `java.lang.StackOverflowError`

This could be implemented by trimming the recursion. Same approach is used in Apache Spark, for example. [GitHub](https://github.com/apache/spark/blob/master/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala#L178)

then output Table schemas for the above proto-schema will be like this:
```
recursiveFieldMaxDepth=0: message: ROW< id: INTEGER > 
recursiveFieldMaxDepth=1: message: ROW< id: INTEGER, message: ROW< id: INTEGER > >
recursiveFieldMaxDepth=2: message: ROW< id: INTEGER, message: ROW< id: INTEGER, message: ROW< id: INTEGER > > > 
```

## Brief change log

- trim recursive schema by setting `recursiveFieldMaxDepth` parameter


## Verifying this change

This change is already covered by all existing unit tests and e2e tests for the Protobuf format for correctness. And I also added a couple of new test.

I also tested this for the use case in my company

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? ~yes
  - If yes, how is the feature documented? JavaDocs
