### PR TITLE
[FLINK-34622][docs] fix typo in execution_mode.md

### DIFF
--- a/docs/content.zh/docs/dev/datastream/execution_mode.md
+++ b/docs/content.zh/docs/dev/datastream/execution_mode.md
@@ -49,7 +49,7 @@ Apache Flink 对流处理和批处理采取统一的处理方式，这意味着�
 
 ## 配置批执行模式
 
-执行模式可以通过 `execute.runtime-mode` 设置来配置。有三种可选的值：
+执行模式可以通过 `execution.runtime-mode` 设置来配置。有三种可选的值：
 
  - `STREAMING`: 经典 DataStream 执行模式（默认)
  - `BATCH`: 在 DataStream API 上进行批量式执行


### PR DESCRIPTION
## What is the purpose of the change

fix typo in execution_mode.md


## Brief change log

  - Replace `execute.runtime-mode` with `execution.runtime-mode` in Chinese documents


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
