### PR TITLE
[FLINK-34647][core] Optimize Path normalization

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
@@ -63,6 +63,9 @@ public class Path implements IOReadableWritable, Serializable {
     /** A pre-compiled regex/state-machine to match the windows drive pattern. */
     private static final Pattern WINDOWS_ROOT_DIR_REGEX = Pattern.compile("/\\p{Alpha}+:/");
 
+    /** A pre-compiled regex to identify duplicate consecutive slashes. */
+    private static final Pattern DUPLICATE_CONSECUTIVE_SLASHES = Pattern.compile("/{2,}");
+
     /** The internal representation of the path, a hierarchical URI. */
     private URI uri;
 
@@ -245,7 +248,9 @@ public class Path implements IOReadableWritable, Serializable {
     private String normalizePath(String path) {
         // remove consecutive slashes & backslashes
         path = path.replace("\\", "/");
-        path = path.replaceAll("/+", "/");
+        if (path.contains("//")) {
+            path = DUPLICATE_CONSECUTIVE_SLASHES.matcher(path).replaceAll("/");
+        }
 
         // remove tailing separator
         if (path.endsWith(SEPARATOR)


### PR DESCRIPTION
## What is the purpose of the change

Reduce allocations as part of `Path` normalization, triggered as part of checkpointing.

Example from Flink job JFR:

![image](https://github.com/apache/flink/assets/54594/444287e4-bae1-47e3-a0e1-1e0da07b8f57)


## Brief change log

  - Perform allocation-free search for non-normalized duplicate slashes.
  - Precompile regex for matching consecutive slashes


## Verifying this change

This change is already covered by existing tests:

 - [PathTest](https://github.com/apache/flink/blob/master/flink-core/src/test/java/org/apache/flink/core/fs/PathTest.java)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes - checkpointing
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
