### PR TITLE
[FLINK-32513][core] Add predecessor caching

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
@@ -22,10 +22,9 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.core.testutils.OneShotLatch;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,23 +32,21 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link Transformation}. */
-public class TransformationTest extends TestLogger {
+class TransformationTest {
 
     private Transformation<Void> transformation;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         transformation = new TestTransformation<>("t", null, 1);
     }
 
     @Test
-    public void testGetNewNodeIdIsThreadSafe() throws Exception {
+    void testGetNewNodeIdIsThreadSafe() throws Exception {
         final int numThreads = 10;
         final int numIdsPerThread = 100;
 
@@ -84,43 +81,57 @@ public class TransformationTest extends TestLogger {
         final Set<Integer> deduplicatedIds =
                 idLists.stream().flatMap(List::stream).collect(Collectors.toSet());
 
-        assertEquals(numThreads * numIdsPerThread, deduplicatedIds.size());
+        assertThat(numThreads * numIdsPerThread).isEqualTo(deduplicatedIds.size());
     }
 
     @Test
-    public void testDeclareManagedMemoryUseCase() {
+    void testDeclareManagedMemoryUseCase() {
         transformation.declareManagedMemoryUseCaseAtOperatorScope(
                 ManagedMemoryUseCase.OPERATOR, 123);
         transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.STATE_BACKEND);
         assertThat(
-                transformation
-                        .getManagedMemoryOperatorScopeUseCaseWeights()
-                        .get(ManagedMemoryUseCase.OPERATOR),
-                is(123));
-        assertThat(
-                transformation.getManagedMemorySlotScopeUseCases(),
-                contains(ManagedMemoryUseCase.STATE_BACKEND));
+                        transformation
+                                .getManagedMemoryOperatorScopeUseCaseWeights()
+                                .get(ManagedMemoryUseCase.OPERATOR))
+                .isEqualTo(123);
+        assertThat(transformation.getManagedMemorySlotScopeUseCases())
+                .contains(ManagedMemoryUseCase.STATE_BACKEND);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testDeclareManagedMemoryOperatorScopeUseCaseFailWrongScope() {
-        transformation.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.PYTHON, 123);
+    @Test
+    void testDeclareManagedMemoryOperatorScopeUseCaseFailWrongScope() {
+        assertThatThrownBy(
+                        () ->
+                                transformation.declareManagedMemoryUseCaseAtOperatorScope(
+                                        ManagedMemoryUseCase.PYTHON, 123))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testDeclareManagedMemoryOperatorScopeUseCaseFailZeroWeight() {
-        transformation.declareManagedMemoryUseCaseAtOperatorScope(ManagedMemoryUseCase.OPERATOR, 0);
+    @Test
+    void testDeclareManagedMemoryOperatorScopeUseCaseFailZeroWeight() {
+        assertThatThrownBy(
+                        () ->
+                                transformation.declareManagedMemoryUseCaseAtOperatorScope(
+                                        ManagedMemoryUseCase.OPERATOR, 0))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testDeclareManagedMemoryOperatorScopeUseCaseFailNegativeWeight() {
-        transformation.declareManagedMemoryUseCaseAtOperatorScope(
-                ManagedMemoryUseCase.OPERATOR, -1);
+    @Test
+    void testDeclareManagedMemoryOperatorScopeUseCaseFailNegativeWeight() {
+        assertThatThrownBy(
+                        () ->
+                                transformation.declareManagedMemoryUseCaseAtOperatorScope(
+                                        ManagedMemoryUseCase.OPERATOR, -1))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testDeclareManagedMemorySlotScopeUseCaseFailWrongScope() {
-        transformation.declareManagedMemoryUseCaseAtSlotScope(ManagedMemoryUseCase.OPERATOR);
+    @Test
+    void testDeclareManagedMemorySlotScopeUseCaseFailWrongScope() {
+        assertThatThrownBy(
+                        () ->
+                                transformation.declareManagedMemoryUseCaseAtSlotScope(
+                                        ManagedMemoryUseCase.OPERATOR))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     /** A test implementation of {@link Transformation}. */

--- a/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
@@ -142,7 +142,7 @@ class TransformationTest {
         }
 
         @Override
-        public List<Transformation<?>> getTransitivePredecessors() {
+        protected List<Transformation<?>> getTransitivePredecessorsInternal() {
             return Collections.emptyList();
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractBroadcastStateTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractBroadcastStateTransformation.java
@@ -26,6 +26,8 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -103,12 +105,10 @@ public class AbstractBroadcastStateTransformation<IN1, IN2, OUT>
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
-        final List<Transformation<?>> predecessors = new ArrayList<>();
-        predecessors.add(this);
-        predecessors.add(regularInput);
-        predecessors.add(broadcastInput);
-        return predecessors;
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
+        return Stream.of(this, regularInput, broadcastInput)
+                .distinct()
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
@@ -76,10 +76,14 @@ public abstract class AbstractMultipleInputTransformation<OUT> extends PhysicalT
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
-        return inputs.stream()
-                .flatMap(input -> input.getTransitivePredecessors().stream())
-                .collect(Collectors.toList());
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
+        List<Transformation<?>> predecessors =
+                getInputs().stream()
+                        .flatMap(input -> input.getTransitivePredecessors().stream())
+                        .distinct()
+                        .collect(Collectors.toList());
+        predecessors.add(this);
+        return predecessors;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CacheTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CacheTransformation.java
@@ -57,7 +57,7 @@ public class CacheTransformation<T> extends Transformation<T> {
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         if (isCached) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformation.java
@@ -106,7 +106,7 @@ public class CoFeedbackTransformation<F> extends Transformation<F> {
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         return Collections.singletonList(this);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/FeedbackTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/FeedbackTransformation.java
@@ -102,7 +102,7 @@ public class FeedbackTransformation<T> extends Transformation<T> {
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         result.addAll(input.getTransitivePredecessors());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
@@ -136,7 +136,7 @@ public class LegacySinkTransformation<T> extends PhysicalTransformation<T> {
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         result.addAll(input.getTransitivePredecessors());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
@@ -92,7 +92,7 @@ public class LegacySourceTransformation<T> extends PhysicalTransformation<T>
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         return Collections.singletonList(this);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -168,7 +168,7 @@ public class OneInputTransformation<IN, OUT> extends PhysicalTransformation<OUT>
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         result.addAll(input.getTransitivePredecessors());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PartitionTransformation.java
@@ -89,7 +89,7 @@ public class PartitionTransformation<T> extends Transformation<T> {
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         result.addAll(input.getTransitivePredecessors());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
@@ -89,7 +89,7 @@ public final class ReduceTransformation<IN, K> extends PhysicalTransformation<IN
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         result.addAll(input.getTransitivePredecessors());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SideOutputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SideOutputTransformation.java
@@ -53,7 +53,7 @@ public class SideOutputTransformation<T> extends Transformation<T> {
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         result.addAll(input.getTransitivePredecessors());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
@@ -73,7 +73,7 @@ public class SinkTransformation<InputT, OutputT> extends PhysicalTransformation<
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         final List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         result.addAll(input.getTransitivePredecessors());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
@@ -92,7 +92,7 @@ public class SourceTransformation<OUT, SplitT extends SourceSplit, EnumChkT>
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         return Collections.singletonList(this);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformationWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformationWrapper.java
@@ -58,7 +58,7 @@ public class SourceTransformationWrapper<T> extends Transformation<T> {
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         result.addAll(input.getTransitivePredecessors());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TimestampsAndWatermarksTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TimestampsAndWatermarksTransformation.java
@@ -77,7 +77,7 @@ public class TimestampsAndWatermarksTransformation<IN> extends PhysicalTransform
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         List<Transformation<?>> transformations = Lists.newArrayList();
         transformations.add(this);
         transformations.addAll(input.getTransitivePredecessors());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
@@ -28,10 +28,10 @@ import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This Transformation represents the application of a {@link TwoInputStreamOperator} to two input
@@ -217,12 +217,14 @@ public class TwoInputTransformation<IN1, IN2, OUT> extends PhysicalTransformatio
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
-        List<Transformation<?>> result = Lists.newArrayList();
-        result.add(this);
-        result.addAll(input1.getTransitivePredecessors());
-        result.addAll(input2.getTransitivePredecessors());
-        return result;
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
+        List<Transformation<?>> predecessors =
+                Stream.of(input1, input2)
+                        .flatMap(input -> input.getTransitivePredecessors().stream())
+                        .distinct()
+                        .collect(Collectors.toList());
+        predecessors.add(this);
+        return predecessors;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/UnionTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/UnionTransformation.java
@@ -25,6 +25,7 @@ import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This transformation represents a union of several input {@link Transformation Transformations}.
@@ -63,12 +64,13 @@ public class UnionTransformation<T> extends Transformation<T> {
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
-        List<Transformation<?>> result = Lists.newArrayList();
-        result.add(this);
-        for (Transformation<T> input : inputs) {
-            result.addAll(input.getTransitivePredecessors());
-        }
-        return result;
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
+        List<Transformation<?>> predecessors =
+                inputs.stream()
+                        .flatMap(input -> input.getTransitivePredecessors().stream())
+                        .distinct()
+                        .collect(Collectors.toList());
+        predecessors.add(this);
+        return predecessors;
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -1024,7 +1024,7 @@ class StreamGraphGeneratorTest {
         }
 
         @Override
-        public List<Transformation<?>> getTransitivePredecessors() {
+        protected List<Transformation<?>> getTransitivePredecessorsInternal() {
             return Collections.emptyList();
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/GetTransitivePredecessorsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/transformations/GetTransitivePredecessorsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@code getTransitivePredecessors} method of {@link Transformation}. */
+class GetTransitivePredecessorsTest {
+
+    private TestTransformation<Integer> commonNode;
+    private Transformation<Integer> midNode;
+
+    @BeforeEach
+    void setup() {
+        commonNode = new TestTransformation<>("commonNode", new MockIntegerTypeInfo(), 1);
+        midNode =
+                new OneInputTransformation<>(
+                        commonNode,
+                        "midNode",
+                        new DummyOneInputOperator(),
+                        new MockIntegerTypeInfo(),
+                        1);
+    }
+
+    @Test
+    void testTwoInputTransformation() {
+        Transformation<Integer> topNode =
+                new TwoInputTransformation<>(
+                        commonNode,
+                        midNode,
+                        "topNode",
+                        new DummyTwoInputOperator<>(),
+                        midNode.getOutputType(),
+                        1);
+        List<Transformation<?>> predecessors = topNode.getTransitivePredecessors();
+        assertThat(predecessors.size()).isEqualTo(3);
+        assertThat(commonNode.getNumGetTransitivePredecessor()).isEqualTo(1);
+    }
+
+    @Test
+    void testUnionTransformation() {
+        Transformation<Integer> topNode =
+                new UnionTransformation<>(Arrays.asList(commonNode, midNode));
+        List<Transformation<?>> predecessors = topNode.getTransitivePredecessors();
+        assertThat(predecessors.size()).isEqualTo(3);
+        assertThat(commonNode.getNumGetTransitivePredecessor()).isEqualTo(1);
+    }
+
+    @Test
+    void testBroadcastStateTransformation() {
+        Transformation<Integer> topNode =
+                new AbstractBroadcastStateTransformation<>(
+                        "topNode", commonNode, midNode, null, midNode.getOutputType(), 1);
+        List<Transformation<?>> predecessors = topNode.getTransitivePredecessors();
+        assertThat(predecessors.size()).isEqualTo(3);
+        assertThat(commonNode.getNumGetTransitivePredecessor()).isEqualTo(0);
+    }
+
+    @Test
+    void testAbstractMultipleInputTransformation() {
+        Transformation<Integer> topNode =
+                new AbstractMultipleInputTransformation<Integer>(
+                        "topNode",
+                        SimpleOperatorFactory.of(new DummyTwoInputOperator<>()),
+                        midNode.getOutputType(),
+                        1) {
+                    @Override
+                    public List<Transformation<?>> getInputs() {
+                        return Arrays.asList(commonNode, midNode);
+                    }
+                };
+        List<Transformation<?>> predecessors = topNode.getTransitivePredecessors();
+        assertThat(predecessors.size()).isEqualTo(3);
+        assertThat(commonNode.getNumGetTransitivePredecessor()).isEqualTo(1);
+    }
+
+    /** A test implementation of {@link Transformation}. */
+    private static class TestTransformation<T> extends Transformation<T> {
+        private int numGetTransitivePredecessor = 0;
+
+        public TestTransformation(String name, TypeInformation<T> outputType, int parallelism) {
+            super(name, outputType, parallelism);
+        }
+
+        @Override
+        protected List<Transformation<?>> getTransitivePredecessorsInternal() {
+            ++numGetTransitivePredecessor;
+            return Collections.singletonList(this);
+        }
+
+        @Override
+        public List<Transformation<?>> getInputs() {
+            return Collections.emptyList();
+        }
+
+        public int getNumGetTransitivePredecessor() {
+            return numGetTransitivePredecessor;
+        }
+    }
+
+    /** A test implementation of {@link OneInputTransformation}. */
+    private static class DummyOneInputOperator extends AbstractStreamOperator<Integer>
+            implements OneInputStreamOperator<Integer, Integer> {
+
+        @Override
+        public void processElement(StreamRecord<Integer> element) throws Exception {}
+    }
+
+    /** A test implementation of {@link TwoInputStreamOperator}. */
+    private static class DummyTwoInputOperator<T> extends AbstractStreamOperator<T>
+            implements TwoInputStreamOperator<T, T, T> {
+
+        @Override
+        public void processElement1(StreamRecord<T> element) throws Exception {
+            output.collect(element);
+        }
+
+        @Override
+        public void processElement2(StreamRecord<T> element) throws Exception {
+            output.collect(element);
+        }
+    }
+
+    /** A test implementation of {@link TypeInformation}. */
+    private static class MockIntegerTypeInfo extends GenericTypeInfo<Integer> {
+        public MockIntegerTypeInfo() {
+            super(Integer.class);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGeneratorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/TableOperatorWrapperGeneratorTest.java
@@ -484,7 +484,7 @@ public class TableOperatorWrapperGeneratorTest extends MultipleInputTestBase {
         }
 
         @Override
-        public List<Transformation<?>> getTransitivePredecessors() {
+        protected List<Transformation<?>> getTransitivePredecessorsInternal() {
             return Collections.emptyList();
         }
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds caching capability to `Transformation`


## Brief change log

  - Change `Transformation::getTransitivePredecessors()` to utilize cache 
  - Introduce `Transformation::getTransitivePredecessorsInternal()`


## Verifying this change

This change added tests to `org.apache.flink.api.dag.TransformationTest::testPredecessorCache()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
