### PR TITLE
[FLINK-31472] Remove external timer service reference from AsyncSinkThrottling Test

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterThrottlingTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterThrottlingTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.operators.ProcessingTimeService;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
@@ -33,8 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Queue;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
 
 /** Test class for rate limiting functionalities of {@link AsyncSinkWriter}. */
 public class AsyncSinkWriterThrottlingTest {
@@ -44,10 +41,8 @@ public class AsyncSinkWriterThrottlingTest {
         int maxBatchSize = 32;
         int maxInFlightRequest = 10;
         int numberOfBatchesToSend = 1000;
-        Queue<String> testRequests = getTestRequestsBuffer();
 
         TestSinkInitContext context = new TestSinkInitContextAnyThreadMailbox();
-        TestProcessingTimeService tpts = context.getTestProcessingTimeService();
 
         ThrottlingWriter writer =
                 new ThrottlingWriter(
@@ -56,14 +51,9 @@ public class AsyncSinkWriterThrottlingTest {
                         maxBatchSize,
                         maxInFlightRequest);
 
-        long currentTime = 0L;
-        tpts.setCurrentTime(currentTime);
-
         // numberOfBatchesToSend should be high enough to overcome initial transient state
-        for (int i = 0; i < numberOfBatchesToSend; i++) {
-            removeBatchAndSend(writer, testRequests, maxBatchSize);
-            tpts.setCurrentTime(currentTime + 50);
-            currentTime += 50L;
+        for (int i = 0; i < numberOfBatchesToSend * maxBatchSize; i++) {
+            writer.write(String.valueOf(i));
         }
 
         /**
@@ -74,19 +64,6 @@ public class AsyncSinkWriterThrottlingTest {
                 .isGreaterThanOrEqualTo(maxBatchSize / 4);
         Assertions.assertThat(writer.getInflightMessagesLimit())
                 .isLessThanOrEqualTo(maxBatchSize / 2 + 10);
-    }
-
-    private Queue<String> getTestRequestsBuffer() {
-        return LongStream.range(1, 1000_000L)
-                .mapToObj(Long::toString)
-                .collect(Collectors.toCollection(ArrayDeque::new));
-    }
-
-    private void removeBatchAndSend(ThrottlingWriter writer, Queue<String> buffer, int batchSize)
-            throws IOException, InterruptedException {
-        for (int i = 0; i < Math.min(batchSize, buffer.size()); ++i) {
-            writer.write(buffer.remove());
-        }
     }
 
     private static class ThrottlingWriter extends AsyncSinkWriter<String, Long> {


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Refactor `AsyncSinkWriterThrottlingTest` to flush when reaching batch sizes without changing processing time. The changes of processing time are in fact not needed for this test and are causing flakiness due to reference of timer call back from external thread.


## Brief change log
- refactored `AsyncSinkWriterThrottlingTest` to send all batch data without change in timer service.


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable 
