### PR TITLE
[FLINK-25544][streaming][JUnit5 Migration] The runtime package of module flink-stream-java

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandlerTest.java
@@ -19,39 +19,38 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.streaming.api.operators.InputSelection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link MultipleInputSelectionHandler}. */
-public class MultipleInputSelectionHandlerTest {
+class MultipleInputSelectionHandlerTest {
 
     @Test
-    public void testShouldSetAvailableForAnotherInput() {
+    void testShouldSetAvailableForAnotherInput() {
         InputSelection secondAndThird = new InputSelection.Builder().select(2).select(3).build();
 
         MultipleInputSelectionHandler selectionHandler =
                 new MultipleInputSelectionHandler(() -> secondAndThird, 3);
         selectionHandler.nextSelection();
 
-        assertFalse(selectionHandler.shouldSetAvailableForAnotherInput());
+        assertThat(selectionHandler.shouldSetAvailableForAnotherInput()).isFalse();
 
         selectionHandler.setUnavailableInput(0);
-        assertFalse(selectionHandler.shouldSetAvailableForAnotherInput());
+        assertThat(selectionHandler.shouldSetAvailableForAnotherInput()).isFalse();
 
         selectionHandler.setUnavailableInput(2);
-        assertTrue(selectionHandler.shouldSetAvailableForAnotherInput());
+        assertThat(selectionHandler.shouldSetAvailableForAnotherInput()).isTrue();
 
         selectionHandler.setAvailableInput(0);
-        assertTrue(selectionHandler.shouldSetAvailableForAnotherInput());
+        assertThat(selectionHandler.shouldSetAvailableForAnotherInput()).isTrue();
 
         selectionHandler.setAvailableInput(2);
-        assertFalse(selectionHandler.shouldSetAvailableForAnotherInput());
+        assertThat(selectionHandler.shouldSetAvailableForAnotherInput()).isFalse();
     }
 
     @Test
-    public void testLargeInputCount() {
+    void testLargeInputCount() {
         int inputCount = MultipleInputSelectionHandler.MAX_SUPPORTED_INPUT_COUNT;
 
         InputSelection.Builder builder = new InputSelection.Builder();
@@ -67,8 +66,8 @@ public class MultipleInputSelectionHandlerTest {
         for (int i = 0; i < inputCount - 1; i++) {
             selectionHandler.setUnavailableInput(i);
         }
-        assertTrue(selectionHandler.isAnyInputAvailable());
+        assertThat(selectionHandler.isAnyInputAvailable()).isTrue();
         selectionHandler.setUnavailableInput(inputCount - 1);
-        assertFalse(selectionHandler.isAnyInputAvailable());
+        assertThat(selectionHandler.isAnyInputAvailable()).isFalse();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/RecordAttributesCombinerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/RecordAttributesCombinerTest.java
@@ -28,10 +28,10 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link RecordAttributesCombiner}. */
-public class RecordAttributesCombinerTest {
+class RecordAttributesCombinerTest {
 
     @Test
-    public void testCombineRecordAttributes() throws Exception {
+    void testCombineRecordAttributes() throws Exception {
         final RecordAttributesCombiner combiner = new RecordAttributesCombiner(3);
         CollectingDataOutput<Object> collectingDataOutput = new CollectingDataOutput<>();
         final RecordAttributes backlogRecordAttribute =
@@ -60,8 +60,7 @@ public class RecordAttributesCombinerTest {
     }
 
     @Test
-    public void testCombinerOnlyOutputNonBacklogWhenAllInputChannelAreNonBacklog()
-            throws Exception {
+    void testCombinerOnlyOutputNonBacklogWhenAllInputChannelAreNonBacklog() throws Exception {
         final RecordAttributesCombiner combiner = new RecordAttributesCombiner(2);
         CollectingDataOutput<Object> collectingDataOutput = new CollectingDataOutput<>();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -60,8 +60,8 @@ import org.apache.flink.streaming.runtime.watermarkstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.clock.SystemClock;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -79,19 +79,19 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link StreamTaskNetworkInput}. */
-public class StreamTaskNetworkInputTest {
+class StreamTaskNetworkInputTest {
 
     private static final int PAGE_SIZE = 1000;
 
     private final IOManager ioManager = new IOManagerAsync();
 
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         ioManager.close();
     }
 
     @Test
-    public void testIsAvailableWithBufferedDataInDeserializer() throws Exception {
+    void testIsAvailableWithBufferedDataInDeserializer() throws Exception {
         List<BufferOrEvent> buffers = Collections.singletonList(createDataBuffer());
 
         VerifyRecordsDataOutput<Long> output = new VerifyRecordsDataOutput<>();
@@ -108,7 +108,7 @@ public class StreamTaskNetworkInputTest {
      * record.
      */
     @Test
-    public void testNoDataProcessedAfterCheckpointBarrier() throws Exception {
+    void testNoDataProcessedAfterCheckpointBarrier() throws Exception {
         CheckpointBarrier barrier =
                 new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation());
 
@@ -135,7 +135,7 @@ public class StreamTaskNetworkInputTest {
     }
 
     @Test
-    public void testSnapshotAfterEndOfPartition() throws Exception {
+    void testSnapshotAfterEndOfPartition() throws Exception {
         int numInputChannels = 1;
         int channelId = 0;
         int checkpointId = 0;
@@ -186,7 +186,7 @@ public class StreamTaskNetworkInputTest {
     }
 
     @Test
-    public void testReleasingDeserializerTimely() throws Exception {
+    void testReleasingDeserializerTimely() throws Exception {
 
         int numInputChannels = 2;
         LongSerializer inSerializer = LongSerializer.INSTANCE;
@@ -212,7 +212,7 @@ public class StreamTaskNetworkInputTest {
     }
 
     @Test
-    public void testInputStatusAfterEndOfRecovery() throws Exception {
+    void testInputStatusAfterEndOfRecovery() throws Exception {
         int numInputChannels = 2;
         LongSerializer inSerializer = LongSerializer.INSTANCE;
         StreamTestSingleInputGate<Long> inputGate =
@@ -235,7 +235,7 @@ public class StreamTaskNetworkInputTest {
     }
 
     @Test
-    public void testRecordsAreProcessedInBatches() throws Exception {
+    void testRecordsAreProcessedInBatches() throws Exception {
         int numInputChannels = 2;
         Random random = new Random();
         LongSerializer inSerializer = LongSerializer.INSTANCE;
@@ -270,7 +270,7 @@ public class StreamTaskNetworkInputTest {
     }
 
     @Test
-    public void testBatchProcessingRecordsCanBeInterrupted() throws Exception {
+    void testBatchProcessingRecordsCanBeInterrupted() throws Exception {
         int numInputChannels = 2;
         Random random = new Random();
         LongSerializer inSerializer = LongSerializer.INSTANCE;
@@ -321,7 +321,7 @@ public class StreamTaskNetworkInputTest {
     }
 
     @Test
-    public void testProcessRecordAttributes() throws Exception {
+    void testProcessRecordAttributes() throws Exception {
         int numInputChannels = 2;
         LongSerializer inSerializer = LongSerializer.INSTANCE;
         StreamTestSingleInputGate<Long> inputGate =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/DataSkewStreamNetworkThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/DataSkewStreamNetworkThroughputBenchmarkTest.java
@@ -21,8 +21,7 @@ package org.apache.flink.streaming.runtime.io.benchmark;
 /**
  * Tests for various network benchmarks based on {@link DataSkewStreamNetworkThroughputBenchmark}.
  */
-public class DataSkewStreamNetworkThroughputBenchmarkTest
-        extends StreamNetworkThroughputBenchmarkTest {
+class DataSkewStreamNetworkThroughputBenchmarkTest extends StreamNetworkThroughputBenchmarkTest {
     @Override
     protected StreamNetworkThroughputBenchmark createBenchmark() {
         return new DataSkewStreamNetworkThroughputBenchmark();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBroadcastThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBroadcastThroughputBenchmarkTest.java
@@ -21,8 +21,7 @@ package org.apache.flink.streaming.runtime.io.benchmark;
 /**
  * Tests for various network benchmarks based on {@link StreamNetworkBroadcastThroughputBenchmark}.
  */
-public class StreamNetworkBroadcastThroughputBenchmarkTest
-        extends StreamNetworkThroughputBenchmarkTest {
+class StreamNetworkBroadcastThroughputBenchmarkTest extends StreamNetworkThroughputBenchmarkTest {
     @Override
     protected StreamNetworkThroughputBenchmark createBenchmark() {
         return new StreamNetworkBroadcastThroughputBenchmark();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkPointToPointBenchmarkTest.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.streaming.runtime.io.benchmark;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link StreamNetworkPointToPointBenchmark}. */
-public class StreamNetworkPointToPointBenchmarkTest {
+class StreamNetworkPointToPointBenchmarkTest {
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         StreamNetworkPointToPointBenchmark benchmark = new StreamNetworkPointToPointBenchmark();
         benchmark.setUp(10);
         try {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
@@ -20,22 +20,21 @@ package org.apache.flink.streaming.runtime.io.benchmark;
 
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 /** Tests for various network benchmarks based on {@link StreamNetworkThroughputBenchmark}. */
-public class StreamNetworkThroughputBenchmarkTest {
-    @Rule public ExpectedException expectedException = ExpectedException.none();
+class StreamNetworkThroughputBenchmarkTest {
 
     protected StreamNetworkThroughputBenchmark createBenchmark() {
         return new StreamNetworkThroughputBenchmark();
     }
 
     @Test
-    public void pointToPointBenchmark() throws Exception {
+    void pointToPointBenchmark() throws Exception {
         StreamNetworkThroughputBenchmark benchmark = createBenchmark();
         benchmark.setUp(1, 1, 100);
         try {
@@ -46,7 +45,7 @@ public class StreamNetworkThroughputBenchmarkTest {
     }
 
     @Test
-    public void largeLocalMode() throws Exception {
+    void largeLocalMode() throws Exception {
         StreamNetworkThroughputBenchmark env = new StreamNetworkThroughputBenchmark();
         env.setUp(4, 10, 100, true);
         env.executeBenchmark(10_000_000);
@@ -54,7 +53,7 @@ public class StreamNetworkThroughputBenchmarkTest {
     }
 
     @Test
-    public void largeRemoteMode() throws Exception {
+    void largeRemoteMode() throws Exception {
         StreamNetworkThroughputBenchmark env = new StreamNetworkThroughputBenchmark();
         env.setUp(4, 10, 100, false);
         env.executeBenchmark(10_000_000);
@@ -62,7 +61,7 @@ public class StreamNetworkThroughputBenchmarkTest {
     }
 
     @Test
-    public void largeRemoteAlwaysFlush() throws Exception {
+    void largeRemoteAlwaysFlush() throws Exception {
         StreamNetworkThroughputBenchmark env = new StreamNetworkThroughputBenchmark();
         env.setUp(1, 1, 0, false);
         env.executeBenchmark(1_000_000);
@@ -70,50 +69,54 @@ public class StreamNetworkThroughputBenchmarkTest {
     }
 
     @Test
-    public void remoteModeInsufficientBuffersSender() throws Exception {
+    void remoteModeInsufficientBuffersSender() {
         StreamNetworkThroughputBenchmark env = new StreamNetworkThroughputBenchmark();
         int writers = 2;
         int channels = 2;
 
-        expectedException.expect(IOException.class);
-        expectedException.expectMessage("Insufficient number of network buffers");
-
-        env.setUp(
-                writers,
-                channels,
-                100,
-                false,
-                writers * channels - 1,
-                writers
-                        * channels
-                        * NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL
-                                .defaultValue());
+        assertThatThrownBy(
+                        () ->
+                                env.setUp(
+                                        writers,
+                                        channels,
+                                        100,
+                                        false,
+                                        writers * channels - 1,
+                                        writers
+                                                * channels
+                                                * NettyShuffleEnvironmentOptions
+                                                        .NETWORK_BUFFERS_PER_CHANNEL
+                                                        .defaultValue()))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Insufficient number of network buffers");
     }
 
     @Test
-    public void remoteModeInsufficientBuffersReceiver() throws Exception {
+    void remoteModeInsufficientBuffersReceiver() throws Exception {
         StreamNetworkThroughputBenchmark env = new StreamNetworkThroughputBenchmark();
         int writers = 2;
         int channels = 2;
 
-        expectedException.expect(IOException.class);
-        expectedException.expectMessage("Insufficient number of network buffers");
-
-        env.setUp(
-                writers,
-                channels,
-                100,
-                false,
-                writers * channels,
-                writers
-                                * channels
-                                * NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL
-                                        .defaultValue()
-                        - 1);
+        assertThatThrownBy(
+                        () ->
+                                env.setUp(
+                                        writers,
+                                        channels,
+                                        100,
+                                        false,
+                                        writers * channels,
+                                        writers
+                                                        * channels
+                                                        * NettyShuffleEnvironmentOptions
+                                                                .NETWORK_BUFFERS_PER_CHANNEL
+                                                                .defaultValue()
+                                                - 1))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Insufficient number of network buffers");
     }
 
     @Test
-    public void remoteModeMinimumBuffers() throws Exception {
+    void remoteModeMinimumBuffers() throws Exception {
         StreamNetworkThroughputBenchmark env = new StreamNetworkThroughputBenchmark();
         int writers = 2;
         int channels = 2;
@@ -134,7 +137,7 @@ public class StreamNetworkThroughputBenchmarkTest {
     }
 
     @Test
-    public void pointToMultiPointBenchmark() throws Exception {
+    void pointToMultiPointBenchmark() throws Exception {
         StreamNetworkThroughputBenchmark benchmark = createBenchmark();
         benchmark.setUp(1, 100, 100);
         try {
@@ -145,7 +148,7 @@ public class StreamNetworkThroughputBenchmarkTest {
     }
 
     @Test
-    public void multiPointToPointBenchmark() throws Exception {
+    void multiPointToPointBenchmark() throws Exception {
         StreamNetworkThroughputBenchmark benchmark = createBenchmark();
         benchmark.setUp(4, 1, 100);
         try {
@@ -156,7 +159,7 @@ public class StreamNetworkThroughputBenchmarkTest {
     }
 
     @Test
-    public void multiPointToMultiPointBenchmark() throws Exception {
+    void multiPointToMultiPointBenchmark() throws Exception {
         StreamNetworkThroughputBenchmark benchmark = createBenchmark();
         benchmark.setUp(4, 100, 100);
         try {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsMassiveRandomTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.util.clock.SystemClock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -47,12 +47,12 @@ import java.util.stream.IntStream;
  * The test generates two random streams (input channels) which independently and randomly generate
  * checkpoint barriers. The two streams are very unaligned, putting heavy work on the BarrierBuffer.
  */
-public class AlignedCheckpointsMassiveRandomTest {
+class AlignedCheckpointsMassiveRandomTest {
 
     private static final int PAGE_SIZE = 1024;
 
     @Test
-    public void testWithTwoChannelsAndRandomBarriers() throws Exception {
+    void testWithTwoChannelsAndRandomBarriers() throws Exception {
         NetworkBufferPool networkBufferPool1 = null;
         NetworkBufferPool networkBufferPool2 = null;
         try {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.runtime.io.checkpointing;
 
 import org.apache.flink.core.memory.MemorySegment;
-import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
@@ -42,12 +41,9 @@ import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.streaming.runtime.io.MockInputGate;
 import org.apache.flink.util.clock.SystemClock;
 
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -57,18 +53,10 @@ import java.util.Random;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.streaming.runtime.io.checkpointing.UnalignedCheckpointsTest.addSequence;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the behavior of aligned checkpoints. */
-public class AlignedCheckpointsTest {
+class AlignedCheckpointsTest {
 
     protected static final int PAGE_SIZE = 512;
 
@@ -82,8 +70,8 @@ public class AlignedCheckpointsTest {
 
     private MockInputGate mockInputGate;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testStartTimeNanos = System.nanoTime();
     }
 
@@ -157,10 +145,10 @@ public class AlignedCheckpointsTest {
                 new SyncMailboxExecutor());
     }
 
-    @After
-    public void ensureEmpty() throws Exception {
-        assertFalse(inputGate.pollNext().isPresent());
-        assertTrue(inputGate.isFinished());
+    @AfterEach
+    void ensureEmpty() throws Exception {
+        assertThat(inputGate.pollNext()).isNotPresent();
+        assertThat(inputGate.isFinished()).isTrue();
 
         inputGate.close();
     }
@@ -174,7 +162,7 @@ public class AlignedCheckpointsTest {
      * input channel.
      */
     @Test
-    public void testSingleChannelNoBarriers() throws Exception {
+    void testSingleChannelNoBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(0), createBuffer(0),
             createBuffer(0), createEndOfPartition(0)
@@ -182,10 +170,10 @@ public class AlignedCheckpointsTest {
         inputGate = createCheckpointedInputGate(1, sequence);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
-        assertEquals(0L, inputGate.getAlignmentDurationNanos());
+        assertThat(inputGate.getAlignmentDurationNanos()).isZero();
     }
 
     /**
@@ -193,7 +181,7 @@ public class AlignedCheckpointsTest {
      * multiple input channels.
      */
     @Test
-    public void testMultiChannelNoBarriers() throws Exception {
+    void testMultiChannelNoBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(2),
             createBuffer(2),
@@ -212,10 +200,10 @@ public class AlignedCheckpointsTest {
         inputGate = createCheckpointedInputGate(4, sequence);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
-        assertEquals(0L, inputGate.getAlignmentDurationNanos());
+        assertThat(inputGate.getAlignmentDurationNanos()).isZero();
     }
 
     /**
@@ -223,7 +211,7 @@ public class AlignedCheckpointsTest {
      * channel, and checkpoint events.
      */
     @Test
-    public void testSingleChannelWithBarriers() throws Exception {
+    void testSingleChannelWithBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(0),
             createBuffer(0),
@@ -249,7 +237,7 @@ public class AlignedCheckpointsTest {
         handler.setNextExpectedCheckpointId(1L);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
@@ -258,7 +246,7 @@ public class AlignedCheckpointsTest {
      * channels.
      */
     @Test
-    public void testMultiChannelWithBarriers() throws Exception {
+    void testMultiChannelWithBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             // checkpoint with data from multi channels
             createBuffer(0),
@@ -308,7 +296,7 @@ public class AlignedCheckpointsTest {
         check(sequence[0], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[1], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[2], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(1L, handler.getNextExpectedCheckpointId());
+        assertThat(handler.getNextExpectedCheckpointId()).isOne();
 
         long startTs = System.nanoTime();
 
@@ -317,9 +305,9 @@ public class AlignedCheckpointsTest {
         check(sequence[4], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[5], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[6], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(2L, handler.getNextExpectedCheckpointId());
+        assertThat(handler.getNextExpectedCheckpointId()).isEqualTo(2L);
         validateAlignmentTime(startTs, inputGate);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         // pre checkpoint 2
         check(sequence[7], inputGate.pollNext().get(), PAGE_SIZE);
@@ -327,16 +315,16 @@ public class AlignedCheckpointsTest {
         check(sequence[9], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[10], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[11], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(2L, handler.getNextExpectedCheckpointId());
+        assertThat(handler.getNextExpectedCheckpointId()).isEqualTo(2L);
 
         // checkpoint 2 barriers come together
         startTs = System.nanoTime();
         check(sequence[12], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[13], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[14], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(3L, handler.getNextExpectedCheckpointId());
+        assertThat(handler.getNextExpectedCheckpointId()).isEqualTo(3L);
         validateAlignmentTime(startTs, inputGate);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         check(sequence[15], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[16], inputGate.pollNext().get(), PAGE_SIZE);
@@ -347,15 +335,15 @@ public class AlignedCheckpointsTest {
         check(sequence[19], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[20], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[21], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(4L, handler.getNextExpectedCheckpointId());
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(handler.getNextExpectedCheckpointId()).isEqualTo(4L);
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         // checkpoint 4
         check(sequence[22], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[23], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[24], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(5L, handler.getNextExpectedCheckpointId());
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(handler.getNextExpectedCheckpointId()).isEqualTo(5L);
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         // remaining data
         check(sequence[25], inputGate.pollNext().get(), PAGE_SIZE);
@@ -369,7 +357,7 @@ public class AlignedCheckpointsTest {
      * later checkpoint on a non-blocked input.
      */
     @Test
-    public void testMultiChannelJumpingOverCheckpoint() throws Exception {
+    void testMultiChannelJumpingOverCheckpoint() throws Exception {
         BufferOrEvent[] sequence = {
             // checkpoint 1
             /* 0 */ createBuffer(0),
@@ -412,53 +400,53 @@ public class AlignedCheckpointsTest {
 
         // checkpoint 1
         check(sequence[3], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(1L, inputGate.getLatestCheckpointId());
+        assertThat(inputGate.getLatestCheckpointId()).isOne();
         check(sequence[4], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[5], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[6], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         check(sequence[7], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[8], inputGate.pollNext().get(), PAGE_SIZE);
 
         // alignment of checkpoint 2
         check(sequence[9], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(2L, inputGate.getLatestCheckpointId());
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(2L);
         check(sequence[10], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[11], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[12], inputGate.pollNext().get(), PAGE_SIZE);
 
         // checkpoint 2 aborted, checkpoint 3 started
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(0, 1));
+        assertThat(mockInputGate.getBlockedChannels()).containsExactlyInAnyOrder(0, 1);
         check(sequence[13], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(3L, inputGate.getLatestCheckpointId());
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(2));
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(3L);
+        assertThat(mockInputGate.getBlockedChannels()).containsExactlyInAnyOrder(2);
         check(sequence[14], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[15], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[16], inputGate.pollNext().get(), PAGE_SIZE);
 
         // checkpoint 3 aborted, checkpoint 4 started
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(0, 2));
+        assertThat(mockInputGate.getBlockedChannels()).containsExactlyInAnyOrder(0, 2);
         check(sequence[17], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(4L, inputGate.getLatestCheckpointId());
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(1));
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(4L);
+        assertThat(mockInputGate.getBlockedChannels()).containsExactlyInAnyOrder(1);
         check(sequence[18], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[19], inputGate.pollNext().get(), PAGE_SIZE);
 
         // checkpoint 4 aborted (due to end of partition)
         check(sequence[20], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
         check(sequence[21], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[22], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[23], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[24], inputGate.pollNext().get(), PAGE_SIZE);
 
-        assertEquals(1, handler.getTriggeredCheckpointCounter());
-        assertEquals(3, handler.getAbortedCheckpointCounter());
+        assertThat(handler.getTriggeredCheckpointCounter()).isOne();
+        assertThat(handler.getAbortedCheckpointCounter()).isEqualTo(3L);
     }
 
     @Test
-    public void testMetrics() throws Exception {
+    void testMetrics() throws Exception {
         List<BufferOrEvent> output = new ArrayList<>();
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
         int numberOfChannels = 3;
@@ -505,29 +493,23 @@ public class AlignedCheckpointsTest {
         long startDelay = System.currentTimeMillis() - checkpointBarrierCreation;
         long alignmentDuration = System.nanoTime() - alignmentStartNanos;
 
-        assertEquals(checkpointId, inputGate.getCheckpointBarrierHandler().getLatestCheckpointId());
-        assertThat(
-                inputGate.getCheckpointStartDelayNanos() / 1_000_000,
-                Matchers.greaterThanOrEqualTo(sleepTime));
-        assertThat(
-                inputGate.getCheckpointStartDelayNanos() / 1_000_000,
-                Matchers.lessThanOrEqualTo(startDelay));
+        assertThat(inputGate.getCheckpointBarrierHandler().getLatestCheckpointId())
+                .isEqualTo(checkpointId);
+        assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
+                .isGreaterThanOrEqualTo(sleepTime);
+        assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
+                .isLessThanOrEqualTo(startDelay);
 
-        assertTrue(handler.lastAlignmentDurationNanos.isDone());
-        assertThat(
-                handler.lastAlignmentDurationNanos.get() / 1_000_000,
-                Matchers.greaterThanOrEqualTo(sleepTime));
-        assertThat(
-                handler.lastAlignmentDurationNanos.get(),
-                Matchers.lessThanOrEqualTo(alignmentDuration));
+        assertThat(handler.lastAlignmentDurationNanos).isDone();
+        assertThat(handler.lastAlignmentDurationNanos.get() / 1_000_000)
+                .isGreaterThanOrEqualTo(sleepTime);
+        assertThat(handler.lastAlignmentDurationNanos.get()).isLessThanOrEqualTo(alignmentDuration);
 
-        assertTrue(handler.lastBytesProcessedDuringAlignment.isDone());
-        assertThat(
-                handler.lastBytesProcessedDuringAlignment.get(), Matchers.equalTo(3L * bufferSize));
+        assertThat(handler.lastBytesProcessedDuringAlignment).isCompletedWithValue(3L * bufferSize);
     }
 
     @Test
-    public void testMissingCancellationBarriers() throws Exception {
+    void testMissingCancellationBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             createBarrier(1L, 0),
             createCancellationBarrier(3L, 1),
@@ -539,14 +521,14 @@ public class AlignedCheckpointsTest {
         inputGate = createCheckpointedInputGate(2, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
     }
 
     @Test
-    public void testStartAlignmentWithClosedChannels() throws Exception {
+    void testStartAlignmentWithClosedChannels() throws Exception {
         BufferOrEvent[] sequence = {
             // close some channels immediately
             createEndOfPartition(2),
@@ -587,14 +569,14 @@ public class AlignedCheckpointsTest {
         // checkpoint 2 alignment
         check(sequence[5], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[6], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(2L, inputGate.getLatestCheckpointId());
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(2L);
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         // checkpoint 3 alignment
         check(sequence[7], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[8], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(3L, inputGate.getLatestCheckpointId());
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(3L);
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         // after checkpoint 3
         check(sequence[9], inputGate.pollNext().get(), PAGE_SIZE);
@@ -605,15 +587,15 @@ public class AlignedCheckpointsTest {
 
         // checkpoint 4 alignment
         check(sequence[14], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(4L, inputGate.getLatestCheckpointId());
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(4L);
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         check(sequence[15], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[16], inputGate.pollNext().get(), PAGE_SIZE);
     }
 
     @Test
-    public void testEndOfStreamWhileCheckpoint() throws Exception {
+    void testEndOfStreamWhileCheckpoint() throws Exception {
         BufferOrEvent[] sequence = {
             // one checkpoint
             createBarrier(1, 0),
@@ -644,22 +626,22 @@ public class AlignedCheckpointsTest {
         check(sequence[0], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[1], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[2], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         check(sequence[3], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[4], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[5], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(1L, inputGate.getLatestCheckpointId());
+        assertThat(inputGate.getLatestCheckpointId()).isOne();
 
         // alignment of second checkpoint
         check(sequence[6], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(2L, inputGate.getLatestCheckpointId());
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(2L);
         check(sequence[7], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[8], inputGate.pollNext().get(), PAGE_SIZE);
 
         // first end-of-partition encountered: checkpoint will not be completed
         check(sequence[9], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         check(sequence[10], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[11], inputGate.pollNext().get(), PAGE_SIZE);
@@ -667,7 +649,7 @@ public class AlignedCheckpointsTest {
     }
 
     @Test
-    public void testSingleChannelAbortCheckpoint() throws Exception {
+    void testSingleChannelAbortCheckpoint() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(0),
             createBarrier(1, 0),
@@ -686,48 +668,45 @@ public class AlignedCheckpointsTest {
         toNotify.setNextExpectedCheckpointId(1);
         check(sequence[0], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[1], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(0L, inputGate.getAlignmentDurationNanos());
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(inputGate.getAlignmentDurationNanos()).isZero();
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         toNotify.setNextExpectedCheckpointId(2);
         check(sequence[2], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[3], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         toNotify.setNextExpectedCheckpointId(5);
         check(sequence[4], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[5], inputGate.pollNext().get(), 0);
-        assertEquals(4L, inputGate.getLatestCheckpointId());
-        assertEquals(4, toNotify.getLastCanceledCheckpointId());
-        assertEquals(
-                CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER,
-                toNotify.getCheckpointFailureReason());
-        assertEquals(0L, inputGate.getAlignmentDurationNanos());
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(4L);
+        assertThat(toNotify.getLastCanceledCheckpointId()).isEqualTo(4);
+        assertThat(toNotify.getCheckpointFailureReason())
+                .isEqualTo(CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER);
+        assertThat(inputGate.getAlignmentDurationNanos()).isZero();
         check(sequence[6], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(5L, inputGate.getLatestCheckpointId());
-        assertEquals(4, toNotify.getLastCanceledCheckpointId());
-        assertEquals(
-                CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER,
-                toNotify.getCheckpointFailureReason());
-        assertEquals(0L, inputGate.getAlignmentDurationNanos());
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(5L);
+        assertThat(toNotify.getLastCanceledCheckpointId()).isEqualTo(4);
+        assertThat(toNotify.getCheckpointFailureReason())
+                .isEqualTo(CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER);
+        assertThat(inputGate.getAlignmentDurationNanos()).isZero();
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         check(sequence[7], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[8], inputGate.pollNext().get(), 0);
         check(sequence[9], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(6L, inputGate.getLatestCheckpointId());
-        assertEquals(6, toNotify.getLastCanceledCheckpointId());
-        assertEquals(
-                CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER,
-                toNotify.getCheckpointFailureReason());
-        assertEquals(0L, inputGate.getAlignmentDurationNanos());
+        assertThat(inputGate.getLatestCheckpointId()).isEqualTo(6L);
+        assertThat(toNotify.getLastCanceledCheckpointId()).isEqualTo(6);
+        assertThat(toNotify.getCheckpointFailureReason())
+                .isEqualTo(CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER);
+        assertThat(inputGate.getAlignmentDurationNanos()).isZero();
 
-        assertEquals(3, toNotify.getTriggeredCheckpointCounter());
-        assertEquals(2, toNotify.getAbortedCheckpointCounter());
+        assertThat(toNotify.getTriggeredCheckpointCounter()).isEqualTo(3);
+        assertThat(toNotify.getAbortedCheckpointCounter()).isEqualTo(2);
     }
 
     @Test
-    public void testMultiChannelAbortCheckpoint() throws Exception {
+    void testMultiChannelAbortCheckpoint() throws Exception {
         BufferOrEvent[] sequence = {
             // some buffers and a successful checkpoint
             /* 0 */ createBuffer(0),
@@ -792,31 +771,30 @@ public class AlignedCheckpointsTest {
         startTs = System.nanoTime();
         toNotify.setNextExpectedCheckpointId(1);
         check(sequence[3], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(1));
+        assertThat(mockInputGate.getBlockedChannels()).containsExactly(1);
         check(sequence[4], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(1, 2));
+        assertThat(mockInputGate.getBlockedChannels()).containsExactlyInAnyOrder(1, 2);
         check(sequence[5], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[6], inputGate.pollNext().get(), PAGE_SIZE);
         validateAlignmentTime(startTs, inputGate);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         check(sequence[7], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[8], inputGate.pollNext().get(), PAGE_SIZE);
 
         // alignment of second checkpoint
         check(sequence[9], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(0));
+        assertThat(mockInputGate.getBlockedChannels()).containsExactly(0);
         check(sequence[10], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(0, 2));
+        assertThat(mockInputGate.getBlockedChannels()).containsExactlyInAnyOrder(0, 2);
         check(sequence[11], inputGate.pollNext().get(), PAGE_SIZE);
 
         // canceled checkpoint on last barrier
         check(sequence[12], inputGate.pollNext().get(), 0);
-        assertEquals(2, toNotify.getLastCanceledCheckpointId());
-        assertThat(mockInputGate.getBlockedChannels(), empty());
-        assertEquals(
-                CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER,
-                toNotify.getCheckpointFailureReason());
+        assertThat(toNotify.getLastCanceledCheckpointId()).isEqualTo(2);
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
+        assertThat(toNotify.getCheckpointFailureReason())
+                .isEqualTo(CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER);
         check(sequence[13], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[14], inputGate.pollNext().get(), PAGE_SIZE);
 
@@ -827,22 +805,21 @@ public class AlignedCheckpointsTest {
         check(sequence[16], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[17], inputGate.pollNext().get(), PAGE_SIZE);
         validateAlignmentTime(startTs, inputGate);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
         check(sequence[18], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[19], inputGate.pollNext().get(), PAGE_SIZE);
 
         // this checkpoint gets immediately canceled
         check(sequence[20], inputGate.pollNext().get(), 0);
-        assertEquals(4, toNotify.getLastCanceledCheckpointId());
-        assertEquals(
-                CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER,
-                toNotify.getCheckpointFailureReason());
-        assertEquals(0L, inputGate.getAlignmentDurationNanos());
+        assertThat(toNotify.getLastCanceledCheckpointId()).isEqualTo(4);
+        assertThat(toNotify.getCheckpointFailureReason())
+                .isEqualTo(CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER);
+        assertThat(inputGate.getAlignmentDurationNanos()).isZero();
         check(sequence[21], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
         check(sequence[22], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[23], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         // some buffers
         check(sequence[24], inputGate.pollNext().get(), PAGE_SIZE);
@@ -856,24 +833,23 @@ public class AlignedCheckpointsTest {
         check(sequence[28], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[29], inputGate.pollNext().get(), PAGE_SIZE);
         validateAlignmentTime(startTs, inputGate);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
         check(sequence[30], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[31], inputGate.pollNext().get(), PAGE_SIZE);
 
         // this checkpoint gets immediately canceled
         check(sequence[32], inputGate.pollNext().get(), 0);
         check(sequence[33], inputGate.pollNext().get(), 0);
-        assertEquals(6, toNotify.getLastCanceledCheckpointId());
-        assertEquals(
-                CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER,
-                toNotify.getCheckpointFailureReason());
-        assertEquals(0L, inputGate.getAlignmentDurationNanos());
+        assertThat(toNotify.getLastCanceledCheckpointId()).isEqualTo(6);
+        assertThat(toNotify.getCheckpointFailureReason())
+                .isEqualTo(CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER);
+        assertThat(inputGate.getAlignmentDurationNanos()).isZero();
         check(sequence[34], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
         check(sequence[35], inputGate.pollNext().get(), PAGE_SIZE);
 
-        assertEquals(3, toNotify.getTriggeredCheckpointCounter());
-        assertEquals(3, toNotify.getAbortedCheckpointCounter());
+        assertThat(toNotify.getTriggeredCheckpointCounter()).isEqualTo(3);
+        assertThat(toNotify.getAbortedCheckpointCounter()).isEqualTo(3);
     }
 
     /**
@@ -882,7 +858,7 @@ public class AlignedCheckpointsTest {
      * <p>The newer checkpoint barrier must not try to cancel the already canceled checkpoint.
      */
     @Test
-    public void testAbortOnCanceledBarriers() throws Exception {
+    void testAbortOnCanceledBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             // starting a checkpoint
             /*  0 */ createBuffer(1),
@@ -934,11 +910,10 @@ public class AlignedCheckpointsTest {
         // cancelled by cancellation barrier
         check(sequence[4], inputGate.pollNext().get(), 0);
         check(sequence[5], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(1, toNotify.getLastCanceledCheckpointId());
-        assertEquals(
-                CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER,
-                toNotify.getCheckpointFailureReason());
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(toNotify.getLastCanceledCheckpointId()).isOne();
+        assertThat(toNotify.getCheckpointFailureReason())
+                .isEqualTo(CheckpointFailureReason.CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER);
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         // the next checkpoint alignment
         startTs = System.nanoTime();
@@ -948,7 +923,7 @@ public class AlignedCheckpointsTest {
 
         // ignored barrier and unblock channel directly
         check(sequence[9], inputGate.pollNext().get(), PAGE_SIZE);
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(1));
+        assertThat(mockInputGate.getBlockedChannels()).containsExactly(1);
         check(sequence[10], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[11], inputGate.pollNext().get(), PAGE_SIZE);
 
@@ -957,15 +932,15 @@ public class AlignedCheckpointsTest {
         check(sequence[12], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[13], inputGate.pollNext().get(), PAGE_SIZE);
         validateAlignmentTime(startTs, inputGate);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         // trailing data
         check(sequence[14], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[15], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[16], inputGate.pollNext().get(), PAGE_SIZE);
 
-        assertEquals(1, toNotify.getTriggeredCheckpointCounter());
-        assertEquals(1, toNotify.getAbortedCheckpointCounter());
+        assertThat(toNotify.getTriggeredCheckpointCounter()).isOne();
+        assertThat(toNotify.getAbortedCheckpointCounter()).isOne();
     }
 
     /**
@@ -973,7 +948,7 @@ public class AlignedCheckpointsTest {
      * to receiving a newer checkpoint barrier.
      */
     @Test
-    public void testIgnoreCancelBarrierIfCheckpointSubsumed() throws Exception {
+    void testIgnoreCancelBarrierIfCheckpointSubsumed() throws Exception {
         BufferOrEvent[] sequence = {
             // starting a checkpoint
             /*  0 */ createBuffer(2),
@@ -1020,13 +995,12 @@ public class AlignedCheckpointsTest {
 
         // future barrier aborts checkpoint
         startTs = System.nanoTime();
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(0, 1));
+        assertThat(mockInputGate.getBlockedChannels()).containsExactlyInAnyOrder(0, 1);
         check(sequence[4], inputGate.pollNext().get(), PAGE_SIZE);
-        assertEquals(3, toNotify.getLastCanceledCheckpointId());
-        assertEquals(
-                CheckpointFailureReason.CHECKPOINT_DECLINED_SUBSUMED,
-                toNotify.getCheckpointFailureReason());
-        assertThat(mockInputGate.getBlockedChannels(), containsInAnyOrder(2));
+        assertThat(toNotify.getLastCanceledCheckpointId()).isEqualTo(3);
+        assertThat(toNotify.getCheckpointFailureReason())
+                .isEqualTo(CheckpointFailureReason.CHECKPOINT_DECLINED_SUBSUMED);
+        assertThat(mockInputGate.getBlockedChannels()).containsExactly(2);
         check(sequence[5], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[6], inputGate.pollNext().get(), PAGE_SIZE);
 
@@ -1040,7 +1014,7 @@ public class AlignedCheckpointsTest {
         check(sequence[10], inputGate.pollNext().get(), PAGE_SIZE);
         check(sequence[11], inputGate.pollNext().get(), PAGE_SIZE);
         validateAlignmentTime(startTs, inputGate);
-        assertThat(mockInputGate.getBlockedChannels(), empty());
+        assertThat(mockInputGate.getBlockedChannels()).isEmpty();
 
         // remaining data
         check(sequence[12], inputGate.pollNext().get(), PAGE_SIZE);
@@ -1048,12 +1022,12 @@ public class AlignedCheckpointsTest {
         check(sequence[14], inputGate.pollNext().get(), PAGE_SIZE);
 
         // check overall notifications
-        assertEquals(1, toNotify.getTriggeredCheckpointCounter());
-        assertEquals(1, toNotify.getAbortedCheckpointCounter());
+        assertThat(toNotify.getTriggeredCheckpointCounter()).isOne();
+        assertThat(toNotify.getAbortedCheckpointCounter()).isOne();
     }
 
     @Test
-    public void testTriggerCheckpointsWithEndOfPartition() throws Exception {
+    void testTriggerCheckpointsWithEndOfPartition() throws Exception {
         BufferOrEvent[] sequence = {
             createBarrier(1, 0), createBarrier(1, 1), createEndOfPartition(2)
         };
@@ -1065,13 +1039,13 @@ public class AlignedCheckpointsTest {
             check(bufferOrEvent, inputGate.pollNext().get(), PAGE_SIZE);
         }
 
-        assertThat(validator.triggeredCheckpoints, contains(1L));
-        assertEquals(0, validator.getAbortedCheckpointCounter());
-        assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending(), equalTo(false));
+        assertThat(validator.triggeredCheckpoints).contains(1L);
+        assertThat(validator.getAbortedCheckpointCounter()).isZero();
+        assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending()).isFalse();
     }
 
     @Test
-    public void testDeduplicateChannelsWithBothBarrierAndEndOfPartition() throws Exception {
+    void testDeduplicateChannelsWithBothBarrierAndEndOfPartition() throws Exception {
         BufferOrEvent[] sequence = {
             /* 0 */ createBarrier(2, 0),
             /* 1 */ createBarrier(2, 1),
@@ -1087,17 +1061,17 @@ public class AlignedCheckpointsTest {
         }
 
         // Here the checkpoint should not be triggered.
-        assertEquals(0, validator.getTriggeredCheckpointCounter());
-        assertEquals(0, validator.getAbortedCheckpointCounter());
+        assertThat(validator.getTriggeredCheckpointCounter()).isZero();
+        assertThat(validator.getAbortedCheckpointCounter()).isZero();
 
         // The last barrier aligned the pending checkpoint 2.
-        assertEquals(sequence[3], inputGate.pollNext().get());
-        assertThat(validator.triggeredCheckpoints, contains(2L));
-        assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending(), equalTo(false));
+        assertThat(inputGate.pollNext()).hasValue(sequence[3]);
+        assertThat(validator.triggeredCheckpoints).contains(2L);
+        assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending()).isFalse();
     }
 
     @Test
-    public void testTriggerCheckpointsAfterReceivedEndOfPartition() throws Exception {
+    void testTriggerCheckpointsAfterReceivedEndOfPartition() throws Exception {
         BufferOrEvent[] sequence = {
             /* 0 */ createEndOfPartition(2),
             /* 2 */ createBarrier(6, 0),
@@ -1113,9 +1087,9 @@ public class AlignedCheckpointsTest {
             check(bufferOrEvent, inputGate.pollNext().get(), PAGE_SIZE);
         }
 
-        assertThat(validator.triggeredCheckpoints, contains(6L, 7L));
-        assertEquals(0, validator.getAbortedCheckpointCounter());
-        assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending(), equalTo(false));
+        assertThat(validator.triggeredCheckpoints).contains(6L, 7L);
+        assertThat(validator.getAbortedCheckpointCounter()).isZero();
+        assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending()).isFalse();
     }
 
     // ------------------------------------------------------------------------
@@ -1156,21 +1130,21 @@ public class AlignedCheckpointsTest {
     }
 
     private static void check(BufferOrEvent expected, BufferOrEvent present, int pageSize) {
-        assertNotNull(expected);
-        assertNotNull(present);
-        assertEquals(expected.isBuffer(), present.isBuffer());
+        assertThat(expected).isNotNull();
+        assertThat(present).isNotNull();
+        assertThat(present.isBuffer()).isEqualTo(expected.isBuffer());
 
         if (expected.isBuffer()) {
-            assertEquals(
-                    expected.getBuffer().getMaxCapacity(), present.getBuffer().getMaxCapacity());
-            assertEquals(expected.getBuffer().getSize(), present.getBuffer().getSize());
+            assertThat(present.getBuffer().getMaxCapacity())
+                    .isEqualTo(expected.getBuffer().getMaxCapacity());
+            assertThat(present.getBuffer().getSize()).isEqualTo(expected.getBuffer().getSize());
             MemorySegment expectedMem = expected.getBuffer().getMemorySegment();
             MemorySegment presentMem = present.getBuffer().getMemorySegment();
-            assertTrue(
-                    "memory contents differs",
-                    expectedMem.compare(presentMem, 0, 0, pageSize) == 0);
+            assertThat(expectedMem.compare(presentMem, 0, 0, pageSize) == 0)
+                    .as("memory contents differs")
+                    .isTrue();
         } else {
-            assertEquals(expected.getEvent(), present.getEvent());
+            assertThat(present.getEvent()).isEqualTo(expected.getEvent());
         }
     }
 
@@ -1178,41 +1152,12 @@ public class AlignedCheckpointsTest {
             long alignmentStartTimestamp, CheckpointedInputGate inputGate) {
         long elapsedAlignment = System.nanoTime() - alignmentStartTimestamp;
         long elapsedTotalTime = System.nanoTime() - testStartTimeNanos;
-        assertThat(
-                inputGate.getAlignmentDurationNanos(),
-                Matchers.lessThanOrEqualTo(elapsedAlignment));
+        assertThat(inputGate.getAlignmentDurationNanos()).isLessThanOrEqualTo(elapsedAlignment);
 
         // Barrier lag is calculated with System.currentTimeMillis(), so we need a tolerance of 1ms
         // when comparing to time elapsed via System.nanoTime()
         long tolerance = 1_000_000;
-        assertThat(
-                inputGate.getCheckpointStartDelayNanos(),
-                Matchers.lessThanOrEqualTo(elapsedTotalTime + tolerance));
-    }
-
-    // ------------------------------------------------------------------------
-    //  Testing Mocks
-    // ------------------------------------------------------------------------
-
-    /** A validation matcher for checkpoint exception against failure reason. */
-    public static class CheckpointExceptionMatcher extends BaseMatcher<CheckpointException> {
-
-        private final CheckpointFailureReason failureReason;
-
-        public CheckpointExceptionMatcher(CheckpointFailureReason failureReason) {
-            this.failureReason = failureReason;
-        }
-
-        @Override
-        public boolean matches(Object o) {
-            return o != null
-                    && o.getClass() == CheckpointException.class
-                    && ((CheckpointException) o).getCheckpointFailureReason().equals(failureReason);
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText("CheckpointException - reason = " + failureReason);
-        }
+        assertThat(inputGate.getCheckpointStartDelayNanos())
+                .isLessThanOrEqualTo(elapsedTotalTime + tolerance);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlignedCheckpointsTest.java
@@ -496,9 +496,7 @@ class AlignedCheckpointsTest {
         assertThat(inputGate.getCheckpointBarrierHandler().getLatestCheckpointId())
                 .isEqualTo(checkpointId);
         assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
-                .isGreaterThanOrEqualTo(sleepTime);
-        assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
-                .isLessThanOrEqualTo(startDelay);
+                .isBetween(sleepTime, startDelay);
 
         assertThat(handler.lastAlignmentDurationNanos).isDone();
         assertThat(handler.lastAlignmentDurationNanos.get() / 1_000_000)
@@ -1039,7 +1037,7 @@ class AlignedCheckpointsTest {
             check(bufferOrEvent, inputGate.pollNext().get(), PAGE_SIZE);
         }
 
-        assertThat(validator.triggeredCheckpoints).contains(1L);
+        assertThat(validator.triggeredCheckpoints).containsExactly(1L);
         assertThat(validator.getAbortedCheckpointCounter()).isZero();
         assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending()).isFalse();
     }
@@ -1066,7 +1064,7 @@ class AlignedCheckpointsTest {
 
         // The last barrier aligned the pending checkpoint 2.
         assertThat(inputGate.pollNext()).hasValue(sequence[3]);
-        assertThat(validator.triggeredCheckpoints).contains(2L);
+        assertThat(validator.triggeredCheckpoints).containsExactly(2L);
         assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending()).isFalse();
     }
 
@@ -1087,7 +1085,7 @@ class AlignedCheckpointsTest {
             check(bufferOrEvent, inputGate.pollNext().get(), PAGE_SIZE);
         }
 
-        assertThat(validator.triggeredCheckpoints).contains(6L, 7L);
+        assertThat(validator.triggeredCheckpoints).containsExactly(6L, 7L);
         assertThat(validator.getAbortedCheckpointCounter()).isZero();
         assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending()).isFalse();
     }
@@ -1140,9 +1138,9 @@ class AlignedCheckpointsTest {
             assertThat(present.getBuffer().getSize()).isEqualTo(expected.getBuffer().getSize());
             MemorySegment expectedMem = expected.getBuffer().getMemorySegment();
             MemorySegment presentMem = present.getBuffer().getMemorySegment();
-            assertThat(expectedMem.compare(presentMem, 0, 0, pageSize) == 0)
+            assertThat(expectedMem.compare(presentMem, 0, 0, pageSize))
                     .as("memory contents differs")
-                    .isTrue();
+                    .isZero();
         } else {
             assertThat(present.getEvent()).isEqualTo(expected.getEvent());
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCheckpointsTest.java
@@ -44,7 +44,7 @@ import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.ManualClock;
 import org.apache.flink.util.concurrent.FutureUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
@@ -58,8 +58,7 @@ import java.util.PriorityQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.Collections.singletonList;
-import static junit.framework.TestCase.assertTrue;
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.apache.flink.runtime.checkpoint.CheckpointOptions.AlignmentType;
 import static org.apache.flink.runtime.checkpoint.CheckpointOptions.alignedNoTimeout;
 import static org.apache.flink.runtime.checkpoint.CheckpointOptions.alignedWithTimeout;
@@ -68,17 +67,10 @@ import static org.apache.flink.runtime.checkpoint.CheckpointType.CHECKPOINT;
 import static org.apache.flink.runtime.io.network.api.serialization.EventSerializer.toBuffer;
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Timing out aligned checkpoints tests. */
-public class AlternatingCheckpointsTest {
+class AlternatingCheckpointsTest {
 
     private final ClockWithDelayedActions clock = new ClockWithDelayedActions();
 
@@ -95,7 +87,7 @@ public class AlternatingCheckpointsTest {
      * buffers.
      */
     @Test
-    public void testChannelResetOnNewBarrier() throws Exception {
+    void testChannelResetOnNewBarrier() throws Exception {
         RecordingChannelStateWriter stateWriter = new RecordingChannelStateWriter();
         try (CheckpointedInputGate gate =
                 new TestCheckpointedInputGateBuilder(
@@ -123,7 +115,7 @@ public class AlternatingCheckpointsTest {
                     1,
                     gate);
 
-            assertFalse(stateWriter.getAddedInput().isEmpty());
+            assertThat(stateWriter.getAddedInput().isEmpty()).isFalse();
         }
     }
 
@@ -132,7 +124,7 @@ public class AlternatingCheckpointsTest {
      * another channel, this UC barrier should be processed by the UC controller.
      */
     @Test
-    public void testSwitchToUnalignedByUpstream() throws Exception {
+    void testSwitchToUnalignedByUpstream() throws Exception {
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         try (CheckpointedInputGate gate =
                 new TestCheckpointedInputGateBuilder(2, getTestBarrierHandlerFactory(target))
@@ -149,28 +141,28 @@ public class AlternatingCheckpointsTest {
                     toBuffer(new EventAnnouncement(aligned, 0), true),
                     0,
                     gate); // process announcement but not the barrier
-            assertEquals(0, target.triggeredCheckpointCounter);
+            assertThat(target.triggeredCheckpointCounter).isZero();
             send(
                     toBuffer(aligned.asUnaligned(), true),
                     1,
                     gate); // pretend it came from upstream before the first (AC) barrier was picked
             // up
-            assertEquals(1, target.triggeredCheckpointCounter);
+            assertThat(target.triggeredCheckpointCounter).isOne();
         }
     }
 
     @Test
-    public void testCheckpointHandling() throws Exception {
+    void testCheckpointHandling() throws Exception {
         testBarrierHandling(CHECKPOINT);
     }
 
     @Test
-    public void testSavepointHandling() throws Exception {
+    void testSavepointHandling() throws Exception {
         testBarrierHandling(SavepointType.savepoint(SavepointFormatType.CANONICAL));
     }
 
     @Test
-    public void testAlternation() throws Exception {
+    void testAlternation() throws Exception {
         int numBarriers = 123;
         int numChannels = 123;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
@@ -197,12 +189,12 @@ public class AlternatingCheckpointsTest {
                             gate);
                 }
             }
-            assertEquals(barriers, target.triggeredCheckpoints);
+            assertThat(target.triggeredCheckpoints).isEqualTo(barriers);
         }
     }
 
     @Test
-    public void testAlignedAfterTimedOut() throws Exception {
+    void testAlignedAfterTimedOut() throws Exception {
         int numChannels = 1;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         long alignedCheckpointTimeout = 100L;
@@ -226,7 +218,7 @@ public class AlternatingCheckpointsTest {
             clock.advanceTime(alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
             assertBarrier(gate);
 
-            assertEquals(1, target.getTriggeredCheckpointCounter());
+            assertThat(target.getTriggeredCheckpointCounter()).isOne();
             Buffer barrier2 =
                     barrier(
                             2,
@@ -239,20 +231,19 @@ public class AlternatingCheckpointsTest {
             assertAnnouncement(gate);
             assertBarrier(gate);
 
-            assertEquals(2, target.getTriggeredCheckpointCounter());
-            assertThat(
-                    target.getTriggeredCheckpointOptions(),
-                    contains(
+            assertThat(target.getTriggeredCheckpointCounter()).isEqualTo(2);
+            assertThat(target.getTriggeredCheckpointOptions())
+                    .contains(
                             unaligned(CheckpointType.CHECKPOINT, getDefault()),
                             alignedWithTimeout(
                                     CheckpointType.CHECKPOINT,
                                     getDefault(),
-                                    alignedCheckpointTimeout)));
+                                    alignedCheckpointTimeout));
         }
     }
 
     @Test
-    public void testAlignedNeverTimeoutableCheckpoint() throws Exception {
+    void testAlignedNeverTimeoutableCheckpoint() throws Exception {
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         try (CheckpointedInputGate gate =
@@ -263,15 +254,15 @@ public class AlternatingCheckpointsTest {
             Buffer neverTimeoutableCheckpoint = withTimeout(Integer.MAX_VALUE);
             send(neverTimeoutableCheckpoint, 0, gate);
             sendData(1000, 1, gate);
-            assertEquals(0, target.getTriggeredCheckpointCounter());
+            assertThat(target.getTriggeredCheckpointCounter()).isZero();
 
             send(neverTimeoutableCheckpoint, 1, gate);
-            assertEquals(1, target.getTriggeredCheckpointCounter());
+            assertThat(target.getTriggeredCheckpointCounter()).isOne();
         }
     }
 
     @Test
-    public void testTimeoutAlignment() throws Exception {
+    void testTimeoutAlignment() throws Exception {
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         try (CheckpointedInputGate gate =
                 new TestCheckpointedInputGateBuilder(2, getTestBarrierHandlerFactory(target))
@@ -283,7 +274,7 @@ public class AlternatingCheckpointsTest {
     }
 
     @Test
-    public void testTimeoutAlignmentAfterProcessingBarrier() throws Exception {
+    void testTimeoutAlignmentAfterProcessingBarrier() throws Exception {
         int numChannels = 3;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         try (CheckpointedInputGate gate =
@@ -302,7 +293,7 @@ public class AlternatingCheckpointsTest {
                     2,
                     gate);
 
-            assertEquals(0, target.getTriggeredCheckpointCounter());
+            assertThat(target.getTriggeredCheckpointCounter()).isZero();
 
             testTimeoutBarrierOnTwoChannels(target, gate, Integer.MAX_VALUE);
         }
@@ -321,16 +312,15 @@ public class AlternatingCheckpointsTest {
         getChannel(gate, 1).onBuffer(dataBuffer(), 0, 0, 0);
         getChannel(gate, 1).onBuffer(checkpointBarrier.retainBuffer(), 1, 0, 0);
 
-        assertEquals(0, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isZero();
         assertAnnouncement(gate);
         clock.advanceTime(alignedCheckpointTimeout * 2, TimeUnit.MILLISECONDS);
         assertAnnouncement(gate);
         assertBarrier(gate);
         assertBarrier(gate);
-        assertEquals(1, target.getTriggeredCheckpointCounter());
-        assertThat(
-                target.getTriggeredCheckpointOptions(),
-                contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
+        assertThat(target.getTriggeredCheckpointOptions())
+                .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
         // Followed by overtaken buffers
         assertData(gate);
         assertData(gate);
@@ -346,7 +336,7 @@ public class AlternatingCheckpointsTest {
      * EventAnnouncement} but before/during processing the first {@link CheckpointBarrier}.
      */
     @Test
-    public void testTimeoutAlignmentOnFirstBarrier() throws Exception {
+    void testTimeoutAlignmentOnFirstBarrier() throws Exception {
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         CheckpointedInputGate gate =
@@ -363,20 +353,20 @@ public class AlternatingCheckpointsTest {
             (getChannel(gate, i)).onBuffer(checkpointBarrier.retainBuffer(), 0, 0, 0);
         }
 
-        assertEquals(0, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isZero();
         for (int i = 0; i < numChannels; i++) {
             assertAnnouncement(gate);
         }
-        assertEquals(0, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isZero();
 
         clock.advanceTime(alignedCheckpointTimeout * 4, TimeUnit.MILLISECONDS);
 
         assertBarrier(gate);
-        assertEquals(1, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
     }
 
     @Test
-    public void testTimeoutAlignmentBeforeFirstBarrier() throws Exception {
+    void testTimeoutAlignmentBeforeFirstBarrier() throws Exception {
         // given: Local channels.
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
@@ -396,11 +386,11 @@ public class AlternatingCheckpointsTest {
 
         // then: The UC is triggered as soon as the first barrier is received.
         assertBarrier(gate);
-        assertEquals(1, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
     }
 
     @Test
-    public void testTimeoutAlignmentWhenLocalBarrierFirst() throws Exception {
+    void testTimeoutAlignmentWhenLocalBarrierFirst() throws Exception {
         // given: Gate with remote and local channels.
         int numChannels = 3;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
@@ -426,7 +416,7 @@ public class AlternatingCheckpointsTest {
         assertBarrier(gate);
 
         // then: The checkpoint executed successfully.
-        assertEquals(1, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
 
         // given: The time in the future.
         clock.advanceTime(alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
@@ -439,7 +429,7 @@ public class AlternatingCheckpointsTest {
         assertBarrier(gate);
 
         // then: Nothing happens because the alignment timeout should only start after this barrier.
-        assertEquals(1, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
 
         // when: Receiving the barrier from second channel(with/without) announcement after time
         // more than alignment timeout.
@@ -449,15 +439,14 @@ public class AlternatingCheckpointsTest {
         assertBarrier(gate);
 
         // then: The checkpoint should started as unaligned.
-        assertEquals(2, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isEqualTo(2);
         List<CheckpointOptions> checkpointOptions = target.getTriggeredCheckpointOptions();
-        assertEquals(
-                AlignmentType.UNALIGNED,
-                checkpointOptions.get(checkpointOptions.size() - 1).getAlignment());
+        assertThat(checkpointOptions.get(checkpointOptions.size() - 1).getAlignment())
+                .isEqualTo(AlignmentType.UNALIGNED);
     }
 
     @Test
-    public void testActiveTimeoutAfterLocalBarrierPassiveTimeout() throws Exception {
+    void testActiveTimeoutAfterLocalBarrierPassiveTimeout() throws Exception {
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         try (CheckpointedInputGate gate =
@@ -476,7 +465,7 @@ public class AlternatingCheckpointsTest {
             getChannel(gate, 1).onBuffer(dataBuffer(), 0, 0, 0);
             getChannel(gate, 1).onBuffer(checkpointBarrier.retainBuffer(), 1, 0, 0);
 
-            assertEquals(0, target.getTriggeredCheckpointCounter());
+            assertThat(target.getTriggeredCheckpointCounter()).isZero();
             clock.advanceTimeWithoutRunningCallables(
                     alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
             // the announcement should passively time out causing the barriers to overtake the data
@@ -485,10 +474,9 @@ public class AlternatingCheckpointsTest {
             // we simulate active time out firing after the passive one
             clock.executeCallables();
             assertBarrier(gate);
-            assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(
-                    target.getTriggeredCheckpointOptions(),
-                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
+            assertThat(target.getTriggeredCheckpointCounter()).isOne();
+            assertThat(target.getTriggeredCheckpointOptions())
+                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -501,7 +489,7 @@ public class AlternatingCheckpointsTest {
      * least second checkpoint.
      */
     @Test
-    public void testTimeoutAlignmentOnAnnouncementForSecondCheckpoint() throws Exception {
+    void testTimeoutAlignmentOnAnnouncementForSecondCheckpoint() throws Exception {
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         CheckpointedInputGate gate =
@@ -513,7 +501,7 @@ public class AlternatingCheckpointsTest {
 
         long alignedCheckpointTimeout = 100;
         performFirstCheckpoint(numChannels, target, gate, alignedCheckpointTimeout);
-        assertEquals(1, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
 
         Buffer checkpointBarrier = withTimeout(2, alignedCheckpointTimeout);
 
@@ -522,16 +510,16 @@ public class AlternatingCheckpointsTest {
             (getChannel(gate, i)).onBuffer(checkpointBarrier.retainBuffer(), 2, 0, 0);
         }
 
-        assertEquals(1, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
         for (int i = 0; i < numChannels; i++) {
             assertAnnouncement(gate);
         }
-        assertEquals(1, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
 
         clock.advanceTime(alignedCheckpointTimeout * 4, TimeUnit.MILLISECONDS);
         // the barrier should overtake the data buffers
         assertBarrier(gate);
-        assertEquals(2, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isEqualTo(2);
     }
 
     private void performFirstCheckpoint(
@@ -544,7 +532,7 @@ public class AlternatingCheckpointsTest {
         for (int i = 0; i < numChannels; i++) {
             (getChannel(gate, i)).onBuffer(checkpointBarrier.retainBuffer(), 0, 0, 0);
         }
-        assertEquals(0, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isZero();
         for (int i = 0; i < numChannels; i++) {
             assertAnnouncement(gate);
         }
@@ -554,7 +542,7 @@ public class AlternatingCheckpointsTest {
     }
 
     @Test
-    public void testPassiveTimeoutAlignmentOnAnnouncement() throws Exception {
+    void testPassiveTimeoutAlignmentOnAnnouncement() throws Exception {
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         CheckpointedInputGate gate =
@@ -568,7 +556,7 @@ public class AlternatingCheckpointsTest {
         Buffer checkpointBarrier = withTimeout(alignedCheckpointTimeout);
 
         (getChannel(gate, 0)).onBuffer(checkpointBarrier.retainBuffer(), 0, 0, 0);
-        assertEquals(0, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isZero();
         assertAnnouncement(gate);
         assertBarrier(gate);
         clock.advanceTimeWithoutRunningCallables(
@@ -577,11 +565,11 @@ public class AlternatingCheckpointsTest {
         assertAnnouncement(gate);
 
         assertBarrier(gate);
-        assertEquals(1, target.getTriggeredCheckpointCounter());
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
     }
 
     @Test
-    public void testActiveTimeoutAlignmentOnFirstBarrier() throws Exception {
+    void testActiveTimeoutAlignmentOnFirstBarrier() throws Exception {
         int numberOfChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         CheckpointedInputGate gate =
@@ -597,13 +585,12 @@ public class AlternatingCheckpointsTest {
         send(checkpointBarrier, 0, gate);
 
         clock.advanceTime(alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
-        assertThat(
-                target.getTriggeredCheckpointOptions(),
-                contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
+        assertThat(target.getTriggeredCheckpointOptions())
+                .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
     }
 
     @Test
-    public void testAllChannelsUnblockedAfteralignedCheckpointTimeout() throws Exception {
+    void testAllChannelsUnblockedAfteralignedCheckpointTimeout() throws Exception {
         int numberOfChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         CheckpointedInputGate gate =
@@ -634,16 +621,15 @@ public class AlternatingCheckpointsTest {
         ((TestInputChannel) gate.getChannel(1)).setBlocked(true);
         send(checkpointBarrierBuffer, 1, gate);
 
-        assertThat(target.getTriggeredCheckpointOptions().size(), equalTo(1));
-        assertThat(
-                target.getTriggeredCheckpointOptions(),
-                contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
-        assertFalse(((TestInputChannel) gate.getChannel(0)).isBlocked());
-        assertFalse(((TestInputChannel) gate.getChannel(1)).isBlocked());
+        assertThat(target.getTriggeredCheckpointOptions()).hasSize(1);
+        assertThat(target.getTriggeredCheckpointOptions())
+                .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+        assertThat(((TestInputChannel) gate.getChannel(0)).isBlocked()).isFalse();
+        assertThat(((TestInputChannel) gate.getChannel(1)).isBlocked()).isFalse();
     }
 
     @Test
-    public void testNoActiveTimeoutAlignmentAfterLastBarrier() throws Exception {
+    void testNoActiveTimeoutAlignmentAfterLastBarrier() throws Exception {
         int numberOfChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         CheckpointedInputGate gate =
@@ -660,13 +646,12 @@ public class AlternatingCheckpointsTest {
         send(checkpointBarrier, 1, gate);
         clock.advanceTime(alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
 
-        assertThat(
-                target.getTriggeredCheckpointOptions(),
-                not(contains(unaligned(CheckpointType.CHECKPOINT, getDefault()))));
+        assertThat(target.getTriggeredCheckpointOptions())
+                .doesNotContain(unaligned(CheckpointType.CHECKPOINT, getDefault()));
     }
 
     @Test
-    public void testNoActiveTimeoutAlignmentAfterAbort() throws Exception {
+    void testNoActiveTimeoutAlignmentAfterAbort() throws Exception {
         int numberOfChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         CheckpointedInputGate gate =
@@ -684,11 +669,11 @@ public class AlternatingCheckpointsTest {
         send(toBuffer(new CancelCheckpointMarker(1L), true), 1, gate);
         clock.advanceTime(alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
 
-        assertThat(target.getTriggeredCheckpointOptions().size(), equalTo(0));
+        assertThat(target.getTriggeredCheckpointOptions()).isEmpty();
     }
 
     @Test
-    public void testNoActiveTimeoutAlignmentAfterClose() throws Exception {
+    void testNoActiveTimeoutAlignmentAfterClose() throws Exception {
         int numberOfChannels = 2;
         ClockWithDelayedActions clockWithDelayedActions =
                 new ClockWithDelayedActions() {
@@ -717,11 +702,11 @@ public class AlternatingCheckpointsTest {
         gate.close();
         clockWithDelayedActions.advanceTime(alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
 
-        assertThat(target.getTriggeredCheckpointOptions().size(), equalTo(0));
+        assertThat(target.getTriggeredCheckpointOptions()).isEmpty();
     }
 
     @Test
-    public void testActiveTimeoutAlignmentOnAnnouncement() throws Exception {
+    void testActiveTimeoutAlignmentOnAnnouncement() throws Exception {
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         try (CheckpointedInputGate gate =
@@ -739,17 +724,16 @@ public class AlternatingCheckpointsTest {
             getChannel(gate, 1).onBuffer(dataBuffer(), 0, 0, 0);
             getChannel(gate, 1).onBuffer(checkpointBarrier.retainBuffer(), 1, 0, 0);
 
-            assertEquals(0, target.getTriggeredCheckpointCounter());
+            assertThat(target.getTriggeredCheckpointCounter()).isZero();
             assertAnnouncement(gate);
             assertAnnouncement(gate);
             // the announcement should time out causing the barriers to overtake the data buffers
             clock.advanceTime(alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
             assertBarrier(gate);
             assertBarrier(gate);
-            assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(
-                    target.getTriggeredCheckpointOptions(),
-                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
+            assertThat(target.getTriggeredCheckpointCounter()).isOne();
+            assertThat(target.getTriggeredCheckpointOptions())
+                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -758,7 +742,7 @@ public class AlternatingCheckpointsTest {
     }
 
     @Test
-    public void testActiveTimeoutAfterAnnouncementPassiveTimeout() throws Exception {
+    void testActiveTimeoutAfterAnnouncementPassiveTimeout() throws Exception {
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         try (CheckpointedInputGate gate =
@@ -776,7 +760,7 @@ public class AlternatingCheckpointsTest {
             getChannel(gate, 1).onBuffer(dataBuffer(), 0, 0, 0);
             getChannel(gate, 1).onBuffer(checkpointBarrier.retainBuffer(), 1, 0, 0);
 
-            assertEquals(0, target.getTriggeredCheckpointCounter());
+            assertThat(target.getTriggeredCheckpointCounter()).isZero();
             assertAnnouncement(gate);
             clock.advanceTimeWithoutRunningCallables(
                     alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
@@ -787,10 +771,9 @@ public class AlternatingCheckpointsTest {
             clock.executeCallables();
             assertBarrier(gate);
             assertBarrier(gate);
-            assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(
-                    target.getTriggeredCheckpointOptions(),
-                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
+            assertThat(target.getTriggeredCheckpointCounter()).isOne();
+            assertThat(target.getTriggeredCheckpointOptions())
+                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -799,7 +782,7 @@ public class AlternatingCheckpointsTest {
     }
 
     @Test
-    public void testActiveTimeoutBeforeFirstAnnouncementPassiveTimeout() throws Exception {
+    void testActiveTimeoutBeforeFirstAnnouncementPassiveTimeout() throws Exception {
         // given: Two barriers from two channels.
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
@@ -817,7 +800,7 @@ public class AlternatingCheckpointsTest {
             getChannel(gate, 1).onBuffer(dataBuffer(), 0, 0, 0);
             getChannel(gate, 1).onBuffer(checkpointBarrier.retainBuffer(), 1, 0, 0);
 
-            assertEquals(0, target.getTriggeredCheckpointCounter());
+            assertThat(target.getTriggeredCheckpointCounter()).isZero();
 
             // when: The receiving of the first announcement is delayed on more than alignment
             // checkpoint timeout.
@@ -832,10 +815,9 @@ public class AlternatingCheckpointsTest {
             assertAnnouncement(gate);
             assertBarrier(gate);
             assertBarrier(gate);
-            assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(
-                    target.getTriggeredCheckpointOptions(),
-                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
+            assertThat(target.getTriggeredCheckpointCounter()).isOne();
+            assertThat(target.getTriggeredCheckpointOptions())
+                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -843,7 +825,7 @@ public class AlternatingCheckpointsTest {
     }
 
     @Test
-    public void testActiveTimeoutAfterBarrierPassiveTimeout() throws Exception {
+    void testActiveTimeoutAfterBarrierPassiveTimeout() throws Exception {
         int numChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         try (CheckpointedInputGate gate =
@@ -859,7 +841,7 @@ public class AlternatingCheckpointsTest {
             getChannel(gate, 0).onBuffer(dataBuffer(), 1, 0, 0);
             getChannel(gate, 0).onBuffer(checkpointBarrier.retainBuffer(), 2, 0, 0);
 
-            assertEquals(0, target.getTriggeredCheckpointCounter());
+            assertThat(target.getTriggeredCheckpointCounter()).isZero();
             assertAnnouncement(gate);
             // we simulate active time out firing after the passive one
             assertData(gate);
@@ -876,10 +858,9 @@ public class AlternatingCheckpointsTest {
             assertAnnouncement(gate);
             assertBarrier(gate);
 
-            assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(
-                    target.getTriggeredCheckpointOptions(),
-                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
+            assertThat(target.getTriggeredCheckpointCounter()).isOne();
+            assertThat(target.getTriggeredCheckpointOptions())
+                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
         }
@@ -890,7 +871,7 @@ public class AlternatingCheckpointsTest {
      * unaligned {@link CheckpointBarrier}, that has timed out on an upstream task.
      */
     @Test
-    public void testTimeoutAlignmentOnUnalignedCheckpoint() throws Exception {
+    void testTimeoutAlignmentOnUnalignedCheckpoint() throws Exception {
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         RecordingChannelStateWriter channelStateWriter = new RecordingChannelStateWriter();
         CheckpointedInputGate gate =
@@ -922,17 +903,13 @@ public class AlternatingCheckpointsTest {
 
         assertBarrier(gate);
 
-        assertEquals(
-                2,
-                channelStateWriter
-                        .getAddedInput()
-                        .get(getChannel(gate, 1).getChannelInfo())
-                        .size());
-        assertEquals(1, target.getTriggeredCheckpointCounter());
+        assertThat(channelStateWriter.getAddedInput().get(getChannel(gate, 1).getChannelInfo()))
+                .hasSize(2);
+        assertThat(target.getTriggeredCheckpointCounter()).isOne();
     }
 
     @Test
-    public void testTimeoutAlignmentAfterReceivedEndOfPartition() throws Exception {
+    void testTimeoutAlignmentAfterReceivedEndOfPartition() throws Exception {
         int numChannels = 3;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         long alignedCheckpointTimeout = 100L;
@@ -975,10 +952,9 @@ public class AlternatingCheckpointsTest {
             assertData(gate);
             assertEvent(gate, EndOfPartitionEvent.class);
 
-            assertEquals(1, target.getTriggeredCheckpointCounter());
-            assertThat(
-                    target.getTriggeredCheckpointOptions(),
-                    contains(unaligned(CheckpointType.CHECKPOINT, getDefault())));
+            assertThat(target.getTriggeredCheckpointCounter()).isOne();
+            assertThat(target.getTriggeredCheckpointOptions())
+                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
         }
     }
 
@@ -990,7 +966,7 @@ public class AlternatingCheckpointsTest {
      * More information is available in https://issues.apache.org/jira/browse/FLINK-24068.
      */
     @Test
-    public void testStartNewCheckpointViaAnnouncement() throws Exception {
+    void testStartNewCheckpointViaAnnouncement() throws Exception {
         int numChannels = 3;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         long alignedCheckpointTimeout = 10000L;
@@ -1020,7 +996,7 @@ public class AlternatingCheckpointsTest {
 
             // When received the EndOfPartition from channel 1 markAlignmentStart should be called.
             assertEvent(gate, EndOfPartitionEvent.class);
-            assertTrue(gate.getCheckpointBarrierHandler().isDuringAlignment());
+            assertThat(gate.getCheckpointBarrierHandler().isDuringAlignment()).isTrue();
 
             // Received barrier from channel 0.
             assertBarrier(gate);
@@ -1041,7 +1017,7 @@ public class AlternatingCheckpointsTest {
             assertAnnouncement(gate);
             assertBarrier(gate);
 
-            assertThat(target.triggeredCheckpoints, contains(1L));
+            assertThat(target.triggeredCheckpoints).contains(1L);
         }
     }
 
@@ -1050,7 +1026,7 @@ public class AlternatingCheckpointsTest {
     }
 
     @Test
-    public void testMetricsAlternation() throws Exception {
+    void testMetricsAlternation() throws Exception {
         int numChannels = 2;
         int bufferSize = 1000;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
@@ -1146,7 +1122,7 @@ public class AlternatingCheckpointsTest {
     }
 
     @Test
-    public void testMetricsSingleChannel() throws Exception {
+    void testMetricsSingleChannel() throws Exception {
         int numChannels = 1;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         CheckpointedInputGate gate =
@@ -1187,22 +1163,20 @@ public class AlternatingCheckpointsTest {
             long alignmentDurationNanosMin,
             long startDelayNanos,
             long bytesProcessedDuringAlignment) {
-        assertThat(checkpointBarrierHandler.getLatestCheckpointId(), equalTo(latestCheckpointId));
+        assertThat(checkpointBarrierHandler.getLatestCheckpointId()).isEqualTo(latestCheckpointId);
         long alignmentDurationNanos = checkpointBarrierHandler.getAlignmentDurationNanos();
         long expectedAlignmentDurationNanosMax =
                 clock.relativeTimeNanos() - alignmentDurationStartNanos;
-        assertThat(alignmentDurationNanos, greaterThanOrEqualTo(alignmentDurationNanosMin));
-        assertThat(alignmentDurationNanos, lessThanOrEqualTo(expectedAlignmentDurationNanosMax));
-        assertThat(
-                checkpointBarrierHandler.getCheckpointStartDelayNanos(),
-                greaterThanOrEqualTo(startDelayNanos));
-        assertThat(
-                FutureUtils.getOrDefault(target.getLastBytesProcessedDuringAlignment(), -1L),
-                equalTo(bytesProcessedDuringAlignment));
+        assertThat(alignmentDurationNanos).isGreaterThanOrEqualTo(alignmentDurationNanosMin);
+        assertThat(alignmentDurationNanos).isLessThanOrEqualTo(expectedAlignmentDurationNanosMax);
+        assertThat(checkpointBarrierHandler.getCheckpointStartDelayNanos())
+                .isGreaterThanOrEqualTo(startDelayNanos);
+        assertThat(FutureUtils.getOrDefault(target.getLastBytesProcessedDuringAlignment(), -1L))
+                .isEqualTo(bytesProcessedDuringAlignment);
     }
 
     @Test
-    public void testPreviousHandlerReset() throws Exception {
+    void testPreviousHandlerReset() throws Exception {
         SingleInputGate inputGate = new SingleInputGateBuilder().setNumberOfChannels(2).build();
         TestInputChannel[] channels = {
             new TestInputChannel(inputGate, 0), new TestInputChannel(inputGate, 1)
@@ -1231,15 +1205,15 @@ public class AlternatingCheckpointsTest {
                     new InputChannelInfo(0, channel),
                     false);
             if (type.isSavepoint()) {
-                assertTrue(channels[channel].isBlocked());
-                assertFalse(channels[(channel + 1) % 2].isBlocked());
+                assertThat(channels[channel].isBlocked()).isTrue();
+                assertThat(channels[(channel + 1) % 2].isBlocked()).isFalse();
             } else {
-                assertFalse(channels[0].isBlocked());
-                assertFalse(channels[1].isBlocked());
+                assertThat(channels[0].isBlocked()).isFalse();
+                assertThat(channels[1].isBlocked()).isFalse();
             }
 
-            assertTrue(barrierHandler.isCheckpointPending());
-            assertFalse(barrierHandler.getAllBarriersReceivedFuture(i).isDone());
+            assertThat(barrierHandler.isCheckpointPending()).isTrue();
+            assertThat(barrierHandler.getAllBarriersReceivedFuture(i)).isNotDone();
 
             channels[0].setBlocked(false);
             channels[1].setBlocked(false);
@@ -1247,7 +1221,7 @@ public class AlternatingCheckpointsTest {
     }
 
     @Test
-    public void testHasInflightDataBeforeProcessBarrier() throws Exception {
+    void testHasInflightDataBeforeProcessBarrier() throws Exception {
         SingleInputGate inputGate = new SingleInputGateBuilder().setNumberOfChannels(2).build();
         inputGate.setInputChannels(
                 new TestInputChannel(inputGate, 0), new TestInputChannel(inputGate, 1));
@@ -1264,11 +1238,11 @@ public class AlternatingCheckpointsTest {
                 new InputChannelInfo(0, 0),
                 false);
 
-        assertFalse(barrierHandler.getAllBarriersReceivedFuture(id).isDone());
+        assertThat(barrierHandler.getAllBarriersReceivedFuture(id)).isNotDone();
     }
 
     @Test
-    public void testOutOfOrderBarrier() throws Exception {
+    void testOutOfOrderBarrier() throws Exception {
         SingleInputGate inputGate = new SingleInputGateBuilder().setNumberOfChannels(2).build();
         TestInputChannel firstChannel = new TestInputChannel(inputGate, 0);
         TestInputChannel secondChannel = new TestInputChannel(inputGate, 1);
@@ -1298,12 +1272,12 @@ public class AlternatingCheckpointsTest {
                 new InputChannelInfo(0, 1),
                 false);
 
-        assertEquals(checkpointId, barrierHandler.getLatestCheckpointId());
-        assertFalse(secondChannel.isBlocked());
+        assertThat(barrierHandler.getLatestCheckpointId()).isEqualTo(checkpointId);
+        assertThat(secondChannel.isBlocked()).isFalse();
     }
 
     @Test
-    public void testNextFirstCheckpointBarrierOvertakesCancellationBarrier() throws Exception {
+    void testNextFirstCheckpointBarrierOvertakesCancellationBarrier() throws Exception {
         int numberOfChannels = 2;
         ValidatingCheckpointHandler target = new ValidatingCheckpointHandler();
         CheckpointedInputGate gate =
@@ -1325,9 +1299,9 @@ public class AlternatingCheckpointsTest {
         send(withTimeout(2, alignedCheckpointTimeout), 1, gate);
         clock.advanceTime(Duration.ofSeconds(1));
 
-        assertEquals(
-                Duration.ofSeconds(2).toNanos(),
-                target.lastAlignmentDurationNanos.get().longValue());
+        assertThatFuture(target.lastAlignmentDurationNanos)
+                .eventuallySucceeds()
+                .isEqualTo(Duration.ofSeconds(2).toNanos());
     }
 
     private void testBarrierHandling(SnapshotType checkpointType) throws Exception {
@@ -1353,15 +1327,15 @@ public class AlternatingCheckpointsTest {
                         : unaligned(CheckpointType.CHECKPOINT, getDefault());
         Buffer barrier = barrier(barrierId, 1, options);
         send(barrier.retainBuffer(), fast, checkpointedGate);
-        assertEquals(checkpointType.isSavepoint(), target.triggeredCheckpoints.isEmpty());
+        assertThat(target.triggeredCheckpoints.isEmpty()).isEqualTo(checkpointType.isSavepoint());
         send(barrier.retainBuffer(), slow, checkpointedGate);
 
-        assertEquals(singletonList(barrierId), target.triggeredCheckpoints);
+        assertThat(target.triggeredCheckpoints).containsExactly(barrierId);
         if (checkpointType.isSavepoint()) {
             for (InputChannel channel : gate.inputChannels()) {
-                assertFalse(
-                        String.format("channel %d should be resumed", channel.getChannelIndex()),
-                        ((TestInputChannel) channel).isBlocked());
+                assertThat(((TestInputChannel) channel).isBlocked())
+                        .as("channel %d should be resumed", channel.getChannelIndex())
+                        .isFalse();
             }
         }
     }
@@ -1438,27 +1412,28 @@ public class AlternatingCheckpointsTest {
     private static <T extends RuntimeEvent> void assertEvent(
             CheckpointedInputGate gate, Class<T> clazz) throws IOException, InterruptedException {
         Optional<BufferOrEvent> bufferOrEvent = assertPoll(gate);
-        assertTrue(
-                "expected event, got data buffer on " + bufferOrEvent.get().getChannelInfo(),
-                bufferOrEvent.get().isEvent());
-        assertEquals(clazz, bufferOrEvent.get().getEvent().getClass());
+        assertThat(bufferOrEvent.get().isEvent())
+                .as("expected event, got data buffer on " + bufferOrEvent.get().getChannelInfo())
+                .isTrue();
+        assertThat(bufferOrEvent.get().getEvent().getClass()).isEqualTo(clazz);
     }
 
     private static <T extends RuntimeEvent> void assertData(CheckpointedInputGate gate)
             throws IOException, InterruptedException {
         Optional<BufferOrEvent> bufferOrEvent = assertPoll(gate);
-        assertTrue(
-                "expected data, got "
-                        + bufferOrEvent.get().getEvent()
-                        + "  on "
-                        + bufferOrEvent.get().getChannelInfo(),
-                bufferOrEvent.get().isBuffer());
+        assertThat(bufferOrEvent.get().isBuffer())
+                .as(
+                        "expected data, got "
+                                + bufferOrEvent.get().getEvent()
+                                + "  on "
+                                + bufferOrEvent.get().getChannelInfo())
+                .isTrue();
     }
 
     private static Optional<BufferOrEvent> assertPoll(CheckpointedInputGate gate)
             throws IOException, InterruptedException {
         Optional<BufferOrEvent> bufferOrEvent = gate.pollNext();
-        assertTrue("empty gate", bufferOrEvent.isPresent());
+        assertThat(bufferOrEvent).as("empty gate").isPresent();
         return bufferOrEvent;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/AlternatingCheckpointsTest.java
@@ -233,7 +233,7 @@ class AlternatingCheckpointsTest {
 
             assertThat(target.getTriggeredCheckpointCounter()).isEqualTo(2);
             assertThat(target.getTriggeredCheckpointOptions())
-                    .contains(
+                    .containsExactly(
                             unaligned(CheckpointType.CHECKPOINT, getDefault()),
                             alignedWithTimeout(
                                     CheckpointType.CHECKPOINT,
@@ -320,7 +320,7 @@ class AlternatingCheckpointsTest {
         assertBarrier(gate);
         assertThat(target.getTriggeredCheckpointCounter()).isOne();
         assertThat(target.getTriggeredCheckpointOptions())
-                .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+                .containsExactly(unaligned(CheckpointType.CHECKPOINT, getDefault()));
         // Followed by overtaken buffers
         assertData(gate);
         assertData(gate);
@@ -476,7 +476,7 @@ class AlternatingCheckpointsTest {
             assertBarrier(gate);
             assertThat(target.getTriggeredCheckpointCounter()).isOne();
             assertThat(target.getTriggeredCheckpointOptions())
-                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+                    .containsExactly(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -586,7 +586,7 @@ class AlternatingCheckpointsTest {
 
         clock.advanceTime(alignedCheckpointTimeout + 1, TimeUnit.MILLISECONDS);
         assertThat(target.getTriggeredCheckpointOptions())
-                .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+                .containsExactly(unaligned(CheckpointType.CHECKPOINT, getDefault()));
     }
 
     @Test
@@ -623,7 +623,7 @@ class AlternatingCheckpointsTest {
 
         assertThat(target.getTriggeredCheckpointOptions()).hasSize(1);
         assertThat(target.getTriggeredCheckpointOptions())
-                .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+                .containsExactly(unaligned(CheckpointType.CHECKPOINT, getDefault()));
         assertThat(((TestInputChannel) gate.getChannel(0)).isBlocked()).isFalse();
         assertThat(((TestInputChannel) gate.getChannel(1)).isBlocked()).isFalse();
     }
@@ -733,7 +733,7 @@ class AlternatingCheckpointsTest {
             assertBarrier(gate);
             assertThat(target.getTriggeredCheckpointCounter()).isOne();
             assertThat(target.getTriggeredCheckpointOptions())
-                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+                    .containsExactly(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -773,7 +773,7 @@ class AlternatingCheckpointsTest {
             assertBarrier(gate);
             assertThat(target.getTriggeredCheckpointCounter()).isOne();
             assertThat(target.getTriggeredCheckpointOptions())
-                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+                    .containsExactly(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -817,7 +817,7 @@ class AlternatingCheckpointsTest {
             assertBarrier(gate);
             assertThat(target.getTriggeredCheckpointCounter()).isOne();
             assertThat(target.getTriggeredCheckpointOptions())
-                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+                    .containsExactly(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
             assertData(gate);
@@ -860,7 +860,7 @@ class AlternatingCheckpointsTest {
 
             assertThat(target.getTriggeredCheckpointCounter()).isOne();
             assertThat(target.getTriggeredCheckpointOptions())
-                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+                    .containsExactly(unaligned(CheckpointType.CHECKPOINT, getDefault()));
             // Followed by overtaken buffers
             assertData(gate);
         }
@@ -954,7 +954,7 @@ class AlternatingCheckpointsTest {
 
             assertThat(target.getTriggeredCheckpointCounter()).isOne();
             assertThat(target.getTriggeredCheckpointOptions())
-                    .contains(unaligned(CheckpointType.CHECKPOINT, getDefault()));
+                    .containsExactly(unaligned(CheckpointType.CHECKPOINT, getDefault()));
         }
     }
 
@@ -1017,7 +1017,7 @@ class AlternatingCheckpointsTest {
             assertAnnouncement(gate);
             assertBarrier(gate);
 
-            assertThat(target.triggeredCheckpoints).contains(1L);
+            assertThat(target.triggeredCheckpoints).containsExactly(1L);
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/BarrierAlignmentUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/BarrierAlignmentUtilTest.java
@@ -26,19 +26,18 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
-import org.apache.flink.util.ExceptionUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** {@link BarrierAlignmentUtil} test. */
-public class BarrierAlignmentUtilTest {
+class BarrierAlignmentUtilTest {
 
     @Test
-    public void testDelayableTimerNotHiddenException() throws Exception {
+    void testDelayableTimerNotHiddenException() throws Exception {
         TaskMailbox mailbox = new TaskMailboxImpl();
         MailboxProcessor mailboxProcessor =
                 new MailboxProcessor(controller -> {}, mailbox, StreamTaskActionExecutor.IMMEDIATE);
@@ -63,12 +62,8 @@ public class BarrierAlignmentUtilTest {
 
         timerService.advance(delay.toMillis());
 
-        Throwable t =
-                assertThrows(
-                        "BarrierAlignmentUtil.DelayableTimer should not hidden exception",
-                        Exception.class,
-                        () -> mailboxProcessor.runMailboxStep());
-
-        ExceptionUtils.assertThrowable(t, ExpectedTestException.class);
+        assertThatThrownBy(mailboxProcessor::runMailboxStep)
+                .as("BarrierAlignmentUtil.DelayableTimer should not hidden exception")
+                .isInstanceOf(ExpectedTestException.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
@@ -44,8 +44,8 @@ import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.clock.ManualClock;
 import org.apache.flink.util.clock.SystemClock;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -56,43 +56,35 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.apache.flink.streaming.runtime.io.checkpointing.UnalignedCheckpointsTest.addSequence;
-import static org.hamcrest.Matchers.both;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the behavior of the barrier tracker. */
-public class CheckpointBarrierTrackerTest {
+class CheckpointBarrierTrackerTest {
 
     private static final int PAGE_SIZE = 512;
 
     private CheckpointedInputGate inputGate;
 
-    @After
-    public void ensureEmpty() throws Exception {
-        assertFalse(inputGate.pollNext().isPresent());
-        assertTrue(inputGate.isFinished());
+    @AfterEach
+    void ensureEmpty() throws Exception {
+        assertThat(inputGate.pollNext()).isNotPresent();
+        assertThat(inputGate.isFinished()).isTrue();
     }
 
     @Test
-    public void testSingleChannelNoBarriers() throws Exception {
+    void testSingleChannelNoBarriers() throws Exception {
         BufferOrEvent[] sequence = {createBuffer(0), createBuffer(0), createBuffer(0)};
         inputGate = createCheckpointedInputGate(1, sequence);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
     @Test
-    public void testMultiChannelNoBarriers() throws Exception {
+    void testMultiChannelNoBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(2),
             createBuffer(2),
@@ -107,12 +99,12 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(4, sequence);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
     @Test
-    public void testSingleChannelWithBarriers() throws Exception {
+    void testSingleChannelWithBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(0),
             createBuffer(0),
@@ -135,12 +127,12 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(1, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
     @Test
-    public void testSingleChannelWithSkippedBarriers() throws Exception {
+    void testSingleChannelWithSkippedBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(0),
             createBarrier(1, 0),
@@ -160,12 +152,12 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(1, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
     @Test
-    public void testMultiChannelWithBarriers() throws Exception {
+    void testMultiChannelWithBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(0),
             createBuffer(2),
@@ -199,12 +191,12 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
     @Test
-    public void testMultiChannelSkippingCheckpoints() throws Exception {
+    void testMultiChannelSkippingCheckpoints() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(0),
             createBuffer(2),
@@ -242,7 +234,7 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
@@ -255,7 +247,7 @@ public class CheckpointBarrierTrackerTest {
      * checkpoints, or fail to complete a checkpoint all together.
      */
     @Test
-    public void testCompleteCheckpointsOnLateBarriers() throws Exception {
+    void testCompleteCheckpointsOnLateBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             // checkpoint 2
             createBuffer(1),
@@ -341,12 +333,12 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
     @Test
-    public void testNextFirstCheckpointBarrierOvertakesCancellationBarrier() throws Exception {
+    void testNextFirstCheckpointBarrierOvertakesCancellationBarrier() throws Exception {
         BufferOrEvent[] sequence = {
             // start checkpoint 1
             createBarrier(1, 1),
@@ -363,16 +355,16 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(2, sequence, validator, manualClock);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
             manualClock.advanceTime(Duration.ofSeconds(1));
         }
-        assertEquals(
-                Duration.ofSeconds(2).toNanos(),
-                validator.lastAlignmentDurationNanos.get().longValue());
+        assertThatFuture(validator.lastAlignmentDurationNanos)
+                .eventuallySucceeds()
+                .isEqualTo(Duration.ofSeconds(2).toNanos());
     }
 
     @Test
-    public void testSingleChannelAbortCheckpoint() throws Exception {
+    void testSingleChannelAbortCheckpoint() throws Exception {
         BufferOrEvent[] sequence = {
             createBuffer(0),
             createBarrier(1, 0),
@@ -389,12 +381,12 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(1, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
     @Test
-    public void testMultiChannelAbortCheckpoint() throws Exception {
+    void testMultiChannelAbortCheckpoint() throws Exception {
         BufferOrEvent[] sequence = {
             // some buffers and a successful checkpoint
             createBuffer(0),
@@ -452,7 +444,7 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
@@ -461,7 +453,7 @@ public class CheckpointBarrierTrackerTest {
      * barrier arrival of two consecutive checkpoints.
      */
     @Test
-    public void testInterleavedCancellationBarriers() throws Exception {
+    void testInterleavedCancellationBarriers() throws Exception {
         BufferOrEvent[] sequence = {
             createBarrier(1L, 0),
             createCancellationBarrier(2L, 0),
@@ -475,12 +467,12 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
     }
 
     @Test
-    public void testMetrics() throws Exception {
+    void testMetrics() throws Exception {
         List<BufferOrEvent> output = new ArrayList<>();
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
         int numberOfChannels = 3;
@@ -526,23 +518,25 @@ public class CheckpointBarrierTrackerTest {
         long startDelay = System.currentTimeMillis() - checkpointBarrierCreation;
         long alignmentDuration = System.nanoTime() - alignmentStartNanos;
 
-        assertThat(
-                inputGate.getCheckpointStartDelayNanos() / 1_000_000,
-                is(both(greaterThanOrEqualTo(sleepTime)).and(lessThanOrEqualTo(startDelay))));
+        assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
+                .isBetween(sleepTime, startDelay);
 
-        assertTrue(handler.getLastAlignmentDurationNanos().isDone());
-        assertThat(
-                handler.getLastAlignmentDurationNanos().get() / 1_000_000,
-                is(
-                        both(greaterThanOrEqualTo(sleepTime))
-                                .and(lessThanOrEqualTo(alignmentDuration))));
+        assertThatFuture(handler.getLastAlignmentDurationNanos())
+                .eventuallySucceeds()
+                .satisfies(
+                        duration ->
+                                assertThat(duration / 1_000_000)
+                                        .isBetween(sleepTime, alignmentDuration));
+        assertThat(handler.getLastAlignmentDurationNanos()).isDone();
+        assertThat(handler.getLastAlignmentDurationNanos().get() / 1_000_000)
+                .isBetween(sleepTime, alignmentDuration);
 
-        assertTrue(handler.getLastBytesProcessedDuringAlignment().isDone());
-        assertThat(handler.getLastBytesProcessedDuringAlignment().get(), equalTo(3L * bufferSize));
+        assertThat(handler.getLastBytesProcessedDuringAlignment())
+                .isCompletedWithValue(3L * bufferSize);
     }
 
     @Test
-    public void testSingleChannelMetrics() throws Exception {
+    void testSingleChannelMetrics() throws Exception {
         List<BufferOrEvent> output = new ArrayList<>();
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler();
         int numberOfChannels = 1;
@@ -568,22 +562,17 @@ public class CheckpointBarrierTrackerTest {
 
         long startDelay = System.currentTimeMillis() - checkpointBarrierCreation;
 
-        assertThat(
-                inputGate.getCheckpointStartDelayNanos() / 1_000_000,
-                greaterThanOrEqualTo(sleepTime));
-        assertThat(
-                inputGate.getCheckpointStartDelayNanos() / 1_000_000,
-                lessThanOrEqualTo(startDelay));
+        assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
+                .isGreaterThanOrEqualTo(sleepTime);
+        assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
+                .isLessThanOrEqualTo(startDelay);
 
-        assertTrue(handler.getLastAlignmentDurationNanos().isDone());
-        assertThat(handler.getLastAlignmentDurationNanos().get(), equalTo(0L));
-
-        assertTrue(handler.getLastBytesProcessedDuringAlignment().isDone());
-        assertThat(handler.getLastBytesProcessedDuringAlignment().get(), equalTo(0L));
+        assertThat(handler.getLastAlignmentDurationNanos()).isCompletedWithValue(0L);
+        assertThat(handler.getLastBytesProcessedDuringAlignment()).isCompletedWithValue(0L);
     }
 
     @Test
-    public void testTriggerCheckpointsWithEndOfPartition() throws Exception {
+    void testTriggerCheckpointsWithEndOfPartition() throws Exception {
         BufferOrEvent[] sequence = {
             createBarrier(1, 0),
             createBarrier(2, 0),
@@ -602,18 +591,18 @@ public class CheckpointBarrierTrackerTest {
                 (CheckpointBarrierTracker) inputGate.getCheckpointBarrierHandler();
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
         // Only checkpoints 4 is triggered and the previous checkpoints are ignored.
-        assertThat(validator.triggeredCheckpoints, contains(4L));
-        assertEquals(0, validator.getAbortedCheckpointCounter());
-        assertThat(checkpointBarrierTracker.getPendingCheckpointIds(), contains(5L));
-        assertEquals(2, checkpointBarrierTracker.getNumOpenChannels());
+        assertThat(validator.triggeredCheckpoints).contains(4L);
+        assertThat(validator.getAbortedCheckpointCounter()).isZero();
+        assertThat(checkpointBarrierTracker.getPendingCheckpointIds()).contains(5L);
+        assertThat(checkpointBarrierTracker.getNumOpenChannels()).isEqualTo(2);
     }
 
     @Test
-    public void testDeduplicateChannelsWithBothBarrierAndEndOfPartition() throws Exception {
+    void testDeduplicateChannelsWithBothBarrierAndEndOfPartition() throws Exception {
         BufferOrEvent[] sequence = {
             /* 0 */ createBarrier(2, 0),
             /* 1 */ createBarrier(2, 1),
@@ -625,20 +614,20 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
         for (int i = 0; i <= 2; ++i) {
-            assertEquals(sequence[i], inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(sequence[i]);
         }
 
         // Here the checkpoint should not be triggered.
-        assertEquals(0, validator.getTriggeredCheckpointCounter());
-        assertEquals(0, validator.getAbortedCheckpointCounter());
+        assertThat(validator.getTriggeredCheckpointCounter()).isZero();
+        assertThat(validator.getAbortedCheckpointCounter()).isZero();
 
         // The last barrier aligned the pending checkpoint 2.
-        assertEquals(sequence[3], inputGate.pollNext().get());
-        assertThat(validator.triggeredCheckpoints, contains(2L));
+        assertThat(inputGate.pollNext()).hasValue(sequence[3]);
+        assertThat(validator.triggeredCheckpoints).contains(2L);
     }
 
     @Test
-    public void testTriggerCheckpointsAfterReceivedEndOfPartition() throws Exception {
+    void testTriggerCheckpointsAfterReceivedEndOfPartition() throws Exception {
         BufferOrEvent[] sequence = {
             /* 0 */ createEndOfPartition(2),
             /* 1 */ createBarrier(5, 0),
@@ -652,15 +641,15 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
-        assertThat(validator.triggeredCheckpoints, contains(6L, 7L));
-        assertEquals(0, validator.getAbortedCheckpointCounter());
+        assertThat(validator.triggeredCheckpoints).contains(6L, 7L);
+        assertThat(validator.getAbortedCheckpointCounter()).isZero();
     }
 
     @Test
-    public void testNoFastPathWithChannelFinishedDuringCheckpoints() throws Exception {
+    void testNoFastPathWithChannelFinishedDuringCheckpoints() throws Exception {
         BufferOrEvent[] sequence = {
             createBarrier(1, 0), createEndOfPartition(0), createBarrier(1, 1)
         };
@@ -669,16 +658,16 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(2, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
         // The last barrier should finish the pending checkpoint instead of trigger a "new" one.
-        assertEquals(1, validator.getTriggeredCheckpointCounter());
-        assertFalse(inputGate.getCheckpointBarrierHandler().isCheckpointPending());
+        assertThat(validator.getTriggeredCheckpointCounter()).isOne();
+        assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending()).isFalse();
     }
 
     @Test
-    public void testCompleteAndRemoveAbortedCheckpointWithEndOfPartition() throws Exception {
+    void testCompleteAndRemoveAbortedCheckpointWithEndOfPartition() throws Exception {
         BufferOrEvent[] sequence = {
             createCancellationBarrier(4, 0),
             createBarrier(4, 1),
@@ -693,18 +682,18 @@ public class CheckpointBarrierTrackerTest {
                 (CheckpointBarrierTracker) inputGate.getCheckpointBarrierHandler();
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
-        assertEquals(1, validator.getAbortedCheckpointCounter());
-        assertEquals(4L, validator.getLastCanceledCheckpointId());
-        assertEquals(0, validator.getTriggeredCheckpointCounter());
-        assertThat(checkpointBarrierTracker.getPendingCheckpointIds(), contains(5L));
-        assertEquals(2, checkpointBarrierTracker.getNumOpenChannels());
+        assertThat(validator.getAbortedCheckpointCounter()).isOne();
+        assertThat(validator.getLastCanceledCheckpointId()).isEqualTo(4L);
+        assertThat(validator.getTriggeredCheckpointCounter()).isZero();
+        assertThat(checkpointBarrierTracker.getPendingCheckpointIds()).contains(5L);
+        assertThat(checkpointBarrierTracker.getNumOpenChannels()).isEqualTo(2L);
     }
 
     @Test
-    public void testAbortCheckpointsAfterEndOfPartitionReceived() throws Exception {
+    void testAbortCheckpointsAfterEndOfPartitionReceived() throws Exception {
         BufferOrEvent[] sequence = {
             /* 0 */ createEndOfPartition(2),
             /* 1 */ createBarrier(5, 0),
@@ -718,15 +707,15 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(3, sequence, validator);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
-        assertThat(validator.abortedCheckpoints, contains(5L, 6L, 7L));
-        assertEquals(0, validator.getTriggeredCheckpointCounter());
+        assertThat(validator.abortedCheckpoints).contains(5L, 6L, 7L);
+        assertThat(validator.getTriggeredCheckpointCounter()).isZero();
     }
 
     @Test
-    public void testNoFastPathWithChannelFinishedDuringCheckpointsCancel() throws Exception {
+    void testNoFastPathWithChannelFinishedDuringCheckpointsCancel() throws Exception {
         BufferOrEvent[] sequence = {
             createBarrier(1, 0, 0), createEndOfPartition(0), createCancellationBarrier(1, 1)
         };
@@ -735,16 +724,16 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(2, sequence, checkpointHandler);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
-        assertEquals(1, checkpointHandler.getLastCanceledCheckpointId());
+        assertThat(checkpointHandler.getLastCanceledCheckpointId()).isOne();
         // If go with the fast path, the pending checkpoint would not be removed normally.
-        assertFalse(inputGate.getCheckpointBarrierHandler().isCheckpointPending());
+        assertThat(inputGate.getCheckpointBarrierHandler().isCheckpointPending()).isFalse();
     }
 
     @Test
-    public void testTwoLastBarriersOneByOne() throws Exception {
+    void testTwoLastBarriersOneByOne() throws Exception {
         BufferOrEvent[] sequence = {
             // start checkpoint 1
             createBarrier(1, 1),
@@ -761,12 +750,12 @@ public class CheckpointBarrierTrackerTest {
         inputGate = createCheckpointedInputGate(2, sequence, validator, manualClock);
 
         for (BufferOrEvent boe : sequence) {
-            assertEquals(boe, inputGate.pollNext().get());
+            assertThat(inputGate.pollNext()).hasValue(boe);
             manualClock.advanceTime(Duration.ofSeconds(1));
         }
-        assertEquals(
-                Duration.ofSeconds(2).toNanos(),
-                validator.lastAlignmentDurationNanos.get().longValue());
+        assertThatFuture(validator.lastAlignmentDurationNanos)
+                .eventuallySucceeds()
+                .isEqualTo(Duration.ofSeconds(2).toNanos());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointBarrierTrackerTest.java
@@ -563,9 +563,7 @@ class CheckpointBarrierTrackerTest {
         long startDelay = System.currentTimeMillis() - checkpointBarrierCreation;
 
         assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
-                .isGreaterThanOrEqualTo(sleepTime);
-        assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
-                .isLessThanOrEqualTo(startDelay);
+                .isBetween(sleepTime, startDelay);
 
         assertThat(handler.getLastAlignmentDurationNanos()).isCompletedWithValue(0L);
         assertThat(handler.getLastBytesProcessedDuringAlignment()).isCompletedWithValue(0L);
@@ -595,9 +593,9 @@ class CheckpointBarrierTrackerTest {
         }
 
         // Only checkpoints 4 is triggered and the previous checkpoints are ignored.
-        assertThat(validator.triggeredCheckpoints).contains(4L);
+        assertThat(validator.triggeredCheckpoints).containsExactly(4L);
         assertThat(validator.getAbortedCheckpointCounter()).isZero();
-        assertThat(checkpointBarrierTracker.getPendingCheckpointIds()).contains(5L);
+        assertThat(checkpointBarrierTracker.getPendingCheckpointIds()).containsExactly(5L);
         assertThat(checkpointBarrierTracker.getNumOpenChannels()).isEqualTo(2);
     }
 
@@ -623,7 +621,7 @@ class CheckpointBarrierTrackerTest {
 
         // The last barrier aligned the pending checkpoint 2.
         assertThat(inputGate.pollNext()).hasValue(sequence[3]);
-        assertThat(validator.triggeredCheckpoints).contains(2L);
+        assertThat(validator.triggeredCheckpoints).containsExactly(2L);
     }
 
     @Test
@@ -644,7 +642,7 @@ class CheckpointBarrierTrackerTest {
             assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
-        assertThat(validator.triggeredCheckpoints).contains(6L, 7L);
+        assertThat(validator.triggeredCheckpoints).containsExactly(6L, 7L);
         assertThat(validator.getAbortedCheckpointCounter()).isZero();
     }
 
@@ -688,7 +686,7 @@ class CheckpointBarrierTrackerTest {
         assertThat(validator.getAbortedCheckpointCounter()).isOne();
         assertThat(validator.getLastCanceledCheckpointId()).isEqualTo(4L);
         assertThat(validator.getTriggeredCheckpointCounter()).isZero();
-        assertThat(checkpointBarrierTracker.getPendingCheckpointIds()).contains(5L);
+        assertThat(checkpointBarrierTracker.getPendingCheckpointIds()).containsExactly(5L);
         assertThat(checkpointBarrierTracker.getNumOpenChannels()).isEqualTo(2L);
     }
 
@@ -710,7 +708,7 @@ class CheckpointBarrierTrackerTest {
             assertThat(inputGate.pollNext()).hasValue(boe);
         }
 
-        assertThat(validator.abortedCheckpoints).contains(5L, 6L, 7L);
+        assertThat(validator.abortedCheckpoints).containsExactly(5L, 6L, 7L);
         assertThat(validator.getTriggeredCheckpointCounter()).isZero();
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -52,8 +52,8 @@ import org.apache.flink.util.clock.SystemClock;
 
 import org.apache.flink.shaded.guava31.com.google.common.io.Closer;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -62,28 +62,26 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.buildSomeBuffer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** {@link CheckpointedInputGate} test. */
-public class CheckpointedInputGateTest {
+class CheckpointedInputGateTest {
     private final HashMap<Integer, Integer> channelIndexToSequenceNumber = new HashMap<>();
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         channelIndexToSequenceNumber.clear();
     }
 
     @Test
-    public void testUpstreamResumedUponEndOfRecovery() throws Exception {
+    void testUpstreamResumedUponEndOfRecovery() throws Exception {
         int numberOfChannels = 11;
         NetworkBufferPool bufferPool = new NetworkBufferPool(numberOfChannels * 3, 1024);
         try {
             ResumeCountingConnectionManager resumeCounter = new ResumeCountingConnectionManager();
             CheckpointedInputGate gate =
                     setupInputGate(numberOfChannels, bufferPool, resumeCounter);
-            assertFalse(gate.pollNext().isPresent());
+            assertThat(gate.pollNext()).isNotPresent();
             for (int channelIndex = 0; channelIndex < numberOfChannels - 1; channelIndex++) {
                 enqueueEndOfState(gate, channelIndex);
                 Optional<BufferOrEvent> bufferOrEvent = gate.pollNext();
@@ -92,30 +90,30 @@ public class CheckpointedInputGateTest {
                         && !gate.allChannelsRecovered()) {
                     bufferOrEvent = gate.pollNext();
                 }
-                assertFalse("should align (block all channels)", bufferOrEvent.isPresent());
+                assertThat(bufferOrEvent).as("should align (block all channels)").isNotPresent();
             }
 
             enqueueEndOfState(gate, numberOfChannels - 1);
             Optional<BufferOrEvent> polled = gate.pollNext();
-            assertTrue(polled.isPresent());
-            assertTrue(polled.get().isEvent());
-            assertEquals(EndOfChannelStateEvent.INSTANCE, polled.get().getEvent());
-            assertEquals(numberOfChannels, resumeCounter.getNumResumed());
-            assertFalse(
-                    "should only be a single event no matter of what is the number of channels",
-                    gate.pollNext().isPresent());
+            assertThat(polled).isPresent();
+            assertThat(polled.get().isEvent()).isTrue();
+            assertThat(polled.get().getEvent()).isEqualTo(EndOfChannelStateEvent.INSTANCE);
+            assertThat(resumeCounter.getNumResumed()).isEqualTo(numberOfChannels);
+            assertThat(gate.pollNext())
+                    .as("should only be a single event no matter of what is the number of channels")
+                    .isNotPresent();
         } finally {
             bufferPool.destroy();
         }
     }
 
     @Test
-    public void testPersisting() throws Exception {
+    void testPersisting() throws Exception {
         testPersisting(false);
     }
 
     @Test
-    public void testPersistingWithDrainingTheGate() throws Exception {
+    void testPersistingWithDrainingTheGate() throws Exception {
         testPersisting(true);
     }
 
@@ -127,7 +125,7 @@ public class CheckpointedInputGateTest {
      * notifyCheckpointAborted RPCs) and Task should be able to handle this properly. In FLINK-21104
      * the problem was that this obsoleted checkpoint barrier was causing a checkState to fail.
      */
-    public void testPersisting(boolean drainGate) throws Exception {
+    private void testPersisting(boolean drainGate) throws Exception {
 
         int numberOfChannels = 3;
         NetworkBufferPool bufferPool = new NetworkBufferPool(numberOfChannels * 3, 1024);
@@ -151,10 +149,10 @@ public class CheckpointedInputGateTest {
             enqueue(gate, 1, buildSomeBuffer());
             enqueue(gate, 2, buildSomeBuffer());
 
-            assertEquals(0, validatingHandler.getTriggeredCheckpointCounter());
+            assertThat(validatingHandler.getTriggeredCheckpointCounter()).isZero();
             // trigger checkpoint
             gate.pollNext();
-            assertEquals(1, validatingHandler.getTriggeredCheckpointCounter());
+            assertThat(validatingHandler.getTriggeredCheckpointCounter()).isOne();
 
             assertAddedInputSize(stateWriter, 0, 1);
             assertAddedInputSize(stateWriter, 1, 2);
@@ -200,7 +198,7 @@ public class CheckpointedInputGateTest {
      * processed while draining mailbox but can't pull any data anymore.
      */
     @Test
-    public void testPriorityBeforeClose() throws IOException, InterruptedException {
+    void testPriorityBeforeClose() throws IOException, InterruptedException {
 
         NetworkBufferPool bufferPool = new NetworkBufferPool(10, 1024);
         try (Closer closer = Closer.create()) {
@@ -259,7 +257,7 @@ public class CheckpointedInputGateTest {
                 beforeLatch.countDown();
                 try {
                     while (mailboxExecutor.tryYield()) {}
-                    assertEquals(1L, validatingHandler.triggeredCheckpointCounter);
+                    assertThat(validatingHandler.triggeredCheckpointCounter).isOne();
                 } catch (CancelTaskException e) {
                 }
                 canceler.join();
@@ -278,9 +276,8 @@ public class CheckpointedInputGateTest {
 
     private void assertAddedInputSize(
             RecordingChannelStateWriter stateWriter, int channelIndex, int size) {
-        assertEquals(
-                size,
-                stateWriter.getAddedInput().get(new InputChannelInfo(0, channelIndex)).size());
+        assertThat(stateWriter.getAddedInput().get(new InputChannelInfo(0, channelIndex)))
+                .hasSize(size);
     }
 
     private void enqueueEndOfState(CheckpointedInputGate checkpointedInputGate, int channelIndex)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/InputProcessorUtilTest.java
@@ -39,23 +39,23 @@ import org.apache.flink.streaming.runtime.tasks.TestSubtaskCheckpointCoordinator
 import org.apache.flink.streaming.util.MockStreamTask;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for the behaviors of the {@link
  * org.apache.flink.streaming.runtime.io.checkpointing.InputProcessorUtil}.
  */
-public class InputProcessorUtilTest {
+class InputProcessorUtilTest {
 
     @Test
-    public void testCreateCheckpointedMultipleInputGate() throws Exception {
+    void testCreateCheckpointedMultipleInputGate() throws Exception {
         try (CloseableRegistry registry = new CloseableRegistry()) {
             MockEnvironment environment = new MockEnvironmentBuilder().build();
             MockStreamTask streamTask = new MockStreamTaskBuilder(environment).build();
@@ -112,7 +112,7 @@ public class InputProcessorUtilTest {
                             false);
                 }
             }
-            assertTrue(barrierHandler.getAllBarriersReceivedFuture(1).isDone());
+            assertThat(barrierHandler.getAllBarriersReceivedFuture(1)).isDone();
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsTest.java
@@ -335,9 +335,7 @@ class UnalignedCheckpointsTest {
 
         assertThat(handler.getLastAlignmentDurationNanos()).isDone();
         assertThat(handler.getLastAlignmentDurationNanos().get() / 1_000_000)
-                .isGreaterThanOrEqualTo(sleepTime);
-        assertThat(handler.getLastAlignmentDurationNanos().get())
-                .isLessThanOrEqualTo(alignmentDuration);
+                .isBetween(sleepTime, alignmentDuration);
 
         assertThat(handler.getLastBytesProcessedDuringAlignment())
                 .isCompletedWithValue(6L * bufferSize);
@@ -840,7 +838,7 @@ class UnalignedCheckpointsTest {
                         /* 6 */ createEndOfPartition(1));
 
         assertOutput(sequence);
-        assertThat(validator.triggeredCheckpoints).contains(1L);
+        assertThat(validator.triggeredCheckpoints).containsExactly(1L);
         assertThat(validator.getAbortedCheckpointCounter()).isZero();
         assertInflightData(sequence[1]);
     }
@@ -861,7 +859,7 @@ class UnalignedCheckpointsTest {
                         /* 5 */ createBarrier(3, 2));
         assertOutput(sequence1);
         assertInflightData(sequence1[3]);
-        assertThat(validator.triggeredCheckpoints).contains(3L);
+        assertThat(validator.triggeredCheckpoints).containsExactly(3L);
         assertThat(validator.getAbortedCheckpointCounter()).isZero();
 
         BufferOrEvent[] sequence2 =
@@ -872,7 +870,7 @@ class UnalignedCheckpointsTest {
                         /* 2 */ createEndOfPartition(2));
         assertOutput(sequence2);
         assertInflightData();
-        assertThat(validator.triggeredCheckpoints).contains(3L, 4L);
+        assertThat(validator.triggeredCheckpoints).containsExactly(3L, 4L);
         assertThat(validator.getAbortedCheckpointCounter()).isZero();
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsTest.java
@@ -46,10 +46,9 @@ import org.apache.flink.streaming.runtime.tasks.TestSubtaskCheckpointCoordinator
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
 import org.apache.flink.util.clock.SystemClock;
 
-import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -64,14 +63,10 @@ import java.util.stream.IntStream;
 
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
 import static org.apache.flink.util.Preconditions.checkState;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the behaviors of the {@link CheckpointedInputGate}. */
-public class UnalignedCheckpointsTest {
+class UnalignedCheckpointsTest {
 
     private static final long DEFAULT_CHECKPOINT_ID = 0L;
 
@@ -85,16 +80,16 @@ public class UnalignedCheckpointsTest {
 
     private List<BufferOrEvent> output;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         channelStateWriter = new RecordingChannelStateWriter();
     }
 
-    @After
-    public void ensureEmpty() throws Exception {
+    @AfterEach
+    void ensureEmpty() throws Exception {
         if (inputGate != null) {
-            assertFalse(inputGate.pollNext().isPresent());
-            assertTrue(inputGate.isFinished());
+            assertThat(inputGate.pollNext()).isNotPresent();
+            assertThat(inputGate.isFinished()).isTrue();
             inputGate.close();
         }
 
@@ -112,7 +107,7 @@ public class UnalignedCheckpointsTest {
      * input channel.
      */
     @Test
-    public void testSingleChannelNoBarriers() throws Exception {
+    void testSingleChannelNoBarriers() throws Exception {
         inputGate = createInputGate(1, new ValidatingCheckpointHandler(1));
         final BufferOrEvent[] sequence =
                 addSequence(
@@ -131,7 +126,7 @@ public class UnalignedCheckpointsTest {
      * multiple input channels.
      */
     @Test
-    public void testMultiChannelNoBarriers() throws Exception {
+    void testMultiChannelNoBarriers() throws Exception {
         inputGate = createInputGate(4, new ValidatingCheckpointHandler(1));
         final BufferOrEvent[] sequence =
                 addSequence(
@@ -159,7 +154,7 @@ public class UnalignedCheckpointsTest {
      * channel, and checkpoint events.
      */
     @Test
-    public void testSingleChannelWithBarriers() throws Exception {
+    void testSingleChannelWithBarriers() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(1);
         inputGate = createInputGate(1, handler);
         final BufferOrEvent[] sequence =
@@ -191,7 +186,7 @@ public class UnalignedCheckpointsTest {
      * channels, by buffering and blocking certain inputs.
      */
     @Test
-    public void testMultiChannelWithBarriers() throws Exception {
+    void testMultiChannelWithBarriers() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(1);
         inputGate = createInputGate(3, handler);
 
@@ -211,7 +206,7 @@ public class UnalignedCheckpointsTest {
 
         // checkpoint 1 triggered unaligned
         assertOutput(sequence1);
-        assertEquals(1L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isOne();
         assertInflightData(sequence1[7]);
 
         // checkpoint without in-flight data
@@ -228,7 +223,7 @@ public class UnalignedCheckpointsTest {
                         createBarrier(2, 2));
 
         assertOutput(sequence2);
-        assertEquals(2L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(2L);
         assertInflightData();
 
         // checkpoint with data only from one channel
@@ -244,14 +239,14 @@ public class UnalignedCheckpointsTest {
                         createBarrier(3, 1));
 
         assertOutput(sequence3);
-        assertEquals(3L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(3L);
         assertInflightData();
 
         // empty checkpoint
         addSequence(inputGate, createBarrier(4, 1), createBarrier(4, 2), createBarrier(4, 0));
 
         assertOutput();
-        assertEquals(4L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(4L);
         assertInflightData();
 
         // checkpoint with in-flight data in mixed order
@@ -274,7 +269,7 @@ public class UnalignedCheckpointsTest {
                         createBarrier(5, 0));
 
         assertOutput(sequence5);
-        assertEquals(5L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(5L);
         assertInflightData(sequence5[4], sequence5[5], sequence5[6], sequence5[10]);
 
         // some trailing data
@@ -291,7 +286,7 @@ public class UnalignedCheckpointsTest {
     }
 
     @Test
-    public void testMetrics() throws Exception {
+    void testMetrics() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(1);
         inputGate = createInputGate(3, handler);
         int bufferSize = 100;
@@ -333,30 +328,23 @@ public class UnalignedCheckpointsTest {
 
         long alignmentDuration = System.nanoTime() - alignmentStartNanos;
 
-        assertEquals(checkpointId, inputGate.getCheckpointBarrierHandler().getLatestCheckpointId());
-        assertThat(
-                inputGate.getCheckpointStartDelayNanos() / 1_000_000,
-                Matchers.greaterThanOrEqualTo(sleepTime));
-        assertThat(
-                inputGate.getCheckpointStartDelayNanos() / 1_000_000,
-                Matchers.lessThanOrEqualTo(startDelay));
+        assertThat(inputGate.getCheckpointBarrierHandler().getLatestCheckpointId())
+                .isEqualTo(checkpointId);
+        assertThat(inputGate.getCheckpointStartDelayNanos() / 1_000_000)
+                .isBetween(sleepTime, startDelay);
 
-        assertTrue(handler.getLastAlignmentDurationNanos().isDone());
-        assertThat(
-                handler.getLastAlignmentDurationNanos().get() / 1_000_000,
-                Matchers.greaterThanOrEqualTo(sleepTime));
-        assertThat(
-                handler.getLastAlignmentDurationNanos().get(),
-                Matchers.lessThanOrEqualTo(alignmentDuration));
+        assertThat(handler.getLastAlignmentDurationNanos()).isDone();
+        assertThat(handler.getLastAlignmentDurationNanos().get() / 1_000_000)
+                .isGreaterThanOrEqualTo(sleepTime);
+        assertThat(handler.getLastAlignmentDurationNanos().get())
+                .isLessThanOrEqualTo(alignmentDuration);
 
-        assertTrue(handler.getLastBytesProcessedDuringAlignment().isDone());
-        assertThat(
-                handler.getLastBytesProcessedDuringAlignment().get(),
-                Matchers.equalTo(6L * bufferSize));
+        assertThat(handler.getLastBytesProcessedDuringAlignment())
+                .isCompletedWithValue(6L * bufferSize);
     }
 
     @Test
-    public void testMultiChannelTrailingInflightData() throws Exception {
+    void testMultiChannelTrailingInflightData() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(1);
         inputGate = createInputGate(3, handler, false);
 
@@ -385,13 +373,13 @@ public class UnalignedCheckpointsTest {
                         createEndOfPartition(0));
 
         assertOutput(sequence);
-        assertEquals(2L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(2L);
         // TODO: treat EndOfPartitionEvent as a special CheckpointBarrier?
         assertInflightData();
     }
 
     @Test
-    public void testMissingCancellationBarriers() throws Exception {
+    void testMissingCancellationBarriers() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(1);
         inputGate = createInputGate(2, handler);
         final BufferOrEvent[] sequence =
@@ -406,13 +394,13 @@ public class UnalignedCheckpointsTest {
                         createEndOfPartition(1));
 
         assertOutput(sequence);
-        assertEquals(1L, channelStateWriter.getLastStartedCheckpointId());
-        assertEquals(3L, handler.getLastCanceledCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isOne();
+        assertThat(handler.getLastCanceledCheckpointId()).isEqualTo(3L);
         assertInflightData();
     }
 
     @Test
-    public void testEarlyCleanup() throws Exception {
+    void testEarlyCleanup() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(1);
         inputGate = createInputGate(3, handler, false);
 
@@ -427,7 +415,7 @@ public class UnalignedCheckpointsTest {
                         createBarrier(1, 2),
                         createBarrier(1, 0));
         assertOutput(sequence1);
-        assertEquals(1L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isOne();
         assertInflightData();
 
         // checkpoint 2
@@ -449,12 +437,12 @@ public class UnalignedCheckpointsTest {
                         createBuffer(0),
                         createEndOfPartition(0));
         assertOutput(sequence2);
-        assertEquals(2L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(2L);
         assertInflightData();
     }
 
     @Test
-    public void testStartAlignmentWithClosedChannels() throws Exception {
+    void testStartAlignmentWithClosedChannels() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(2);
         inputGate = createInputGate(4, handler);
 
@@ -472,7 +460,7 @@ public class UnalignedCheckpointsTest {
                         createBarrier(2, 3),
                         createBarrier(2, 0));
         assertOutput(sequence1);
-        assertEquals(2L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(2L);
         assertInflightData();
 
         // checkpoint with in-flight data
@@ -486,14 +474,14 @@ public class UnalignedCheckpointsTest {
                         createBuffer(0),
                         createBarrier(3, 0));
         assertOutput(sequence2);
-        assertEquals(3L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(3L);
         assertInflightData(sequence2[4]);
 
         // empty checkpoint
         final BufferOrEvent[] sequence3 =
                 addSequence(inputGate, createBarrier(4, 0), createBarrier(4, 3));
         assertOutput(sequence3);
-        assertEquals(4L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(4L);
         assertInflightData();
 
         // some data, one channel closes
@@ -505,7 +493,7 @@ public class UnalignedCheckpointsTest {
                         createBuffer(3),
                         createEndOfPartition(0));
         assertOutput(sequence4);
-        assertEquals(-1L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(-1L);
         assertInflightData();
 
         // checkpoint on last remaining channel
@@ -517,12 +505,12 @@ public class UnalignedCheckpointsTest {
                         createBuffer(3),
                         createEndOfPartition(3));
         assertOutput(sequence5);
-        assertEquals(5L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(5L);
         assertInflightData();
     }
 
     @Test
-    public void testEndOfStreamWhileCheckpoint() throws Exception {
+    void testEndOfStreamWhileCheckpoint() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(1);
         inputGate = createInputGate(3, handler);
 
@@ -531,7 +519,7 @@ public class UnalignedCheckpointsTest {
                 addSequence(
                         inputGate, createBarrier(1, 0), createBarrier(1, 1), createBarrier(1, 2));
         assertOutput(sequence1);
-        assertEquals(1L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isOne();
         assertInflightData();
 
         final BufferOrEvent[] sequence2 =
@@ -557,12 +545,12 @@ public class UnalignedCheckpointsTest {
                         // final end of stream
                         createEndOfPartition(0));
         assertOutput(sequence2);
-        assertEquals(2L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(2L);
         assertInflightData(sequence2[7]);
     }
 
     @Test
-    public void testNotifyAbortCheckpointBeforeCanellingAsyncCheckpoint() throws Exception {
+    void testNotifyAbortCheckpointBeforeCanellingAsyncCheckpoint() throws Exception {
         ValidateAsyncFutureNotCompleted handler = new ValidateAsyncFutureNotCompleted(1);
         inputGate = createInputGate(2, handler);
         handler.setInputGate(inputGate);
@@ -572,7 +560,7 @@ public class UnalignedCheckpointsTest {
     }
 
     @Test
-    public void testSingleChannelAbortCheckpoint() throws Exception {
+    void testSingleChannelAbortCheckpoint() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(1);
         inputGate = createInputGate(1, handler);
         final BufferOrEvent[] sequence1 =
@@ -585,8 +573,8 @@ public class UnalignedCheckpointsTest {
                         createCancellationBarrier(4, 0));
 
         assertOutput(sequence1);
-        assertEquals(2L, channelStateWriter.getLastStartedCheckpointId());
-        assertEquals(4L, handler.getLastCanceledCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(2L);
+        assertThat(handler.getLastCanceledCheckpointId()).isEqualTo(4L);
         assertInflightData();
 
         final BufferOrEvent[] sequence2 =
@@ -599,13 +587,13 @@ public class UnalignedCheckpointsTest {
                         createEndOfPartition(0));
 
         assertOutput(sequence2);
-        assertEquals(5L, channelStateWriter.getLastStartedCheckpointId());
-        assertEquals(6L, handler.getLastCanceledCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(5L);
+        assertThat(handler.getLastCanceledCheckpointId()).isEqualTo(6L);
         assertInflightData();
     }
 
     @Test
-    public void testMultiChannelAbortCheckpoint() throws Exception {
+    void testMultiChannelAbortCheckpoint() throws Exception {
         ValidatingCheckpointHandler handler = new ValidatingCheckpointHandler(1);
         inputGate = createInputGate(3, handler);
         // some buffers and a successful checkpoint
@@ -624,7 +612,7 @@ public class UnalignedCheckpointsTest {
                         createBuffer(2));
 
         assertOutput(sequence1);
-        assertEquals(1L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isOne();
         assertInflightData();
 
         // canceled checkpoint on last barrier
@@ -638,8 +626,8 @@ public class UnalignedCheckpointsTest {
                         createCancellationBarrier(2, 1));
 
         assertOutput(sequence2);
-        assertEquals(2L, channelStateWriter.getLastStartedCheckpointId());
-        assertEquals(2L, handler.getLastCanceledCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(2L);
+        assertThat(handler.getLastCanceledCheckpointId()).isEqualTo(2L);
         assertInflightData();
 
         // one more successful checkpoint
@@ -653,7 +641,7 @@ public class UnalignedCheckpointsTest {
                         createBarrier(3, 0));
 
         assertOutput(sequence3);
-        assertEquals(3L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(3L);
         assertInflightData();
 
         // this checkpoint gets immediately canceled, don't start a checkpoint at all
@@ -668,8 +656,8 @@ public class UnalignedCheckpointsTest {
                         createBarrier(4, 0));
 
         assertOutput(sequence4);
-        assertEquals(-1, channelStateWriter.getLastStartedCheckpointId());
-        assertEquals(4L, handler.getLastCanceledCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(-1L);
+        assertThat(handler.getLastCanceledCheckpointId()).isEqualTo(4L);
         assertInflightData();
 
         // a simple successful checkpoint
@@ -687,7 +675,7 @@ public class UnalignedCheckpointsTest {
                         createBuffer(1));
 
         assertOutput(sequence5);
-        assertEquals(5L, channelStateWriter.getLastStartedCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(5L);
         assertInflightData();
 
         // abort multiple cancellations and a barrier after the cancellations, don't start a
@@ -704,8 +692,8 @@ public class UnalignedCheckpointsTest {
                         createEndOfPartition(2));
 
         assertOutput(sequence6);
-        assertEquals(-1L, channelStateWriter.getLastStartedCheckpointId());
-        assertEquals(6L, handler.getLastCanceledCheckpointId());
+        assertThat(channelStateWriter.getLastStartedCheckpointId()).isEqualTo(-1L);
+        assertThat(handler.getLastCanceledCheckpointId()).isEqualTo(6L);
         assertInflightData();
     }
 
@@ -716,7 +704,7 @@ public class UnalignedCheckpointsTest {
      * CheckpointBarrierHandler#processBarrier(CheckpointBarrier, InputChannelInfo)}.
      */
     @Test
-    public void testProcessCancellationBarrierAfterProcessBarrier() throws Exception {
+    void testProcessCancellationBarrierAfterProcessBarrier() throws Exception {
         final ValidatingCheckpointInvokable invokable = new ValidatingCheckpointInvokable();
         final SingleInputGate inputGate =
                 new SingleInputGateBuilder()
@@ -736,14 +724,14 @@ public class UnalignedCheckpointsTest {
         handler.processBarrier(
                 buildCheckpointBarrier(DEFAULT_CHECKPOINT_ID), new InputChannelInfo(0, 0), false);
 
-        assertTrue(handler.isCheckpointPending());
-        assertEquals(DEFAULT_CHECKPOINT_ID, handler.getLatestCheckpointId());
+        assertThat(handler.isCheckpointPending()).isTrue();
+        assertThat(handler.getLatestCheckpointId()).isEqualTo(DEFAULT_CHECKPOINT_ID);
 
         testProcessCancellationBarrier(handler, invokable);
     }
 
     @Test
-    public void testProcessCancellationBarrierBeforeProcessAndReceiveBarrier() throws Exception {
+    void testProcessCancellationBarrierBeforeProcessAndReceiveBarrier() throws Exception {
         final ValidatingCheckpointInvokable invokable = new ValidatingCheckpointInvokable();
         final SingleInputGate inputGate =
                 new SingleInputGateBuilder()
@@ -795,13 +783,13 @@ public class UnalignedCheckpointsTest {
             ValidatingCheckpointInvokable invokable,
             long currentCheckpointId) {
 
-        assertFalse(handler.isCheckpointPending());
-        assertEquals(currentCheckpointId, handler.getLatestCheckpointId());
-        assertEquals(currentCheckpointId, invokable.getAbortedCheckpointId());
+        assertThat(handler.isCheckpointPending()).isFalse();
+        assertThat(handler.getLatestCheckpointId()).isEqualTo(currentCheckpointId);
+        assertThat(invokable.getAbortedCheckpointId()).isEqualTo(currentCheckpointId);
     }
 
     @Test
-    public void testEndOfStreamWithPendingCheckpoint() throws Exception {
+    void testEndOfStreamWithPendingCheckpoint() throws Exception {
         final int numberOfChannels = 2;
         final ValidatingCheckpointInvokable invokable = new ValidatingCheckpointInvokable();
         final SingleInputGate inputGate =
@@ -822,21 +810,21 @@ public class UnalignedCheckpointsTest {
         handler.processBarrier(
                 buildCheckpointBarrier(DEFAULT_CHECKPOINT_ID), new InputChannelInfo(0, 0), false);
 
-        assertTrue(handler.isCheckpointPending());
-        assertEquals(DEFAULT_CHECKPOINT_ID, handler.getLatestCheckpointId());
-        assertEquals(numberOfChannels, handler.getNumOpenChannels());
+        assertThat(handler.isCheckpointPending()).isTrue();
+        assertThat(handler.getLatestCheckpointId()).isEqualTo(DEFAULT_CHECKPOINT_ID);
+        assertThat(handler.getNumOpenChannels()).isEqualTo(numberOfChannels);
 
         // should abort current checkpoint while processing eof
         handler.processEndOfPartition(new InputChannelInfo(0, 0));
 
-        assertFalse(handler.isCheckpointPending());
-        assertEquals(DEFAULT_CHECKPOINT_ID, handler.getLatestCheckpointId());
-        assertEquals(numberOfChannels - 1, handler.getNumOpenChannels());
-        assertEquals(DEFAULT_CHECKPOINT_ID, invokable.getAbortedCheckpointId());
+        assertThat(handler.isCheckpointPending()).isFalse();
+        assertThat(handler.getLatestCheckpointId()).isEqualTo(DEFAULT_CHECKPOINT_ID);
+        assertThat(handler.getNumOpenChannels()).isEqualTo(numberOfChannels - 1);
+        assertThat(invokable.getAbortedCheckpointId()).isEqualTo(DEFAULT_CHECKPOINT_ID);
     }
 
     @Test
-    public void testTriggerCheckpointsWithEndOfPartition() throws Exception {
+    void testTriggerCheckpointsWithEndOfPartition() throws Exception {
         ValidatingCheckpointHandler validator = new ValidatingCheckpointHandler(-1);
         inputGate = createInputGate(3, validator);
 
@@ -852,13 +840,13 @@ public class UnalignedCheckpointsTest {
                         /* 6 */ createEndOfPartition(1));
 
         assertOutput(sequence);
-        assertThat(validator.triggeredCheckpoints, contains(1L));
-        assertEquals(0, validator.getAbortedCheckpointCounter());
+        assertThat(validator.triggeredCheckpoints).contains(1L);
+        assertThat(validator.getAbortedCheckpointCounter()).isZero();
         assertInflightData(sequence[1]);
     }
 
     @Test
-    public void testTriggerCheckpointsAfterReceivedEndOfPartition() throws Exception {
+    void testTriggerCheckpointsAfterReceivedEndOfPartition() throws Exception {
         ValidatingCheckpointHandler validator = new ValidatingCheckpointHandler(-1);
         inputGate = createInputGate(3, validator);
 
@@ -873,8 +861,8 @@ public class UnalignedCheckpointsTest {
                         /* 5 */ createBarrier(3, 2));
         assertOutput(sequence1);
         assertInflightData(sequence1[3]);
-        assertThat(validator.triggeredCheckpoints, contains(3L));
-        assertEquals(0, validator.getAbortedCheckpointCounter());
+        assertThat(validator.triggeredCheckpoints).contains(3L);
+        assertThat(validator.getAbortedCheckpointCounter()).isZero();
 
         BufferOrEvent[] sequence2 =
                 addSequence(
@@ -884,8 +872,8 @@ public class UnalignedCheckpointsTest {
                         /* 2 */ createEndOfPartition(2));
         assertOutput(sequence2);
         assertInflightData();
-        assertThat(validator.triggeredCheckpoints, contains(3L, 4L));
-        assertEquals(0, validator.getAbortedCheckpointCounter());
+        assertThat(validator.triggeredCheckpoints).contains(3L, 4L);
+        assertThat(validator.getAbortedCheckpointCounter()).isZero();
     }
 
     // ------------------------------------------------------------------------
@@ -1024,10 +1012,9 @@ public class UnalignedCheckpointsTest {
 
     private void assertInflightData(BufferOrEvent... expected) {
         Collection<BufferOrEvent> andResetInflightData = getAndResetInflightData();
-        assertEquals(
-                "Unexpected in-flight sequence: " + andResetInflightData,
-                getIds(Arrays.asList(expected)),
-                getIds(andResetInflightData));
+        assertThat(getIds(andResetInflightData))
+                .as("Unexpected in-flight sequence: " + andResetInflightData)
+                .isEqualTo(getIds(Arrays.asList(expected)));
     }
 
     private Collection<BufferOrEvent> getAndResetInflightData() {
@@ -1040,10 +1027,9 @@ public class UnalignedCheckpointsTest {
     }
 
     private void assertOutput(BufferOrEvent... expectedSequence) {
-        assertEquals(
-                "Unexpected output sequence",
-                getIds(Arrays.asList(expectedSequence)),
-                getIds(output));
+        assertThat(getIds(output))
+                .as("Unexpected output sequence")
+                .isEqualTo(getIds(Arrays.asList(expectedSequence)));
     }
 
     private List<Object> getIds(Collection<BufferOrEvent> buffers) {
@@ -1094,7 +1080,7 @@ public class UnalignedCheckpointsTest {
         public void abortCheckpointOnBarrier(long checkpointId, CheckpointException cause) {
             super.abortCheckpointOnBarrier(checkpointId, cause);
             checkState(inputGate != null);
-            assertFalse(inputGate.getAllBarriersReceivedFuture(checkpointId).isDone());
+            assertThat(inputGate.getAllBarriersReceivedFuture(checkpointId)).isNotDone();
         }
 
         public void setInputGate(CheckpointedInputGate inputGate) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ValidatingCheckpointHandler.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/ValidatingCheckpointHandler.java
@@ -32,8 +32,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** The invokable handler used for triggering checkpoint and validation. */
 public class ValidatingCheckpointHandler extends AbstractInvokable {
@@ -112,9 +111,9 @@ public class ValidatingCheckpointHandler extends AbstractInvokable {
             CheckpointOptions checkpointOptions,
             CheckpointMetricsBuilder checkpointMetrics) {
         if (nextExpectedCheckpointId != -1L) {
-            assertEquals(nextExpectedCheckpointId, checkpointMetaData.getCheckpointId());
+            assertThat(checkpointMetaData.getCheckpointId()).isEqualTo(nextExpectedCheckpointId);
         }
-        assertTrue(checkpointMetaData.getTimestamp() > 0);
+        assertThat(checkpointMetaData.getTimestamp()).isPositive();
 
         nextExpectedCheckpointId = checkpointMetaData.getCheckpointId() + 1;
         triggeredCheckpointCounter++;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/recovery/DemultiplexingRecordDeserializerTest.java
@@ -40,17 +40,13 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Iterables;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.mockito.internal.util.collections.Sets;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -64,24 +60,22 @@ import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescripto
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.set;
 import static org.apache.flink.runtime.checkpoint.InflightDataRescalingDescriptorUtil.to;
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createBufferBuilder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests {@link DemultiplexingRecordDeserializer}. */
-public class DemultiplexingRecordDeserializerTest {
-    @Rule public TemporaryFolder folder = new TemporaryFolder();
+class DemultiplexingRecordDeserializerTest {
 
     private final ThreadLocalRandom random = ThreadLocalRandom.current();
 
     private IOManager ioManager;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         ioManager = new IOManagerAsync();
     }
 
-    @After
-    public void cleanup() {
+    @AfterEach
+    void cleanup() {
         ioManager = new IOManagerAsync();
     }
 
@@ -90,7 +84,7 @@ public class DemultiplexingRecordDeserializerTest {
      * channels.
      */
     @Test
-    public void testUpscale() throws IOException {
+    void testUpscale() throws IOException {
         DemultiplexingRecordDeserializer<Long> deserializer =
                 DemultiplexingRecordDeserializer.create(
                         new InputChannelInfo(2, 0),
@@ -103,13 +97,12 @@ public class DemultiplexingRecordDeserializerTest {
                                         ioManager.getSpillingDirectoriesPaths()),
                         unused -> RecordFilter.all());
 
-        assertEquals(
-                Sets.newSet(
+        assertThat(deserializer.getVirtualChannelSelectors())
+                .containsOnly(
                         new SubtaskConnectionDescriptor(0, 2),
                         new SubtaskConnectionDescriptor(0, 3),
                         new SubtaskConnectionDescriptor(1, 2),
-                        new SubtaskConnectionDescriptor(1, 3)),
-                deserializer.getVirtualChannelSelectors());
+                        new SubtaskConnectionDescriptor(1, 3));
 
         for (int i = 0; i < 100; i++) {
             SubtaskConnectionDescriptor selector =
@@ -125,15 +118,14 @@ public class DemultiplexingRecordDeserializerTest {
                 deserializer.setNextBuffer(buffer);
             }
 
-            assertEquals(
-                    Arrays.asList(start + 1L, start + 2L, start + 3L), readLongs(deserializer));
-            assertTrue(memorySegment.isFreed());
+            assertThat(readLongs(deserializer)).containsExactly(start + 1L, start + 2L, start + 3L);
+            assertThat(memorySegment.isFreed()).isTrue();
         }
     }
 
     /** Tests that {@link RecordFilter} are used correctly. */
     @Test
-    public void testAmbiguousChannels() throws IOException {
+    void testAmbiguousChannels() throws IOException {
         DemultiplexingRecordDeserializer<Long> deserializer =
                 DemultiplexingRecordDeserializer.create(
                         new InputChannelInfo(1, 0),
@@ -146,13 +138,12 @@ public class DemultiplexingRecordDeserializerTest {
                                         ioManager.getSpillingDirectoriesPaths()),
                         unused -> new RecordFilter(new ModSelector(2), LongSerializer.INSTANCE, 1));
 
-        assertEquals(
-                Sets.newSet(
+        assertThat(deserializer.getVirtualChannelSelectors())
+                .containsOnly(
                         new SubtaskConnectionDescriptor(41, 2),
                         new SubtaskConnectionDescriptor(41, 3),
                         new SubtaskConnectionDescriptor(42, 2),
-                        new SubtaskConnectionDescriptor(42, 3)),
-                deserializer.getVirtualChannelSelectors());
+                        new SubtaskConnectionDescriptor(42, 3));
 
         for (int i = 0; i < 100; i++) {
             MemorySegment memorySegment = allocateUnpooledSegment(128);
@@ -166,20 +157,20 @@ public class DemultiplexingRecordDeserializerTest {
                 deserializer.setNextBuffer(buffer);
 
                 if (selector.getInputSubtaskIndex() == 41) {
-                    assertEquals(Arrays.asList((long) i, i + 1L), readLongs(deserializer));
+                    assertThat(readLongs(deserializer)).containsExactly((long) i, i + 1L);
                 } else {
                     // only odd should occur in output
-                    assertEquals(Arrays.asList(i / 2 * 2 + 1L), readLongs(deserializer));
+                    assertThat(readLongs(deserializer)).containsExactly(i / 2 * 2 + 1L);
                 }
             }
 
-            assertTrue(memorySegment.isFreed());
+            assertThat(memorySegment.isFreed()).isTrue();
         }
     }
 
     /** Tests that Watermarks are only forwarded when all watermarks are received. */
     @Test
-    public void testWatermarks() throws IOException {
+    void testWatermarks() throws IOException {
         DemultiplexingRecordDeserializer<Long> deserializer =
                 DemultiplexingRecordDeserializer.create(
                         new InputChannelInfo(0, 0),
@@ -190,7 +181,7 @@ public class DemultiplexingRecordDeserializerTest {
                                         ioManager.getSpillingDirectoriesPaths()),
                         unused -> RecordFilter.all());
 
-        assertEquals(4, deserializer.getVirtualChannelSelectors().size());
+        assertThat(deserializer.getVirtualChannelSelectors()).hasSize(4);
 
         for (Iterator<SubtaskConnectionDescriptor> iterator =
                         deserializer.getVirtualChannelSelectors().iterator();
@@ -207,13 +198,13 @@ public class DemultiplexingRecordDeserializerTest {
             }
 
             if (iterator.hasNext()) {
-                assertEquals(Collections.emptyList(), read(deserializer));
+                assertThat(read(deserializer)).isEmpty();
             } else {
                 // last channel, min should be 42 + 0 + 0
-                assertEquals(Arrays.asList(new Watermark(42)), read(deserializer));
+                assertThat(read(deserializer)).containsExactly(new Watermark(42));
             }
 
-            assertTrue(memorySegment.isFreed());
+            assertThat(memorySegment.isFreed()).isTrue();
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/MinWatermarkGaugeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/MinWatermarkGaugeTest.java
@@ -18,27 +18,28 @@
 
 package org.apache.flink.streaming.runtime.metrics;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link MinWatermarkGauge}. */
-public class MinWatermarkGaugeTest {
+class MinWatermarkGaugeTest {
 
     @Test
-    public void testSetCurrentLowWatermark() {
+    void testSetCurrentLowWatermark() {
         WatermarkGauge metric1 = new WatermarkGauge();
         WatermarkGauge metric2 = new WatermarkGauge();
         MinWatermarkGauge metric = new MinWatermarkGauge(metric1, metric2);
 
-        Assert.assertEquals(Long.MIN_VALUE, metric.getValue().longValue());
+        assertThat(metric.getValue()).isEqualTo(Long.MIN_VALUE);
 
         metric1.setCurrentWatermark(1);
-        Assert.assertEquals(Long.MIN_VALUE, metric.getValue().longValue());
+        assertThat(metric.getValue()).isEqualTo(Long.MIN_VALUE);
 
         metric2.setCurrentWatermark(2);
-        Assert.assertEquals(1L, metric.getValue().longValue());
+        assertThat(metric.getValue()).isOne();
 
         metric1.setCurrentWatermark(3);
-        Assert.assertEquals(2L, metric.getValue().longValue());
+        assertThat(metric.getValue()).isEqualTo(2L);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/WatermarkGaugeTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/metrics/WatermarkGaugeTest.java
@@ -18,19 +18,20 @@
 
 package org.apache.flink.streaming.runtime.metrics;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link WatermarkGauge}. */
-public class WatermarkGaugeTest {
+class WatermarkGaugeTest {
 
     @Test
-    public void testSetCurrentLowWatermark() {
+    void testSetCurrentLowWatermark() {
         WatermarkGauge metric = new WatermarkGauge();
 
-        Assert.assertEquals(Long.MIN_VALUE, metric.getValue().longValue());
+        assertThat(metric.getValue()).isEqualTo(Long.MIN_VALUE);
 
         metric.setCurrentWatermark(64);
-        Assert.assertEquals(64, metric.getValue().longValue());
+        assertThat(metric.getValue()).isEqualTo(64L);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ContinuousFileProcessingRescalingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/ContinuousFileProcessingRescalingTest.java
@@ -36,8 +36,7 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.SteppingMailboxProcessor
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.util.Preconditions;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -50,16 +49,17 @@ import java.util.stream.Stream;
 
 import static org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness.repackageState;
 import static org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness.repartitionOperatorState;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test processing files during rescaling. */
-public class ContinuousFileProcessingRescalingTest {
+class ContinuousFileProcessingRescalingTest {
 
     private final int maxParallelism = 10;
     private final int sizeOfSplit = 20;
 
     /** Simulates the scenario of scaling down from 2 to 1 instances. */
     @Test
-    public void testReaderScalingDown() throws Exception {
+    void testReaderScalingDown() throws Exception {
         HarnessWithFormat[] beforeRescale = {};
         try {
             beforeRescale = buildAndStart(5, 15);
@@ -76,7 +76,7 @@ public class ContinuousFileProcessingRescalingTest {
                     i.awaitEverythingProcessed();
                 }
 
-                Assert.assertEquals(collectOutput(beforeRescale), collectOutput(afterRescale));
+                assertThat(collectOutput(afterRescale)).isEqualTo(collectOutput(beforeRescale));
             }
         } finally {
             for (HarnessWithFormat harness : beforeRescale) {
@@ -87,7 +87,7 @@ public class ContinuousFileProcessingRescalingTest {
 
     /** Simulates the scenario of scaling up from 1 to 2 instances. */
     @Test
-    public void testReaderScalingUp() throws Exception {
+    void testReaderScalingUp() throws Exception {
         try (HarnessWithFormat beforeRescale = buildAndStart(1, 0, 5, null, buildSplits(2))) {
             OperatorSubtaskState snapshot = beforeRescale.getHarness().snapshot(0, 0);
             try (HarnessWithFormat afterRescale0 =
@@ -110,8 +110,8 @@ public class ContinuousFileProcessingRescalingTest {
                     harness.awaitEverythingProcessed();
                 }
 
-                Assert.assertEquals(
-                        collectOutput(beforeRescale), collectOutput(afterRescale0, afterRescale1));
+                assertThat(collectOutput(afterRescale0, afterRescale1))
+                        .isEqualTo(collectOutput(beforeRescale));
             }
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/MailboxOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/MailboxOperatorTest.java
@@ -25,28 +25,25 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarness;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.RunnableWithException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 
 import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.IntStream;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test to verify that timer triggers are run according to operator precedence (combined with
  * yield() at operator level).
  */
-public class MailboxOperatorTest extends TestLogger {
+class MailboxOperatorTest {
 
     @Test
-    public void testAvoidTaskStarvation() throws Exception {
+    void testAvoidTaskStarvation() throws Exception {
         final int numRecords = 3;
 
         StreamTaskMailboxTestHarnessBuilder<Integer> builder =
@@ -72,9 +69,9 @@ public class MailboxOperatorTest extends TestLogger {
                     testHarness.getOutput().stream()
                             .mapToInt(r -> ((StreamRecord<Integer>) r).getValue())
                             .toArray();
-            assertArrayEquals(output, IntStream.range(0, numRecords).toArray());
-            assertThat(mail1.getMailCount(), equalTo(numRecords + 1));
-            assertThat(mail2.getMailCount(), equalTo(numRecords + 1));
+            assertThat(output).isEqualTo(IntStream.range(0, numRecords).toArray());
+            assertThat(mail1.getMailCount()).isEqualTo(numRecords + 1);
+            assertThat(mail2.getMailCount()).isEqualTo(numRecords + 1);
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/SourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/SourceOperatorLatencyMetricsTest.java
@@ -30,33 +30,29 @@ import org.apache.flink.streaming.api.operators.SourceOperator;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.util.SourceOperatorTestHarness;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the emission of latency markers by {@link SourceOperator} operators. */
-public class SourceOperatorLatencyMetricsTest extends TestLogger {
+class SourceOperatorLatencyMetricsTest {
 
     private static final long MAX_PROCESSING_TIME = 100L;
     private static final long LATENCY_MARK_INTERVAL = 10L;
 
     /** Verifies that by default no latency metrics are emitted. */
     @Test
-    public void testLatencyMarkEmissionDisabled() throws Exception {
+    void testLatencyMarkEmissionDisabled() throws Exception {
         testLatencyMarkEmission(false, new Configuration(), new ExecutionConfig());
     }
 
     /** Verifies that latency metrics can be enabled via the {@link ExecutionConfig}. */
     @Test
-    public void testLatencyMarkEmissionEnabledViaExecutionConfig() throws Exception {
+    void testLatencyMarkEmissionEnabledViaExecutionConfig() throws Exception {
 
         Configuration taskConfiguration = new Configuration();
         ExecutionConfig executionConfig = new ExecutionConfig();
@@ -67,7 +63,7 @@ public class SourceOperatorLatencyMetricsTest extends TestLogger {
 
     /** Verifies that latency metrics can be enabled via the configuration. */
     @Test
-    public void testLatencyMarkEmissionEnabledViaFlinkConfig() throws Exception {
+    void testLatencyMarkEmissionEnabledViaFlinkConfig() throws Exception {
         Configuration taskConfiguration = new Configuration();
         taskConfiguration.set(MetricOptions.LATENCY_INTERVAL, LATENCY_MARK_INTERVAL);
         ExecutionConfig executionConfig = new ExecutionConfig();
@@ -80,7 +76,7 @@ public class SourceOperatorLatencyMetricsTest extends TestLogger {
      * disabled via the configuration.
      */
     @Test
-    public void testLatencyMarkEmissionEnabledOverrideViaExecutionConfig() throws Exception {
+    void testLatencyMarkEmissionEnabledOverrideViaExecutionConfig() throws Exception {
         Configuration taskConfiguration = new Configuration();
         taskConfiguration.set(MetricOptions.LATENCY_INTERVAL, 0L);
         ExecutionConfig executionConfig = new ExecutionConfig();
@@ -94,7 +90,7 @@ public class SourceOperatorLatencyMetricsTest extends TestLogger {
      * are enabled via the configuration.
      */
     @Test
-    public void testLatencyMarkEmissionDisabledOverrideViaExecutionConfig() throws Exception {
+    void testLatencyMarkEmissionDisabledOverrideViaExecutionConfig() throws Exception {
         Configuration taskConfiguration = new Configuration();
         taskConfiguration.set(MetricOptions.LATENCY_INTERVAL, LATENCY_MARK_INTERVAL);
         ExecutionConfig executionConfig = new ExecutionConfig();
@@ -132,7 +128,7 @@ public class SourceOperatorLatencyMetricsTest extends TestLogger {
 
             List<LatencyMarker> expectedOutput = new ArrayList<>();
             if (!shouldExpectLatencyMarkers) {
-                assertTrue(testHarness.getOutput().isEmpty());
+                assertThat(testHarness.getOutput()).isEmpty();
             } else {
                 expectedOutput.add(
                         new LatencyMarker(1, testHarness.getOperator().getOperatorID(), 0));
@@ -143,9 +139,7 @@ public class SourceOperatorLatencyMetricsTest extends TestLogger {
                             new LatencyMarker(
                                     markedTime, testHarness.getOperator().getOperatorID(), 0));
                 }
-                assertThat(
-                        (Collection<Object>) testHarness.getOutput(),
-                        contains(expectedOutput.toArray()));
+                assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
             }
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/SourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/SourceOperatorLatencyMetricsTest.java
@@ -99,10 +99,6 @@ class SourceOperatorLatencyMetricsTest {
         testLatencyMarkEmission(false, taskConfiguration, executionConfig);
     }
 
-    private interface OperatorSetupOperation {
-        void setupSourceOperator(SourceOperator<Integer, ?> operator) throws Exception;
-    }
-
     private void testLatencyMarkEmission(
             boolean shouldExpectLatencyMarkers,
             Configuration taskManagerConfig,
@@ -139,7 +135,7 @@ class SourceOperatorLatencyMetricsTest {
                             new LatencyMarker(
                                     markedTime, testHarness.getOperator().getOperatorID(), 0));
                 }
-                assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+                assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
             }
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -55,7 +55,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for stream operator chaining behaviour. */
 @SuppressWarnings("serial")
-public class StreamOperatorChainingTest {
+class StreamOperatorChainingTest {
 
     // We have to use static fields because the sink functions will go through serialization
     private static List<String> sink1Results;
@@ -141,8 +141,8 @@ public class StreamOperatorChainingTest {
             headOperator.processElement(new StreamRecord<>(2));
             headOperator.processElement(new StreamRecord<>(3));
 
-            assertThat(sink1Results).contains("First: 1", "First: 2", "First: 3");
-            assertThat(sink2Results).contains("Second: 1", "Second: 2", "Second: 3");
+            assertThat(sink1Results).containsExactly("First: 1", "First: 2", "First: 3");
+            assertThat(sink2Results).containsExactly("Second: 1", "Second: 2", "Second: 3");
         }
     }
 
@@ -267,9 +267,9 @@ public class StreamOperatorChainingTest {
             headOperator.processElement(new StreamRecord<>(2));
             headOperator.processElement(new StreamRecord<>(3));
 
-            assertThat(sink1Results).contains("First 1: 1");
-            assertThat(sink2Results).contains("First 2: 1");
-            assertThat(sink3Results).contains("Second: 2", "Second: 3");
+            assertThat(sink1Results).containsExactly("First 1: 1");
+            assertThat(sink2Results).containsExactly("First 2: 1");
+            assertThat(sink3Results).containsExactly("Second: 2", "Second: 3");
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamOperatorChainingTest.java
@@ -46,14 +46,12 @@ import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for stream operator chaining behaviour. */
 @SuppressWarnings("serial")
@@ -65,7 +63,7 @@ public class StreamOperatorChainingTest {
     private static List<String> sink3Results;
 
     @Test
-    public void testMultiChainingWithObjectReuse() throws Exception {
+    void testMultiChainingWithObjectReuse() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
 
@@ -73,7 +71,7 @@ public class StreamOperatorChainingTest {
     }
 
     @Test
-    public void testMultiChainingWithoutObjectReuse() throws Exception {
+    void testMultiChainingWithoutObjectReuse() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().disableObjectReuse();
 
@@ -118,7 +116,7 @@ public class StreamOperatorChainingTest {
         // be build our own StreamTask and OperatorChain
         JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
-        Assert.assertTrue(jobGraph.getVerticesSortedTopologicallyFromSources().size() == 2);
+        assertThat(jobGraph.getVerticesSortedTopologicallyFromSources()).hasSize(2);
 
         JobVertex chainedVertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(1);
 
@@ -143,8 +141,8 @@ public class StreamOperatorChainingTest {
             headOperator.processElement(new StreamRecord<>(2));
             headOperator.processElement(new StreamRecord<>(3));
 
-            assertThat(sink1Results, contains("First: 1", "First: 2", "First: 3"));
-            assertThat(sink2Results, contains("Second: 1", "Second: 2", "Second: 3"));
+            assertThat(sink1Results).contains("First: 1", "First: 2", "First: 3");
+            assertThat(sink2Results).contains("Second: 1", "Second: 2", "Second: 3");
         }
     }
 
@@ -158,7 +156,7 @@ public class StreamOperatorChainingTest {
     }
 
     @Test
-    public void testMultiChainingWithSplitWithObjectReuse() throws Exception {
+    void testMultiChainingWithSplitWithObjectReuse() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().enableObjectReuse();
 
@@ -166,7 +164,7 @@ public class StreamOperatorChainingTest {
     }
 
     @Test
-    public void testMultiChainingWithSplitWithoutObjectReuse() throws Exception {
+    void testMultiChainingWithSplitWithoutObjectReuse() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.getConfig().disableObjectReuse();
 
@@ -244,7 +242,7 @@ public class StreamOperatorChainingTest {
         // be build our own StreamTask and OperatorChain
         JobGraph jobGraph = env.getStreamGraph().getJobGraph();
 
-        Assert.assertTrue(jobGraph.getVerticesSortedTopologicallyFromSources().size() == 2);
+        assertThat(jobGraph.getVerticesSortedTopologicallyFromSources()).hasSize(2);
 
         JobVertex chainedVertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(1);
 
@@ -269,9 +267,9 @@ public class StreamOperatorChainingTest {
             headOperator.processElement(new StreamRecord<>(2));
             headOperator.processElement(new StreamRecord<>(3));
 
-            assertThat(sink1Results, contains("First 1: 1"));
-            assertThat(sink2Results, contains("First 2: 1"));
-            assertThat(sink3Results, contains("Second: 2", "Second: 3"));
+            assertThat(sink1Results).contains("First 1: 1");
+            assertThat(sink2Results).contains("First 2: 1");
+            assertThat(sink3Results).contains("Second: 2", "Second: 3");
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorLatencyMetricsTest.java
@@ -42,28 +42,25 @@ import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.streaming.util.CollectorOutput;
 import org.apache.flink.streaming.util.MockStreamTask;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /** Tests for the emission of latency markers by {@link StreamSource} operators. */
-public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
+class StreamSourceOperatorLatencyMetricsTest {
 
     private static final long maxProcessingTime = 100L;
     private static final long latencyMarkInterval = 10L;
 
     /** Verifies that by default no latency metrics are emitted. */
     @Test
-    public void testLatencyMarkEmissionDisabled() throws Exception {
+    void testLatencyMarkEmissionDisabled() throws Exception {
         testLatencyMarkEmission(
                 0,
                 (operator, timeProvider) ->
@@ -76,7 +73,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 
     /** Verifies that latency metrics can be enabled via the {@link ExecutionConfig}. */
     @Test
-    public void testLatencyMarkEmissionEnabledViaExecutionConfig() throws Exception {
+    void testLatencyMarkEmissionEnabledViaExecutionConfig() throws Exception {
         testLatencyMarkEmission(
                 (int) (maxProcessingTime / latencyMarkInterval) + 1,
                 (operator, timeProvider) -> {
@@ -93,7 +90,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 
     /** Verifies that latency metrics can be enabled via the configuration. */
     @Test
-    public void testLatencyMarkEmissionEnabledViaFlinkConfig() throws Exception {
+    void testLatencyMarkEmissionEnabledViaFlinkConfig() throws Exception {
         testLatencyMarkEmission(
                 (int) (maxProcessingTime / latencyMarkInterval) + 1,
                 (operator, timeProvider) -> {
@@ -115,7 +112,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
      * disabled via the configuration.
      */
     @Test
-    public void testLatencyMarkEmissionEnabledOverrideViaExecutionConfig() throws Exception {
+    void testLatencyMarkEmissionEnabledOverrideViaExecutionConfig() throws Exception {
         testLatencyMarkEmission(
                 (int) (maxProcessingTime / latencyMarkInterval) + 1,
                 (operator, timeProvider) -> {
@@ -140,7 +137,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
      * are enabled via the configuration.
      */
     @Test
-    public void testLatencyMarkEmissionDisabledOverrideViaExecutionConfig() throws Exception {
+    void testLatencyMarkEmissionDisabledOverrideViaExecutionConfig() throws Exception {
         testLatencyMarkEmission(
                 0,
                 (operator, timeProvider) -> {
@@ -162,8 +159,8 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
 
     private interface OperatorSetupOperation {
         void setupSourceOperator(
-                StreamSource<Long, ?> operator,
-                TestProcessingTimeService testProcessingTimeService);
+                StreamSource<Long, ?> operator, TestProcessingTimeService testProcessingTimeService)
+                throws Exception;
     }
 
     private void testLatencyMarkEmission(
@@ -196,7 +193,7 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
             operatorChain.close();
         }
 
-        assertEquals(numberLatencyMarkers, output.size());
+        assertThat(output).hasSize(numberLatencyMarkers);
 
         long timestamp = 0L;
         int expectedLatencyIndex = 0;
@@ -205,9 +202,9 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
         // verify that its only latency markers
         for (; i < numberLatencyMarkers; i++) {
             StreamElement se = output.get(i);
-            Assert.assertTrue(se.isLatencyMarker());
-            Assert.assertEquals(operator.getOperatorID(), se.asLatencyMarker().getOperatorId());
-            Assert.assertEquals(0, se.asLatencyMarker().getSubtaskIndex());
+            assertThat(se.isLatencyMarker()).isTrue();
+            assertThat(se.asLatencyMarker().getOperatorId()).isEqualTo(operator.getOperatorID());
+            assertThat(se.asLatencyMarker().getSubtaskIndex()).isZero();
 
             // determines the next latency mark that should've been emitted
             // latency marks are emitted once per latencyMarkInterval,
@@ -215,9 +212,8 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
             while (timestamp > processingTimes.get(expectedLatencyIndex)) {
                 expectedLatencyIndex++;
             }
-            Assert.assertEquals(
-                    processingTimes.get(expectedLatencyIndex).longValue(),
-                    se.asLatencyMarker().getMarkedTime());
+            assertThat(se.asLatencyMarker().getMarkedTime())
+                    .isEqualTo(processingTimes.get(expectedLatencyIndex));
 
             timestamp += latencyMarkInterval;
         }
@@ -230,7 +226,8 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
             StreamSource<T, ?> operator,
             ExecutionConfig executionConfig,
             Environment env,
-            TimerService timerService) {
+            TimerService timerService)
+            throws Exception {
 
         StreamConfig cfg = new StreamConfig(new Configuration());
         cfg.setStateBackend(new MemoryStateBackend());
@@ -239,21 +236,16 @@ public class StreamSourceOperatorLatencyMetricsTest extends TestLogger {
         cfg.setOperatorID(new OperatorID());
         cfg.serializeAllConfigs();
 
-        try {
-            MockStreamTask mockTask =
-                    new MockStreamTaskBuilder(env)
-                            .setConfig(cfg)
-                            .setExecutionConfig(executionConfig)
-                            .setTimerService(timerService)
-                            .build();
+        MockStreamTask mockTask =
+                new MockStreamTaskBuilder(env)
+                        .setConfig(cfg)
+                        .setExecutionConfig(executionConfig)
+                        .setTimerService(timerService)
+                        .build();
 
-            operator.setProcessingTimeService(
-                    mockTask.getProcessingTimeServiceFactory().createProcessingTimeService(null));
-            operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        operator.setProcessingTimeService(
+                mockTask.getProcessingTimeServiceFactory().createProcessingTimeService(null));
+        operator.setup(mockTask, cfg, (Output<StreamRecord<T>>) mock(Output.class));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskOperatorTimerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamTaskOperatorTimerTest.java
@@ -34,27 +34,24 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
 import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test to verify that timer triggers are run according to operator precedence (combined with
  * yield() at operator level).
  */
-public class StreamTaskOperatorTimerTest extends TestLogger {
+class StreamTaskOperatorTimerTest {
     private static final String TRIGGER_PREFIX = "trigger:";
     private static final String RESULT_PREFIX = "timer:";
 
     @Test
-    public void testOperatorYieldExecutesSelectedTimers() throws Exception {
+    void testOperatorYieldExecutesSelectedTimers() throws Exception {
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
                         OneInputStreamTask::new,
@@ -79,8 +76,7 @@ public class StreamTaskOperatorTimerTest extends TestLogger {
         testHarness
                 .getOutput()
                 .forEach(element -> events.add(((StreamRecord<String>) element).getValue()));
-        assertThat(
-                events, is(Arrays.asList(trigger, RESULT_PREFIX + "1:0", RESULT_PREFIX + "0:0")));
+        assertThat(events).containsExactly(trigger, RESULT_PREFIX + "1:0", RESULT_PREFIX + "0:0");
     }
 
     private static class TestOperatorFactory extends AbstractStreamOperatorFactory<String>

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/TestProcessingTimeServiceTest.java
@@ -27,15 +27,15 @@ import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTestHarness;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link TestProcessingTimeService}. */
-public class TestProcessingTimeServiceTest {
+class TestProcessingTimeServiceTest {
 
     @Test
-    public void testCustomTimeServiceProvider() throws Throwable {
+    void testCustomTimeServiceProvider() throws Throwable {
         final TestProcessingTimeService tp = new TestProcessingTimeService();
 
         final OneInputStreamTaskTestHarness<String, String> testHarness =
@@ -59,27 +59,27 @@ public class TestProcessingTimeServiceTest {
         ProcessingTimeService processingTimeService =
                 ((StreamMap<?, ?>) testHarness.getHeadOperator()).getProcessingTimeService();
 
-        assertEquals(Long.MIN_VALUE, processingTimeService.getCurrentProcessingTime());
+        assertThat(processingTimeService.getCurrentProcessingTime()).isEqualTo(Long.MIN_VALUE);
 
         tp.setCurrentTime(11);
-        assertEquals(processingTimeService.getCurrentProcessingTime(), 11);
+        assertThat(processingTimeService.getCurrentProcessingTime()).isEqualTo(11);
 
         tp.setCurrentTime(15);
         tp.setCurrentTime(16);
-        assertEquals(processingTimeService.getCurrentProcessingTime(), 16);
+        assertThat(processingTimeService.getCurrentProcessingTime()).isEqualTo(16);
 
         // register 2 tasks
         processingTimeService.registerTimer(30, timestamp -> {});
 
         processingTimeService.registerTimer(40, timestamp -> {});
 
-        assertEquals(2, tp.getNumActiveTimers());
+        assertThat(tp.getNumActiveTimers()).isEqualTo(2);
 
         tp.setCurrentTime(35);
-        assertEquals(1, tp.getNumActiveTimers());
+        assertThat(tp.getNumActiveTimers()).isOne();
 
         tp.setCurrentTime(40);
-        assertEquals(0, tp.getNumActiveTimers());
+        assertThat(tp.getNumActiveTimers()).isZero();
 
         tp.shutdownService();
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/WriteAheadSinkTestBase.java
@@ -23,14 +23,11 @@ import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.flink.util.TestLoggerExtension;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Test base for {@link GenericWriteAheadSink}. */
-@ExtendWith(TestLoggerExtension.class)
-public abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink<IN>> {
+abstract class WriteAheadSinkTestBase<IN, S extends GenericWriteAheadSink<IN>> {
 
     protected abstract S createSink() throws Exception;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperatorTestBase.java
@@ -119,7 +119,7 @@ abstract class SinkWriterOperatorTestBase {
     }
 
     @Test
-    public void testTimeBasedBufferingSinkWriter() throws Exception {
+    void testTimeBasedBufferingSinkWriter() throws Exception {
         final long initialTime = 0;
 
         final OneInputStreamOperatorTestHarness<Integer, CommittableMessage<Integer>> testHarness =
@@ -421,7 +421,7 @@ abstract class SinkWriterOperatorTestBase {
         assertThat(initContext.get().getTaskInfo().getIndexOfThisSubtask()).isEqualTo(subtaskId);
         assertThat(initContext.get().getTaskInfo().getNumberOfParallelSubtasks())
                 .isEqualTo(parallelism);
-        assertThat(initContext.get().getTaskInfo().getAttemptNumber()).isEqualTo(0);
+        assertThat(initContext.get().getTaskInfo().getAttemptNumber()).isZero();
         assertThat(initContext.get().metricGroup()).isNotNull();
         assertThat(initContext.get().getRestoredCheckpointId()).isNotPresent();
         assertThat(initContext.get().isObjectReuseEnabled()).isTrue();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSink.java
@@ -47,7 +47,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * A {@link Sink TestSink} for all the sink related tests. Use only for tests where {@link
@@ -312,7 +312,7 @@ public class TestSink<T> implements Sink<T, String, String, String> {
         @Override
         public List<String> commit(List<String> committables) {
             if (committedData == null) {
-                assertNotNull(queueSupplier);
+                assertThat(queueSupplier).isNotNull();
                 committedData = queueSupplier.get();
             }
             committedData.addAll(committables);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
@@ -57,7 +57,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** A {@link Sink} for all the sink related tests. */
 public class TestSinkV2<InputT> implements Sink<InputT> {
@@ -426,7 +426,7 @@ public class TestSinkV2<InputT> implements Sink<InputT> {
         @Override
         public void commit(Collection<CommitRequest<String>> committables) {
             if (committedData == null) {
-                assertNotNull(queueSupplier);
+                assertThat(queueSupplier).isNotNull();
                 committedData = queueSupplier.get();
             }
             committedData.addAll(committables);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
@@ -126,7 +126,7 @@ class CommittableCollectorSerializerTest {
     }
 
     @Test
-    public void testCommittablesForSameSubtaskIdV2SerDe() throws IOException {
+    void testCommittablesForSameSubtaskIdV2SerDe() throws IOException {
 
         int subtaskId = 1;
         int numberOfSubtasks = 3;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/deprecated/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/deprecated/TestSinkV2.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * A {@link org.apache.flink.api.connector.sink2.Sink} for all the sink related tests.
@@ -373,7 +373,7 @@ public class TestSinkV2<InputT> implements Sink<InputT> {
         @Override
         public void commit(Collection<CommitRequest<String>> committables) {
             if (committedData == null) {
-                assertNotNull(queueSupplier);
+                assertThat(queueSupplier).isNotNull();
                 committedData = queueSupplier.get();
             }
             committedData.addAll(committables);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AllWindowTranslationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/AllWindowTranslationTest.java
@@ -55,15 +55,12 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.util.Collector;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * These tests verify that the api calls on {@link AllWindowedStream} instantiate the correct window
@@ -73,9 +70,7 @@ import static org.junit.Assert.fail;
  * some output.
  */
 @SuppressWarnings("serial")
-public class AllWindowTranslationTest {
-
-    @Rule public ExpectedException expectedException = ExpectedException.none();
+class AllWindowTranslationTest {
 
     // ------------------------------------------------------------------------
     //  rich function tests
@@ -85,48 +80,53 @@ public class AllWindowTranslationTest {
      * .reduce() does not support RichReduceFunction, since the reduce function is used internally
      * in a {@code ReducingState}.
      */
-    @Test(expected = UnsupportedOperationException.class)
-    public void testReduceWithRichReducerFails() throws Exception {
+    @Test
+    void testReduceWithRichReducerFails() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
                 env.fromData(Tuple2.of("hello", 1), Tuple2.of("hello", 2));
 
-        source.windowAll(
-                        SlidingEventTimeWindows.of(
-                                Time.of(1, TimeUnit.SECONDS), Time.of(100, TimeUnit.MILLISECONDS)))
-                .reduce(
-                        new RichReduceFunction<Tuple2<String, Integer>>() {
-                            private static final long serialVersionUID = -6448847205314995812L;
+        assertThatThrownBy(
+                        () ->
+                                source.windowAll(
+                                                SlidingEventTimeWindows.of(
+                                                        Time.of(1, TimeUnit.SECONDS),
+                                                        Time.of(100, TimeUnit.MILLISECONDS)))
+                                        .reduce(
+                                                new RichReduceFunction<Tuple2<String, Integer>>() {
+                                                    private static final long serialVersionUID =
+                                                            -6448847205314995812L;
 
-                            @Override
-                            public Tuple2<String, Integer> reduce(
-                                    Tuple2<String, Integer> value1, Tuple2<String, Integer> value2)
-                                    throws Exception {
-                                return null;
-                            }
-                        });
-
-        fail("exception was not thrown");
+                                                    @Override
+                                                    public Tuple2<String, Integer> reduce(
+                                                            Tuple2<String, Integer> value1,
+                                                            Tuple2<String, Integer> value2) {
+                                                        return null;
+                                                    }
+                                                }))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     /**
      * .aggregate() does not support RichAggregateFunction, since the AggregateFunction is used
      * internally in an {@code AggregatingState}.
      */
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAggregateWithRichFunctionFails() throws Exception {
+    @Test
+    void testAggregateWithRichFunctionFails() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
                 env.fromData(Tuple2.of("hello", 1), Tuple2.of("hello", 2));
 
-        source.windowAll(
-                        SlidingEventTimeWindows.of(
-                                Time.of(1, TimeUnit.SECONDS), Time.of(100, TimeUnit.MILLISECONDS)))
-                .aggregate(new DummyRichAggregationFunction<Tuple2<String, Integer>>());
-
-        fail("exception was not thrown");
+        assertThatThrownBy(
+                        () ->
+                                source.windowAll(
+                                                SlidingEventTimeWindows.of(
+                                                        Time.of(1, TimeUnit.SECONDS),
+                                                        Time.of(100, TimeUnit.MILLISECONDS)))
+                                        .aggregate(new DummyRichAggregationFunction<>()))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     // ------------------------------------------------------------------------
@@ -134,58 +134,66 @@ public class AllWindowTranslationTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testMergingAssignerWithNonMergingTriggerFails() throws Exception {
-        // verify that we check for trigger compatibility
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage(
-                "A merging window assigner cannot be used with a trigger"
-                        + " that does not support merging");
+    void testMergingAssignerWithNonMergingTriggerFails() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
-        env.fromData("Hello", "Ciao")
-                .windowAll(EventTimeSessionWindows.withGap(Time.seconds(5)))
-                .trigger(
-                        new Trigger<String, TimeWindow>() {
-                            private static final long serialVersionUID = 6558046711583024443L;
+        // verify that we check for trigger compatibility
+        assertThatThrownBy(
+                        () ->
+                                env.fromData("Hello", "Ciao")
+                                        .windowAll(EventTimeSessionWindows.withGap(Time.seconds(5)))
+                                        .trigger(
+                                                new Trigger<String, TimeWindow>() {
+                                                    private static final long serialVersionUID =
+                                                            6558046711583024443L;
 
-                            @Override
-                            public TriggerResult onElement(
-                                    String element,
-                                    long timestamp,
-                                    TimeWindow window,
-                                    TriggerContext ctx)
-                                    throws Exception {
-                                return null;
-                            }
+                                                    @Override
+                                                    public TriggerResult onElement(
+                                                            String element,
+                                                            long timestamp,
+                                                            TimeWindow window,
+                                                            TriggerContext ctx)
+                                                            throws Exception {
+                                                        return null;
+                                                    }
 
-                            @Override
-                            public TriggerResult onProcessingTime(
-                                    long time, TimeWindow window, TriggerContext ctx)
-                                    throws Exception {
-                                return null;
-                            }
+                                                    @Override
+                                                    public TriggerResult onProcessingTime(
+                                                            long time,
+                                                            TimeWindow window,
+                                                            TriggerContext ctx)
+                                                            throws Exception {
+                                                        return null;
+                                                    }
 
-                            @Override
-                            public TriggerResult onEventTime(
-                                    long time, TimeWindow window, TriggerContext ctx)
-                                    throws Exception {
-                                return null;
-                            }
+                                                    @Override
+                                                    public TriggerResult onEventTime(
+                                                            long time,
+                                                            TimeWindow window,
+                                                            TriggerContext ctx)
+                                                            throws Exception {
+                                                        return null;
+                                                    }
 
-                            @Override
-                            public boolean canMerge() {
-                                return false;
-                            }
+                                                    @Override
+                                                    public boolean canMerge() {
+                                                        return false;
+                                                    }
 
-                            @Override
-                            public void clear(TimeWindow window, TriggerContext ctx)
-                                    throws Exception {}
-                        });
+                                                    @Override
+                                                    public void clear(
+                                                            TimeWindow window, TriggerContext ctx)
+                                                            throws Exception {}
+                                                }))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining(
+                        "A merging window assigner cannot be used with a trigger"
+                                + " that does not support merging");
     }
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testMergingWindowsWithEvictor() throws Exception {
+    void testMergingWindowsWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -201,12 +209,12 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof EventTimeSessionWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(EventTimeSessionWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -221,7 +229,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceEventTime() throws Exception {
+    void testReduceEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -239,12 +247,12 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -255,7 +263,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceProcessingTime() throws Exception {
+    void testReduceProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -273,12 +281,13 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(SlidingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -289,7 +298,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithWindowFunctionEventTime() throws Exception {
+    void testReduceWithWindowFunctionEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -324,12 +333,12 @@ public class AllWindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -340,7 +349,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithWindowFunctionProcessingTime() throws Exception {
+    void testReduceWithWindowFunctionProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -373,12 +382,13 @@ public class AllWindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -389,7 +399,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithProcessWindowFunctionEventTime() throws Exception {
+    void testReduceWithProcessWindowFunctionEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -424,12 +434,12 @@ public class AllWindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -440,7 +450,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithProcessWindowFunctionProcessingTime() throws Exception {
+    void testReduceWithProcessWindowFunctionProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -473,12 +483,13 @@ public class AllWindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -489,7 +500,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithEvictorAndProcessFunction() throws Exception {
+    void testReduceWithEvictorAndProcessFunction() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -526,13 +537,13 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof EvictingWindowOperator);
+        assertThat(operator).isInstanceOf(EvictingWindowOperator.class);
         EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?> winOperator =
                 (EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getEvictor() instanceof CountEvictor);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getEvictor()).isInstanceOf(CountEvictor.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -544,7 +555,7 @@ public class AllWindowTranslationTest {
     /** Test for the deprecated .apply(Reducer, WindowFunction). */
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyWithPreReducerEventTime() throws Exception {
+    void testApplyWithPreReducerEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -579,12 +590,12 @@ public class AllWindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -598,7 +609,7 @@ public class AllWindowTranslationTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testAggregateEventTime() throws Exception {
+    void testAggregateEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -618,13 +629,13 @@ public class AllWindowTranslationTest {
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -634,7 +645,7 @@ public class AllWindowTranslationTest {
     }
 
     @Test
-    public void testAggregateProcessingTime() throws Exception {
+    void testAggregateProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -654,13 +665,14 @@ public class AllWindowTranslationTest {
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(SlidingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -670,7 +682,7 @@ public class AllWindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithWindowFunctionEventTime() throws Exception {
+    void testAggregateWithWindowFunctionEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -687,13 +699,13 @@ public class AllWindowTranslationTest {
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -703,7 +715,7 @@ public class AllWindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithWindowFunctionProcessingTime() throws Exception {
+    void testAggregateWithWindowFunctionProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -720,13 +732,14 @@ public class AllWindowTranslationTest {
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -736,7 +749,7 @@ public class AllWindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithEvictor() throws Exception {
+    void testAggregateWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -757,13 +770,13 @@ public class AllWindowTranslationTest {
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -773,7 +786,7 @@ public class AllWindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithEvictorAndProcessFunction() throws Exception {
+    void testAggregateWithEvictorAndProcessFunction() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -810,13 +823,13 @@ public class AllWindowTranslationTest {
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -831,7 +844,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testProcessEventTime() throws Exception {
+    void testProcessEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -863,12 +876,12 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -879,7 +892,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testProcessProcessingTime() throws Exception {
+    void testProcessProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -911,12 +924,13 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -927,7 +941,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testProcessWithEvictor() throws Exception {
+    void testProcessWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -961,13 +975,13 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof EvictingWindowOperator);
+        assertThat(operator).isInstanceOf(EvictingWindowOperator.class);
         EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?> winOperator =
                 (EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getEvictor() instanceof TimeEvictor);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getEvictor()).isInstanceOf(TimeEvictor.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -978,7 +992,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testProcessWithCustomTrigger() throws Exception {
+    void testProcessWithCustomTrigger() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1011,12 +1025,12 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1031,7 +1045,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyEventTime() throws Exception {
+    void testApplyEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1063,12 +1077,12 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1079,7 +1093,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyProcessingTimeTime() throws Exception {
+    void testApplyProcessingTimeTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1111,12 +1125,13 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1127,7 +1142,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithCustomTrigger() throws Exception {
+    void testReduceWithCustomTrigger() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1148,12 +1163,12 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1164,7 +1179,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyWithCustomTrigger() throws Exception {
+    void testApplyWithCustomTrigger() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1197,12 +1212,12 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1213,7 +1228,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithEvictor() throws Exception {
+    void testReduceWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1234,13 +1249,13 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof EvictingWindowOperator);
+        assertThat(operator).isInstanceOf(EvictingWindowOperator.class);
         EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?> winOperator =
                 (EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getEvictor() instanceof CountEvictor);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getEvictor()).isInstanceOf(CountEvictor.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1251,7 +1266,7 @@ public class AllWindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyWithEvictor() throws Exception {
+    void testApplyWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1285,13 +1300,13 @@ public class AllWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof EvictingWindowOperator);
+        assertThat(operator).isInstanceOf(EvictingWindowOperator.class);
         EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?> winOperator =
                 (EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getEvictor() instanceof TimeEvictor);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getEvictor()).isInstanceOf(TimeEvictor.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1326,7 +1341,7 @@ public class AllWindowTranslationTest {
         testHarness.processWatermark(Long.MAX_VALUE);
 
         // we at least get the two watermarks and should also see an output element
-        assertTrue(testHarness.getOutput().size() >= 3);
+        assertThat(testHarness.getOutput()).hasSizeGreaterThanOrEqualTo(3);
 
         testHarness.close();
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ContinuousEventTimeTriggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ContinuousEventTimeTriggerTest.java
@@ -27,39 +27,37 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ContinuousEventTimeTrigger}. */
-public class ContinuousEventTimeTriggerTest {
+class ContinuousEventTimeTriggerTest {
 
     /**
      * Verify that the trigger doesn't fail with an NPE if we insert a timer firing when there is no
      * trigger state.
      */
     @Test
-    public void testTriggerHandlesAllOnTimerCalls() throws Exception {
+    void testTriggerHandlesAllOnTimerCalls() throws Exception {
         TriggerTestHarness<Object, TimeWindow> testHarness =
                 new TriggerTestHarness<>(
                         ContinuousEventTimeTrigger.<TimeWindow>of(Time.milliseconds(5)),
                         new TimeWindow.Serializer());
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(0, testHarness.numEventTimeTimers());
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
 
         // this will make the elements we now process fall into late windows, i.e. no trigger state
         // will be created
         testHarness.advanceWatermark(10);
 
         // late fires immediately
-        assertEquals(
-                TriggerResult.FIRE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.FIRE);
 
         // simulate a GC timer firing
         testHarness.invokeOnEventTime(20, new TimeWindow(0, 2));
@@ -67,34 +65,29 @@ public class ContinuousEventTimeTriggerTest {
 
     /** Verify that state &lt;TimeWindow&gt;of separate windows does not leak into other windows. */
     @Test
-    public void testWindowSeparationAndFiring() throws Exception {
+    void testWindowSeparationAndFiring() throws Exception {
         TriggerTestHarness<Object, TimeWindow> testHarness =
                 new TriggerTestHarness<>(
                         ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)),
                         new TimeWindow.Serializer());
 
         // inject several elements
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
-        assertEquals(2, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(4, testHarness.numEventTimeTimers());
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isEqualTo(2);
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(4);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(0, 2))).isEqualTo(2);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(2, 4))).isEqualTo(2);
 
         Collection<Tuple2<TimeWindow, TriggerResult>> triggerResults =
                 testHarness.advanceWatermark(2);
@@ -102,37 +95,37 @@ public class ContinuousEventTimeTriggerTest {
         for (Tuple2<TimeWindow, TriggerResult> r : triggerResults) {
             if (r.f0.equals(new TimeWindow(0, 2))) {
                 sawFiring = true;
-                assertTrue(r.f1.equals(TriggerResult.FIRE));
+                assertThat(r.f1).isEqualTo(TriggerResult.FIRE);
             }
         }
-        assertTrue(sawFiring);
+        assertThat(sawFiring).isTrue();
 
-        assertEquals(2, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(3, testHarness.numEventTimeTimers());
-        assertEquals(1, testHarness.numEventTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isEqualTo(2);
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(3);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(0, 2))).isOne();
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(2, 4))).isEqualTo(2);
 
         triggerResults = testHarness.advanceWatermark(4);
         sawFiring = false;
         for (Tuple2<TimeWindow, TriggerResult> r : triggerResults) {
             if (r.f0.equals(new TimeWindow(2, 4))) {
                 sawFiring = true;
-                assertTrue(r.f1.equals(TriggerResult.FIRE));
+                assertThat(r.f1).isEqualTo(TriggerResult.FIRE);
             }
         }
-        assertTrue(sawFiring);
+        assertThat(sawFiring).isTrue();
 
-        assertEquals(2, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(2, testHarness.numEventTimeTimers());
+        assertThat(testHarness.numStateEntries()).isEqualTo(2);
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(2);
     }
 
     /**
      * Verify that late elements trigger immediately and also that we don't set a timer for those.
      */
     @Test
-    public void testLateElementTriggersImmediately() throws Exception {
+    void testLateElementTriggersImmediately() throws Exception {
         TriggerTestHarness<Object, TimeWindow> testHarness =
                 new TriggerTestHarness<>(
                         ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)),
@@ -140,83 +133,79 @@ public class ContinuousEventTimeTriggerTest {
 
         testHarness.advanceWatermark(2);
 
-        assertEquals(
-                TriggerResult.FIRE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.FIRE);
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(0, testHarness.numEventTimeTimers());
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
     }
 
     /** Verify that clear() does not leak across windows. */
     @Test
-    public void testClear() throws Exception {
+    void testClear() throws Exception {
         TriggerTestHarness<Object, TimeWindow> testHarness =
                 new TriggerTestHarness<>(
                         ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)),
                         new TimeWindow.Serializer());
 
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
-        assertEquals(2, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(4, testHarness.numEventTimeTimers());
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isEqualTo(2);
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(4);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(0, 2))).isEqualTo(2);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(2, 4))).isEqualTo(2);
 
         testHarness.clearTriggerState(new TimeWindow(2, 4));
 
-        assertEquals(1, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(3, testHarness.numEventTimeTimers());
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(1, testHarness.numEventTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isOne();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(3);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(0, 2))).isEqualTo(2);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(2, 4))).isOne();
 
         testHarness.clearTriggerState(new TimeWindow(0, 2));
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(2, testHarness.numEventTimeTimers()); // doesn't clean up timers
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(2); // doesn't clean up timers
     }
 
     @Test
-    public void testMergingWindows() throws Exception {
+    void testMergingWindows() throws Exception {
         TriggerTestHarness<Object, TimeWindow> testHarness =
                 new TriggerTestHarness<>(
                         ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)),
                         new TimeWindow.Serializer());
 
-        assertTrue(ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)).canMerge());
+        assertThat(ContinuousEventTimeTrigger.<TimeWindow>of(Time.hours(1)).canMerge()).isTrue();
 
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
-        assertEquals(2, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(4, testHarness.numEventTimeTimers());
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isEqualTo(2);
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(4);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(0, 2))).isEqualTo(2);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(2, 4))).isEqualTo(2);
 
         testHarness.mergeWindows(
                 new TimeWindow(0, 4),
                 Lists.newArrayList(new TimeWindow(0, 2), new TimeWindow(2, 4)));
 
-        assertEquals(1, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(5, testHarness.numEventTimeTimers()); // on merging, timers are not cleaned up
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(2, testHarness.numEventTimeTimers(new TimeWindow(2, 4)));
-        assertEquals(1, testHarness.numEventTimeTimers(new TimeWindow(0, 4)));
+        assertThat(testHarness.numStateEntries()).isOne();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers())
+                .isEqualTo(5); // on merging, timers are not cleaned up
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(0, 2))).isEqualTo(2);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(2, 4))).isEqualTo(2);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(0, 4))).isOne();
 
         Collection<Tuple2<TimeWindow, TriggerResult>> triggerResults =
                 testHarness.advanceWatermark(4);
@@ -224,14 +213,14 @@ public class ContinuousEventTimeTriggerTest {
         for (Tuple2<TimeWindow, TriggerResult> r : triggerResults) {
             if (r.f0.equals(new TimeWindow(0, 4))) {
                 sawFiring = true;
-                assertTrue(r.f1.equals(TriggerResult.FIRE));
+                assertThat(r.f1).isEqualTo(TriggerResult.FIRE);
             }
         }
 
-        assertTrue(sawFiring);
+        assertThat(sawFiring).isTrue();
 
-        assertEquals(1, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(1, testHarness.numEventTimeTimers());
+        assertThat(testHarness.numStateEntries()).isOne();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isOne();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ContinuousProcessingTimeTriggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ContinuousProcessingTimeTriggerTest.java
@@ -35,16 +35,16 @@ import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.Collector;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
 import java.util.Objects;
 import java.util.stream.StreamSupport;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ContinuousProcessingTimeTrigger}. */
-public class ContinuousProcessingTimeTriggerTest {
+class ContinuousProcessingTimeTriggerTest {
 
     private static final long NO_TIMESTAMP = Watermark.UNINITIALIZED.getTimestamp();
 
@@ -96,11 +96,11 @@ public class ContinuousProcessingTimeTriggerTest {
 
     /** Verify ContinuousProcessingTimeTrigger fire. */
     @Test
-    public void testWindowFiring() throws Exception {
+    void testWindowFiring() throws Exception {
         ContinuousProcessingTimeTrigger<TimeWindow> trigger =
                 ContinuousProcessingTimeTrigger.of(Time.milliseconds(5));
 
-        assertTrue(trigger.canMerge());
+        assertThat(trigger.canMerge()).isTrue();
 
         ListStateDescriptor<Integer> stateDesc =
                 new ListStateDescriptor<>(
@@ -173,11 +173,11 @@ public class ContinuousProcessingTimeTriggerTest {
     }
 
     @Test
-    public void testMergingWindows() throws Exception {
+    void testMergingWindows() throws Exception {
         ContinuousProcessingTimeTrigger<TimeWindow> trigger =
                 ContinuousProcessingTimeTrigger.of(Time.milliseconds(5));
 
-        assertTrue(trigger.canMerge());
+        assertThat(trigger.canMerge()).isTrue();
 
         ListStateDescriptor<Integer> stateDesc =
                 new ListStateDescriptor<>(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/DynamicEventTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/DynamicEventTimeSessionWindowsTest.java
@@ -25,24 +25,17 @@ import org.apache.flink.streaming.api.windowing.assigners.SessionWindowTimeGapEx
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.util.TestLogger;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
-import static org.apache.flink.streaming.util.StreamRecordMatchers.timeWindow;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.contains;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Mockito.eq;
@@ -54,10 +47,10 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /** Tests for {@link DynamicEventTimeSessionWindows}. */
-public class DynamicEventTimeSessionWindowsTest extends TestLogger {
+class DynamicEventTimeSessionWindowsTest {
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
 
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
@@ -69,18 +62,16 @@ public class DynamicEventTimeSessionWindowsTest extends TestLogger {
         DynamicEventTimeSessionWindows<String> assigner =
                 DynamicEventTimeSessionWindows.withDynamicGap(extractor);
 
-        assertThat(
-                assigner.assignWindows("gap5000", 0L, mockContext), contains(timeWindow(0, 5000)));
-        assertThat(
-                assigner.assignWindows("gap4000", 4999L, mockContext),
-                contains(timeWindow(4999, 8999)));
-        assertThat(
-                assigner.assignWindows("gap9000", 5000L, mockContext),
-                contains(timeWindow(5000, 14000)));
+        assertThat(assigner.assignWindows("gap5000", 0L, mockContext))
+                .contains(new TimeWindow(0, 5000));
+        assertThat(assigner.assignWindows("gap4000", 4999L, mockContext))
+                .contains(new TimeWindow(4999, 8999));
+        assertThat(assigner.assignWindows("gap9000", 5000L, mockContext))
+                .contains(new TimeWindow(5000, 14000));
     }
 
     @Test
-    public void testMergeSinglePointWindow() {
+    void testMergeSinglePointWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
@@ -89,13 +80,13 @@ public class DynamicEventTimeSessionWindowsTest extends TestLogger {
         DynamicEventTimeSessionWindows assigner =
                 DynamicEventTimeSessionWindows.withDynamicGap(extractor);
 
-        assigner.mergeWindows(Lists.newArrayList(new TimeWindow(0, 0)), callback);
+        assigner.mergeWindows(Collections.singletonList(new TimeWindow(0, 0)), callback);
 
         verify(callback, never()).merge(anyCollection(), Matchers.anyObject());
     }
 
     @Test
-    public void testMergeSingleWindow() {
+    void testMergeSingleWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
@@ -104,13 +95,13 @@ public class DynamicEventTimeSessionWindowsTest extends TestLogger {
         DynamicEventTimeSessionWindows assigner =
                 DynamicEventTimeSessionWindows.withDynamicGap(extractor);
 
-        assigner.mergeWindows(Lists.newArrayList(new TimeWindow(0, 1)), callback);
+        assigner.mergeWindows(Collections.singletonList(new TimeWindow(0, 1)), callback);
 
         verify(callback, never()).merge(anyCollection(), Matchers.anyObject());
     }
 
     @Test
-    public void testMergeConsecutiveWindows() {
+    void testMergeConsecutiveWindows() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
@@ -120,7 +111,7 @@ public class DynamicEventTimeSessionWindowsTest extends TestLogger {
                 DynamicEventTimeSessionWindows.withDynamicGap(extractor);
 
         assigner.mergeWindows(
-                Lists.newArrayList(
+                Arrays.asList(
                         new TimeWindow(0, 1),
                         new TimeWindow(1, 2),
                         new TimeWindow(2, 3),
@@ -150,7 +141,7 @@ public class DynamicEventTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testMergeCoveringWindow() {
+    void testMergeCoveringWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
@@ -160,7 +151,7 @@ public class DynamicEventTimeSessionWindowsTest extends TestLogger {
                 DynamicEventTimeSessionWindows.withDynamicGap(extractor);
 
         assigner.mergeWindows(
-                Lists.newArrayList(
+                Arrays.asList(
                         new TimeWindow(1, 1),
                         new TimeWindow(0, 2),
                         new TimeWindow(4, 7),
@@ -187,47 +178,34 @@ public class DynamicEventTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testInvalidParameters() {
+    void testInvalidParameters() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
-        try {
-            SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
-            when(extractor.extract(any())).thenReturn(-1L);
+        SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
+        when(extractor.extract(any())).thenReturn(-1L);
 
-            DynamicEventTimeSessionWindows assigner =
-                    DynamicEventTimeSessionWindows.withDynamicGap(extractor);
-            assigner.assignWindows(Lists.newArrayList(new Object()), 1, mockContext);
+        DynamicEventTimeSessionWindows assigner =
+                DynamicEventTimeSessionWindows.withDynamicGap(extractor);
 
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("0 < gap"));
-        }
-
-        try {
-            SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
-            when(extractor.extract(any())).thenReturn(0L);
-
-            DynamicEventTimeSessionWindows assigner =
-                    DynamicEventTimeSessionWindows.withDynamicGap(extractor);
-            assigner.assignWindows(Lists.newArrayList(new Object()), 1, mockContext);
-
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("0 < gap"));
-        }
+        assertThatThrownBy(
+                        () ->
+                                assigner.assignWindows(
+                                        Collections.singletonList(new Object()), 1, mockContext))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("0 < gap");
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
         when(extractor.extract(any())).thenReturn(5000L);
 
         DynamicEventTimeSessionWindows assigner =
                 DynamicEventTimeSessionWindows.withDynamicGap(extractor);
 
-        assertTrue(assigner.isEventTime());
-        assertEquals(
-                new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
-        assertThat(assigner.getDefaultTrigger(), instanceOf(EventTimeTrigger.class));
+        assertThat(assigner.isEventTime()).isTrue();
+        assertThat(assigner.getWindowSerializer(new ExecutionConfig()))
+                .isEqualTo(new TimeWindow.Serializer());
+        assertThat(assigner.getDefaultTrigger()).isInstanceOf(EventTimeTrigger.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/DynamicEventTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/DynamicEventTimeSessionWindowsTest.java
@@ -63,11 +63,11 @@ class DynamicEventTimeSessionWindowsTest {
                 DynamicEventTimeSessionWindows.withDynamicGap(extractor);
 
         assertThat(assigner.assignWindows("gap5000", 0L, mockContext))
-                .contains(new TimeWindow(0, 5000));
+                .containsExactly(new TimeWindow(0, 5000));
         assertThat(assigner.assignWindows("gap4000", 4999L, mockContext))
-                .contains(new TimeWindow(4999, 8999));
+                .containsExactly(new TimeWindow(4999, 8999));
         assertThat(assigner.assignWindows("gap9000", 5000L, mockContext))
-                .contains(new TimeWindow(5000, 14000));
+                .containsExactly(new TimeWindow(5000, 14000));
     }
 
     @Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/DynamicProcessingTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/DynamicProcessingTimeSessionWindowsTest.java
@@ -25,24 +25,17 @@ import org.apache.flink.streaming.api.windowing.assigners.SessionWindowTimeGapEx
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.triggers.ProcessingTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.util.TestLogger;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
-import static org.apache.flink.streaming.util.StreamRecordMatchers.timeWindow;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.contains;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Mockito.eq;
@@ -54,10 +47,10 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /** Tests for {@link DynamicProcessingTimeSessionWindows}. */
-public class DynamicProcessingTimeSessionWindowsTest extends TestLogger {
+class DynamicProcessingTimeSessionWindowsTest {
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
 
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
@@ -70,23 +63,20 @@ public class DynamicProcessingTimeSessionWindowsTest extends TestLogger {
                 DynamicProcessingTimeSessionWindows.withDynamicGap(extractor);
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
-        assertThat(
-                assigner.assignWindows("gap5000", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(0, 5000)));
+        assertThat(assigner.assignWindows("gap5000", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4999L);
-        assertThat(
-                assigner.assignWindows("gap4000", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(4999, 8999)));
+        assertThat(assigner.assignWindows("gap4000", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(4999, 8999));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
-        assertThat(
-                assigner.assignWindows("gap9000", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(5000, 14000)));
+        assertThat(assigner.assignWindows("gap9000", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(5000, 14000));
     }
 
     @Test
-    public void testMergeSinglePointWindow() {
+    void testMergeSinglePointWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
@@ -95,13 +85,13 @@ public class DynamicProcessingTimeSessionWindowsTest extends TestLogger {
         DynamicProcessingTimeSessionWindows assigner =
                 DynamicProcessingTimeSessionWindows.withDynamicGap(extractor);
 
-        assigner.mergeWindows(Lists.newArrayList(new TimeWindow(0, 0)), callback);
+        assigner.mergeWindows(Collections.singletonList(new TimeWindow(0, 0)), callback);
 
         verify(callback, never()).merge(anyCollection(), Matchers.anyObject());
     }
 
     @Test
-    public void testMergeSingleWindow() {
+    void testMergeSingleWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
@@ -110,13 +100,13 @@ public class DynamicProcessingTimeSessionWindowsTest extends TestLogger {
         DynamicProcessingTimeSessionWindows assigner =
                 DynamicProcessingTimeSessionWindows.withDynamicGap(extractor);
 
-        assigner.mergeWindows(Lists.newArrayList(new TimeWindow(0, 1)), callback);
+        assigner.mergeWindows(Collections.singletonList(new TimeWindow(0, 1)), callback);
 
         verify(callback, never()).merge(anyCollection(), Matchers.anyObject());
     }
 
     @Test
-    public void testMergeConsecutiveWindows() {
+    void testMergeConsecutiveWindows() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
@@ -126,7 +116,7 @@ public class DynamicProcessingTimeSessionWindowsTest extends TestLogger {
                 DynamicProcessingTimeSessionWindows.withDynamicGap(extractor);
 
         assigner.mergeWindows(
-                Lists.newArrayList(
+                Arrays.asList(
                         new TimeWindow(0, 1),
                         new TimeWindow(1, 2),
                         new TimeWindow(2, 3),
@@ -156,7 +146,7 @@ public class DynamicProcessingTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testMergeCoveringWindow() {
+    void testMergeCoveringWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
@@ -166,7 +156,7 @@ public class DynamicProcessingTimeSessionWindowsTest extends TestLogger {
                 DynamicProcessingTimeSessionWindows.withDynamicGap(extractor);
 
         assigner.mergeWindows(
-                Lists.newArrayList(
+                Arrays.asList(
                         new TimeWindow(1, 1),
                         new TimeWindow(0, 2),
                         new TimeWindow(4, 7),
@@ -193,45 +183,34 @@ public class DynamicProcessingTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testInvalidParameters() {
+    void testInvalidParameters() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
-        try {
-            SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
-            when(extractor.extract(any())).thenReturn(-1L);
+        SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
+        when(extractor.extract(any())).thenReturn(-1L);
 
-            DynamicProcessingTimeSessionWindows assigner =
-                    DynamicProcessingTimeSessionWindows.withDynamicGap(extractor);
-            assigner.assignWindows(Lists.newArrayList(new Object()), 1, mockContext);
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("0 < gap"));
-        }
+        DynamicProcessingTimeSessionWindows assigner =
+                DynamicProcessingTimeSessionWindows.withDynamicGap(extractor);
 
-        try {
-            SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
-            when(extractor.extract(any())).thenReturn(-1L);
-
-            DynamicProcessingTimeSessionWindows assigner =
-                    DynamicProcessingTimeSessionWindows.withDynamicGap(extractor);
-            assigner.assignWindows(Lists.newArrayList(new Object()), 1, mockContext);
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("0 < gap"));
-        }
+        assertThatThrownBy(
+                        () ->
+                                assigner.assignWindows(
+                                        Collections.singletonList(new Object()), 1, mockContext))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("0 < gap");
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         SessionWindowTimeGapExtractor extractor = mock(SessionWindowTimeGapExtractor.class);
         when(extractor.extract(any())).thenReturn(5000L);
 
         DynamicProcessingTimeSessionWindows assigner =
                 DynamicProcessingTimeSessionWindows.withDynamicGap(extractor);
 
-        assertFalse(assigner.isEventTime());
-        assertEquals(
-                new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
-        assertThat(assigner.getDefaultTrigger(), instanceOf(ProcessingTimeTrigger.class));
+        assertThat(assigner.isEventTime()).isFalse();
+        assertThat(assigner.getWindowSerializer(new ExecutionConfig()))
+                .isEqualTo(new TimeWindow.Serializer());
+        assertThat(assigner.getDefaultTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/DynamicProcessingTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/DynamicProcessingTimeSessionWindowsTest.java
@@ -64,15 +64,15 @@ class DynamicProcessingTimeSessionWindowsTest {
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
         assertThat(assigner.assignWindows("gap5000", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(0, 5000));
+                .containsExactly(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4999L);
         assertThat(assigner.assignWindows("gap4000", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(4999, 8999));
+                .containsExactly(new TimeWindow(4999, 8999));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
         assertThat(assigner.assignWindows("gap9000", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(5000, 14000));
+                .containsExactly(new TimeWindow(5000, 14000));
     }
 
     @Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EventTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EventTimeSessionWindowsTest.java
@@ -60,11 +60,11 @@ class EventTimeSessionWindowsTest {
                 EventTimeSessionWindows.withGap(Time.milliseconds(sessionGap));
 
         assertThat(assigner.assignWindows("String", 0L, mockContext))
-                .contains(new TimeWindow(0, 0 + sessionGap));
+                .containsExactly(new TimeWindow(0, 0 + sessionGap));
         assertThat(assigner.assignWindows("String", 4999L, mockContext))
-                .contains(new TimeWindow(4999, 4999 + sessionGap));
+                .containsExactly(new TimeWindow(4999, 4999 + sessionGap));
         assertThat(assigner.assignWindows("String", 5000L, mockContext))
-                .contains(new TimeWindow(5000, 5000 + sessionGap));
+                .containsExactly(new TimeWindow(5000, 5000 + sessionGap));
     }
 
     @Test
@@ -175,11 +175,11 @@ class EventTimeSessionWindowsTest {
                 EventTimeSessionWindows.withGap(Time.seconds(sessionGap / 1000));
 
         assertThat(assigner.assignWindows("String", 0L, mockContext))
-                .contains(new TimeWindow(0, 0 + sessionGap));
+                .containsExactly(new TimeWindow(0, 0 + sessionGap));
         assertThat(assigner.assignWindows("String", 4999L, mockContext))
-                .contains(new TimeWindow(4999, 4999 + sessionGap));
+                .containsExactly(new TimeWindow(4999, 4999 + sessionGap));
         assertThat(assigner.assignWindows("String", 5000L, mockContext))
-                .contains(new TimeWindow(5000, 5000 + sessionGap));
+                .containsExactly(new TimeWindow(5000, 5000 + sessionGap));
     }
 
     @Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EventTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EventTimeSessionWindowsTest.java
@@ -27,25 +27,17 @@ import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.util.TestLogger;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
-import static org.apache.flink.streaming.util.StreamRecordMatchers.timeWindow;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.contains;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -55,10 +47,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /** Tests for {@link EventTimeSessionWindows}. */
-public class EventTimeSessionWindowsTest extends TestLogger {
+class EventTimeSessionWindowsTest {
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         final int sessionGap = 5000;
 
         WindowAssigner.WindowAssignerContext mockContext =
@@ -67,50 +59,47 @@ public class EventTimeSessionWindowsTest extends TestLogger {
         EventTimeSessionWindows assigner =
                 EventTimeSessionWindows.withGap(Time.milliseconds(sessionGap));
 
-        assertThat(
-                assigner.assignWindows("String", 0L, mockContext),
-                contains(timeWindow(0, 0 + sessionGap)));
-        assertThat(
-                assigner.assignWindows("String", 4999L, mockContext),
-                contains(timeWindow(4999, 4999 + sessionGap)));
-        assertThat(
-                assigner.assignWindows("String", 5000L, mockContext),
-                contains(timeWindow(5000, 5000 + sessionGap)));
+        assertThat(assigner.assignWindows("String", 0L, mockContext))
+                .contains(new TimeWindow(0, 0 + sessionGap));
+        assertThat(assigner.assignWindows("String", 4999L, mockContext))
+                .contains(new TimeWindow(4999, 4999 + sessionGap));
+        assertThat(assigner.assignWindows("String", 5000L, mockContext))
+                .contains(new TimeWindow(5000, 5000 + sessionGap));
     }
 
     @Test
-    public void testMergeSinglePointWindow() {
+    void testMergeSinglePointWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
 
         EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
 
-        assigner.mergeWindows(Lists.newArrayList(new TimeWindow(0, 0)), callback);
+        assigner.mergeWindows(Collections.singletonList(new TimeWindow(0, 0)), callback);
 
         verify(callback, never()).merge(anyCollection(), Matchers.anyObject());
     }
 
     @Test
-    public void testMergeSingleWindow() {
+    void testMergeSingleWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
 
         EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
 
-        assigner.mergeWindows(Lists.newArrayList(new TimeWindow(0, 1)), callback);
+        assigner.mergeWindows(Collections.singletonList(new TimeWindow(0, 1)), callback);
 
         verify(callback, never()).merge(anyCollection(), Matchers.anyObject());
     }
 
     @Test
-    public void testMergeConsecutiveWindows() {
+    void testMergeConsecutiveWindows() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
 
         EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
 
         assigner.mergeWindows(
-                Lists.newArrayList(
+                Arrays.asList(
                         new TimeWindow(0, 1),
                         new TimeWindow(1, 2),
                         new TimeWindow(2, 3),
@@ -140,14 +129,14 @@ public class EventTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testMergeCoveringWindow() {
+    void testMergeCoveringWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
 
         EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.milliseconds(5000));
 
         assigner.mergeWindows(
-                Lists.newArrayList(
+                Arrays.asList(
                         new TimeWindow(1, 1),
                         new TimeWindow(0, 2),
                         new TimeWindow(4, 7),
@@ -174,7 +163,7 @@ public class EventTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testTimeUnits() {
+    void testTimeUnits() {
         // sanity check with one other time unit
 
         final int sessionGap = 5000;
@@ -185,51 +174,42 @@ public class EventTimeSessionWindowsTest extends TestLogger {
         EventTimeSessionWindows assigner =
                 EventTimeSessionWindows.withGap(Time.seconds(sessionGap / 1000));
 
-        assertThat(
-                assigner.assignWindows("String", 0L, mockContext),
-                contains(timeWindow(0, 0 + sessionGap)));
-        assertThat(
-                assigner.assignWindows("String", 4999L, mockContext),
-                contains(timeWindow(4999, 4999 + sessionGap)));
-        assertThat(
-                assigner.assignWindows("String", 5000L, mockContext),
-                contains(timeWindow(5000, 5000 + sessionGap)));
+        assertThat(assigner.assignWindows("String", 0L, mockContext))
+                .contains(new TimeWindow(0, 0 + sessionGap));
+        assertThat(assigner.assignWindows("String", 4999L, mockContext))
+                .contains(new TimeWindow(4999, 4999 + sessionGap));
+        assertThat(assigner.assignWindows("String", 5000L, mockContext))
+                .contains(new TimeWindow(5000, 5000 + sessionGap));
     }
 
     @Test
-    public void testInvalidParameters() {
-        try {
-            EventTimeSessionWindows.withGap(Time.seconds(-1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("0 < size"));
-        }
+    void testInvalidParameters() {
+        assertThatThrownBy(() -> EventTimeSessionWindows.withGap(Time.seconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("0 < size");
 
-        try {
-            EventTimeSessionWindows.withGap(Time.seconds(0));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("0 < size"));
-        }
+        assertThatThrownBy(() -> EventTimeSessionWindows.withGap(Time.seconds(0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("0 < size");
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         EventTimeSessionWindows assigner = EventTimeSessionWindows.withGap(Time.seconds(5));
 
-        assertTrue(assigner.isEventTime());
-        assertEquals(
-                new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
-        assertThat(assigner.getDefaultTrigger(), instanceOf(EventTimeTrigger.class));
+        assertThat(assigner.isEventTime()).isTrue();
+        assertThat(assigner.getWindowSerializer(new ExecutionConfig()))
+                .isEqualTo(new TimeWindow.Serializer());
+        assertThat(assigner.getDefaultTrigger()).isInstanceOf(EventTimeTrigger.class);
     }
 
     @Test
-    public void testDynamicGapProperties() {
+    void testDynamicGapProperties() {
         SessionWindowTimeGapExtractor<String> extractor = mock(SessionWindowTimeGapExtractor.class);
         DynamicEventTimeSessionWindows<String> assigner =
                 EventTimeSessionWindows.withDynamicGap(extractor);
 
-        assertNotNull(assigner);
-        assertTrue(assigner.isEventTime());
+        assertThat(assigner).isNotNull();
+        assertThat(assigner.isEventTime()).isTrue();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorContractTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorContractTest.java
@@ -41,7 +41,7 @@ import org.apache.flink.util.OutputTag;
  *
  * <p>These tests document the implicit contract that exists between the windowing components.
  */
-public class EvictingWindowOperatorContractTest extends WindowOperatorContractTest {
+class EvictingWindowOperatorContractTest extends WindowOperatorContractTest {
 
     protected <W extends Window, OUT>
             KeyedOneInputStreamOperatorTestHarness<Integer, Integer, OUT> createWindowOperator(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/EvictingWindowOperatorTest.java
@@ -52,23 +52,24 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.Collector;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Tests for {@link EvictingWindowOperator}. */
-public class EvictingWindowOperatorTest {
+class EvictingWindowOperatorTest {
 
     private static final TypeInformation<Tuple2<String, Integer>> STRING_INT_TUPLE =
             TypeInformation.of(new TypeHint<Tuple2<String, Integer>>() {});
 
     /** Tests CountEvictor evictAfter behavior. */
     @Test
-    public void testCountEvictorEvictAfter() throws Exception {
+    void testCountEvictorEvictAfter() throws Exception {
         AtomicInteger closeCalled = new AtomicInteger(0);
         final int windowSize = 4;
         final int triggerCount = 2;
@@ -156,12 +157,12 @@ public class EvictingWindowOperatorTest {
 
         testHarness.close();
 
-        Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+        assertThat(closeCalled).as("Close was not called.").hasValue(1);
     }
 
     /** Tests TimeEvictor evictAfter behavior. */
     @Test
-    public void testTimeEvictorEvictAfter() throws Exception {
+    void testTimeEvictorEvictAfter() throws Exception {
         AtomicInteger closeCalled = new AtomicInteger(0);
         final int triggerCount = 2;
         final boolean evictAfter = true;
@@ -238,12 +239,12 @@ public class EvictingWindowOperatorTest {
 
         testHarness.close();
 
-        Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+        assertThat(closeCalled).as("Close was not called.").hasValue(1);
     }
 
     /** Tests TimeEvictor evictBefore behavior. */
     @Test
-    public void testTimeEvictorEvictBefore() throws Exception {
+    void testTimeEvictorEvictBefore() throws Exception {
         AtomicInteger closeCalled = new AtomicInteger(0);
         final int triggerCount = 2;
         final int windowSize = 4;
@@ -319,7 +320,7 @@ public class EvictingWindowOperatorTest {
 
         testHarness.close();
 
-        Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+        assertThat(closeCalled).as("Close was not called.").hasValue(1);
     }
 
     /**
@@ -327,7 +328,7 @@ public class EvictingWindowOperatorTest {
      * evicted from the window.
      */
     @Test
-    public void testTimeEvictorNoTimestamp() throws Exception {
+    void testTimeEvictorNoTimestamp() throws Exception {
         AtomicInteger closeCalled = new AtomicInteger(0);
         final int triggerCount = 2;
         final boolean evictAfter = true;
@@ -402,12 +403,12 @@ public class EvictingWindowOperatorTest {
 
         testHarness.close();
 
-        Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+        assertThat(closeCalled).as("Close was not called.").hasValue(1);
     }
 
     /** Tests DeltaEvictor, evictBefore behavior. */
     @Test
-    public void testDeltaEvictorEvictBefore() throws Exception {
+    void testDeltaEvictorEvictBefore() throws Exception {
         AtomicInteger closeCalled = new AtomicInteger(0);
         final int triggerCount = 2;
         final boolean evictAfter = false;
@@ -496,12 +497,12 @@ public class EvictingWindowOperatorTest {
 
         testHarness.close();
 
-        Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+        assertThat(closeCalled).as("Close was not called.").hasValue(1);
     }
 
     /** Tests DeltaEvictor, evictAfter behavior. */
     @Test
-    public void testDeltaEvictorEvictAfter() throws Exception {
+    void testDeltaEvictorEvictAfter() throws Exception {
         AtomicInteger closeCalled = new AtomicInteger(0);
         final int triggerCount = 2;
         final boolean evictAfter = true;
@@ -590,12 +591,12 @@ public class EvictingWindowOperatorTest {
 
         testHarness.close();
 
-        Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+        assertThat(closeCalled).as("Close was not called.").hasValue(1);
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testCountTrigger() throws Exception {
+    void testCountTrigger() throws Exception {
 
         final int windowSize = 4;
         final int windowSlide = 2;
@@ -685,7 +686,7 @@ public class EvictingWindowOperatorTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testCountTriggerWithApply() throws Exception {
+    void testCountTriggerWithApply() throws Exception {
         AtomicInteger closeCalled = new AtomicInteger(0);
 
         final int windowSize = 4;
@@ -766,12 +767,12 @@ public class EvictingWindowOperatorTest {
 
         testHarness.close();
 
-        Assert.assertEquals("Close was not called.", 1, closeCalled.get());
+        assertThat(closeCalled).as("Close was not called.").hasValue(1);
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testTumblingWindowWithApply() throws Exception {
+    void testTumblingWindowWithApply() throws Exception {
         AtomicInteger closeCalled = new AtomicInteger(0);
 
         final int windowSize = 4;
@@ -889,9 +890,7 @@ public class EvictingWindowOperatorTest {
                 Collector<Tuple2<String, Integer>> out)
                 throws Exception {
 
-            if (!openCalled) {
-                Assert.fail("Open was not called");
-            }
+            assertThat(openCalled).as("Open was not called").isTrue();
             int sum = 0;
 
             for (Tuple2<String, Integer> t : input) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/GlobalWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/GlobalWindowsTest.java
@@ -22,44 +22,39 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.windows.GlobalWindow;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /** Tests for {@link GlobalWindows}. */
-public class GlobalWindowsTest extends TestLogger {
+class GlobalWindowsTest {
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
         GlobalWindows assigner = GlobalWindows.create();
 
-        assertThat(assigner.assignWindows("String", 0L, mockContext), contains(GlobalWindow.get()));
-        assertThat(
-                assigner.assignWindows("String", 4999L, mockContext), contains(GlobalWindow.get()));
-        assertThat(
-                assigner.assignWindows("String", 5000L, mockContext), contains(GlobalWindow.get()));
+        assertThat(assigner.assignWindows("String", 0L, mockContext)).contains(GlobalWindow.get());
+        assertThat(assigner.assignWindows("String", 4999L, mockContext))
+                .contains(GlobalWindow.get());
+        assertThat(assigner.assignWindows("String", 5000L, mockContext))
+                .contains(GlobalWindow.get());
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         GlobalWindows assigner = GlobalWindows.create();
 
-        assertFalse(assigner.isEventTime());
-        assertEquals(
-                new GlobalWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
-        assertThat(assigner.getDefaultTrigger(), instanceOf(GlobalWindows.NeverTrigger.class));
+        assertThat(assigner.isEventTime()).isFalse();
+        assertThat(assigner.getWindowSerializer(new ExecutionConfig()))
+                .isEqualTo(new GlobalWindow.Serializer());
+        assertThat(assigner.getDefaultTrigger()).isInstanceOf(GlobalWindows.NeverTrigger.class);
         assigner = GlobalWindows.createWithEndOfStreamTrigger();
-        assertThat(
-                assigner.getDefaultTrigger(), instanceOf(GlobalWindows.EndOfStreamTrigger.class));
+        assertThat(assigner.getDefaultTrigger())
+                .isInstanceOf(GlobalWindows.EndOfStreamTrigger.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/GlobalWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/GlobalWindowsTest.java
@@ -38,11 +38,12 @@ class GlobalWindowsTest {
 
         GlobalWindows assigner = GlobalWindows.create();
 
-        assertThat(assigner.assignWindows("String", 0L, mockContext)).contains(GlobalWindow.get());
+        assertThat(assigner.assignWindows("String", 0L, mockContext))
+                .containsExactly(GlobalWindow.get());
         assertThat(assigner.assignWindows("String", 4999L, mockContext))
-                .contains(GlobalWindow.get());
+                .containsExactly(GlobalWindow.get());
         assertThat(assigner.assignWindows("String", 5000L, mockContext))
-                .contains(GlobalWindow.get());
+                .containsExactly(GlobalWindow.get());
     }
 
     @Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapPutIfAbsentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapPutIfAbsentTest.java
@@ -18,88 +18,76 @@
 
 package org.apache.flink.streaming.runtime.operators.windowing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link KeyMap}. */
-public class KeyMapPutIfAbsentTest {
+class KeyMapPutIfAbsentTest {
 
     @Test
-    public void testPutIfAbsentUniqueKeysAndGrowth() {
-        try {
-            KeyMap<Integer, Integer> map = new KeyMap<>();
-            IntegerFactory factory = new IntegerFactory();
+    void testPutIfAbsentUniqueKeysAndGrowth() {
+        KeyMap<Integer, Integer> map = new KeyMap<>();
+        IntegerFactory factory = new IntegerFactory();
 
-            final int numElements = 1000000;
+        final int numElements = 1000000;
 
-            for (int i = 0; i < numElements; i++) {
-                factory.set(2 * i + 1);
-                map.putIfAbsent(i, factory);
+        for (int i = 0; i < numElements; i++) {
+            factory.set(2 * i + 1);
+            map.putIfAbsent(i, factory);
 
-                assertEquals(i + 1, map.size());
-                assertTrue(map.getCurrentTableCapacity() > map.size());
-                assertTrue(map.getCurrentTableCapacity() > map.getRehashThreshold());
-                assertTrue(map.size() <= map.getRehashThreshold());
-            }
-
-            assertEquals(numElements, map.size());
-            assertEquals(numElements, map.traverseAndCountElements());
-            assertEquals(1 << 21, map.getCurrentTableCapacity());
-
-            for (int i = 0; i < numElements; i++) {
-                assertEquals(2 * i + 1, map.get(i).intValue());
-            }
-
-            for (int i = numElements - 1; i >= 0; i--) {
-                assertEquals(2 * i + 1, map.get(i).intValue());
-            }
-
-            assertEquals(numElements, map.size());
-            assertEquals(numElements, map.traverseAndCountElements());
-            assertEquals(1 << 21, map.getCurrentTableCapacity());
-            assertTrue(map.getLongestChainLength() <= 7);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+            assertThat(map.size()).isEqualTo(i + 1).isLessThanOrEqualTo(map.getRehashThreshold());
+            assertThat(map.getCurrentTableCapacity())
+                    .isGreaterThan(map.size())
+                    .isGreaterThan(map.getRehashThreshold());
         }
+
+        assertThat(map).hasSize(numElements);
+        assertThat(map.traverseAndCountElements()).isEqualTo(numElements);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(1 << 21);
+
+        for (int i = 0; i < numElements; i++) {
+            assertThat(map.get(i)).isEqualTo(2 * i + 1);
+        }
+
+        for (int i = numElements - 1; i >= 0; i--) {
+            assertThat(map.get(i)).isEqualTo(2 * i + 1);
+        }
+
+        assertThat(map).hasSize(numElements);
+        assertThat(map.traverseAndCountElements()).isEqualTo(numElements);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(1 << 21);
+        assertThat(map.getLongestChainLength()).isLessThanOrEqualTo(7);
     }
 
     @Test
-    public void testPutIfAbsentDuplicateKeysAndGrowth() {
-        try {
-            KeyMap<Integer, Integer> map = new KeyMap<>();
-            IntegerFactory factory = new IntegerFactory();
+    void testPutIfAbsentDuplicateKeysAndGrowth() {
+        KeyMap<Integer, Integer> map = new KeyMap<>();
+        IntegerFactory factory = new IntegerFactory();
 
-            final int numElements = 1000000;
+        final int numElements = 1000000;
 
-            for (int i = 0; i < numElements; i++) {
-                int val = 2 * i + 1;
-                factory.set(val);
-                Integer put = map.putIfAbsent(i, factory);
-                assertEquals(val, put.intValue());
-            }
-
-            for (int i = 0; i < numElements; i += 3) {
-                factory.set(2 * i);
-                Integer put = map.putIfAbsent(i, factory);
-                assertEquals(2 * i + 1, put.intValue());
-            }
-
-            for (int i = 0; i < numElements; i++) {
-                assertEquals(2 * i + 1, map.get(i).intValue());
-            }
-
-            assertEquals(numElements, map.size());
-            assertEquals(numElements, map.traverseAndCountElements());
-            assertEquals(1 << 21, map.getCurrentTableCapacity());
-            assertTrue(map.getLongestChainLength() <= 7);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        for (int i = 0; i < numElements; i++) {
+            int val = 2 * i + 1;
+            factory.set(val);
+            Integer put = map.putIfAbsent(i, factory);
+            assertThat(put).isEqualTo(val);
         }
+
+        for (int i = 0; i < numElements; i += 3) {
+            factory.set(2 * i);
+            Integer put = map.putIfAbsent(i, factory);
+            assertThat(put).isEqualTo(2 * i + 1);
+        }
+
+        for (int i = 0; i < numElements; i++) {
+            assertThat(map.get(i)).isEqualTo(2 * i + 1);
+        }
+
+        assertThat(map).hasSize(numElements);
+        assertThat(map.traverseAndCountElements()).isEqualTo(numElements);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(1 << 21);
+        assertThat(map.getLongestChainLength()).isLessThanOrEqualTo(7);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapTest.java
@@ -282,10 +282,10 @@ class KeyMapTest {
 
         assertThat(map1.getCurrentTableCapacity()).isLessThan(map2.getCurrentTableCapacity());
 
-        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map1, map1) == 0).isTrue();
-        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map2, map2) == 0).isTrue();
-        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map1, map2) > 0).isTrue();
-        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map2, map1) < 0).isTrue();
+        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map1, map1)).isZero();
+        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map2, map2)).isZero();
+        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map1, map2)).isPositive();
+        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map2, map1)).isNegative();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/KeyMapTest.java
@@ -18,304 +18,274 @@
 
 package org.apache.flink.streaming.runtime.operators.windowing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link KeyMap}. */
-public class KeyMapTest {
+class KeyMapTest {
 
     @Test
-    public void testInitialSizeComputation() {
+    void testInitialSizeComputation() {
+        KeyMap<String, String> map;
+
+        map = new KeyMap<>();
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(64);
+        assertThat(map.getLog2TableCapacity()).isEqualTo(6);
+        assertThat(map.getShift()).isEqualTo(24);
+        assertThat(map.getRehashThreshold()).isEqualTo(48);
+
+        map = new KeyMap<>(0);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(64);
+        assertThat(map.getLog2TableCapacity()).isEqualTo(6);
+        assertThat(map.getShift()).isEqualTo(24);
+        assertThat(map.getRehashThreshold()).isEqualTo(48);
+
+        map = new KeyMap<>(1);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(64);
+        assertThat(map.getLog2TableCapacity()).isEqualTo(6);
+        assertThat(map.getShift()).isEqualTo(24);
+        assertThat(map.getRehashThreshold()).isEqualTo(48);
+
+        map = new KeyMap<>(9);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(64);
+        assertThat(map.getLog2TableCapacity()).isEqualTo(6);
+        assertThat(map.getShift()).isEqualTo(24);
+        assertThat(map.getRehashThreshold()).isEqualTo(48);
+
+        map = new KeyMap<>(63);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(64);
+        assertThat(map.getLog2TableCapacity()).isEqualTo(6);
+        assertThat(map.getShift()).isEqualTo(24);
+        assertThat(map.getRehashThreshold()).isEqualTo(48);
+
+        map = new KeyMap<>(64);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(128);
+        assertThat(map.getLog2TableCapacity()).isEqualTo(7);
+        assertThat(map.getShift()).isEqualTo(23);
+        assertThat(map.getRehashThreshold()).isEqualTo(96);
+
+        map = new KeyMap<>(500);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(512);
+        assertThat(map.getLog2TableCapacity()).isEqualTo(9);
+        assertThat(map.getShift()).isEqualTo(21);
+        assertThat(map.getRehashThreshold()).isEqualTo(384);
+
+        map = new KeyMap<>(127);
+        assertThat(map.getCurrentTableCapacity()).isEqualTo(128);
+        assertThat(map.getLog2TableCapacity()).isEqualTo(7);
+        assertThat(map.getShift()).isEqualTo(23);
+        assertThat(map.getRehashThreshold()).isEqualTo(96);
+
+        // no negative number of elements
+        assertThatThrownBy(() -> new KeyMap<>(-1)).isInstanceOf(IllegalArgumentException.class);
+
+        // check integer overflow
         try {
-            KeyMap<String, String> map;
+            map = new KeyMap<>(0x65715522);
 
-            map = new KeyMap<>();
-            assertEquals(64, map.getCurrentTableCapacity());
-            assertEquals(6, map.getLog2TableCapacity());
-            assertEquals(24, map.getShift());
-            assertEquals(48, map.getRehashThreshold());
-
-            map = new KeyMap<>(0);
-            assertEquals(64, map.getCurrentTableCapacity());
-            assertEquals(6, map.getLog2TableCapacity());
-            assertEquals(24, map.getShift());
-            assertEquals(48, map.getRehashThreshold());
-
-            map = new KeyMap<>(1);
-            assertEquals(64, map.getCurrentTableCapacity());
-            assertEquals(6, map.getLog2TableCapacity());
-            assertEquals(24, map.getShift());
-            assertEquals(48, map.getRehashThreshold());
-
-            map = new KeyMap<>(9);
-            assertEquals(64, map.getCurrentTableCapacity());
-            assertEquals(6, map.getLog2TableCapacity());
-            assertEquals(24, map.getShift());
-            assertEquals(48, map.getRehashThreshold());
-
-            map = new KeyMap<>(63);
-            assertEquals(64, map.getCurrentTableCapacity());
-            assertEquals(6, map.getLog2TableCapacity());
-            assertEquals(24, map.getShift());
-            assertEquals(48, map.getRehashThreshold());
-
-            map = new KeyMap<>(64);
-            assertEquals(128, map.getCurrentTableCapacity());
-            assertEquals(7, map.getLog2TableCapacity());
-            assertEquals(23, map.getShift());
-            assertEquals(96, map.getRehashThreshold());
-
-            map = new KeyMap<>(500);
-            assertEquals(512, map.getCurrentTableCapacity());
-            assertEquals(9, map.getLog2TableCapacity());
-            assertEquals(21, map.getShift());
-            assertEquals(384, map.getRehashThreshold());
-
-            map = new KeyMap<>(127);
-            assertEquals(128, map.getCurrentTableCapacity());
-            assertEquals(7, map.getLog2TableCapacity());
-            assertEquals(23, map.getShift());
-            assertEquals(96, map.getRehashThreshold());
-
-            // no negative number of elements
-            try {
-                new KeyMap<>(-1);
-                fail("should fail with an exception");
-            } catch (IllegalArgumentException e) {
-                // expected
-            }
-
-            // check integer overflow
-            try {
-                map = new KeyMap<>(0x65715522);
-
-                final int maxCap = Integer.highestOneBit(Integer.MAX_VALUE);
-                assertEquals(
-                        Integer.highestOneBit(Integer.MAX_VALUE), map.getCurrentTableCapacity());
-                assertEquals(30, map.getLog2TableCapacity());
-                assertEquals(0, map.getShift());
-                assertEquals(maxCap / 4 * 3, map.getRehashThreshold());
-            } catch (OutOfMemoryError e) {
-                // this may indeed happen in small test setups. we tolerate this in this test
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+            final int maxCap = Integer.highestOneBit(Integer.MAX_VALUE);
+            assertThat(map.getCurrentTableCapacity()).isEqualTo(maxCap);
+            assertThat(map.getLog2TableCapacity()).isEqualTo(30);
+            assertThat(map.getShift()).isZero();
+            assertThat(map.getRehashThreshold()).isEqualTo(maxCap / 4 * 3);
+        } catch (OutOfMemoryError e) {
+            // this may indeed happen in small test setups. we tolerate this in this test
         }
     }
 
     @Test
-    public void testPutAndGetRandom() {
-        try {
-            final KeyMap<Integer, Integer> map = new KeyMap<>();
-            final Random rnd = new Random();
+    void testPutAndGetRandom() {
+        final KeyMap<Integer, Integer> map = new KeyMap<>();
+        final Random rnd = new Random();
 
-            final long seed = rnd.nextLong();
-            final int numElements = 10000;
+        final long seed = rnd.nextLong();
+        final int numElements = 10000;
 
-            final HashMap<Integer, Integer> groundTruth = new HashMap<>();
+        final HashMap<Integer, Integer> groundTruth = new HashMap<>();
 
-            rnd.setSeed(seed);
-            for (int i = 0; i < numElements; i++) {
-                Integer key = rnd.nextInt();
-                Integer value = rnd.nextInt();
+        rnd.setSeed(seed);
+        for (int i = 0; i < numElements; i++) {
+            Integer key = rnd.nextInt();
+            Integer value = rnd.nextInt();
 
-                if (rnd.nextBoolean()) {
-                    groundTruth.put(key, value);
-                    map.put(key, value);
-                }
+            if (rnd.nextBoolean()) {
+                groundTruth.put(key, value);
+                map.put(key, value);
             }
+        }
 
-            rnd.setSeed(seed);
-            for (int i = 0; i < numElements; i++) {
-                Integer key = rnd.nextInt();
+        rnd.setSeed(seed);
+        for (int i = 0; i < numElements; i++) {
+            Integer key = rnd.nextInt();
 
-                // skip these, evaluating it is tricky due to duplicates
-                rnd.nextInt();
-                rnd.nextBoolean();
+            // skip these, evaluating it is tricky due to duplicates
+            rnd.nextInt();
+            rnd.nextBoolean();
 
-                Integer expected = groundTruth.get(key);
-                if (expected == null) {
-                    assertNull(map.get(key));
-                } else {
-                    Integer contained = map.get(key);
-                    assertNotNull(contained);
-                    assertEquals(expected, contained);
-                }
+            Integer expected = groundTruth.get(key);
+            if (expected == null) {
+                assertThat(map.get(key)).isNull();
+            } else {
+                Integer contained = map.get(key);
+                assertThat(contained).isNotNull().isEqualTo(expected);
             }
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
         }
     }
 
     @Test
-    public void testConjunctTraversal() {
-        try {
-            final Random rootRnd = new Random(654685486325439L);
+    void testConjunctTraversal() throws Exception {
+        final Random rootRnd = new Random(654685486325439L);
 
-            final int numMaps = 7;
-            final int numKeys = 1000000;
+        final int numMaps = 7;
+        final int numKeys = 1000000;
 
-            // ------ create a set of maps ------
-            @SuppressWarnings("unchecked")
-            final KeyMap<Integer, Integer>[] maps =
-                    (KeyMap<Integer, Integer>[]) new KeyMap<?, ?>[numMaps];
-            for (int i = 0; i < numMaps; i++) {
-                maps[i] = new KeyMap<>();
+        // ------ create a set of maps ------
+        @SuppressWarnings("unchecked")
+        final KeyMap<Integer, Integer>[] maps =
+                (KeyMap<Integer, Integer>[]) new KeyMap<?, ?>[numMaps];
+        for (int i = 0; i < numMaps; i++) {
+            maps[i] = new KeyMap<>();
+        }
+
+        // ------ prepare probabilities for maps ------
+        final double[] probabilities = new double[numMaps];
+        final double[] probabilitiesTemp = new double[numMaps];
+        {
+            probabilities[0] = 0.5;
+            double remainingProb = 1.0 - probabilities[0];
+            for (int i = 1; i < numMaps - 1; i++) {
+                remainingProb /= 2;
+                probabilities[i] = remainingProb;
             }
 
-            // ------ prepare probabilities for maps ------
-            final double[] probabilities = new double[numMaps];
-            final double[] probabilitiesTemp = new double[numMaps];
-            {
-                probabilities[0] = 0.5;
-                double remainingProb = 1.0 - probabilities[0];
-                for (int i = 1; i < numMaps - 1; i++) {
-                    remainingProb /= 2;
-                    probabilities[i] = remainingProb;
+            // compensate for rounding errors
+            probabilities[numMaps - 1] = remainingProb;
+        }
+
+        // ------ generate random elements ------
+        final long probSeed = rootRnd.nextLong();
+        final long keySeed = rootRnd.nextLong();
+
+        final Random probRnd = new Random(probSeed);
+        final Random keyRnd = new Random(keySeed);
+
+        final int maxStride = Integer.MAX_VALUE / numKeys;
+
+        int totalNumElements = 0;
+        int nextKeyValue = 1;
+
+        for (int i = 0; i < numKeys; i++) {
+            int numCopies = (nextKeyValue % 3) + 1;
+            System.arraycopy(probabilities, 0, probabilitiesTemp, 0, numMaps);
+
+            double totalProb = 1.0;
+            for (int copy = 0; copy < numCopies; copy++) {
+                int pos = drawPosProportionally(probabilitiesTemp, totalProb, probRnd);
+                totalProb -= probabilitiesTemp[pos];
+                probabilitiesTemp[pos] = 0.0;
+
+                Integer boxed = nextKeyValue;
+                Integer previous = maps[pos].put(boxed, boxed);
+                assertThat(previous).as("Test problem - test does not assign unique maps").isNull();
+            }
+
+            totalNumElements += numCopies;
+            nextKeyValue += keyRnd.nextInt(maxStride) + 1;
+        }
+
+        // check that all maps contain the total number of elements
+        int numContained = 0;
+        for (KeyMap<?, ?> map : maps) {
+            numContained += map.size();
+        }
+        assertThat(numContained).isEqualTo(totalNumElements);
+
+        // ------ check that all elements can be found in the maps ------
+        keyRnd.setSeed(keySeed);
+
+        numContained = 0;
+        nextKeyValue = 1;
+        for (int i = 0; i < numKeys; i++) {
+            int numCopiesExpected = (nextKeyValue % 3) + 1;
+            int numCopiesContained = 0;
+
+            for (KeyMap<Integer, Integer> map : maps) {
+                Integer val = map.get(nextKeyValue);
+                if (val != null) {
+                    assertThat(val).isEqualTo(nextKeyValue);
+                    numCopiesContained++;
                 }
-
-                // compensate for rounding errors
-                probabilities[numMaps - 1] = remainingProb;
             }
 
-            // ------ generate random elements ------
-            final long probSeed = rootRnd.nextLong();
-            final long keySeed = rootRnd.nextLong();
+            assertThat(numCopiesContained).isEqualTo(numCopiesExpected);
+            numContained += numCopiesContained;
 
-            final Random probRnd = new Random(probSeed);
-            final Random keyRnd = new Random(keySeed);
+            nextKeyValue += keyRnd.nextInt(maxStride) + 1;
+        }
+        assertThat(numContained).isEqualTo(totalNumElements);
 
-            final int maxStride = Integer.MAX_VALUE / numKeys;
+        // ------ make a traversal over all keys and validate the keys in the traversal ------
+        final int[] keysStartedAndFinished = {0, 0};
+        KeyMap.TraversalEvaluator<Integer, Integer> traversal =
+                new KeyMap.TraversalEvaluator<Integer, Integer>() {
 
-            int totalNumElements = 0;
-            int nextKeyValue = 1;
+                    private int key;
+                    private int valueCount;
 
-            for (int i = 0; i < numKeys; i++) {
-                int numCopies = (nextKeyValue % 3) + 1;
-                System.arraycopy(probabilities, 0, probabilitiesTemp, 0, numMaps);
+                    @Override
+                    public void startNewKey(Integer key) {
+                        this.key = key;
+                        this.valueCount = 0;
 
-                double totalProb = 1.0;
-                for (int copy = 0; copy < numCopies; copy++) {
-                    int pos = drawPosProportionally(probabilitiesTemp, totalProb, probRnd);
-                    totalProb -= probabilitiesTemp[pos];
-                    probabilitiesTemp[pos] = 0.0;
-
-                    Integer boxed = nextKeyValue;
-                    Integer previous = maps[pos].put(boxed, boxed);
-                    assertNull("Test problem - test does not assign unique maps", previous);
-                }
-
-                totalNumElements += numCopies;
-                nextKeyValue += keyRnd.nextInt(maxStride) + 1;
-            }
-
-            // check that all maps contain the total number of elements
-            int numContained = 0;
-            for (KeyMap<?, ?> map : maps) {
-                numContained += map.size();
-            }
-            assertEquals(totalNumElements, numContained);
-
-            // ------ check that all elements can be found in the maps ------
-            keyRnd.setSeed(keySeed);
-
-            numContained = 0;
-            nextKeyValue = 1;
-            for (int i = 0; i < numKeys; i++) {
-                int numCopiesExpected = (nextKeyValue % 3) + 1;
-                int numCopiesContained = 0;
-
-                for (KeyMap<Integer, Integer> map : maps) {
-                    Integer val = map.get(nextKeyValue);
-                    if (val != null) {
-                        assertEquals(nextKeyValue, val.intValue());
-                        numCopiesContained++;
+                        keysStartedAndFinished[0]++;
                     }
-                }
 
-                assertEquals(numCopiesExpected, numCopiesContained);
-                numContained += numCopiesContained;
+                    @Override
+                    public void nextValue(Integer value) {
+                        assertThat(value).isEqualTo(this.key);
+                        this.valueCount++;
+                    }
 
-                nextKeyValue += keyRnd.nextInt(maxStride) + 1;
-            }
-            assertEquals(totalNumElements, numContained);
-
-            // ------ make a traversal over all keys and validate the keys in the traversal ------
-            final int[] keysStartedAndFinished = {0, 0};
-            KeyMap.TraversalEvaluator<Integer, Integer> traversal =
-                    new KeyMap.TraversalEvaluator<Integer, Integer>() {
-
-                        private int key;
-                        private int valueCount;
-
-                        @Override
-                        public void startNewKey(Integer key) {
-                            this.key = key;
-                            this.valueCount = 0;
-
-                            keysStartedAndFinished[0]++;
-                        }
-
-                        @Override
-                        public void nextValue(Integer value) {
-                            assertEquals(this.key, value.intValue());
-                            this.valueCount++;
-                        }
-
-                        @Override
-                        public void keyDone() {
-                            int expected = (key % 3) + 1;
-                            if (expected != valueCount) {
-                                fail(
+                    @Override
+                    public void keyDone() {
+                        int expected = (key % 3) + 1;
+                        assertThat(valueCount)
+                                .as(
                                         "Wrong count for key "
                                                 + key
                                                 + " ; expected="
                                                 + expected
                                                 + " , count="
-                                                + valueCount);
-                            }
+                                                + valueCount)
+                                .isEqualTo(expected);
 
-                            keysStartedAndFinished[1]++;
-                        }
-                    };
+                        keysStartedAndFinished[1]++;
+                    }
+                };
 
-            KeyMap.traverseMaps(shuffleArray(maps, rootRnd), traversal, 17);
+        KeyMap.traverseMaps(shuffleArray(maps, rootRnd), traversal, 17);
 
-            assertEquals(numKeys, keysStartedAndFinished[0]);
-            assertEquals(numKeys, keysStartedAndFinished[1]);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        assertThat(keysStartedAndFinished[0]).isEqualTo(numKeys);
+        assertThat(keysStartedAndFinished[1]).isEqualTo(numKeys);
     }
 
     @Test
-    public void testSizeComparator() {
-        try {
-            KeyMap<String, String> map1 = new KeyMap<>(5);
-            KeyMap<String, String> map2 = new KeyMap<>(80);
+    void testSizeComparator() {
+        KeyMap<String, String> map1 = new KeyMap<>(5);
+        KeyMap<String, String> map2 = new KeyMap<>(80);
 
-            assertTrue(map1.getCurrentTableCapacity() < map2.getCurrentTableCapacity());
+        assertThat(map1.getCurrentTableCapacity()).isLessThan(map2.getCurrentTableCapacity());
 
-            assertTrue(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map1, map1) == 0);
-            assertTrue(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map2, map2) == 0);
-            assertTrue(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map1, map2) > 0);
-            assertTrue(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map2, map1) < 0);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
-        }
+        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map1, map1) == 0).isTrue();
+        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map2, map2) == 0).isTrue();
+        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map1, map2) > 0).isTrue();
+        assertThat(KeyMap.CapacityDescendingComparator.INSTANCE.compare(map2, map1) < 0).isTrue();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSetTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSetTest.java
@@ -32,7 +32,7 @@ import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 
 import java.util.ArrayList;
@@ -41,17 +41,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -62,7 +52,7 @@ import static org.mockito.Mockito.when;
  * Tests for verifying that {@link MergingWindowSet} correctly merges windows in various situations
  * and that the merge callback is called with the correct sets of windows.
  */
-public class MergingWindowSetTest {
+class MergingWindowSetTest {
 
     /**
      * This test uses a special (misbehaving) {@code MergingWindowAssigner} that produces cases
@@ -70,7 +60,7 @@ public class MergingWindowSetTest {
      * the merging window set is nevertheless correct and contains all added windows.
      */
     @Test
-    public void testNonEagerMerging() throws Exception {
+    void testNonEagerMerging() throws Exception {
         @SuppressWarnings("unchecked")
         ListState<Tuple2<TimeWindow, TimeWindow>> mockState = mock(ListState.class);
 
@@ -83,23 +73,23 @@ public class MergingWindowSetTest {
 
         mergeFunction.reset();
         result = windowSet.addWindow(new TimeWindow(0, 2), mergeFunction);
-        assertNotNull(windowSet.getStateWindow(result));
+        assertThat(windowSet.getStateWindow(result)).isNotNull();
 
         mergeFunction.reset();
         result = windowSet.addWindow(new TimeWindow(2, 5), mergeFunction);
-        assertNotNull(windowSet.getStateWindow(result));
+        assertThat(windowSet.getStateWindow(result)).isNotNull();
 
         mergeFunction.reset();
         result = windowSet.addWindow(new TimeWindow(1, 2), mergeFunction);
-        assertNotNull(windowSet.getStateWindow(result));
+        assertThat(windowSet.getStateWindow(result)).isNotNull();
 
         mergeFunction.reset();
         result = windowSet.addWindow(new TimeWindow(10, 12), mergeFunction);
-        assertNotNull(windowSet.getStateWindow(result));
+        assertThat(windowSet.getStateWindow(result)).isNotNull();
     }
 
     @Test
-    public void testIncrementalMerging() throws Exception {
+    void testIncrementalMerging() throws Exception {
         @SuppressWarnings("unchecked")
         ListState<Tuple2<TimeWindow, TimeWindow>> mockState = mock(ListState.class);
 
@@ -111,110 +101,113 @@ public class MergingWindowSetTest {
 
         // add initial window
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 4), windowSet.addWindow(new TimeWindow(0, 4), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(0, 4), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 4));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
-        assertTrue(windowSet.getStateWindow(new TimeWindow(0, 4)).equals(new TimeWindow(0, 4)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 4))).isEqualTo(new TimeWindow(0, 4));
 
         // add some more windows
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 4), windowSet.addWindow(new TimeWindow(0, 4), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(0, 4), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 4));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 5), windowSet.addWindow(new TimeWindow(3, 5), mergeFunction));
-        assertTrue(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(0, 5), mergeFunction.mergeTarget());
-        assertEquals(new TimeWindow(0, 4), mergeFunction.stateWindow());
-        assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(0, 4)));
-        assertTrue(mergeFunction.mergedStateWindows().isEmpty());
+        assertThat(windowSet.addWindow(new TimeWindow(3, 5), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 5));
+        assertThat(mergeFunction.hasMerged()).isTrue();
+        assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(0, 5));
+        assertThat(mergeFunction.stateWindow()).isEqualTo(new TimeWindow(0, 4));
+        assertThat(mergeFunction.mergeSources()).contains(new TimeWindow(0, 4));
+        assertThat(mergeFunction.mergedStateWindows()).isEmpty();
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(4, 6), mergeFunction));
-        assertTrue(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(0, 6), mergeFunction.mergeTarget());
-        assertEquals(new TimeWindow(0, 4), mergeFunction.stateWindow());
-        assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(0, 5)));
-        assertTrue(mergeFunction.mergedStateWindows().isEmpty());
+        assertThat(windowSet.addWindow(new TimeWindow(4, 6), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 6));
+        assertThat(mergeFunction.hasMerged()).isTrue();
+        assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(0, 6));
+        assertThat(mergeFunction.stateWindow()).isEqualTo(new TimeWindow(0, 4));
+        assertThat(mergeFunction.mergeSources()).contains(new TimeWindow(0, 5));
+        assertThat(mergeFunction.mergedStateWindows()).isEmpty();
 
-        assertEquals(new TimeWindow(0, 4), windowSet.getStateWindow(new TimeWindow(0, 6)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 6))).isEqualTo(new TimeWindow(0, 4));
 
         // add some windows that falls into the already merged region
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(1, 4), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(1, 4), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 6));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(0, 4), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(0, 4), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 6));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(3, 5), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(3, 5), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 6));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 6), windowSet.addWindow(new TimeWindow(4, 6), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(4, 6), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 6));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
-        assertEquals(new TimeWindow(0, 4), windowSet.getStateWindow(new TimeWindow(0, 6)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 6))).isEqualTo(new TimeWindow(0, 4));
 
         // add some more windows that don't merge with the first bunch
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(11, 14), windowSet.addWindow(new TimeWindow(11, 14), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(11, 14), mergeFunction))
+                .isEqualTo(new TimeWindow(11, 14));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
-        assertEquals(new TimeWindow(0, 4), windowSet.getStateWindow(new TimeWindow(0, 6)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 6))).isEqualTo(new TimeWindow(0, 4));
 
-        assertEquals(new TimeWindow(11, 14), windowSet.getStateWindow(new TimeWindow(11, 14)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(11, 14)))
+                .isEqualTo(new TimeWindow(11, 14));
 
         // add some more windows that merge with the second bunch
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(10, 14), windowSet.addWindow(new TimeWindow(10, 13), mergeFunction));
-        assertTrue(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(10, 14), mergeFunction.mergeTarget());
-        assertEquals(new TimeWindow(11, 14), mergeFunction.stateWindow());
-        assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(11, 14)));
-        assertTrue(mergeFunction.mergedStateWindows().isEmpty());
+        assertThat(windowSet.addWindow(new TimeWindow(10, 13), mergeFunction))
+                .isEqualTo(new TimeWindow(10, 14));
+        assertThat(mergeFunction.hasMerged()).isTrue();
+        assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(10, 14));
+        assertThat(mergeFunction.stateWindow()).isEqualTo(new TimeWindow(11, 14));
+        assertThat(mergeFunction.mergeSources()).contains(new TimeWindow(11, 14));
+        assertThat(mergeFunction.mergedStateWindows()).isEmpty();
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(10, 15), windowSet.addWindow(new TimeWindow(12, 15), mergeFunction));
-        assertTrue(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(10, 15), mergeFunction.mergeTarget());
-        assertEquals(new TimeWindow(11, 14), mergeFunction.stateWindow());
-        assertThat(mergeFunction.mergeSources(), containsInAnyOrder(new TimeWindow(10, 14)));
-        assertTrue(mergeFunction.mergedStateWindows().isEmpty());
+        assertThat(windowSet.addWindow(new TimeWindow(12, 15), mergeFunction))
+                .isEqualTo(new TimeWindow(10, 15));
+        assertThat(mergeFunction.hasMerged()).isTrue();
+        assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(10, 15));
+        assertThat(mergeFunction.stateWindow()).isEqualTo(new TimeWindow(11, 14));
+        assertThat(mergeFunction.mergeSources()).contains(new TimeWindow(10, 14));
+        assertThat(mergeFunction.mergedStateWindows()).isEmpty();
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(10, 15), windowSet.addWindow(new TimeWindow(11, 14), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(11, 14), mergeFunction))
+                .isEqualTo(new TimeWindow(10, 15));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
-        assertEquals(new TimeWindow(0, 4), windowSet.getStateWindow(new TimeWindow(0, 6)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 6))).isEqualTo(new TimeWindow(0, 4));
 
-        assertEquals(new TimeWindow(11, 14), windowSet.getStateWindow(new TimeWindow(10, 15)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(10, 15)))
+                .isEqualTo(new TimeWindow(11, 14));
 
         // retire the first batch of windows
         windowSet.retireWindow(new TimeWindow(0, 6));
 
-        assertTrue(windowSet.getStateWindow(new TimeWindow(0, 6)) == null);
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 6))).isNull();
 
-        assertTrue(windowSet.getStateWindow(new TimeWindow(10, 15)).equals(new TimeWindow(11, 14)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(10, 15)))
+                .isEqualTo(new TimeWindow(11, 14));
     }
 
     @Test
-    public void testLateMerging() throws Exception {
+    void testLateMerging() throws Exception {
         @SuppressWarnings("unchecked")
         ListState<Tuple2<TimeWindow, TimeWindow>> mockState = mock(ListState.class);
 
@@ -227,97 +220,92 @@ public class MergingWindowSetTest {
         // add several non-overlapping initial windows
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 3), windowSet.addWindow(new TimeWindow(0, 3), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(0, 3), windowSet.getStateWindow(new TimeWindow(0, 3)));
+        assertThat(windowSet.addWindow(new TimeWindow(0, 3), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 3));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 3))).isEqualTo(new TimeWindow(0, 3));
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(5, 8), windowSet.addWindow(new TimeWindow(5, 8), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(5, 8), windowSet.getStateWindow(new TimeWindow(5, 8)));
+        assertThat(windowSet.addWindow(new TimeWindow(5, 8), mergeFunction))
+                .isEqualTo(new TimeWindow(5, 8));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+        assertThat(windowSet.getStateWindow(new TimeWindow(5, 8))).isEqualTo(new TimeWindow(5, 8));
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(10, 13), windowSet.addWindow(new TimeWindow(10, 13), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(10, 13), windowSet.getStateWindow(new TimeWindow(10, 13)));
+        assertThat(windowSet.addWindow(new TimeWindow(10, 13), mergeFunction))
+                .isEqualTo(new TimeWindow(10, 13));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+        assertThat(windowSet.getStateWindow(new TimeWindow(10, 13)))
+                .isEqualTo(new TimeWindow(10, 13));
 
         // add a window that merges the later two windows
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(5, 13), windowSet.addWindow(new TimeWindow(8, 10), mergeFunction));
-        assertTrue(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(5, 13), mergeFunction.mergeTarget());
-        assertThat(
-                mergeFunction.stateWindow(),
-                anyOf(is(new TimeWindow(5, 8)), is(new TimeWindow(10, 13))));
-        assertThat(
-                mergeFunction.mergeSources(),
-                containsInAnyOrder(new TimeWindow(5, 8), new TimeWindow(10, 13)));
-        assertThat(
-                mergeFunction.mergedStateWindows(),
-                anyOf(
-                        containsInAnyOrder(new TimeWindow(10, 13)),
-                        containsInAnyOrder(new TimeWindow(5, 8))));
-        assertThat(mergeFunction.mergedStateWindows(), not(hasItem(mergeFunction.mergeTarget())));
+        assertThat(windowSet.addWindow(new TimeWindow(8, 10), mergeFunction))
+                .isEqualTo(new TimeWindow(5, 13));
+        assertThat(mergeFunction.hasMerged()).isTrue();
+        assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(5, 13));
+        assertThat(mergeFunction.stateWindow())
+                .satisfiesAnyOf(
+                        w -> assertThat(w).isEqualTo(new TimeWindow(5, 8)),
+                        w -> assertThat(w).isEqualTo(new TimeWindow(10, 13)));
+        assertThat(mergeFunction.mergeSources())
+                .containsExactlyInAnyOrder(new TimeWindow(5, 8), new TimeWindow(10, 13));
+        assertThat(mergeFunction.mergedStateWindows())
+                .containsAnyOf(new TimeWindow(5, 8), new TimeWindow(10, 13));
 
-        assertEquals(new TimeWindow(0, 3), windowSet.getStateWindow(new TimeWindow(0, 3)));
+        assertThat(mergeFunction.mergedStateWindows().toArray())
+                .satisfiesAnyOf(
+                        o -> assertThat(o).containsExactly(new TimeWindow(10, 13)),
+                        o -> assertThat(o).containsExactly(new TimeWindow(5, 8)));
 
-        mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(5, 13), windowSet.addWindow(new TimeWindow(5, 8), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(mergeFunction.mergedStateWindows()).doesNotContain(mergeFunction.mergeTarget());
+
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 3))).isEqualTo(new TimeWindow(0, 3));
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(5, 13), windowSet.addWindow(new TimeWindow(8, 10), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(5, 8), mergeFunction))
+                .isEqualTo(new TimeWindow(5, 13));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(5, 13), windowSet.addWindow(new TimeWindow(10, 13), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
+        assertThat(windowSet.addWindow(new TimeWindow(8, 10), mergeFunction))
+                .isEqualTo(new TimeWindow(5, 13));
+        assertThat(mergeFunction.hasMerged()).isFalse();
 
-        assertThat(
-                windowSet.getStateWindow(new TimeWindow(5, 13)),
-                anyOf(is(new TimeWindow(5, 8)), is(new TimeWindow(10, 13))));
+        mergeFunction.reset();
+        assertThat(windowSet.addWindow(new TimeWindow(10, 13), mergeFunction))
+                .isEqualTo(new TimeWindow(5, 13));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+
+        assertThat(windowSet.getStateWindow(new TimeWindow(5, 13)))
+                .isIn(new TimeWindow(5, 8), new TimeWindow(10, 13));
 
         // add a window that merges all of them together
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 13), windowSet.addWindow(new TimeWindow(3, 5), mergeFunction));
-        assertTrue(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(0, 13), mergeFunction.mergeTarget());
-        assertThat(
-                mergeFunction.stateWindow(),
-                anyOf(
-                        is(new TimeWindow(0, 3)),
-                        is(new TimeWindow(5, 8)),
-                        is(new TimeWindow(10, 13))));
-        assertThat(
-                mergeFunction.mergeSources(),
-                containsInAnyOrder(new TimeWindow(0, 3), new TimeWindow(5, 13)));
-        assertThat(
-                mergeFunction.mergedStateWindows(),
-                anyOf(
-                        containsInAnyOrder(new TimeWindow(0, 3)),
-                        containsInAnyOrder(new TimeWindow(5, 8)),
-                        containsInAnyOrder(new TimeWindow(10, 13))));
-        assertThat(mergeFunction.mergedStateWindows(), not(hasItem(mergeFunction.mergeTarget())));
+        assertThat(windowSet.addWindow(new TimeWindow(0, 13), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 13));
+        assertThat(mergeFunction.hasMerged()).isTrue();
+        assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(0, 13));
+        assertThat(mergeFunction.stateWindow())
+                .isIn(new TimeWindow(0, 3), new TimeWindow(5, 8), new TimeWindow(10, 13));
 
-        assertThat(
-                windowSet.getStateWindow(new TimeWindow(0, 13)),
-                anyOf(
-                        is(new TimeWindow(0, 3)),
-                        is(new TimeWindow(5, 8)),
-                        is(new TimeWindow(10, 13))));
+        assertThat(mergeFunction.mergeSources())
+                .containsExactlyInAnyOrder(new TimeWindow(0, 3), new TimeWindow(5, 13));
+
+        assertThat(mergeFunction.mergedStateWindows().toArray())
+                .satisfiesAnyOf(
+                        o -> assertThat(o).containsExactly(new TimeWindow(0, 3)),
+                        o -> assertThat(o).containsExactly(new TimeWindow(5, 8)),
+                        o -> assertThat(o).containsExactly(new TimeWindow(10, 13)));
+
+        assertThat(mergeFunction.mergedStateWindows()).doesNotContain(mergeFunction.mergeTarget());
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 13)))
+                .isIn(new TimeWindow(0, 3), new TimeWindow(5, 8), new TimeWindow(10, 13));
     }
 
     /** Test merging of a large new window that covers one existing windows. */
     @Test
-    public void testMergeLargeWindowCoveringSingleWindow() throws Exception {
+    void testMergeLargeWindowCoveringSingleWindow() throws Exception {
         @SuppressWarnings("unchecked")
         ListState<Tuple2<TimeWindow, TimeWindow>> mockState = mock(ListState.class);
 
@@ -330,18 +318,18 @@ public class MergingWindowSetTest {
         // add an initial small window
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(1, 2), windowSet.addWindow(new TimeWindow(1, 2), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(1, 2), windowSet.getStateWindow(new TimeWindow(1, 2)));
+        assertThat(windowSet.addWindow(new TimeWindow(1, 2), mergeFunction))
+                .isEqualTo(new TimeWindow(1, 2));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+        assertThat(windowSet.getStateWindow(new TimeWindow(1, 2))).isEqualTo(new TimeWindow(1, 2));
 
         // add a new window that completely covers the existing window
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 3), windowSet.addWindow(new TimeWindow(0, 3), mergeFunction));
-        assertTrue(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(1, 2), windowSet.getStateWindow(new TimeWindow(0, 3)));
+        assertThat(windowSet.addWindow(new TimeWindow(0, 3), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 3));
+        assertThat(mergeFunction.hasMerged()).isTrue();
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 3))).isEqualTo(new TimeWindow(1, 2));
     }
 
     /**
@@ -349,7 +337,7 @@ public class MergingWindowSetTest {
      * merge.
      */
     @Test
-    public void testAddingIdenticalWindows() throws Exception {
+    void testAddingIdenticalWindows() throws Exception {
         @SuppressWarnings("unchecked")
         ListState<Tuple2<TimeWindow, TimeWindow>> mockState = mock(ListState.class);
 
@@ -360,21 +348,21 @@ public class MergingWindowSetTest {
         TestingMergeFunction mergeFunction = new TestingMergeFunction();
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(1, 2), windowSet.addWindow(new TimeWindow(1, 2), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(1, 2), windowSet.getStateWindow(new TimeWindow(1, 2)));
+        assertThat(windowSet.addWindow(new TimeWindow(1, 2), mergeFunction))
+                .isEqualTo(new TimeWindow(1, 2));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+        assertThat(windowSet.getStateWindow(new TimeWindow(1, 2))).isEqualTo(new TimeWindow(1, 2));
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(1, 2), windowSet.addWindow(new TimeWindow(1, 2), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(1, 2), windowSet.getStateWindow(new TimeWindow(1, 2)));
+        assertThat(windowSet.addWindow(new TimeWindow(1, 2), mergeFunction))
+                .isEqualTo(new TimeWindow(1, 2));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+        assertThat(windowSet.getStateWindow(new TimeWindow(1, 2))).isEqualTo(new TimeWindow(1, 2));
     }
 
     /** Test merging of a large new window that covers multiple existing windows. */
     @Test
-    public void testMergeLargeWindowCoveringMultipleWindows() throws Exception {
+    void testMergeLargeWindowCoveringMultipleWindows() throws Exception {
         @SuppressWarnings("unchecked")
         ListState<Tuple2<TimeWindow, TimeWindow>> mockState = mock(ListState.class);
 
@@ -387,45 +375,52 @@ public class MergingWindowSetTest {
         // add several non-overlapping initial windows
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(1, 3), windowSet.addWindow(new TimeWindow(1, 3), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(1, 3), windowSet.getStateWindow(new TimeWindow(1, 3)));
+        assertThat(windowSet.addWindow(new TimeWindow(1, 3), mergeFunction))
+                .isEqualTo(new TimeWindow(1, 3));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+        assertThat(windowSet.getStateWindow(new TimeWindow(1, 3))).isEqualTo(new TimeWindow(1, 3));
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(5, 8), windowSet.addWindow(new TimeWindow(5, 8), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(5, 8), windowSet.getStateWindow(new TimeWindow(5, 8)));
+        assertThat(windowSet.addWindow(new TimeWindow(5, 8), mergeFunction))
+                .isEqualTo(new TimeWindow(5, 8));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+        assertThat(windowSet.getStateWindow(new TimeWindow(5, 8))).isEqualTo(new TimeWindow(5, 8));
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(10, 13), windowSet.addWindow(new TimeWindow(10, 13), mergeFunction));
-        assertFalse(mergeFunction.hasMerged());
-        assertEquals(new TimeWindow(10, 13), windowSet.getStateWindow(new TimeWindow(10, 13)));
+        assertThat(windowSet.addWindow(new TimeWindow(10, 13), mergeFunction))
+                .isEqualTo(new TimeWindow(10, 13));
+        assertThat(mergeFunction.hasMerged()).isFalse();
+        assertThat(windowSet.getStateWindow(new TimeWindow(10, 13)))
+                .isEqualTo(new TimeWindow(10, 13));
 
         // add a new window that completely covers the existing windows
 
         mergeFunction.reset();
-        assertEquals(
-                new TimeWindow(0, 13), windowSet.addWindow(new TimeWindow(0, 13), mergeFunction));
-        assertTrue(mergeFunction.hasMerged());
-        assertThat(
-                mergeFunction.mergedStateWindows(),
-                anyOf(
-                        containsInAnyOrder(new TimeWindow(0, 3), new TimeWindow(5, 8)),
-                        containsInAnyOrder(new TimeWindow(0, 3), new TimeWindow(10, 13)),
-                        containsInAnyOrder(new TimeWindow(5, 8), new TimeWindow(10, 13))));
-        assertThat(
-                windowSet.getStateWindow(new TimeWindow(0, 13)),
-                anyOf(
-                        is(new TimeWindow(1, 3)),
-                        is(new TimeWindow(5, 8)),
-                        is(new TimeWindow(10, 13))));
+        assertThat(windowSet.addWindow(new TimeWindow(0, 13), mergeFunction))
+                .isEqualTo(new TimeWindow(0, 13));
+        assertThat(mergeFunction.hasMerged()).isTrue();
+
+        assertThat(mergeFunction.mergedStateWindows().toArray())
+                .satisfiesAnyOf(
+                        o ->
+                                assertThat(o)
+                                        .containsExactlyInAnyOrder(
+                                                new TimeWindow(0, 3), new TimeWindow(5, 8)),
+                        o ->
+                                assertThat(o)
+                                        .containsExactlyInAnyOrder(
+                                                new TimeWindow(0, 3), new TimeWindow(10, 13)),
+                        o ->
+                                assertThat(o)
+                                        .containsExactlyInAnyOrder(
+                                                new TimeWindow(5, 8), new TimeWindow(10, 13)));
+
+        assertThat(windowSet.getStateWindow(new TimeWindow(0, 13)))
+                .isIn(new TimeWindow(1, 3), new TimeWindow(5, 8), new TimeWindow(10, 13));
     }
 
     @Test
-    public void testRestoreFromState() throws Exception {
+    void testRestoreFromState() throws Exception {
         @SuppressWarnings("unchecked")
         ListState<Tuple2<TimeWindow, TimeWindow>> mockState = mock(ListState.class);
         when(mockState.get())
@@ -438,12 +433,13 @@ public class MergingWindowSetTest {
                 new MergingWindowSet<>(
                         EventTimeSessionWindows.withGap(Time.milliseconds(3)), mockState);
 
-        assertEquals(new TimeWindow(42, 17), windowSet.getStateWindow(new TimeWindow(17, 42)));
-        assertEquals(new TimeWindow(3, 4), windowSet.getStateWindow(new TimeWindow(1, 2)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(17, 42)))
+                .isEqualTo(new TimeWindow(42, 17));
+        assertThat(windowSet.getStateWindow(new TimeWindow(1, 2))).isEqualTo(new TimeWindow(3, 4));
     }
 
     @Test
-    public void testPersist() throws Exception {
+    void testPersist() throws Exception {
         @SuppressWarnings("unchecked")
         ListState<Tuple2<TimeWindow, TimeWindow>> mockState = mock(ListState.class);
 
@@ -456,8 +452,9 @@ public class MergingWindowSetTest {
         windowSet.addWindow(new TimeWindow(1, 2), mergeFunction);
         windowSet.addWindow(new TimeWindow(17, 42), mergeFunction);
 
-        assertEquals(new TimeWindow(1, 2), windowSet.getStateWindow(new TimeWindow(1, 2)));
-        assertEquals(new TimeWindow(17, 42), windowSet.getStateWindow(new TimeWindow(17, 42)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(1, 2))).isEqualTo(new TimeWindow(1, 2));
+        assertThat(windowSet.getStateWindow(new TimeWindow(17, 42)))
+                .isEqualTo(new TimeWindow(17, 42));
 
         windowSet.persist();
 
@@ -476,7 +473,7 @@ public class MergingWindowSetTest {
     }
 
     @Test
-    public void testPersistOnlyIfHaveUpdates() throws Exception {
+    void testPersistOnlyIfHaveUpdates() throws Exception {
         @SuppressWarnings("unchecked")
         ListState<Tuple2<TimeWindow, TimeWindow>> mockState = mock(ListState.class);
         when(mockState.get())
@@ -489,8 +486,9 @@ public class MergingWindowSetTest {
                 new MergingWindowSet<>(
                         EventTimeSessionWindows.withGap(Time.milliseconds(3)), mockState);
 
-        assertEquals(new TimeWindow(42, 17), windowSet.getStateWindow(new TimeWindow(17, 42)));
-        assertEquals(new TimeWindow(3, 4), windowSet.getStateWindow(new TimeWindow(1, 2)));
+        assertThat(windowSet.getStateWindow(new TimeWindow(17, 42)))
+                .isEqualTo(new TimeWindow(42, 17));
+        assertThat(windowSet.getStateWindow(new TimeWindow(1, 2))).isEqualTo(new TimeWindow(3, 4));
 
         windowSet.persist();
 
@@ -539,9 +537,9 @@ public class MergingWindowSetTest {
                 TimeWindow stateWindowResult,
                 Collection<TimeWindow> mergedStateWindows)
                 throws Exception {
-            if (target != null) {
-                fail("More than one merge for adding a Window should not occur.");
-            }
+            assertThat(target)
+                    .as("More than one merge for adding a Window should not occur.")
+                    .isNull();
             this.stateWindow = stateWindowResult;
             this.target = mergeResult;
             this.mergedStateWindows = mergedStateWindows;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSetTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MergingWindowSetTest.java
@@ -119,7 +119,7 @@ class MergingWindowSetTest {
         assertThat(mergeFunction.hasMerged()).isTrue();
         assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(0, 5));
         assertThat(mergeFunction.stateWindow()).isEqualTo(new TimeWindow(0, 4));
-        assertThat(mergeFunction.mergeSources()).contains(new TimeWindow(0, 4));
+        assertThat(mergeFunction.mergeSources()).containsExactly(new TimeWindow(0, 4));
         assertThat(mergeFunction.mergedStateWindows()).isEmpty();
 
         mergeFunction.reset();
@@ -128,7 +128,7 @@ class MergingWindowSetTest {
         assertThat(mergeFunction.hasMerged()).isTrue();
         assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(0, 6));
         assertThat(mergeFunction.stateWindow()).isEqualTo(new TimeWindow(0, 4));
-        assertThat(mergeFunction.mergeSources()).contains(new TimeWindow(0, 5));
+        assertThat(mergeFunction.mergeSources()).containsExactly(new TimeWindow(0, 5));
         assertThat(mergeFunction.mergedStateWindows()).isEmpty();
 
         assertThat(windowSet.getStateWindow(new TimeWindow(0, 6))).isEqualTo(new TimeWindow(0, 4));
@@ -175,7 +175,7 @@ class MergingWindowSetTest {
         assertThat(mergeFunction.hasMerged()).isTrue();
         assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(10, 14));
         assertThat(mergeFunction.stateWindow()).isEqualTo(new TimeWindow(11, 14));
-        assertThat(mergeFunction.mergeSources()).contains(new TimeWindow(11, 14));
+        assertThat(mergeFunction.mergeSources()).containsExactly(new TimeWindow(11, 14));
         assertThat(mergeFunction.mergedStateWindows()).isEmpty();
 
         mergeFunction.reset();
@@ -184,7 +184,7 @@ class MergingWindowSetTest {
         assertThat(mergeFunction.hasMerged()).isTrue();
         assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(10, 15));
         assertThat(mergeFunction.stateWindow()).isEqualTo(new TimeWindow(11, 14));
-        assertThat(mergeFunction.mergeSources()).contains(new TimeWindow(10, 14));
+        assertThat(mergeFunction.mergeSources()).containsExactly(new TimeWindow(10, 14));
         assertThat(mergeFunction.mergedStateWindows()).isEmpty();
 
         mergeFunction.reset();
@@ -282,7 +282,7 @@ class MergingWindowSetTest {
 
         // add a window that merges all of them together
         mergeFunction.reset();
-        assertThat(windowSet.addWindow(new TimeWindow(0, 13), mergeFunction))
+        assertThat(windowSet.addWindow(new TimeWindow(3, 5), mergeFunction))
                 .isEqualTo(new TimeWindow(0, 13));
         assertThat(mergeFunction.hasMerged()).isTrue();
         assertThat(mergeFunction.mergeTarget()).isEqualTo(new TimeWindow(0, 13));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ProcessingTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ProcessingTimeSessionWindowsTest.java
@@ -60,15 +60,15 @@ class ProcessingTimeSessionWindowsTest {
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(0, 5000));
+                .containsExactly(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4999L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(4999, 9999));
+                .containsExactly(new TimeWindow(4999, 9999));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(5000, 10000));
+                .containsExactly(new TimeWindow(5000, 10000));
     }
 
     @Test
@@ -182,15 +182,15 @@ class ProcessingTimeSessionWindowsTest {
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(0, 5000));
+                .containsExactly(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4999L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(4999, 9999));
+                .containsExactly(new TimeWindow(4999, 9999));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(5000, 10000));
+                .containsExactly(new TimeWindow(5000, 10000));
     }
 
     @Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ProcessingTimeSessionWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ProcessingTimeSessionWindowsTest.java
@@ -27,25 +27,17 @@ import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.ProcessingTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 
 import java.util.Collection;
 
-import static org.apache.flink.streaming.util.StreamRecordMatchers.timeWindow;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.contains;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -56,10 +48,10 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /** Tests for {@link ProcessingTimeSessionWindows}. */
-public class ProcessingTimeSessionWindowsTest extends TestLogger {
+class ProcessingTimeSessionWindowsTest {
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -67,23 +59,20 @@ public class ProcessingTimeSessionWindowsTest extends TestLogger {
                 ProcessingTimeSessionWindows.withGap(Time.milliseconds(5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(0, 5000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4999L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(4999, 9999)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(4999, 9999));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(5000, 10000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(5000, 10000));
     }
 
     @Test
-    public void testMergeSinglePointWindow() {
+    void testMergeSinglePointWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
 
@@ -96,7 +85,7 @@ public class ProcessingTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testMergeSingleWindow() {
+    void testMergeSingleWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
 
@@ -109,7 +98,7 @@ public class ProcessingTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testMergeConsecutiveWindows() {
+    void testMergeConsecutiveWindows() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
 
@@ -147,7 +136,7 @@ public class ProcessingTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testMergeCoveringWindow() {
+    void testMergeCoveringWindow() {
         MergingWindowAssigner.MergeCallback callback =
                 mock(MergingWindowAssigner.MergeCallback.class);
 
@@ -182,7 +171,7 @@ public class ProcessingTimeSessionWindowsTest extends TestLogger {
     }
 
     @Test
-    public void testTimeUnits() {
+    void testTimeUnits() {
         // sanity check with one other time unit
 
         WindowAssigner.WindowAssignerContext mockContext =
@@ -192,56 +181,47 @@ public class ProcessingTimeSessionWindowsTest extends TestLogger {
                 ProcessingTimeSessionWindows.withGap(Time.seconds(5));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(0, 5000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4999L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(4999, 9999)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(4999, 9999));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(5000, 10000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(5000, 10000));
     }
 
     @Test
-    public void testInvalidParameters() {
-        try {
-            ProcessingTimeSessionWindows.withGap(Time.seconds(-1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("0 < size"));
-        }
+    void testInvalidParameters() {
+        assertThatThrownBy(() -> ProcessingTimeSessionWindows.withGap(Time.seconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("0 < size");
 
-        try {
-            ProcessingTimeSessionWindows.withGap(Time.seconds(0));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("0 < size"));
-        }
+        assertThatThrownBy(() -> ProcessingTimeSessionWindows.withGap(Time.seconds(0)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("0 < size");
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         ProcessingTimeSessionWindows assigner =
                 ProcessingTimeSessionWindows.withGap(Time.seconds(5));
 
-        assertFalse(assigner.isEventTime());
-        assertEquals(
-                new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
-        assertThat(assigner.getDefaultTrigger(), instanceOf(ProcessingTimeTrigger.class));
+        assertThat(assigner.isEventTime()).isFalse();
+        assertThat(assigner.getWindowSerializer(new ExecutionConfig()))
+                .isEqualTo(new TimeWindow.Serializer());
+        assertThat(assigner.getDefaultTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
     }
 
     @Test
-    public void testDynamicGapProperties() {
+    void testDynamicGapProperties() {
         SessionWindowTimeGapExtractor<String> extractor = mock(SessionWindowTimeGapExtractor.class);
         DynamicProcessingTimeSessionWindows<String> assigner =
                 ProcessingTimeSessionWindows.withDynamicGap(extractor);
 
-        assertNotNull(assigner);
-        assertFalse(assigner.isEventTime());
+        assertThat(assigner).isNotNull();
+        assertThat(assigner.isEventTime()).isFalse();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ProcessingTimeTriggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ProcessingTimeTriggerTest.java
@@ -25,134 +25,124 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ProcessingTimeTrigger}. */
-public class ProcessingTimeTriggerTest {
+class ProcessingTimeTriggerTest {
 
     /** Verify that state of separate windows does not leak into other windows. */
     @Test
-    public void testWindowSeparationAndFiring() throws Exception {
+    void testWindowSeparationAndFiring() throws Exception {
         TriggerTestHarness<Object, TimeWindow> testHarness =
                 new TriggerTestHarness<>(
                         ProcessingTimeTrigger.create(), new TimeWindow.Serializer());
 
         // inject several elements
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numEventTimeTimers());
-        assertEquals(2, testHarness.numProcessingTimeTimers());
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isEqualTo(2);
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isOne();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(2, 4))).isOne();
 
-        assertEquals(
-                TriggerResult.FIRE, testHarness.advanceProcessingTime(2, new TimeWindow(0, 2)));
+        assertThat(testHarness.advanceProcessingTime(2, new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.FIRE);
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numEventTimeTimers());
-        assertEquals(1, testHarness.numProcessingTimeTimers());
-        assertEquals(0, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isOne();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isZero();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(2, 4))).isOne();
 
-        assertEquals(
-                TriggerResult.FIRE, testHarness.advanceProcessingTime(4, new TimeWindow(2, 4)));
+        assertThat(testHarness.advanceProcessingTime(4, new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.FIRE);
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(0, testHarness.numEventTimeTimers());
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
     }
 
     /** Verify that clear() does not leak across windows. */
     @Test
-    public void testClear() throws Exception {
+    void testClear() throws Exception {
         TriggerTestHarness<Object, TimeWindow> testHarness =
                 new TriggerTestHarness<>(
                         ProcessingTimeTrigger.create(), new TimeWindow.Serializer());
 
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numEventTimeTimers());
-        assertEquals(2, testHarness.numProcessingTimeTimers());
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isEqualTo(2);
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isOne();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(2, 4))).isOne();
 
         testHarness.clearTriggerState(new TimeWindow(2, 4));
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numEventTimeTimers());
-        assertEquals(1, testHarness.numProcessingTimeTimers());
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(0, testHarness.numProcessingTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isOne();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isOne();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(2, 4))).isZero();
 
         testHarness.clearTriggerState(new TimeWindow(0, 2));
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
     }
 
     @Test
-    public void testMergingWindows() throws Exception {
+    void testMergingWindows() throws Exception {
         TriggerTestHarness<Object, TimeWindow> testHarness =
                 new TriggerTestHarness<>(
                         ProcessingTimeTrigger.create(), new TimeWindow.Serializer());
 
-        assertTrue(ProcessingTimeTrigger.create().canMerge());
+        assertThat(ProcessingTimeTrigger.create().canMerge()).isTrue();
 
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numEventTimeTimers());
-        assertEquals(2, testHarness.numProcessingTimeTimers());
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isEqualTo(2);
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isOne();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(2, 4))).isOne();
 
         testHarness.mergeWindows(
                 new TimeWindow(0, 4),
                 Lists.newArrayList(new TimeWindow(0, 2), new TimeWindow(2, 4)));
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numEventTimeTimers());
-        assertEquals(1, testHarness.numProcessingTimeTimers());
-        assertEquals(0, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(0, testHarness.numProcessingTimeTimers(new TimeWindow(2, 4)));
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(0, 4)));
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isOne();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isZero();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(2, 4))).isZero();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 4))).isOne();
 
-        assertEquals(
-                TriggerResult.FIRE, testHarness.advanceProcessingTime(4, new TimeWindow(0, 4)));
+        assertThat(testHarness.advanceProcessingTime(4, new TimeWindow(0, 4)))
+                .isEqualTo(TriggerResult.FIRE);
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(0, testHarness.numEventTimeTimers());
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
     }
 
     /**
@@ -160,43 +150,41 @@ public class ProcessingTimeTriggerTest {
      * from onElement() on the merged window and one from the timer.
      */
     @Test
-    public void testMergingLateWindows() throws Exception {
+    void testMergingLateWindows() throws Exception {
         TriggerTestHarness<Object, TimeWindow> testHarness =
                 new TriggerTestHarness<>(
                         ProcessingTimeTrigger.create(), new TimeWindow.Serializer());
 
-        assertTrue(ProcessingTimeTrigger.create().canMerge());
+        assertThat(ProcessingTimeTrigger.create().canMerge()).isTrue();
 
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(2, 4)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(2, 4)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numEventTimeTimers());
-        assertEquals(2, testHarness.numProcessingTimeTimers());
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(1, testHarness.numProcessingTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isEqualTo(2);
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isOne();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(2, 4))).isOne();
 
         testHarness.advanceProcessingTime(10);
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numEventTimeTimers());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(0, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(0, testHarness.numProcessingTimeTimers(new TimeWindow(2, 4)));
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isZero();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(2, 4))).isZero();
 
         testHarness.mergeWindows(
                 new TimeWindow(0, 4),
                 Lists.newArrayList(new TimeWindow(0, 2), new TimeWindow(2, 4)));
 
-        assertEquals(0, testHarness.numStateEntries());
-        assertEquals(0, testHarness.numEventTimeTimers());
-        assertEquals(0, testHarness.numProcessingTimeTimers());
-        assertEquals(0, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(0, testHarness.numProcessingTimeTimers(new TimeWindow(2, 4)));
-        assertEquals(0, testHarness.numProcessingTimeTimers(new TimeWindow(0, 4)));
+        assertThat(testHarness.numStateEntries()).isZero();
+        assertThat(testHarness.numEventTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers()).isZero();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isZero();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(2, 4))).isZero();
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 4))).isZero();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/PurgingTriggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/PurgingTriggerTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.streaming.api.windowing.triggers.TriggerResult;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -35,7 +35,7 @@ import java.util.Collections;
 import static org.apache.flink.streaming.runtime.operators.windowing.WindowOperatorContractTest.anyOnMergeContext;
 import static org.apache.flink.streaming.runtime.operators.windowing.WindowOperatorContractTest.anyTimeWindow;
 import static org.apache.flink.streaming.runtime.operators.windowing.WindowOperatorContractTest.anyTriggerContext;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
@@ -45,13 +45,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link PurgingTrigger}. */
-public class PurgingTriggerTest {
+class PurgingTriggerTest {
 
     /**
      * Check if {@link PurgingTrigger} implements all methods of {@link Trigger}, as a sanity check.
      */
     @Test
-    public void testAllMethodsImplemented() throws NoSuchMethodException {
+    void testAllMethodsImplemented() throws NoSuchMethodException {
         for (Method triggerMethod : Trigger.class.getDeclaredMethods()) {
 
             // try retrieving the method, this will throw an exception if we can't find it
@@ -61,7 +61,7 @@ public class PurgingTriggerTest {
     }
 
     @Test
-    public void testForwarding() throws Exception {
+    void testForwarding() throws Exception {
         Trigger<Object, TimeWindow> mockTrigger = mock(Trigger.class);
 
         TriggerTestHarness<Object, TimeWindow> testHarness =
@@ -71,30 +71,26 @@ public class PurgingTriggerTest {
         when(mockTrigger.onElement(
                         Matchers.anyObject(), anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.CONTINUE);
-        assertEquals(
-                TriggerResult.CONTINUE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
         when(mockTrigger.onElement(
                         Matchers.anyObject(), anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.FIRE);
-        assertEquals(
-                TriggerResult.FIRE_AND_PURGE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.FIRE_AND_PURGE);
 
         when(mockTrigger.onElement(
                         Matchers.anyObject(), anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.FIRE_AND_PURGE);
-        assertEquals(
-                TriggerResult.FIRE_AND_PURGE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.FIRE_AND_PURGE);
 
         when(mockTrigger.onElement(
                         Matchers.anyObject(), anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.PURGE);
-        assertEquals(
-                TriggerResult.PURGE,
-                testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2)));
+        assertThat(testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.PURGE);
 
         doAnswer(
                         new Answer<TriggerResult>() {
@@ -122,29 +118,29 @@ public class PurgingTriggerTest {
                         anyTriggerContext());
 
         // set up our timers
-        testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2));
+        testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2));
 
-        assertEquals(4, testHarness.numEventTimeTimers(new TimeWindow(0, 2)));
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(0, 2))).isEqualTo(4);
 
         when(mockTrigger.onEventTime(anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.CONTINUE);
-        assertEquals(TriggerResult.CONTINUE, testHarness.advanceWatermark(1, new TimeWindow(0, 2)));
+        assertThat(testHarness.advanceWatermark(1, new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
         when(mockTrigger.onEventTime(anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.FIRE);
-        assertEquals(
-                TriggerResult.FIRE_AND_PURGE,
-                testHarness.advanceWatermark(2, new TimeWindow(0, 2)));
+        assertThat(testHarness.advanceWatermark(2, new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.FIRE_AND_PURGE);
 
         when(mockTrigger.onEventTime(anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.FIRE_AND_PURGE);
-        assertEquals(
-                TriggerResult.FIRE_AND_PURGE,
-                testHarness.advanceWatermark(3, new TimeWindow(0, 2)));
+        assertThat(testHarness.advanceWatermark(3, new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.FIRE_AND_PURGE);
 
         when(mockTrigger.onEventTime(anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.PURGE);
-        assertEquals(TriggerResult.PURGE, testHarness.advanceWatermark(4, new TimeWindow(0, 2)));
+        assertThat(testHarness.advanceWatermark(4, new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.PURGE);
 
         doAnswer(
                         new Answer<TriggerResult>() {
@@ -172,32 +168,30 @@ public class PurgingTriggerTest {
                         anyTriggerContext());
 
         // set up our timers
-        testHarness.processElement(new StreamRecord<Object>(1), new TimeWindow(0, 2));
+        testHarness.processElement(new StreamRecord<>(1), new TimeWindow(0, 2));
 
-        assertEquals(4, testHarness.numProcessingTimeTimers(new TimeWindow(0, 2)));
-        assertEquals(0, testHarness.numEventTimeTimers(new TimeWindow(0, 2)));
+        assertThat(testHarness.numProcessingTimeTimers(new TimeWindow(0, 2))).isEqualTo(4);
+        assertThat(testHarness.numEventTimeTimers(new TimeWindow(0, 2))).isZero();
 
         when(mockTrigger.onProcessingTime(anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.CONTINUE);
-        assertEquals(
-                TriggerResult.CONTINUE, testHarness.advanceProcessingTime(1, new TimeWindow(0, 2)));
+        assertThat(testHarness.advanceProcessingTime(1, new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.CONTINUE);
 
         when(mockTrigger.onProcessingTime(anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.FIRE);
-        assertEquals(
-                TriggerResult.FIRE_AND_PURGE,
-                testHarness.advanceProcessingTime(2, new TimeWindow(0, 2)));
+        assertThat(testHarness.advanceProcessingTime(2, new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.FIRE_AND_PURGE);
 
         when(mockTrigger.onProcessingTime(anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.FIRE_AND_PURGE);
-        assertEquals(
-                TriggerResult.FIRE_AND_PURGE,
-                testHarness.advanceProcessingTime(3, new TimeWindow(0, 2)));
+        assertThat(testHarness.advanceProcessingTime(3, new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.FIRE_AND_PURGE);
 
         when(mockTrigger.onProcessingTime(anyLong(), anyTimeWindow(), anyTriggerContext()))
                 .thenReturn(TriggerResult.PURGE);
-        assertEquals(
-                TriggerResult.PURGE, testHarness.advanceProcessingTime(4, new TimeWindow(0, 2)));
+        assertThat(testHarness.advanceProcessingTime(4, new TimeWindow(0, 2)))
+                .isEqualTo(TriggerResult.PURGE);
 
         testHarness.mergeWindows(
                 new TimeWindow(0, 2), Collections.singletonList(new TimeWindow(0, 1)));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/RegularWindowOperatorContractTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/RegularWindowOperatorContractTest.java
@@ -39,14 +39,14 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.util.OutputTag;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
@@ -63,10 +63,10 @@ import static org.mockito.Mockito.when;
  *
  * <p>These tests document the implicit contract that exists between the windowing components.
  */
-public class RegularWindowOperatorContractTest extends WindowOperatorContractTest {
+class RegularWindowOperatorContractTest extends WindowOperatorContractTest {
 
     @Test
-    public void testReducingWindow() throws Exception {
+    void testReducingWindow() throws Exception {
 
         WindowAssigner<Integer, TimeWindow> mockAssigner = mockTimeWindowAssigner();
         Trigger<Integer, TimeWindow> mockTrigger = mockTrigger();
@@ -98,8 +98,8 @@ public class RegularWindowOperatorContractTest extends WindowOperatorContractTes
         when(mockAssigner.assignWindows(anyInt(), anyLong(), anyAssignerContext()))
                 .thenReturn(Arrays.asList(new TimeWindow(2, 4), new TimeWindow(0, 2)));
 
-        assertEquals(0, testHarness.getOutput().size());
-        assertEquals(0, testHarness.numKeyedStateEntries());
+        assertThat(testHarness.getOutput()).isEmpty();
+        assertThat(testHarness.numKeyedStateEntries()).isZero();
 
         // insert two elements without firing
         testHarness.processElement(new StreamRecord<>(1, 0L));
@@ -153,8 +153,9 @@ public class RegularWindowOperatorContractTest extends WindowOperatorContractTes
         verify(mockTrigger, never()).clear(anyTimeWindow(), anyTriggerContext());
 
         // FIRE should not purge contents
-        assertEquals(4, testHarness.numKeyedStateEntries()); // window contents plus trigger state
-        assertEquals(4, testHarness.numEventTimeTimers()); // window timers/gc timers
+        assertThat(testHarness.numKeyedStateEntries())
+                .isEqualTo(4); // window contents plus trigger state
+        assertThat(testHarness.numEventTimeTimers()).isEqualTo(4); // window timers/gc timers
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/SlidingEventTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/SlidingEventTimeWindowsTest.java
@@ -24,61 +24,51 @@ import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.apache.flink.streaming.util.StreamRecordMatchers.timeWindow;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 /** Tests for {@link SlidingEventTimeWindows}. */
-public class SlidingEventTimeWindowsTest extends TestLogger {
+class SlidingEventTimeWindowsTest {
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
         SlidingEventTimeWindows assigner =
                 SlidingEventTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(1000));
 
-        assertThat(
-                assigner.assignWindows("String", 0L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-4000, 1000),
-                        timeWindow(-3000, 2000),
-                        timeWindow(-2000, 3000),
-                        timeWindow(-1000, 4000),
-                        timeWindow(0, 5000)));
+        assertThat(assigner.assignWindows("String", 0L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-4000, 1000),
+                        new TimeWindow(-3000, 2000),
+                        new TimeWindow(-2000, 3000),
+                        new TimeWindow(-1000, 4000),
+                        new TimeWindow(0, 5000));
 
-        assertThat(
-                assigner.assignWindows("String", 4999L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(0, 5000),
-                        timeWindow(1000, 6000),
-                        timeWindow(2000, 7000),
-                        timeWindow(3000, 8000),
-                        timeWindow(4000, 9000)));
+        assertThat(assigner.assignWindows("String", 4999L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(0, 5000),
+                        new TimeWindow(1000, 6000),
+                        new TimeWindow(2000, 7000),
+                        new TimeWindow(3000, 8000),
+                        new TimeWindow(4000, 9000));
 
-        assertThat(
-                assigner.assignWindows("String", 5000L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(1000, 6000),
-                        timeWindow(2000, 7000),
-                        timeWindow(3000, 8000),
-                        timeWindow(4000, 9000),
-                        timeWindow(5000, 10000)));
+        assertThat(assigner.assignWindows("String", 5000L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(1000, 6000),
+                        new TimeWindow(2000, 7000),
+                        new TimeWindow(3000, 8000),
+                        new TimeWindow(4000, 9000),
+                        new TimeWindow(5000, 10000));
     }
 
     @Test
-    public void testWindowAssignmentWithOffset() {
+    void testWindowAssignmentWithOffset() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -86,36 +76,33 @@ public class SlidingEventTimeWindowsTest extends TestLogger {
                 SlidingEventTimeWindows.of(
                         Time.milliseconds(5000), Time.milliseconds(1000), Time.milliseconds(100));
 
-        assertThat(
-                assigner.assignWindows("String", 100L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-3900, 1100),
-                        timeWindow(-2900, 2100),
-                        timeWindow(-1900, 3100),
-                        timeWindow(-900, 4100),
-                        timeWindow(100, 5100)));
+        assertThat(assigner.assignWindows("String", 100L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-3900, 1100),
+                        new TimeWindow(-2900, 2100),
+                        new TimeWindow(-1900, 3100),
+                        new TimeWindow(-900, 4100),
+                        new TimeWindow(100, 5100));
 
-        assertThat(
-                assigner.assignWindows("String", 5099L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(100, 5100),
-                        timeWindow(1100, 6100),
-                        timeWindow(2100, 7100),
-                        timeWindow(3100, 8100),
-                        timeWindow(4100, 9100)));
+        assertThat(assigner.assignWindows("String", 5099L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(100, 5100),
+                        new TimeWindow(1100, 6100),
+                        new TimeWindow(2100, 7100),
+                        new TimeWindow(3100, 8100),
+                        new TimeWindow(4100, 9100));
 
-        assertThat(
-                assigner.assignWindows("String", 5100L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(1100, 6100),
-                        timeWindow(2100, 7100),
-                        timeWindow(3100, 8100),
-                        timeWindow(4100, 9100),
-                        timeWindow(5100, 10100)));
+        assertThat(assigner.assignWindows("String", 5100L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(1100, 6100),
+                        new TimeWindow(2100, 7100),
+                        new TimeWindow(3100, 8100),
+                        new TimeWindow(4100, 9100),
+                        new TimeWindow(5100, 10100));
     }
 
     @Test
-    public void testWindowAssignmentWithNegativeOffset() {
+    void testWindowAssignmentWithNegativeOffset() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -123,36 +110,33 @@ public class SlidingEventTimeWindowsTest extends TestLogger {
                 SlidingEventTimeWindows.of(
                         Time.milliseconds(5000), Time.milliseconds(1000), Time.milliseconds(-100));
 
-        assertThat(
-                assigner.assignWindows("String", 0L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-4100, 900),
-                        timeWindow(-3100, 1900),
-                        timeWindow(-2100, 2900),
-                        timeWindow(-1100, 3900),
-                        timeWindow(-100, 4900)));
+        assertThat(assigner.assignWindows("String", 0L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-4100, 900),
+                        new TimeWindow(-3100, 1900),
+                        new TimeWindow(-2100, 2900),
+                        new TimeWindow(-1100, 3900),
+                        new TimeWindow(-100, 4900));
 
-        assertThat(
-                assigner.assignWindows("String", 4899L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-100, 4900),
-                        timeWindow(900, 5900),
-                        timeWindow(1900, 6900),
-                        timeWindow(2900, 7900),
-                        timeWindow(3900, 8900)));
+        assertThat(assigner.assignWindows("String", 4899L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-100, 4900),
+                        new TimeWindow(900, 5900),
+                        new TimeWindow(1900, 6900),
+                        new TimeWindow(2900, 7900),
+                        new TimeWindow(3900, 8900));
 
-        assertThat(
-                assigner.assignWindows("String", 4900L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(900, 5900),
-                        timeWindow(1900, 6900),
-                        timeWindow(2900, 7900),
-                        timeWindow(3900, 8900),
-                        timeWindow(4900, 9900)));
+        assertThat(assigner.assignWindows("String", 4900L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(900, 5900),
+                        new TimeWindow(1900, 6900),
+                        new TimeWindow(2900, 7900),
+                        new TimeWindow(3900, 8900),
+                        new TimeWindow(4900, 9900));
     }
 
     @Test
-    public void testTimeUnits() {
+    void testTimeUnits() {
         // sanity check with one other time unit
 
         WindowAssigner.WindowAssignerContext mockContext =
@@ -162,80 +146,72 @@ public class SlidingEventTimeWindowsTest extends TestLogger {
                 SlidingEventTimeWindows.of(
                         Time.seconds(5), Time.seconds(1), Time.milliseconds(500));
 
-        assertThat(
-                assigner.assignWindows("String", 100L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-4500, 500),
-                        timeWindow(-3500, 1500),
-                        timeWindow(-2500, 2500),
-                        timeWindow(-1500, 3500),
-                        timeWindow(-500, 4500)));
+        assertThat(assigner.assignWindows("String", 100L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-4500, 500),
+                        new TimeWindow(-3500, 1500),
+                        new TimeWindow(-2500, 2500),
+                        new TimeWindow(-1500, 3500),
+                        new TimeWindow(-500, 4500));
 
-        assertThat(
-                assigner.assignWindows("String", 5499L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(500, 5500),
-                        timeWindow(1500, 6500),
-                        timeWindow(2500, 7500),
-                        timeWindow(3500, 8500),
-                        timeWindow(4500, 9500)));
+        assertThat(assigner.assignWindows("String", 5499L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(500, 5500),
+                        new TimeWindow(1500, 6500),
+                        new TimeWindow(2500, 7500),
+                        new TimeWindow(3500, 8500),
+                        new TimeWindow(4500, 9500));
 
-        assertThat(
-                assigner.assignWindows("String", 5100L, mockContext),
-                containsInAnyOrder(
-                        timeWindow(500, 5500),
-                        timeWindow(1500, 6500),
-                        timeWindow(2500, 7500),
-                        timeWindow(3500, 8500),
-                        timeWindow(4500, 9500)));
+        assertThat(assigner.assignWindows("String", 5100L, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(500, 5500),
+                        new TimeWindow(1500, 6500),
+                        new TimeWindow(2500, 7500),
+                        new TimeWindow(3500, 8500),
+                        new TimeWindow(4500, 9500));
     }
 
     @Test
-    public void testInvalidParameters() {
-        try {
-            SlidingEventTimeWindows.of(Time.seconds(-2), Time.seconds(1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+    void testInvalidParameters() {
 
-        try {
-            SlidingEventTimeWindows.of(Time.seconds(2), Time.seconds(-1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+        assertThatThrownBy(() -> SlidingEventTimeWindows.of(Time.seconds(-2), Time.seconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
 
-        try {
-            SlidingEventTimeWindows.of(Time.seconds(-20), Time.seconds(10), Time.seconds(-1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+        assertThatThrownBy(() -> SlidingEventTimeWindows.of(Time.seconds(2), Time.seconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
 
-        try {
-            SlidingEventTimeWindows.of(Time.seconds(20), Time.seconds(10), Time.seconds(-11));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+        assertThatThrownBy(
+                        () ->
+                                SlidingEventTimeWindows.of(
+                                        Time.seconds(-20), Time.seconds(10), Time.seconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
 
-        try {
-            SlidingEventTimeWindows.of(Time.seconds(20), Time.seconds(10), Time.seconds(11));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+        assertThatThrownBy(
+                        () ->
+                                SlidingEventTimeWindows.of(
+                                        Time.seconds(20), Time.seconds(10), Time.seconds(-11)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
+
+        assertThatThrownBy(
+                        () ->
+                                SlidingEventTimeWindows.of(
+                                        Time.seconds(20), Time.seconds(10), Time.seconds(11)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         SlidingEventTimeWindows assigner =
                 SlidingEventTimeWindows.of(Time.seconds(5), Time.milliseconds(100));
 
-        assertTrue(assigner.isEventTime());
-        assertEquals(
-                new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
-        assertThat(assigner.getDefaultTrigger(), instanceOf(EventTimeTrigger.class));
+        assertThat(assigner.isEventTime()).isTrue();
+        assertThat(assigner.getWindowSerializer(new ExecutionConfig()))
+                .isEqualTo(new TimeWindow.Serializer());
+        assertThat(assigner.getDefaultTrigger()).isInstanceOf(EventTimeTrigger.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/SlidingProcessingTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/SlidingProcessingTimeWindowsTest.java
@@ -24,26 +24,19 @@ import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.ProcessingTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.apache.flink.streaming.util.StreamRecordMatchers.timeWindow;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link SlidingProcessingTimeWindows}. */
-public class SlidingProcessingTimeWindowsTest extends TestLogger {
+class SlidingProcessingTimeWindowsTest {
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -51,38 +44,35 @@ public class SlidingProcessingTimeWindowsTest extends TestLogger {
                 SlidingProcessingTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(1000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-4000, 1000),
-                        timeWindow(-3000, 2000),
-                        timeWindow(-2000, 3000),
-                        timeWindow(-1000, 4000),
-                        timeWindow(0, 5000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-4000, 1000),
+                        new TimeWindow(-3000, 2000),
+                        new TimeWindow(-2000, 3000),
+                        new TimeWindow(-1000, 4000),
+                        new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4999L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(0, 5000),
-                        timeWindow(1000, 6000),
-                        timeWindow(2000, 7000),
-                        timeWindow(3000, 8000),
-                        timeWindow(4000, 9000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(0, 5000),
+                        new TimeWindow(1000, 6000),
+                        new TimeWindow(2000, 7000),
+                        new TimeWindow(3000, 8000),
+                        new TimeWindow(4000, 9000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(1000, 6000),
-                        timeWindow(2000, 7000),
-                        timeWindow(3000, 8000),
-                        timeWindow(4000, 9000),
-                        timeWindow(5000, 10000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(1000, 6000),
+                        new TimeWindow(2000, 7000),
+                        new TimeWindow(3000, 8000),
+                        new TimeWindow(4000, 9000),
+                        new TimeWindow(5000, 10000));
     }
 
     @Test
-    public void testWindowAssignmentWithOffset() {
+    void testWindowAssignmentWithOffset() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -91,38 +81,35 @@ public class SlidingProcessingTimeWindowsTest extends TestLogger {
                         Time.milliseconds(5000), Time.milliseconds(1000), Time.milliseconds(100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(100L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-3900, 1100),
-                        timeWindow(-2900, 2100),
-                        timeWindow(-1900, 3100),
-                        timeWindow(-900, 4100),
-                        timeWindow(100, 5100)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-3900, 1100),
+                        new TimeWindow(-2900, 2100),
+                        new TimeWindow(-1900, 3100),
+                        new TimeWindow(-900, 4100),
+                        new TimeWindow(100, 5100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5099L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(100, 5100),
-                        timeWindow(1100, 6100),
-                        timeWindow(2100, 7100),
-                        timeWindow(3100, 8100),
-                        timeWindow(4100, 9100)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(100, 5100),
+                        new TimeWindow(1100, 6100),
+                        new TimeWindow(2100, 7100),
+                        new TimeWindow(3100, 8100),
+                        new TimeWindow(4100, 9100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5100L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(1100, 6100),
-                        timeWindow(2100, 7100),
-                        timeWindow(3100, 8100),
-                        timeWindow(4100, 9100),
-                        timeWindow(5100, 10100)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(1100, 6100),
+                        new TimeWindow(2100, 7100),
+                        new TimeWindow(3100, 8100),
+                        new TimeWindow(4100, 9100),
+                        new TimeWindow(5100, 10100));
     }
 
     @Test
-    public void testWindowAssignmentWithNegativeOffset() {
+    void testWindowAssignmentWithNegativeOffset() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -131,38 +118,35 @@ public class SlidingProcessingTimeWindowsTest extends TestLogger {
                         Time.milliseconds(5000), Time.milliseconds(1000), Time.milliseconds(-100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-4100, 900),
-                        timeWindow(-3100, 1900),
-                        timeWindow(-2100, 2900),
-                        timeWindow(-1100, 3900),
-                        timeWindow(-100, 4900)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-4100, 900),
+                        new TimeWindow(-3100, 1900),
+                        new TimeWindow(-2100, 2900),
+                        new TimeWindow(-1100, 3900),
+                        new TimeWindow(-100, 4900));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4899L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-100, 4900),
-                        timeWindow(900, 5900),
-                        timeWindow(1900, 6900),
-                        timeWindow(2900, 7900),
-                        timeWindow(3900, 8900)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-100, 4900),
+                        new TimeWindow(900, 5900),
+                        new TimeWindow(1900, 6900),
+                        new TimeWindow(2900, 7900),
+                        new TimeWindow(3900, 8900));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4900L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(900, 5900),
-                        timeWindow(1900, 6900),
-                        timeWindow(2900, 7900),
-                        timeWindow(3900, 8900),
-                        timeWindow(4900, 9900)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(900, 5900),
+                        new TimeWindow(1900, 6900),
+                        new TimeWindow(2900, 7900),
+                        new TimeWindow(3900, 8900),
+                        new TimeWindow(4900, 9900));
     }
 
     @Test
-    public void testTimeUnits() {
+    void testTimeUnits() {
         // sanity check with one other time unit
 
         WindowAssigner.WindowAssignerContext mockContext =
@@ -173,82 +157,74 @@ public class SlidingProcessingTimeWindowsTest extends TestLogger {
                         Time.seconds(5), Time.seconds(1), Time.milliseconds(500));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(100L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(-4500, 500),
-                        timeWindow(-3500, 1500),
-                        timeWindow(-2500, 2500),
-                        timeWindow(-1500, 3500),
-                        timeWindow(-500, 4500)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(-4500, 500),
+                        new TimeWindow(-3500, 1500),
+                        new TimeWindow(-2500, 2500),
+                        new TimeWindow(-1500, 3500),
+                        new TimeWindow(-500, 4500));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5499L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(500, 5500),
-                        timeWindow(1500, 6500),
-                        timeWindow(2500, 7500),
-                        timeWindow(3500, 8500),
-                        timeWindow(4500, 9500)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(500, 5500),
+                        new TimeWindow(1500, 6500),
+                        new TimeWindow(2500, 7500),
+                        new TimeWindow(3500, 8500),
+                        new TimeWindow(4500, 9500));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5100L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                containsInAnyOrder(
-                        timeWindow(500, 5500),
-                        timeWindow(1500, 6500),
-                        timeWindow(2500, 7500),
-                        timeWindow(3500, 8500),
-                        timeWindow(4500, 9500)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .containsExactlyInAnyOrder(
+                        new TimeWindow(500, 5500),
+                        new TimeWindow(1500, 6500),
+                        new TimeWindow(2500, 7500),
+                        new TimeWindow(3500, 8500),
+                        new TimeWindow(4500, 9500));
     }
 
     @Test
-    public void testInvalidParameters() {
-        try {
-            SlidingProcessingTimeWindows.of(Time.seconds(-2), Time.seconds(1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+    void testInvalidParameters() {
 
-        try {
-            SlidingProcessingTimeWindows.of(Time.seconds(2), Time.seconds(-1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+        assertThatThrownBy(() -> SlidingProcessingTimeWindows.of(Time.seconds(-2), Time.seconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
 
-        try {
-            SlidingProcessingTimeWindows.of(Time.seconds(-20), Time.seconds(10), Time.seconds(-1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+        assertThatThrownBy(() -> SlidingProcessingTimeWindows.of(Time.seconds(2), Time.seconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
 
-        try {
-            SlidingProcessingTimeWindows.of(Time.seconds(20), Time.seconds(10), Time.seconds(-11));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+        assertThatThrownBy(
+                        () ->
+                                SlidingProcessingTimeWindows.of(
+                                        Time.seconds(-20), Time.seconds(10), Time.seconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
 
-        try {
-            SlidingProcessingTimeWindows.of(Time.seconds(20), Time.seconds(10), Time.seconds(11));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < slide and size > 0"));
-        }
+        assertThatThrownBy(
+                        () ->
+                                SlidingProcessingTimeWindows.of(
+                                        Time.seconds(20), Time.seconds(10), Time.seconds(-11)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
+
+        assertThatThrownBy(
+                        () ->
+                                SlidingProcessingTimeWindows.of(
+                                        Time.seconds(20), Time.seconds(10), Time.seconds(11)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < slide and size > 0");
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         SlidingProcessingTimeWindows assigner =
                 SlidingProcessingTimeWindows.of(Time.seconds(5), Time.milliseconds(100));
 
-        assertFalse(assigner.isEventTime());
-        assertEquals(
-                new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
-        assertThat(assigner.getDefaultTrigger(), instanceOf(ProcessingTimeTrigger.class));
+        assertThat(assigner.isEventTime()).isFalse();
+        assertThat(assigner.getWindowSerializer(new ExecutionConfig()))
+                .isEqualTo(new TimeWindow.Serializer());
+        assertThat(assigner.getDefaultTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TimeWindowTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TimeWindowTest.java
@@ -20,79 +20,80 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Tests for {@link TimeWindow}. */
-public class TimeWindowTest {
+class TimeWindowTest {
     @Test
-    public void testGetWindowStartWithOffset() {
+    void testGetWindowStartWithOffset() {
         // [-21, -14), [-14, -7), [-7, 0), [0, 7), [7, 14), [14, 21)...
         long offset = 0;
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-8, offset, 7), -14);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-7, offset, 7), -7);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-6, offset, 7), -7);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-1, offset, 7), -7);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(1, offset, 7), 0);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(6, offset, 7), 0);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(7, offset, 7), 7);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(8, offset, 7), 7);
+        assertThat(TimeWindow.getWindowStartWithOffset(-8, offset, 7)).isEqualTo(-14);
+        assertThat(TimeWindow.getWindowStartWithOffset(-7, offset, 7)).isEqualTo(-7);
+        assertThat(TimeWindow.getWindowStartWithOffset(-6, offset, 7)).isEqualTo(-7);
+        assertThat(TimeWindow.getWindowStartWithOffset(-1, offset, 7)).isEqualTo(-7);
+        assertThat(TimeWindow.getWindowStartWithOffset(1, offset, 7)).isZero();
+        assertThat(TimeWindow.getWindowStartWithOffset(6, offset, 7)).isZero();
+        assertThat(TimeWindow.getWindowStartWithOffset(7, offset, 7)).isEqualTo(7);
+        assertThat(TimeWindow.getWindowStartWithOffset(8, offset, 7)).isEqualTo(7);
 
         // [-11, -4), [-4, 3), [3, 10), [10, 17)...
         offset = 3;
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-10, offset, 7), -11);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-9, offset, 7), -11);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-3, offset, 7), -4);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-2, offset, 7), -4);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-1, offset, 7), -4);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(1, offset, 7), -4);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(2, offset, 7), -4);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(3, offset, 7), 3);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(9, offset, 7), 3);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(10, offset, 7), 10);
+        assertThat(TimeWindow.getWindowStartWithOffset(-10, offset, 7)).isEqualTo(-11);
+        assertThat(TimeWindow.getWindowStartWithOffset(-9, offset, 7)).isEqualTo(-11);
+        assertThat(TimeWindow.getWindowStartWithOffset(-3, offset, 7)).isEqualTo(-4);
+        assertThat(TimeWindow.getWindowStartWithOffset(-2, offset, 7)).isEqualTo(-4);
+        assertThat(TimeWindow.getWindowStartWithOffset(-1, offset, 7)).isEqualTo(-4);
+        assertThat(TimeWindow.getWindowStartWithOffset(1, offset, 7)).isEqualTo(-4);
+        assertThat(TimeWindow.getWindowStartWithOffset(2, offset, 7)).isEqualTo(-4);
+        assertThat(TimeWindow.getWindowStartWithOffset(3, offset, 7)).isEqualTo(3);
+        assertThat(TimeWindow.getWindowStartWithOffset(9, offset, 7)).isEqualTo(3);
+        assertThat(TimeWindow.getWindowStartWithOffset(10, offset, 7)).isEqualTo(10);
 
         // [-16, -9), [-9, -2), [-2, 5), [5, 12), [12, 19)...
         offset = -2;
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-12, offset, 7), -16);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-7, offset, 7), -9);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-4, offset, 7), -9);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-3, offset, 7), -9);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(2, offset, 7), -2);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-1, offset, 7), -2);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(1, offset, 7), -2);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(-2, offset, 7), -2);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(3, offset, 7), -2);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(4, offset, 7), -2);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(7, offset, 7), 5);
-        Assert.assertEquals(TimeWindow.getWindowStartWithOffset(12, offset, 7), 12);
+        assertThat(TimeWindow.getWindowStartWithOffset(-12, offset, 7)).isEqualTo(-16);
+        assertThat(TimeWindow.getWindowStartWithOffset(-7, offset, 7)).isEqualTo(-9);
+        assertThat(TimeWindow.getWindowStartWithOffset(-4, offset, 7)).isEqualTo(-9);
+        assertThat(TimeWindow.getWindowStartWithOffset(-3, offset, 7)).isEqualTo(-9);
+        assertThat(TimeWindow.getWindowStartWithOffset(2, offset, 7)).isEqualTo(-2);
+        assertThat(TimeWindow.getWindowStartWithOffset(-1, offset, 7)).isEqualTo(-2);
+        assertThat(TimeWindow.getWindowStartWithOffset(1, offset, 7)).isEqualTo(-2);
+        assertThat(TimeWindow.getWindowStartWithOffset(-2, offset, 7)).isEqualTo(-2);
+        assertThat(TimeWindow.getWindowStartWithOffset(3, offset, 7)).isEqualTo(-2);
+        assertThat(TimeWindow.getWindowStartWithOffset(4, offset, 7)).isEqualTo(-2);
+        assertThat(TimeWindow.getWindowStartWithOffset(7, offset, 7)).isEqualTo(5);
+        assertThat(TimeWindow.getWindowStartWithOffset(12, offset, 7)).isEqualTo(12);
 
         // for GMT+08:00
         offset = -TimeUnit.HOURS.toMillis(8);
         long size = TimeUnit.DAYS.toMillis(1);
-        Assert.assertEquals(
-                TimeWindow.getWindowStartWithOffset(1470902048450L, offset, size), 1470844800000L);
+        assertThat(TimeWindow.getWindowStartWithOffset(1470902048450L, offset, size))
+                .isEqualTo(1470844800000L);
     }
 
     private boolean intersects(TimeWindow w0, TimeWindow w1) {
-        Assert.assertEquals(w0.intersects(w1), w1.intersects(w0));
+        assertThat(w0.intersects(w1)).isEqualTo(w1.intersects(w0));
         return w0.intersects(w1);
     }
 
     @Test
-    public void testIntersect() {
+    void testIntersect() {
         // must intersect with itself
         TimeWindow window = new TimeWindow(10, 20);
-        Assert.assertTrue(window.intersects(window));
+        assertThat(window.intersects(window)).isTrue();
 
         // windows are next to each other
-        Assert.assertTrue(intersects(window, new TimeWindow(20, 30)));
+        assertThat(intersects(window, new TimeWindow(20, 30))).isTrue();
 
         // there is distance between the windows
-        Assert.assertFalse(intersects(window, new TimeWindow(21, 30)));
+        assertThat(intersects(window, new TimeWindow(21, 30))).isFalse();
 
         // overlaps by one
-        Assert.assertTrue(intersects(window, new TimeWindow(19, 22)));
+        assertThat(intersects(window, new TimeWindow(19, 22))).isTrue();
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TimeWindowTranslationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TimeWindowTranslationTest.java
@@ -37,23 +37,24 @@ import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * These tests verify that the api calls on {@link WindowedStream} that use the "time" shortcut
  * instantiate the correct window operator.
  */
-public class TimeWindowTranslationTest {
+class TimeWindowTranslationTest {
 
     /**
      * Verifies that calls to timeWindow() instantiate a regular windowOperator instead of an
      * aligned one.
      */
     @Test
-    public void testAlignedWindowDeprecation() throws Exception {
+    void testAlignedWindowDeprecation() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setStreamTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
@@ -74,7 +75,7 @@ public class TimeWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator1 =
                 transform1.getOperator();
-        Assert.assertTrue(operator1 instanceof WindowOperator);
+        assertThat(operator1).isInstanceOf(WindowOperator.class);
 
         DataStream<Tuple2<String, Integer>> window2 =
                 source.keyBy(0)
@@ -101,12 +102,12 @@ public class TimeWindowTranslationTest {
                         window2.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator2 =
                 transform2.getOperator();
-        Assert.assertTrue(operator2 instanceof WindowOperator);
+        assertThat(operator2).isInstanceOf(WindowOperator.class);
     }
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceEventTimeWindows() throws Exception {
+    void testReduceEventTimeWindows() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime);
 
@@ -125,16 +126,16 @@ public class TimeWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator1 =
                 transform1.getOperator();
-        Assert.assertTrue(operator1 instanceof WindowOperator);
+        assertThat(operator1).isInstanceOf(WindowOperator.class);
         WindowOperator winOperator1 = (WindowOperator) operator1;
-        Assert.assertTrue(winOperator1.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator1.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator1.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator1.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator1.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator1.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
     }
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyEventTimeWindows() throws Exception {
+    void testApplyEventTimeWindows() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime);
 
@@ -166,11 +167,11 @@ public class TimeWindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator1 =
                 transform1.getOperator();
-        Assert.assertTrue(operator1 instanceof WindowOperator);
+        assertThat(operator1).isInstanceOf(WindowOperator.class);
         WindowOperator winOperator1 = (WindowOperator) operator1;
-        Assert.assertTrue(winOperator1.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator1.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator1.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator1.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator1.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator1.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
@@ -25,43 +25,34 @@ import org.apache.flink.streaming.api.windowing.assigners.WindowStagger;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.EventTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.apache.flink.streaming.util.StreamRecordMatchers.timeWindow;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link TumblingEventTimeWindows}. */
-public class TumblingEventTimeWindowsTest extends TestLogger {
+class TumblingEventTimeWindowsTest {
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
         TumblingEventTimeWindows assigner = TumblingEventTimeWindows.of(Time.milliseconds(5000));
 
-        assertThat(
-                assigner.assignWindows("String", 0L, mockContext), contains(timeWindow(0, 5000)));
-        assertThat(
-                assigner.assignWindows("String", 4999L, mockContext),
-                contains(timeWindow(0, 5000)));
-        assertThat(
-                assigner.assignWindows("String", 5000L, mockContext),
-                contains(timeWindow(5000, 10000)));
+        assertThat(assigner.assignWindows("String", 0L, mockContext))
+                .contains(new TimeWindow(0, 5000));
+        assertThat(assigner.assignWindows("String", 4999L, mockContext))
+                .contains(new TimeWindow(0, 5000));
+        assertThat(assigner.assignWindows("String", 5000L, mockContext))
+                .contains(new TimeWindow(5000, 10000));
     }
 
     @Test
-    public void testWindowAssignmentWithStagger() {
+    void testWindowAssignmentWithStagger() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -70,57 +61,48 @@ public class TumblingEventTimeWindowsTest extends TestLogger {
                         Time.milliseconds(5000), Time.milliseconds(0), WindowStagger.NATURAL);
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(150L);
-        assertThat(
-                assigner.assignWindows("String", 150L, mockContext),
-                contains(timeWindow(150, 5150)));
-        assertThat(
-                assigner.assignWindows("String", 5099L, mockContext),
-                contains(timeWindow(150, 5150)));
-        assertThat(
-                assigner.assignWindows("String", 5300L, mockContext),
-                contains(timeWindow(5150, 10150)));
+        assertThat(assigner.assignWindows("String", 150L, mockContext))
+                .contains(new TimeWindow(150, 5150));
+        assertThat(assigner.assignWindows("String", 5099L, mockContext))
+                .contains(new TimeWindow(150, 5150));
+        assertThat(assigner.assignWindows("String", 5300L, mockContext))
+                .contains(new TimeWindow(5150, 10150));
     }
 
     @Test
-    public void testWindowAssignmentWithGlobalOffset() {
+    void testWindowAssignmentWithGlobalOffset() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
         TumblingEventTimeWindows assigner =
                 TumblingEventTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(100));
 
-        assertThat(
-                assigner.assignWindows("String", 100L, mockContext),
-                contains(timeWindow(100, 5100)));
-        assertThat(
-                assigner.assignWindows("String", 5099L, mockContext),
-                contains(timeWindow(100, 5100)));
-        assertThat(
-                assigner.assignWindows("String", 5100L, mockContext),
-                contains(timeWindow(5100, 10100)));
+        assertThat(assigner.assignWindows("String", 100L, mockContext))
+                .contains(new TimeWindow(100, 5100));
+        assertThat(assigner.assignWindows("String", 5099L, mockContext))
+                .contains(new TimeWindow(100, 5100));
+        assertThat(assigner.assignWindows("String", 5100L, mockContext))
+                .contains(new TimeWindow(5100, 10100));
     }
 
     @Test
-    public void testWindowAssignmentWithNegativeGlobalOffset() {
+    void testWindowAssignmentWithNegativeGlobalOffset() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
         TumblingEventTimeWindows assigner =
                 TumblingEventTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(-100));
 
-        assertThat(
-                assigner.assignWindows("String", 0L, mockContext),
-                contains(timeWindow(-100, 4900)));
-        assertThat(
-                assigner.assignWindows("String", 4899L, mockContext),
-                contains(timeWindow(-100, 4900)));
-        assertThat(
-                assigner.assignWindows("String", 4900L, mockContext),
-                contains(timeWindow(4900, 9900)));
+        assertThat(assigner.assignWindows("String", 0L, mockContext))
+                .contains(new TimeWindow(-100, 4900));
+        assertThat(assigner.assignWindows("String", 4899L, mockContext))
+                .contains(new TimeWindow(-100, 4900));
+        assertThat(assigner.assignWindows("String", 4900L, mockContext))
+                .contains(new TimeWindow(4900, 9900));
     }
 
     @Test
-    public void testTimeUnits() {
+    void testTimeUnits() {
         // sanity check with one other time unit
 
         WindowAssigner.WindowAssignerContext mockContext =
@@ -129,49 +111,38 @@ public class TumblingEventTimeWindowsTest extends TestLogger {
         TumblingEventTimeWindows assigner =
                 TumblingEventTimeWindows.of(Time.seconds(5), Time.seconds(1));
 
-        assertThat(
-                assigner.assignWindows("String", 1000L, mockContext),
-                contains(timeWindow(1000, 6000)));
-        assertThat(
-                assigner.assignWindows("String", 5999L, mockContext),
-                contains(timeWindow(1000, 6000)));
-        assertThat(
-                assigner.assignWindows("String", 6000L, mockContext),
-                contains(timeWindow(6000, 11000)));
+        assertThat(assigner.assignWindows("String", 1000L, mockContext))
+                .contains(new TimeWindow(1000, 6000));
+        assertThat(assigner.assignWindows("String", 5999L, mockContext))
+                .contains(new TimeWindow(1000, 6000));
+        assertThat(assigner.assignWindows("String", 6000L, mockContext))
+                .contains(new TimeWindow(6000, 11000));
     }
 
     @Test
-    public void testInvalidParameters() {
-        try {
-            TumblingEventTimeWindows.of(Time.seconds(-1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < size"));
-        }
+    void testInvalidParameters() {
 
-        try {
-            TumblingEventTimeWindows.of(Time.seconds(10), Time.seconds(20));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < size"));
-        }
+        assertThatThrownBy(() -> TumblingEventTimeWindows.of(Time.seconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < size");
 
-        try {
-            TumblingEventTimeWindows.of(Time.seconds(10), Time.seconds(-11));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < size"));
-        }
+        assertThatThrownBy(() -> TumblingEventTimeWindows.of(Time.seconds(10), Time.seconds(20)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < size");
+
+        assertThatThrownBy(() -> TumblingEventTimeWindows.of(Time.seconds(10), Time.seconds(-11)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < size");
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         TumblingEventTimeWindows assigner =
                 TumblingEventTimeWindows.of(Time.seconds(5), Time.milliseconds(100));
 
-        assertTrue(assigner.isEventTime());
-        assertEquals(
-                new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
-        assertThat(assigner.getDefaultTrigger(), instanceOf(EventTimeTrigger.class));
+        assertThat(assigner.isEventTime()).isTrue();
+        assertThat(assigner.getWindowSerializer(new ExecutionConfig()))
+                .isEqualTo(new TimeWindow.Serializer());
+        assertThat(assigner.getDefaultTrigger()).isInstanceOf(EventTimeTrigger.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingEventTimeWindowsTest.java
@@ -44,11 +44,11 @@ class TumblingEventTimeWindowsTest {
         TumblingEventTimeWindows assigner = TumblingEventTimeWindows.of(Time.milliseconds(5000));
 
         assertThat(assigner.assignWindows("String", 0L, mockContext))
-                .contains(new TimeWindow(0, 5000));
+                .containsExactly(new TimeWindow(0, 5000));
         assertThat(assigner.assignWindows("String", 4999L, mockContext))
-                .contains(new TimeWindow(0, 5000));
+                .containsExactly(new TimeWindow(0, 5000));
         assertThat(assigner.assignWindows("String", 5000L, mockContext))
-                .contains(new TimeWindow(5000, 10000));
+                .containsExactly(new TimeWindow(5000, 10000));
     }
 
     @Test
@@ -62,11 +62,11 @@ class TumblingEventTimeWindowsTest {
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(150L);
         assertThat(assigner.assignWindows("String", 150L, mockContext))
-                .contains(new TimeWindow(150, 5150));
+                .containsExactly(new TimeWindow(150, 5150));
         assertThat(assigner.assignWindows("String", 5099L, mockContext))
-                .contains(new TimeWindow(150, 5150));
+                .containsExactly(new TimeWindow(150, 5150));
         assertThat(assigner.assignWindows("String", 5300L, mockContext))
-                .contains(new TimeWindow(5150, 10150));
+                .containsExactly(new TimeWindow(5150, 10150));
     }
 
     @Test
@@ -78,11 +78,11 @@ class TumblingEventTimeWindowsTest {
                 TumblingEventTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(100));
 
         assertThat(assigner.assignWindows("String", 100L, mockContext))
-                .contains(new TimeWindow(100, 5100));
+                .containsExactly(new TimeWindow(100, 5100));
         assertThat(assigner.assignWindows("String", 5099L, mockContext))
-                .contains(new TimeWindow(100, 5100));
+                .containsExactly(new TimeWindow(100, 5100));
         assertThat(assigner.assignWindows("String", 5100L, mockContext))
-                .contains(new TimeWindow(5100, 10100));
+                .containsExactly(new TimeWindow(5100, 10100));
     }
 
     @Test
@@ -94,11 +94,11 @@ class TumblingEventTimeWindowsTest {
                 TumblingEventTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(-100));
 
         assertThat(assigner.assignWindows("String", 0L, mockContext))
-                .contains(new TimeWindow(-100, 4900));
+                .containsExactly(new TimeWindow(-100, 4900));
         assertThat(assigner.assignWindows("String", 4899L, mockContext))
-                .contains(new TimeWindow(-100, 4900));
+                .containsExactly(new TimeWindow(-100, 4900));
         assertThat(assigner.assignWindows("String", 4900L, mockContext))
-                .contains(new TimeWindow(4900, 9900));
+                .containsExactly(new TimeWindow(4900, 9900));
     }
 
     @Test
@@ -112,11 +112,11 @@ class TumblingEventTimeWindowsTest {
                 TumblingEventTimeWindows.of(Time.seconds(5), Time.seconds(1));
 
         assertThat(assigner.assignWindows("String", 1000L, mockContext))
-                .contains(new TimeWindow(1000, 6000));
+                .containsExactly(new TimeWindow(1000, 6000));
         assertThat(assigner.assignWindows("String", 5999L, mockContext))
-                .contains(new TimeWindow(1000, 6000));
+                .containsExactly(new TimeWindow(1000, 6000));
         assertThat(assigner.assignWindows("String", 6000L, mockContext))
-                .contains(new TimeWindow(6000, 11000));
+                .containsExactly(new TimeWindow(6000, 11000));
     }
 
     @Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
@@ -46,15 +46,15 @@ class TumblingProcessingTimeWindowsTest {
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(0, 5000));
+                .containsExactly(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4999L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(0, 5000));
+                .containsExactly(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(5000, 10000));
+                .containsExactly(new TimeWindow(5000, 10000));
     }
 
     @Test
@@ -68,15 +68,15 @@ class TumblingProcessingTimeWindowsTest {
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(150L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(150, 5150));
+                .containsExactly(new TimeWindow(150, 5150));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5049L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(150, 5150));
+                .containsExactly(new TimeWindow(150, 5150));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5150L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(5150, 10150));
+                .containsExactly(new TimeWindow(5150, 10150));
     }
 
     @Test
@@ -89,15 +89,15 @@ class TumblingProcessingTimeWindowsTest {
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(100L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(100, 5100));
+                .containsExactly(new TimeWindow(100, 5100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5099L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(100, 5100));
+                .containsExactly(new TimeWindow(100, 5100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5100L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(5100, 10100));
+                .containsExactly(new TimeWindow(5100, 10100));
     }
 
     @Test
@@ -110,15 +110,15 @@ class TumblingProcessingTimeWindowsTest {
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(100L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(-100, 4900));
+                .containsExactly(new TimeWindow(-100, 4900));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4899L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(-100, 4900));
+                .containsExactly(new TimeWindow(-100, 4900));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4900L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(4900, 9900));
+                .containsExactly(new TimeWindow(4900, 9900));
     }
 
     @Test
@@ -133,15 +133,15 @@ class TumblingProcessingTimeWindowsTest {
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(1000L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(1000, 6000));
+                .containsExactly(new TimeWindow(1000, 6000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5999L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(1000, 6000));
+                .containsExactly(new TimeWindow(1000, 6000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(6000L);
         assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
-                .contains(new TimeWindow(6000, 11000));
+                .containsExactly(new TimeWindow(6000, 11000));
     }
 
     @Test
@@ -149,7 +149,7 @@ class TumblingProcessingTimeWindowsTest {
 
         assertThatThrownBy(() -> TumblingProcessingTimeWindows.of(Time.seconds(-1)))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("TumblingProcessingTimeWindows");
+                .hasMessageContaining("abs(offset) < size");
 
         assertThatThrownBy(
                         () -> TumblingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(20)))

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TumblingProcessingTimeWindowsTest.java
@@ -25,26 +25,19 @@ import org.apache.flink.streaming.api.windowing.assigners.WindowStagger;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.triggers.ProcessingTimeTrigger;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.apache.flink.streaming.util.StreamRecordMatchers.timeWindow;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link TumblingProcessingTimeWindows}. */
-public class TumblingProcessingTimeWindowsTest extends TestLogger {
+class TumblingProcessingTimeWindowsTest {
 
     @Test
-    public void testWindowAssignment() {
+    void testWindowAssignment() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -52,23 +45,20 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
                 TumblingProcessingTimeWindows.of(Time.milliseconds(5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(0L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(0, 5000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4999L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(0, 5000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(0, 5000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5000L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(5000, 10000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(5000, 10000));
     }
 
     @Test
-    public void testWindowAssignmentWithStagger() {
+    void testWindowAssignmentWithStagger() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -77,23 +67,20 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
                         Time.milliseconds(5000), Time.milliseconds(0), WindowStagger.NATURAL);
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(150L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(150, 5150)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(150, 5150));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5049L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(150, 5150)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(150, 5150));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5150L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(5150, 10150)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(5150, 10150));
     }
 
     @Test
-    public void testWindowAssignmentWithGlobalOffset() {
+    void testWindowAssignmentWithGlobalOffset() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -101,23 +88,20 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
                 TumblingProcessingTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(100L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(100, 5100)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(100, 5100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5099L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(100, 5100)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(100, 5100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5100L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(5100, 10100)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(5100, 10100));
     }
 
     @Test
-    public void testWindowAssignmentWithNegativeGlobalOffset() {
+    void testWindowAssignmentWithNegativeGlobalOffset() {
         WindowAssigner.WindowAssignerContext mockContext =
                 mock(WindowAssigner.WindowAssignerContext.class);
 
@@ -125,23 +109,20 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
                 TumblingProcessingTimeWindows.of(Time.milliseconds(5000), Time.milliseconds(-100));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(100L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(-100, 4900)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(-100, 4900));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4899L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(-100, 4900)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(-100, 4900));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(4900L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(4900, 9900)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(4900, 9900));
     }
 
     @Test
-    public void testTimeUnits() {
+    void testTimeUnits() {
         // sanity check with one other time unit
 
         WindowAssigner.WindowAssignerContext mockContext =
@@ -151,53 +132,44 @@ public class TumblingProcessingTimeWindowsTest extends TestLogger {
                 TumblingProcessingTimeWindows.of(Time.seconds(5), Time.seconds(1));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(1000L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(1000, 6000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(1000, 6000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(5999L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(1000, 6000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(1000, 6000));
 
         when(mockContext.getCurrentProcessingTime()).thenReturn(6000L);
-        assertThat(
-                assigner.assignWindows("String", Long.MIN_VALUE, mockContext),
-                contains(timeWindow(6000, 11000)));
+        assertThat(assigner.assignWindows("String", Long.MIN_VALUE, mockContext))
+                .contains(new TimeWindow(6000, 11000));
     }
 
     @Test
-    public void testInvalidParameters() {
-        try {
-            TumblingProcessingTimeWindows.of(Time.seconds(-1));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < size"));
-        }
+    void testInvalidParameters() {
 
-        try {
-            TumblingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(20));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < size"));
-        }
+        assertThatThrownBy(() -> TumblingProcessingTimeWindows.of(Time.seconds(-1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("TumblingProcessingTimeWindows");
 
-        try {
-            TumblingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(-11));
-            fail("should fail");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.toString(), containsString("abs(offset) < size"));
-        }
+        assertThatThrownBy(
+                        () -> TumblingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(20)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < size");
+
+        assertThatThrownBy(
+                        () -> TumblingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(-11)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("abs(offset) < size");
     }
 
     @Test
-    public void testProperties() {
+    void testProperties() {
         TumblingProcessingTimeWindows assigner =
                 TumblingProcessingTimeWindows.of(Time.seconds(5), Time.milliseconds(100));
 
-        assertFalse(assigner.isEventTime());
-        assertEquals(
-                new TimeWindow.Serializer(), assigner.getWindowSerializer(new ExecutionConfig()));
-        assertThat(assigner.getDefaultTrigger(), instanceOf(ProcessingTimeTrigger.class));
+        assertThat(assigner.isEventTime()).isFalse();
+        assertThat(assigner.getWindowSerializer(new ExecutionConfig()))
+                .isEqualTo(new TimeWindow.Serializer());
+        assertThat(assigner.getDefaultTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
@@ -55,19 +55,19 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.test.util.MigrationTest;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.Collector;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for checking whether {@link WindowOperator} can restore from snapshots that were done using
@@ -76,11 +76,11 @@ import static org.junit.Assert.fail;
  * <p>This also checks whether {@link WindowOperator} can restore from a checkpoint of the aligned
  * processing-time windows operator of previous Flink versions.
  */
-@RunWith(Parameterized.class)
-public class WindowOperatorMigrationTest implements MigrationTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class WindowOperatorMigrationTest implements MigrationTest {
 
-    @Parameterized.Parameters(name = "Migration Savepoint: {0}")
-    public static Collection<FlinkVersion> parameters() {
+    @Parameters(name = "Migration Savepoint: {0}")
+    private static Collection<FlinkVersion> parameters() {
         return FlinkVersion.rangeOf(
                 FlinkVersion.v1_8, MigrationTest.getMostRecentlyPublishedVersion());
     }
@@ -152,8 +152,8 @@ public class WindowOperatorMigrationTest implements MigrationTest {
         testHarness.close();
     }
 
-    @Test
-    public void testRestoreSessionWindowsWithCountTrigger() throws Exception {
+    @TestTemplate
+    void testRestoreSessionWindowsWithCountTrigger() throws Exception {
 
         final int sessionSize = 3;
 
@@ -278,8 +278,8 @@ public class WindowOperatorMigrationTest implements MigrationTest {
      * This checks that we can restore from a virgin {@code WindowOperator} that has never seen any
      * elements.
      */
-    @Test
-    public void testRestoreSessionWindowsWithCountTriggerInMintCondition() throws Exception {
+    @TestTemplate
+    void testRestoreSessionWindowsWithCountTriggerInMintCondition() throws Exception {
 
         final int sessionSize = 3;
 
@@ -443,8 +443,8 @@ public class WindowOperatorMigrationTest implements MigrationTest {
         testHarness.close();
     }
 
-    @Test
-    public void testRestoreReducingEventTimeWindows() throws Exception {
+    @TestTemplate
+    void testRestoreReducingEventTimeWindows() throws Exception {
         final int windowSize = 3;
 
         ReducingStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -593,8 +593,8 @@ public class WindowOperatorMigrationTest implements MigrationTest {
         testHarness.close();
     }
 
-    @Test
-    public void testRestoreApplyEventTimeWindows() throws Exception {
+    @TestTemplate
+    void testRestoreApplyEventTimeWindows() throws Exception {
         final int windowSize = 3;
 
         ListStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -733,8 +733,8 @@ public class WindowOperatorMigrationTest implements MigrationTest {
         testHarness.close();
     }
 
-    @Test
-    public void testRestoreReducingProcessingTimeWindows() throws Exception {
+    @TestTemplate
+    void testRestoreReducingProcessingTimeWindows() throws Exception {
         final int windowSize = 3;
 
         ReducingStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -869,8 +869,8 @@ public class WindowOperatorMigrationTest implements MigrationTest {
         testHarness.close();
     }
 
-    @Test
-    public void testRestoreApplyProcessingTimeWindows() throws Exception {
+    @TestTemplate
+    void testRestoreApplyProcessingTimeWindows() throws Exception {
         final int windowSize = 3;
 
         ListStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -950,7 +950,7 @@ public class WindowOperatorMigrationTest implements MigrationTest {
 
         TypeSerializer<NonPojoType> keySerializer =
                 TypeInformation.of(NonPojoType.class).createSerializer(new SerializerConfigImpl());
-        assertTrue(keySerializer instanceof KryoSerializer);
+        assertThat(keySerializer).isInstanceOf(KryoSerializer.class);
 
         WindowOperator<
                         NonPojoType,
@@ -1030,8 +1030,8 @@ public class WindowOperatorMigrationTest implements MigrationTest {
         testHarness.close();
     }
 
-    @Test
-    public void testRestoreKryoSerializedKeysWindows() throws Exception {
+    @TestTemplate
+    void testRestoreKryoSerializedKeysWindows() throws Exception {
         final int windowSize = 3;
 
         TypeInformation<Tuple2<NonPojoType, Integer>> inputType =
@@ -1045,7 +1045,7 @@ public class WindowOperatorMigrationTest implements MigrationTest {
 
         TypeSerializer<NonPojoType> keySerializer =
                 TypeInformation.of(NonPojoType.class).createSerializer(new SerializerConfigImpl());
-        assertTrue(keySerializer instanceof KryoSerializer);
+        assertThat(keySerializer).isInstanceOf(KryoSerializer.class);
 
         WindowOperator<
                         NonPojoType,
@@ -1205,9 +1205,8 @@ public class WindowOperatorMigrationTest implements MigrationTest {
                 Collector<Tuple2<String, Integer>> out)
                 throws Exception {
 
-            if (!openCalled) {
-                fail("Open was not called");
-            }
+            assertThat(openCalled).as("Open was not called").isTrue();
+
             int sum = 0;
 
             for (Tuple2<String, Integer> t : input) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -69,13 +69,11 @@ import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava31.com.google.common.base.Joiner;
 import org.apache.flink.shaded.guava31.com.google.common.collect.Iterables;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -85,16 +83,14 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link WindowOperator}. */
 @SuppressWarnings("serial")
-public class WindowOperatorTest extends TestLogger {
+class WindowOperatorTest {
 
     private static final TypeInformation<Tuple2<String, Integer>> STRING_INT_TUPLE =
             TypeInformation.of(new TypeHint<Tuple2<String, Integer>>() {});
@@ -213,7 +209,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testSlidingEventTimeWindowsReduce() throws Exception {
+    void testSlidingEventTimeWindowsReduce() throws Exception {
         closeCalled.set(0);
 
         final int windowSize = 3;
@@ -252,7 +248,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testSlidingEventTimeWindowsApply() throws Exception {
+    void testSlidingEventTimeWindowsApply() throws Exception {
         closeCalled.set(0);
 
         final int windowSize = 3;
@@ -288,7 +284,7 @@ public class WindowOperatorTest extends TestLogger {
         testSlidingEventTimeWindows(operator);
 
         // we close once in the rest...
-        Assert.assertEquals("Close was not called.", 2, closeCalled.get());
+        assertThat(closeCalled).as("Close was not called.").hasValue(2);
     }
 
     private void testTumblingEventTimeWindows(
@@ -396,7 +392,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testTumblingEventTimeWindowsReduce() throws Exception {
+    void testTumblingEventTimeWindowsReduce() throws Exception {
         closeCalled.set(0);
 
         final int windowSize = 3;
@@ -433,7 +429,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testTumblingEventTimeWindowsApply() throws Exception {
+    void testTumblingEventTimeWindowsApply() throws Exception {
         closeCalled.set(0);
 
         final int windowSize = 3;
@@ -466,12 +462,12 @@ public class WindowOperatorTest extends TestLogger {
         testTumblingEventTimeWindows(operator);
 
         // we close once in the rest...
-        Assert.assertEquals("Close was not called.", 2, closeCalled.get());
+        assertThat(closeCalled).as("Close was not called.").hasValue(2);
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testSessionWindows() throws Exception {
+    void testSessionWindows() throws Exception {
         closeCalled.set(0);
 
         final int sessionSize = 3;
@@ -564,7 +560,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testSessionWindowsWithProcessFunction() throws Exception {
+    void testSessionWindowsWithProcessFunction() throws Exception {
         closeCalled.set(0);
 
         final int sessionSize = 3;
@@ -658,7 +654,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testReduceSessionWindows() throws Exception {
+    void testReduceSessionWindows() throws Exception {
         closeCalled.set(0);
 
         final int sessionSize = 3;
@@ -745,7 +741,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testReduceSessionWindowsWithProcessFunction() throws Exception {
+    void testReduceSessionWindowsWithProcessFunction() throws Exception {
         closeCalled.set(0);
 
         final int sessionSize = 3;
@@ -832,7 +828,7 @@ public class WindowOperatorTest extends TestLogger {
 
     /** This tests whether merging works correctly with the CountTrigger. */
     @Test
-    public void testSessionWindowsWithCountTrigger() throws Exception {
+    void testSessionWindowsWithCountTrigger() throws Exception {
         closeCalled.set(0);
 
         final int sessionSize = 3;
@@ -923,7 +919,7 @@ public class WindowOperatorTest extends TestLogger {
 
     /** This tests whether merging works correctly with the ContinuousEventTimeTrigger. */
     @Test
-    public void testSessionWindowsWithContinuousEventTimeTrigger() throws Exception {
+    void testSessionWindowsWithContinuousEventTimeTrigger() throws Exception {
         closeCalled.set(0);
 
         final int sessionSize = 3;
@@ -1019,7 +1015,7 @@ public class WindowOperatorTest extends TestLogger {
      */
     @Test
     @SuppressWarnings("unchecked")
-    public void testPointSessions() throws Exception {
+    void testPointSessions() throws Exception {
         closeCalled.set(0);
 
         ListStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -1097,7 +1093,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testContinuousWatermarkTrigger() throws Exception {
+    void testContinuousWatermarkTrigger() throws Exception {
         closeCalled.set(0);
 
         final int windowSize = 3;
@@ -1222,7 +1218,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testCountTrigger() throws Exception {
+    void testCountTrigger() throws Exception {
         closeCalled.set(0);
 
         final int windowSize = 4;
@@ -1336,7 +1332,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testEndOfStreamTrigger() throws Exception {
+    void testEndOfStreamTrigger() throws Exception {
         ReducingStateDescriptor<Tuple2<String, Integer>> stateDesc =
                 new ReducingStateDescriptor<>(
                         "window-contents",
@@ -1402,7 +1398,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testProcessingTimeTumblingWindows() throws Throwable {
+    void testProcessingTimeTumblingWindows() throws Throwable {
         final int windowSize = 3;
 
         ReducingStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -1479,7 +1475,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testProcessingTimeSlidingWindows() throws Throwable {
+    void testProcessingTimeSlidingWindows() throws Throwable {
         final int windowSize = 3;
         final int windowSlide = 1;
 
@@ -1580,7 +1576,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testProcessingTimeSessionWindows() throws Throwable {
+    void testProcessingTimeSessionWindows() throws Throwable {
         final int windowGap = 3;
 
         ReducingStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -1654,12 +1650,12 @@ public class WindowOperatorTest extends TestLogger {
                 testHarness.getOutput(),
                 new Tuple2ResultSortComparator());
 
-        assertEquals(expectedOutput.size(), testHarness.getOutput().size());
+        assertThat(testHarness.getOutput()).hasSameSizeAs(expectedOutput);
         for (Object elem : testHarness.getOutput()) {
             if (elem instanceof StreamRecord) {
                 StreamRecord<Tuple2<String, Integer>> el =
                         (StreamRecord<Tuple2<String, Integer>>) elem;
-                assertTrue(expectedOutput.contains(el));
+                assertThat(expectedOutput).contains(el);
             }
         }
         testHarness.close();
@@ -1667,7 +1663,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testDynamicEventTimeSessionWindows() throws Exception {
+    void testDynamicEventTimeSessionWindows() throws Exception {
         closeCalled.set(0);
 
         SessionWindowTimeGapExtractor<Tuple2<String, Integer>> extractor =
@@ -1767,7 +1763,7 @@ public class WindowOperatorTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testDynamicProcessingTimeSessionWindows() throws Exception {
+    void testDynamicProcessingTimeSessionWindows() throws Exception {
         closeCalled.set(0);
 
         SessionWindowTimeGapExtractor<Tuple2<String, Integer>> extractor =
@@ -1869,7 +1865,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testLateness() throws Exception {
+    void testLateness() throws Exception {
         final int windowSize = 2;
         final long lateness = 500;
 
@@ -1952,7 +1948,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testCleanupTimeOverflow() throws Exception {
+    void testCleanupTimeOverflow() throws Exception {
         final int windowSize = 1000;
         final long lateness = 2000;
 
@@ -2009,10 +2005,10 @@ public class WindowOperatorTest extends TestLogger {
         testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), timestamp));
 
         // the garbage collection timer would wrap-around
-        Assert.assertTrue(window.maxTimestamp() + lateness < window.maxTimestamp());
+        assertThat(window.maxTimestamp() + lateness).isLessThan(window.maxTimestamp());
 
         // and it would prematurely fire with watermark (Long.MAX_VALUE - 1500)
-        Assert.assertTrue(window.maxTimestamp() + lateness < Long.MAX_VALUE - 1500);
+        assertThat(window.maxTimestamp() + lateness).isLessThan(Long.MAX_VALUE - 1500);
 
         // if we don't correctly prevent wrap-around in the garbage collection
         // timers this watermark will clean our window state for the just-added
@@ -2020,8 +2016,7 @@ public class WindowOperatorTest extends TestLogger {
         testHarness.processWatermark(new Watermark(Long.MAX_VALUE - 1500));
 
         // this watermark is before the end timestamp of our only window
-        Assert.assertTrue(Long.MAX_VALUE - 1500 < window.maxTimestamp());
-        Assert.assertTrue(window.maxTimestamp() < Long.MAX_VALUE);
+        assertThat(window.maxTimestamp()).isBetween(Long.MAX_VALUE - 1500, Long.MAX_VALUE);
 
         // push in a watermark that will trigger computation of our window
         testHarness.processWatermark(new Watermark(window.maxTimestamp()));
@@ -2039,7 +2034,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testSideOutputDueToLatenessTumbling() throws Exception {
+    void testSideOutputDueToLatenessTumbling() throws Exception {
         final int windowSize = 2;
         final long lateness = 0;
 
@@ -2120,7 +2115,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testSideOutputDueToLatenessSliding() throws Exception {
+    void testSideOutputDueToLatenessSliding() throws Exception {
         final int windowSize = 3;
         final int windowSlide = 1;
         final long lateness = 0;
@@ -2219,7 +2214,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testSideOutputDueToLatenessSessionZeroLatenessPurgingTrigger() throws Exception {
+    void testSideOutputDueToLatenessSessionZeroLatenessPurgingTrigger() throws Exception {
         final int gapSize = 3;
         final long lateness = 0;
 
@@ -2325,7 +2320,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testSideOutputDueToLatenessSessionZeroLateness() throws Exception {
+    void testSideOutputDueToLatenessSessionZeroLateness() throws Exception {
         final int gapSize = 3;
         final long lateness = 0;
 
@@ -2424,7 +2419,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testDropDueToLatenessSessionWithLatenessPurgingTrigger() throws Exception {
+    void testDropDueToLatenessSessionWithLatenessPurgingTrigger() throws Exception {
 
         // this has the same output as testSideOutputDueToLatenessSessionZeroLateness() because
         // the allowed lateness is too small to make a difference
@@ -2520,7 +2515,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testNotSideOutputDueToLatenessSessionWithLateness() throws Exception {
+    void testNotSideOutputDueToLatenessSessionWithLateness() throws Exception {
         // same as testSideOutputDueToLatenessSessionWithLateness() but with an accumulating
         // trigger, i.e.
         // one that does not return FIRE_AND_PURGE when firing but just FIRE. The expected
@@ -2614,7 +2609,7 @@ public class WindowOperatorTest extends TestLogger {
 
         TestHarnessUtil.assertOutputEqualsSorted(
                 "Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
-        assertEquals(null, sideActual);
+        assertThat(sideActual).isNull();
 
         testHarness.processWatermark(new Watermark(20000));
 
@@ -2629,14 +2624,13 @@ public class WindowOperatorTest extends TestLogger {
         sideActual = testHarness.getSideOutput(lateOutputTag);
         TestHarnessUtil.assertOutputEqualsSorted(
                 "Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
-        assertEquals(null, sideActual);
+        assertThat(sideActual).isNull();
 
         testHarness.close();
     }
 
     @Test
-    public void testNotSideOutputDueToLatenessSessionWithHugeLatenessPurgingTrigger()
-            throws Exception {
+    void testNotSideOutputDueToLatenessSessionWithHugeLatenessPurgingTrigger() throws Exception {
 
         final int gapSize = 3;
         final long lateness = 10000;
@@ -2717,7 +2711,7 @@ public class WindowOperatorTest extends TestLogger {
                 testHarness.getSideOutput(lateOutputTag);
         TestHarnessUtil.assertOutputEqualsSorted(
                 "Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
-        assertEquals(null, sideActual);
+        assertThat(sideActual).isNull();
 
         testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 14500));
         testHarness.processWatermark(new Watermark(20000));
@@ -2733,13 +2727,13 @@ public class WindowOperatorTest extends TestLogger {
         sideActual = testHarness.getSideOutput(lateOutputTag);
         TestHarnessUtil.assertOutputEqualsSorted(
                 "Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
-        assertEquals(null, sideActual);
+        assertThat(sideActual).isNull();
 
         testHarness.close();
     }
 
     @Test
-    public void testNotSideOutputDueToLatenessSessionWithHugeLateness() throws Exception {
+    void testNotSideOutputDueToLatenessSessionWithHugeLateness() throws Exception {
         final int gapSize = 3;
         final long lateness = 10000;
 
@@ -2821,7 +2815,7 @@ public class WindowOperatorTest extends TestLogger {
                 testHarness.getSideOutput(lateOutputTag);
         TestHarnessUtil.assertOutputEqualsSorted(
                 "Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
-        assertEquals(null, sideActual);
+        assertThat(sideActual).isNull();
 
         testHarness.processElement(new StreamRecord<>(new Tuple2<>("key2", 1), 14500));
         testHarness.processWatermark(new Watermark(20000));
@@ -2837,13 +2831,13 @@ public class WindowOperatorTest extends TestLogger {
 
         TestHarnessUtil.assertOutputEqualsSorted(
                 "Output was not correct.", expected, actual, new Tuple3ResultSortComparator());
-        assertEquals(null, sideActual);
+        assertThat(sideActual).isNull();
 
         testHarness.close();
     }
 
     @Test
-    public void testCleanupTimerWithEmptyListStateForTumblingWindows2() throws Exception {
+    void testCleanupTimerWithEmptyListStateForTumblingWindows2() throws Exception {
         final int windowSize = 2;
         final long lateness = 100;
 
@@ -2915,7 +2909,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testCleanupTimerWithEmptyListStateForTumblingWindows() throws Exception {
+    void testCleanupTimerWithEmptyListStateForTumblingWindows() throws Exception {
         final int windowSize = 2;
         final long lateness = 1;
 
@@ -2972,7 +2966,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testCleanupTimerWithEmptyReduceStateForTumblingWindows() throws Exception {
+    void testCleanupTimerWithEmptyReduceStateForTumblingWindows() throws Exception {
         final int windowSize = 2;
         final long lateness = 1;
 
@@ -3032,7 +3026,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testCleanupTimerWithEmptyListStateForSessionWindows() throws Exception {
+    void testCleanupTimerWithEmptyListStateForSessionWindows() throws Exception {
         final int gapSize = 3;
         final long lateness = 10;
 
@@ -3083,7 +3077,7 @@ public class WindowOperatorTest extends TestLogger {
     }
 
     @Test
-    public void testCleanupTimerWithEmptyReduceStateForSessionWindows() throws Exception {
+    void testCleanupTimerWithEmptyReduceStateForSessionWindows() throws Exception {
 
         final int gapSize = 3;
         final long lateness = 10;
@@ -3195,9 +3189,8 @@ public class WindowOperatorTest extends TestLogger {
                 Collector<Tuple2<String, Integer>> out)
                 throws Exception {
 
-            if (!openCalled) {
-                fail("Open was not called");
-            }
+            assertThat(openCalled).as("Open was not called").isTrue();
+
             int sum = 0;
 
             for (Tuple2<String, Integer> t : input) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -2016,7 +2016,7 @@ class WindowOperatorTest {
         testHarness.processWatermark(new Watermark(Long.MAX_VALUE - 1500));
 
         // this watermark is before the end timestamp of our only window
-        assertThat(window.maxTimestamp()).isBetween(Long.MAX_VALUE - 1500, Long.MAX_VALUE);
+        assertThat(window.maxTimestamp()).isStrictlyBetween(Long.MAX_VALUE - 1500, Long.MAX_VALUE);
 
         // push in a watermark that will trigger computation of our window
         testHarness.processWatermark(new Watermark(window.maxTimestamp()));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowStaggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowStaggerTest.java
@@ -20,27 +20,23 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 
 import org.apache.flink.streaming.api.windowing.assigners.WindowStagger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThan;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link WindowStagger}. */
-public class WindowStaggerTest {
+class WindowStaggerTest {
 
     @Test
-    public void testWindowStagger() {
+    void testWindowStagger() {
         long sizeInMilliseconds = 5000;
 
-        assertEquals(0L, WindowStagger.ALIGNED.getStaggerOffset(500L, sizeInMilliseconds));
-        assertEquals(500L, WindowStagger.NATURAL.getStaggerOffset(5500L, sizeInMilliseconds));
-        assertThat(
-                WindowStagger.RANDOM.getStaggerOffset(0L, sizeInMilliseconds),
-                greaterThanOrEqualTo(0L));
-        assertThat(
-                WindowStagger.RANDOM.getStaggerOffset(0L, sizeInMilliseconds),
-                lessThan(sizeInMilliseconds));
+        assertThat(WindowStagger.ALIGNED.getStaggerOffset(500L, sizeInMilliseconds)).isZero();
+        assertThat(WindowStagger.NATURAL.getStaggerOffset(5500L, sizeInMilliseconds))
+                .isEqualTo(500L);
+        assertThat(WindowStagger.RANDOM.getStaggerOffset(0L, sizeInMilliseconds))
+                .isGreaterThanOrEqualTo(0L);
+        assertThat(WindowStagger.RANDOM.getStaggerOffset(0L, sizeInMilliseconds))
+                .isLessThan(sizeInMilliseconds);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowTranslationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowTranslationTest.java
@@ -58,13 +58,12 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.util.Collector;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * These tests verify that the api calls on {@link WindowedStream} instantiate the correct window
@@ -74,7 +73,7 @@ import static org.junit.Assert.fail;
  * some output.
  */
 @SuppressWarnings("serial")
-public class WindowTranslationTest {
+class WindowTranslationTest {
 
     // ------------------------------------------------------------------------
     //  Rich Pre-Aggregation Functions
@@ -84,49 +83,53 @@ public class WindowTranslationTest {
      * .reduce() does not support RichReduceFunction, since the reduce function is used internally
      * in a {@code ReducingState}.
      */
-    @Test(expected = UnsupportedOperationException.class)
-    public void testReduceWithRichReducerFails() throws Exception {
+    @Test
+    void testReduceWithRichReducerFails() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
                 env.fromData(Tuple2.of("hello", 1), Tuple2.of("hello", 2));
 
-        source.keyBy(0)
-                .window(
-                        SlidingEventTimeWindows.of(
-                                Time.of(1, TimeUnit.SECONDS), Time.of(100, TimeUnit.MILLISECONDS)))
-                .reduce(
-                        new RichReduceFunction<Tuple2<String, Integer>>() {
+        assertThatThrownBy(
+                        () ->
+                                source.keyBy(0)
+                                        .window(
+                                                SlidingEventTimeWindows.of(
+                                                        Time.of(1, TimeUnit.SECONDS),
+                                                        Time.of(100, TimeUnit.MILLISECONDS)))
+                                        .reduce(
+                                                new RichReduceFunction<Tuple2<String, Integer>>() {
 
-                            @Override
-                            public Tuple2<String, Integer> reduce(
-                                    Tuple2<String, Integer> value1, Tuple2<String, Integer> value2)
-                                    throws Exception {
-                                return null;
-                            }
-                        });
-
-        fail("exception was not thrown");
+                                                    @Override
+                                                    public Tuple2<String, Integer> reduce(
+                                                            Tuple2<String, Integer> value1,
+                                                            Tuple2<String, Integer> value2) {
+                                                        return null;
+                                                    }
+                                                }))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     /**
      * .aggregate() does not support RichAggregateFunction, since the AggregationFunction is used
      * internally in a {@code AggregatingState}.
      */
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAggregateWithRichFunctionFails() throws Exception {
+    @Test
+    void testAggregateWithRichFunctionFails() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
                 env.fromData(Tuple2.of("hello", 1), Tuple2.of("hello", 2));
 
-        source.keyBy(0)
-                .window(
-                        SlidingEventTimeWindows.of(
-                                Time.of(1, TimeUnit.SECONDS), Time.of(100, TimeUnit.MILLISECONDS)))
-                .aggregate(new DummyRichAggregationFunction<Tuple2<String, Integer>>());
-
-        fail("exception was not thrown");
+        assertThatThrownBy(
+                        () ->
+                                source.keyBy(0)
+                                        .window(
+                                                SlidingEventTimeWindows.of(
+                                                        Time.of(1, TimeUnit.SECONDS),
+                                                        Time.of(100, TimeUnit.MILLISECONDS)))
+                                        .aggregate(new DummyRichAggregationFunction<>()))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     // ------------------------------------------------------------------------
@@ -134,7 +137,7 @@ public class WindowTranslationTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testMergingAssignerWithNonMergingTriggerFails() throws Exception {
+    void testMergingAssignerWithNonMergingTriggerFails() {
         // verify that we check for trigger compatibility
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -153,53 +156,56 @@ public class WindowTranslationTest {
                                 })
                         .window(EventTimeSessionWindows.withGap(Time.seconds(5)));
 
-        try {
-            windowedStream.trigger(
-                    new Trigger<String, TimeWindow>() {
-                        private static final long serialVersionUID = 6558046711583024443L;
+        assertThatThrownBy(
+                        () ->
+                                windowedStream.trigger(
+                                        new Trigger<String, TimeWindow>() {
+                                            private static final long serialVersionUID =
+                                                    6558046711583024443L;
 
-                        @Override
-                        public TriggerResult onElement(
-                                String element,
-                                long timestamp,
-                                TimeWindow window,
-                                TriggerContext ctx)
-                                throws Exception {
-                            return null;
-                        }
+                                            @Override
+                                            public TriggerResult onElement(
+                                                    String element,
+                                                    long timestamp,
+                                                    TimeWindow window,
+                                                    TriggerContext ctx)
+                                                    throws Exception {
+                                                return null;
+                                            }
 
-                        @Override
-                        public TriggerResult onProcessingTime(
-                                long time, TimeWindow window, TriggerContext ctx) throws Exception {
-                            return null;
-                        }
+                                            @Override
+                                            public TriggerResult onProcessingTime(
+                                                    long time,
+                                                    TimeWindow window,
+                                                    TriggerContext ctx)
+                                                    throws Exception {
+                                                return null;
+                                            }
 
-                        @Override
-                        public TriggerResult onEventTime(
-                                long time, TimeWindow window, TriggerContext ctx) throws Exception {
-                            return null;
-                        }
+                                            @Override
+                                            public TriggerResult onEventTime(
+                                                    long time,
+                                                    TimeWindow window,
+                                                    TriggerContext ctx)
+                                                    throws Exception {
+                                                return null;
+                                            }
 
-                        @Override
-                        public boolean canMerge() {
-                            return false;
-                        }
+                                            @Override
+                                            public boolean canMerge() {
+                                                return false;
+                                            }
 
-                        @Override
-                        public void clear(TimeWindow window, TriggerContext ctx) throws Exception {}
-                    });
-        } catch (UnsupportedOperationException e) {
-            // expected
-            // use a catch to ensure that the exception is thrown by the fold
-            return;
-        }
-
-        fail("The trigger call should fail.");
+                                            @Override
+                                            public void clear(TimeWindow window, TriggerContext ctx)
+                                                    throws Exception {}
+                                        }))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testMergingWindowsWithEvictor() throws Exception {
+    void testMergingWindowsWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Integer> source = env.fromData(1, 2);
@@ -219,12 +225,12 @@ public class WindowTranslationTest {
         final OneInputTransformation<Integer, String> transform =
                 (OneInputTransformation<Integer, String>) window1.getTransformation();
         final OneInputStreamOperator<Integer, String> operator = transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Integer, ?, ?, ?> winOperator =
                 (WindowOperator<String, Integer, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof EventTimeSessionWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(EventTimeSessionWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator, winOperator.getKeySelector(), BasicTypeInfo.STRING_TYPE_INFO, 1);
@@ -236,7 +242,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceEventTime() throws Exception {
+    void testReduceEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -255,12 +261,12 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -271,7 +277,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceProcessingTime() throws Exception {
+    void testReduceProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -290,12 +296,13 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(SlidingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -306,7 +313,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithWindowFunctionEventTime() throws Exception {
+    void testReduceWithWindowFunctionEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -344,12 +351,12 @@ public class WindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -360,7 +367,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithWindowFunctionProcessingTime() throws Exception {
+    void testReduceWithWindowFunctionProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -396,12 +403,13 @@ public class WindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -412,7 +420,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithProcesWindowFunctionEventTime() throws Exception {
+    void testReduceWithProcesWindowFunctionEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -450,12 +458,12 @@ public class WindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -466,7 +474,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithProcessWindowFunctionProcessingTime() throws Exception {
+    void testReduceWithProcessWindowFunctionProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -502,12 +510,13 @@ public class WindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -519,7 +528,7 @@ public class WindowTranslationTest {
     /** Test for the deprecated .apply(Reducer, WindowFunction). */
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyWithPreReducerEventTime() throws Exception {
+    void testApplyWithPreReducerEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -557,12 +566,12 @@ public class WindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -574,7 +583,7 @@ public class WindowTranslationTest {
     /** Test for the deprecated .apply(Reducer, WindowFunction). */
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyWithPreReducerAndEvictor() throws Exception {
+    void testApplyWithPreReducerAndEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -613,12 +622,12 @@ public class WindowTranslationTest {
                         window.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple3<String, String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -632,7 +641,7 @@ public class WindowTranslationTest {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testAggregateEventTime() throws Exception {
+    void testAggregateEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple3<String, String, Integer>> source =
@@ -653,13 +662,13 @@ public class WindowTranslationTest {
         final OneInputStreamOperator<Tuple3<String, String, Integer>, Integer> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -669,7 +678,7 @@ public class WindowTranslationTest {
     }
 
     @Test
-    public void testAggregateProcessingTime() throws Exception {
+    void testAggregateProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple3<String, String, Integer>> source =
@@ -690,13 +699,14 @@ public class WindowTranslationTest {
         final OneInputStreamOperator<Tuple3<String, String, Integer>, Integer> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(SlidingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -706,7 +716,7 @@ public class WindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithWindowFunctionEventTime() throws Exception {
+    void testAggregateWithWindowFunctionEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple3<String, String, Integer>> source =
@@ -726,13 +736,13 @@ public class WindowTranslationTest {
         final OneInputStreamOperator<Tuple3<String, String, Integer>, String> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -742,7 +752,7 @@ public class WindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithWindowFunctionProcessingTime() throws Exception {
+    void testAggregateWithWindowFunctionProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple3<String, String, Integer>> source =
@@ -760,13 +770,14 @@ public class WindowTranslationTest {
         final OneInputStreamOperator<Tuple3<String, String, Integer>, String> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -776,7 +787,7 @@ public class WindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithProcessWindowFunctionEventTime() throws Exception {
+    void testAggregateWithProcessWindowFunctionEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple3<String, String, Integer>> source =
@@ -794,13 +805,13 @@ public class WindowTranslationTest {
         final OneInputStreamOperator<Tuple3<String, String, Integer>, String> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -810,7 +821,7 @@ public class WindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithProcessWindowFunctionProcessingTime() throws Exception {
+    void testAggregateWithProcessWindowFunctionProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple3<String, String, Integer>> source =
@@ -828,13 +839,14 @@ public class WindowTranslationTest {
         final OneInputStreamOperator<Tuple3<String, String, Integer>, String> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof AggregatingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(AggregatingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 operator,
@@ -849,7 +861,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyEventTime() throws Exception {
+    void testApplyEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -884,12 +896,12 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -900,7 +912,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyProcessingTime() throws Exception {
+    void testApplyProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -935,12 +947,13 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -951,7 +964,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testProcessEventTime() throws Exception {
+    void testProcessEventTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -986,12 +999,12 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1002,7 +1015,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testProcessProcessingTime() throws Exception {
+    void testProcessProcessingTime() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1037,12 +1050,13 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof ProcessingTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingProcessingTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(ProcessingTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner())
+                .isInstanceOf(TumblingProcessingTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1053,7 +1067,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithCustomTrigger() throws Exception {
+    void testReduceWithCustomTrigger() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1075,12 +1089,12 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ReducingStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ReducingStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1091,7 +1105,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyWithCustomTrigger() throws Exception {
+    void testApplyWithCustomTrigger() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1127,12 +1141,12 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1143,7 +1157,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testProcessWithCustomTrigger() throws Exception {
+    void testProcessWithCustomTrigger() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1179,12 +1193,12 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple2<String, Integer>, ?, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1195,7 +1209,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithEvictor() throws Exception {
+    void testReduceWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1217,13 +1231,13 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof EvictingWindowOperator);
+        assertThat(operator).isInstanceOf(EvictingWindowOperator.class);
         EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?> winOperator =
                 (EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getEvictor() instanceof CountEvictor);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getEvictor()).isInstanceOf(CountEvictor.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1234,7 +1248,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testReduceWithEvictorAndProcessFunction() throws Exception {
+    void testReduceWithEvictorAndProcessFunction() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1274,13 +1288,13 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof EvictingWindowOperator);
+        assertThat(operator).isInstanceOf(EvictingWindowOperator.class);
         EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?> winOperator =
                 (EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getEvictor() instanceof CountEvictor);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getEvictor()).isInstanceOf(CountEvictor.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1290,7 +1304,7 @@ public class WindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithEvictor() throws Exception {
+    void testAggregateWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple3<String, String, Integer>> source =
@@ -1312,13 +1326,13 @@ public class WindowTranslationTest {
         final OneInputStreamOperator<Tuple3<String, String, Integer>, Integer> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1328,7 +1342,7 @@ public class WindowTranslationTest {
     }
 
     @Test
-    public void testAggregateWithEvictorAndProcessFunction() throws Exception {
+    void testAggregateWithEvictorAndProcessFunction() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple3<String, String, Integer>> source =
@@ -1350,13 +1364,13 @@ public class WindowTranslationTest {
         final OneInputStreamOperator<Tuple3<String, String, Integer>, String> operator =
                 transform.getOperator();
 
-        Assert.assertTrue(operator instanceof WindowOperator);
+        assertThat(operator).isInstanceOf(WindowOperator.class);
         WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?> winOperator =
                 (WindowOperator<String, Tuple3<String, String, Integer>, ?, ?, ?>) operator;
 
-        Assert.assertTrue(winOperator.getTrigger() instanceof EventTimeTrigger);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof SlidingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(EventTimeTrigger.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(SlidingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1367,7 +1381,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testApplyWithEvictor() throws Exception {
+    void testApplyWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1404,13 +1418,13 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof EvictingWindowOperator);
+        assertThat(operator).isInstanceOf(EvictingWindowOperator.class);
         EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?> winOperator =
                 (EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getEvictor() instanceof TimeEvictor);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getEvictor()).isInstanceOf(TimeEvictor.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1421,7 +1435,7 @@ public class WindowTranslationTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void testProcessWithEvictor() throws Exception {
+    void testProcessWithEvictor() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Tuple2<String, Integer>> source =
@@ -1458,13 +1472,13 @@ public class WindowTranslationTest {
                         window1.getTransformation();
         OneInputStreamOperator<Tuple2<String, Integer>, Tuple2<String, Integer>> operator =
                 transform.getOperator();
-        Assert.assertTrue(operator instanceof EvictingWindowOperator);
+        assertThat(operator).isInstanceOf(EvictingWindowOperator.class);
         EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?> winOperator =
                 (EvictingWindowOperator<String, Tuple2<String, Integer>, ?, ?>) operator;
-        Assert.assertTrue(winOperator.getTrigger() instanceof CountTrigger);
-        Assert.assertTrue(winOperator.getEvictor() instanceof TimeEvictor);
-        Assert.assertTrue(winOperator.getWindowAssigner() instanceof TumblingEventTimeWindows);
-        Assert.assertTrue(winOperator.getStateDescriptor() instanceof ListStateDescriptor);
+        assertThat(winOperator.getTrigger()).isInstanceOf(CountTrigger.class);
+        assertThat(winOperator.getEvictor()).isInstanceOf(TimeEvictor.class);
+        assertThat(winOperator.getWindowAssigner()).isInstanceOf(TumblingEventTimeWindows.class);
+        assertThat(winOperator.getStateDescriptor()).isInstanceOf(ListStateDescriptor.class);
 
         processElementAndEnsureOutput(
                 winOperator,
@@ -1506,7 +1520,7 @@ public class WindowTranslationTest {
         testHarness.processWatermark(Long.MAX_VALUE);
 
         // we at least get the two watermarks and should also see an output element
-        assertTrue(testHarness.getOutput().size() >= 3);
+        assertThat(testHarness.getOutput()).hasSizeGreaterThanOrEqualTo(3);
 
         testHarness.close();
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitionerTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class BroadcastPartitionerTest extends StreamPartitionerTest {
 
     @Override
-    protected StreamPartitioner<Tuple> createPartitioner() {
+    StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new BroadcastPartitioner<>();
         assertThat(partitioner.isBroadcast()).isTrue();
         return partitioner;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/BroadcastPartitionerTest.java
@@ -19,29 +19,25 @@ package org.apache.flink.streaming.runtime.partitioner;
 
 import org.apache.flink.api.java.tuple.Tuple;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link BroadcastPartitioner}. */
-public class BroadcastPartitionerTest extends StreamPartitionerTest {
+class BroadcastPartitionerTest extends StreamPartitionerTest {
 
     @Override
-    public StreamPartitioner<Tuple> createPartitioner() {
+    protected StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new BroadcastPartitioner<>();
-        assertTrue(partitioner.isBroadcast());
+        assertThat(partitioner.isBroadcast()).isTrue();
         return partitioner;
     }
 
     @Test
-    public void testSelectChannels() {
-        try {
-            streamPartitioner.selectChannel(serializationDelegate);
-        } catch (UnsupportedOperationException ex) {
-            return;
-        }
-
-        fail("Broadcast selector does not support select channels.");
+    void testSelectChannels() {
+        assertThatThrownBy(() -> streamPartitioner.selectChannel(serializationDelegate))
+                .as("Broadcast selector does not support select channels.")
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitionerTest.java
@@ -19,22 +19,22 @@ package org.apache.flink.streaming.runtime.partitioner;
 
 import org.apache.flink.api.java.tuple.Tuple;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ForwardPartitioner}. */
-public class ForwardPartitionerTest extends StreamPartitionerTest {
+class ForwardPartitionerTest extends StreamPartitionerTest {
 
     @Override
     public StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new ForwardPartitioner<>();
-        assertFalse(partitioner.isBroadcast());
+        assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;
     }
 
     @Test
-    public void testSelectChannelsInterval() {
+    void testSelectChannelsInterval() {
         assertSelectedChannelWithSetup(0, 1);
         assertSelectedChannelWithSetup(0, 2);
         assertSelectedChannelWithSetup(0, 1024);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardPartitionerTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ForwardPartitionerTest extends StreamPartitionerTest {
 
     @Override
-    public StreamPartitioner<Tuple> createPartitioner() {
+    StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new ForwardPartitioner<>();
         assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/GlobalPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/GlobalPartitionerTest.java
@@ -19,22 +19,22 @@ package org.apache.flink.streaming.runtime.partitioner;
 
 import org.apache.flink.api.java.tuple.Tuple;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GlobalPartitioner}. */
-public class GlobalPartitionerTest extends StreamPartitionerTest {
+class GlobalPartitionerTest extends StreamPartitionerTest {
 
     @Override
-    public StreamPartitioner<Tuple> createPartitioner() {
+    protected StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new GlobalPartitioner<>();
-        assertFalse(partitioner.isBroadcast());
+        assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;
     }
 
     @Test
-    public void testSelectChannels() {
+    void testSelectChannels() {
         assertSelectedChannelWithSetup(0, 1);
         assertSelectedChannelWithSetup(0, 2);
         assertSelectedChannelWithSetup(0, 1024);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/GlobalPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/GlobalPartitionerTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class GlobalPartitionerTest extends StreamPartitionerTest {
 
     @Override
-    protected StreamPartitioner<Tuple> createPartitioner() {
+    StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new GlobalPartitioner<>();
         assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/KeyGroupStreamPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/KeyGroupStreamPartitionerTest.java
@@ -21,15 +21,14 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link KeyGroupStreamPartitioner}. */
-public class KeyGroupStreamPartitionerTest extends TestLogger {
+class KeyGroupStreamPartitionerTest {
 
     private KeyGroupStreamPartitioner<Tuple2<String, Integer>, String> keyGroupPartitioner;
     private StreamRecord<Tuple2<String, Integer>> streamRecord1 =
@@ -41,8 +40,8 @@ public class KeyGroupStreamPartitionerTest extends TestLogger {
     private SerializationDelegate<StreamRecord<Tuple2<String, Integer>>> serializationDelegate2 =
             new SerializationDelegate<>(null);
 
-    @Before
-    public void setPartitioner() {
+    @BeforeEach
+    void setPartitioner() {
         keyGroupPartitioner =
                 new KeyGroupStreamPartitioner<>(
                         new KeySelector<Tuple2<String, Integer>, String>() {
@@ -58,19 +57,16 @@ public class KeyGroupStreamPartitionerTest extends TestLogger {
     }
 
     @Test
-    public void testSelectChannelsGrouping() {
+    void testSelectChannelsGrouping() {
         serializationDelegate1.setInstance(streamRecord1);
         serializationDelegate2.setInstance(streamRecord2);
 
-        assertEquals(
-                selectChannels(serializationDelegate1, 1),
-                selectChannels(serializationDelegate2, 1));
-        assertEquals(
-                selectChannels(serializationDelegate1, 2),
-                selectChannels(serializationDelegate2, 2));
-        assertEquals(
-                selectChannels(serializationDelegate1, 1024),
-                selectChannels(serializationDelegate2, 1024));
+        assertThat(selectChannels(serializationDelegate1, 1))
+                .isEqualTo(selectChannels(serializationDelegate2, 1));
+        assertThat(selectChannels(serializationDelegate1, 2))
+                .isEqualTo(selectChannels(serializationDelegate2, 2));
+        assertThat(selectChannels(serializationDelegate1, 1024))
+                .isEqualTo(selectChannels(serializationDelegate2, 1024));
     }
 
     private int selectChannels(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitionerTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RebalancePartitionerTest extends StreamPartitionerTest {
 
     @Override
-    protected StreamPartitioner<Tuple> createPartitioner() {
+    StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new RebalancePartitioner<>();
         assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RebalancePartitionerTest.java
@@ -19,29 +19,27 @@ package org.apache.flink.streaming.runtime.partitioner;
 
 import org.apache.flink.api.java.tuple.Tuple;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link RebalancePartitioner}. */
-public class RebalancePartitionerTest extends StreamPartitionerTest {
+class RebalancePartitionerTest extends StreamPartitionerTest {
 
     @Override
-    public StreamPartitioner<Tuple> createPartitioner() {
+    protected StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new RebalancePartitioner<>();
-        assertFalse(partitioner.isBroadcast());
+        assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;
     }
 
     @Test
-    public void testSelectChannelsInterval() {
+    void testSelectChannelsInterval() {
         final int numberOfChannels = 3;
         streamPartitioner.setup(numberOfChannels);
 
         int initialChannel = streamPartitioner.selectChannel(serializationDelegate);
-        assertTrue(0 <= initialChannel);
-        assertTrue(numberOfChannels > initialChannel);
+        assertThat(initialChannel).isGreaterThanOrEqualTo(0).isLessThan(numberOfChannels);
 
         for (int i = 1; i <= 3; i++) {
             assertSelectedChannel((initialChannel + i) % numberOfChannels);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
@@ -36,11 +36,11 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.Collector;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -49,26 +49,26 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for {@link RescalePartitioner}. */
 @SuppressWarnings("serial")
-public class RescalePartitionerTest extends StreamPartitionerTest {
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
+class RescalePartitionerTest extends StreamPartitionerTest {
+
+    @RegisterExtension
+    private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     @Override
-    public StreamPartitioner<Tuple> createPartitioner() {
+    protected StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new RescalePartitioner<>();
-        assertFalse(partitioner.isBroadcast());
+        assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;
     }
 
     @Test
-    public void testSelectChannelsInterval() {
+    void testSelectChannelsInterval() {
         streamPartitioner.setup(3);
 
         assertSelectedChannel(0);
@@ -78,7 +78,7 @@ public class RescalePartitionerTest extends StreamPartitionerTest {
     }
 
     @Test
-    public void testExecutionGraphGeneration() throws Exception {
+    void testExecutionGraphGeneration() throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
         env.setParallelism(4);
@@ -121,9 +121,9 @@ public class RescalePartitionerTest extends StreamPartitionerTest {
         JobVertex mapVertex = jobVertices.get(1);
         JobVertex sinkVertex = jobVertices.get(2);
 
-        assertEquals(2, sourceVertex.getParallelism());
-        assertEquals(4, mapVertex.getParallelism());
-        assertEquals(2, sinkVertex.getParallelism());
+        assertThat(sourceVertex.getParallelism()).isEqualTo(2);
+        assertThat(mapVertex.getParallelism()).isEqualTo(4);
+        assertThat(sinkVertex.getParallelism()).isEqualTo(2);
 
         ExecutionGraph eg =
                 TestingDefaultExecutionGraphBuilder.newBuilder()
@@ -136,35 +136,33 @@ public class RescalePartitionerTest extends StreamPartitionerTest {
                     jobVertices,
                     UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         } catch (JobException e) {
-            e.printStackTrace();
-            fail("Building ExecutionGraph failed: " + e.getMessage());
+            fail("Building ExecutionGraph failed", e);
         }
 
         ExecutionJobVertex execSourceVertex = eg.getJobVertex(sourceVertex.getID());
         ExecutionJobVertex execMapVertex = eg.getJobVertex(mapVertex.getID());
         ExecutionJobVertex execSinkVertex = eg.getJobVertex(sinkVertex.getID());
 
-        assertEquals(0, execSourceVertex.getInputs().size());
-
-        assertEquals(1, execMapVertex.getInputs().size());
-        assertEquals(4, execMapVertex.getParallelism());
+        assertThat(execSourceVertex.getInputs()).isEmpty();
+        assertThat(execMapVertex.getInputs()).hasSize(1);
+        assertThat(execMapVertex.getParallelism()).isEqualTo(4);
         ExecutionVertex[] mapTaskVertices = execMapVertex.getTaskVertices();
 
         // verify that we have each parallel input partition exactly twice, i.e. that one source
         // sends to two unique mappers
         Map<Integer, Integer> mapInputPartitionCounts = new HashMap<>();
         for (ExecutionVertex mapTaskVertex : mapTaskVertices) {
-            assertEquals(1, mapTaskVertex.getNumberOfInputs());
-            assertEquals(1, mapTaskVertex.getConsumedPartitionGroup(0).size());
+            assertThat(mapTaskVertex.getNumberOfInputs()).isOne();
+            assertThat(mapTaskVertex.getConsumedPartitionGroup(0)).hasSize(1);
             IntermediateResultPartitionID consumedPartitionId =
                     mapTaskVertex.getConsumedPartitionGroup(0).getFirst();
-            assertEquals(
-                    sourceVertex.getID(),
-                    mapTaskVertex
-                            .getExecutionGraphAccessor()
-                            .getResultPartitionOrThrow(consumedPartitionId)
-                            .getProducer()
-                            .getJobvertexId());
+            assertThat(
+                            mapTaskVertex
+                                    .getExecutionGraphAccessor()
+                                    .getResultPartitionOrThrow(consumedPartitionId)
+                                    .getProducer()
+                                    .getJobvertexId())
+                    .isEqualTo(sourceVertex.getID());
             int inputPartition = consumedPartitionId.getPartitionNumber();
             if (!mapInputPartitionCounts.containsKey(inputPartition)) {
                 mapInputPartitionCounts.put(inputPartition, 1);
@@ -174,13 +172,13 @@ public class RescalePartitionerTest extends StreamPartitionerTest {
             }
         }
 
-        assertEquals(2, mapInputPartitionCounts.size());
+        assertThat(mapInputPartitionCounts).hasSize(2);
         for (int count : mapInputPartitionCounts.values()) {
-            assertEquals(2, count);
+            assertThat(count).isEqualTo(2);
         }
 
-        assertEquals(1, execSinkVertex.getInputs().size());
-        assertEquals(2, execSinkVertex.getParallelism());
+        assertThat(execSinkVertex.getInputs()).hasSize(1);
+        assertThat(execSinkVertex.getParallelism()).isEqualTo(2);
         ExecutionVertex[] sinkTaskVertices = execSinkVertex.getTaskVertices();
         InternalExecutionGraphAccessor executionGraphAccessor = execSinkVertex.getGraph();
 
@@ -188,19 +186,20 @@ public class RescalePartitionerTest extends StreamPartitionerTest {
         // only occurs in one unique input edge
         Set<Integer> mapSubpartitions = new HashSet<>();
         for (ExecutionVertex sinkTaskVertex : sinkTaskVertices) {
-            assertEquals(1, sinkTaskVertex.getNumberOfInputs());
-            assertEquals(2, sinkTaskVertex.getConsumedPartitionGroup(0).size());
+            assertThat(sinkTaskVertex.getNumberOfInputs()).isOne();
+            assertThat(sinkTaskVertex.getConsumedPartitionGroup(0)).hasSize(2);
             for (IntermediateResultPartitionID consumedPartitionId :
                     sinkTaskVertex.getConsumedPartitionGroup(0)) {
                 IntermediateResultPartition consumedPartition =
                         executionGraphAccessor.getResultPartitionOrThrow(consumedPartitionId);
-                assertEquals(mapVertex.getID(), consumedPartition.getProducer().getJobvertexId());
+                assertThat(consumedPartition.getProducer().getJobvertexId())
+                        .isEqualTo(mapVertex.getID());
                 int partitionNumber = consumedPartition.getPartitionNumber();
-                assertFalse(mapSubpartitions.contains(partitionNumber));
+                assertThat(mapSubpartitions).doesNotContain(partitionNumber);
                 mapSubpartitions.add(partitionNumber);
             }
         }
 
-        assertEquals(4, mapSubpartitions.size());
+        assertThat(mapSubpartitions).hasSize(4);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
@@ -61,7 +61,7 @@ class RescalePartitionerTest extends StreamPartitionerTest {
             TestingUtils.defaultExecutorExtension();
 
     @Override
-    protected StreamPartitioner<Tuple> createPartitioner() {
+    StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new RescalePartitioner<>();
         assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ShufflePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ShufflePartitionerTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ShufflePartitionerTest extends StreamPartitionerTest {
 
     @Override
-    protected StreamPartitioner<Tuple> createPartitioner() {
+    StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new ShufflePartitioner<>();
         assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ShufflePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ShufflePartitionerTest.java
@@ -19,31 +19,32 @@ package org.apache.flink.streaming.runtime.partitioner;
 
 import org.apache.flink.api.java.tuple.Tuple;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ShufflePartitioner}. */
-public class ShufflePartitionerTest extends StreamPartitionerTest {
+class ShufflePartitionerTest extends StreamPartitionerTest {
 
     @Override
-    public StreamPartitioner<Tuple> createPartitioner() {
+    protected StreamPartitioner<Tuple> createPartitioner() {
         StreamPartitioner<Tuple> partitioner = new ShufflePartitioner<>();
-        assertFalse(partitioner.isBroadcast());
+        assertThat(partitioner.isBroadcast()).isFalse();
         return partitioner;
     }
 
     @Test
-    public void testSelectChannelsInterval() {
+    void testSelectChannelsInterval() {
         assertSelectedChannelWithSetup(0, 1);
 
         streamPartitioner.setup(2);
-        assertTrue(0 <= streamPartitioner.selectChannel(serializationDelegate));
-        assertTrue(2 > streamPartitioner.selectChannel(serializationDelegate));
+        assertThat(streamPartitioner.selectChannel(serializationDelegate))
+                .isGreaterThanOrEqualTo(0)
+                .isLessThan(2);
 
         streamPartitioner.setup(1024);
-        assertTrue(0 <= streamPartitioner.selectChannel(serializationDelegate));
-        assertTrue(1024 > streamPartitioner.selectChannel(serializationDelegate));
+        assertThat(streamPartitioner.selectChannel(serializationDelegate))
+                .isGreaterThanOrEqualTo(0)
+                .isLessThan(1024);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitionerTest.java
@@ -21,33 +21,32 @@ import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.InstantiationUtil;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for different {@link StreamPartitioner} implementations. */
-public abstract class StreamPartitionerTest extends TestLogger {
+abstract class StreamPartitionerTest {
 
     protected final StreamPartitioner<Tuple> streamPartitioner = createPartitioner();
     protected final StreamRecord<Tuple> streamRecord = new StreamRecord<>(null);
     protected final SerializationDelegate<StreamRecord<Tuple>> serializationDelegate =
             new SerializationDelegate<>(null);
 
-    abstract StreamPartitioner<Tuple> createPartitioner();
+    protected abstract StreamPartitioner<Tuple> createPartitioner();
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         serializationDelegate.setInstance(streamRecord);
     }
 
     protected void assertSelectedChannel(int expectedChannel) {
         int actualResult = streamPartitioner.selectChannel(serializationDelegate);
-        assertEquals(expectedChannel, actualResult);
+        assertThat(actualResult).isEqualTo(expectedChannel);
     }
 
     protected void assertSelectedChannelWithSetup(int expectedChannel, int numberOfChannels) {
@@ -56,8 +55,8 @@ public abstract class StreamPartitionerTest extends TestLogger {
     }
 
     @Test
-    public void testSerializable() throws IOException, ClassNotFoundException {
+    void testSerializable() throws IOException, ClassNotFoundException {
         final StreamPartitioner<Tuple> clone = InstantiationUtil.clone(streamPartitioner);
-        assertEquals(streamPartitioner, clone);
+        assertThat(clone).isEqualTo(streamPartitioner);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitionerTest.java
@@ -32,24 +32,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** Tests for different {@link StreamPartitioner} implementations. */
 abstract class StreamPartitionerTest {
 
-    protected final StreamPartitioner<Tuple> streamPartitioner = createPartitioner();
-    protected final StreamRecord<Tuple> streamRecord = new StreamRecord<>(null);
-    protected final SerializationDelegate<StreamRecord<Tuple>> serializationDelegate =
+    final StreamPartitioner<Tuple> streamPartitioner = createPartitioner();
+    final StreamRecord<Tuple> streamRecord = new StreamRecord<>(null);
+    final SerializationDelegate<StreamRecord<Tuple>> serializationDelegate =
             new SerializationDelegate<>(null);
 
-    protected abstract StreamPartitioner<Tuple> createPartitioner();
+    abstract StreamPartitioner<Tuple> createPartitioner();
 
     @BeforeEach
     void setup() {
         serializationDelegate.setInstance(streamRecord);
     }
 
-    protected void assertSelectedChannel(int expectedChannel) {
+    void assertSelectedChannel(int expectedChannel) {
         int actualResult = streamPartitioner.selectChannel(serializationDelegate);
         assertThat(actualResult).isEqualTo(expectedChannel);
     }
 
-    protected void assertSelectedChannelWithSetup(int expectedChannel, int numberOfChannels) {
+    void assertSelectedChannelWithSetup(int expectedChannel, int numberOfChannels) {
         streamPartitioner.setup(numberOfChannels);
         assertSelectedChannel(expectedChannel);
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializerTest.java
@@ -27,22 +27,20 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.watermark.InternalWatermark;
 import org.apache.flink.streaming.api.watermark.Watermark;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link StreamElementSerializer}. */
-public class StreamElementSerializerTest {
+class StreamElementSerializerTest {
 
     @Test
-    public void testDeepDuplication() {
+    void testDeepDuplication() {
         @SuppressWarnings("unchecked")
         TypeSerializer<Long> serializer1 = (TypeSerializer<Long>) mock(TypeSerializer.class);
 
@@ -53,54 +51,60 @@ public class StreamElementSerializerTest {
 
         StreamElementSerializer<Long> streamRecSer = new StreamElementSerializer<Long>(serializer1);
 
-        assertEquals(serializer1, streamRecSer.getContainedTypeSerializer());
+        assertThat(streamRecSer.getContainedTypeSerializer()).isEqualTo(serializer1);
 
         StreamElementSerializer<Long> copy = streamRecSer.duplicate();
-        assertNotEquals(copy, streamRecSer);
-        assertNotEquals(
-                copy.getContainedTypeSerializer(), streamRecSer.getContainedTypeSerializer());
+        assertThat(copy).isNotEqualTo(streamRecSer);
+        assertThat(copy.getContainedTypeSerializer())
+                .isNotEqualTo(streamRecSer.getContainedTypeSerializer());
     }
 
     @Test
-    public void testBasicProperties() {
+    void testBasicProperties() {
         StreamElementSerializer<Long> streamRecSer =
-                new StreamElementSerializer<Long>(LongSerializer.INSTANCE);
+                new StreamElementSerializer<>(LongSerializer.INSTANCE);
 
-        assertFalse(streamRecSer.isImmutableType());
-        assertEquals(Long.class, streamRecSer.createInstance().getValue().getClass());
-        assertEquals(-1L, streamRecSer.getLength());
+        assertThat(streamRecSer.isImmutableType()).isFalse();
+        assertThat(streamRecSer.createInstance().getValue()).isExactlyInstanceOf(Long.class);
+        assertThat(streamRecSer.getLength()).isEqualTo(-1L);
     }
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         final StreamElementSerializer<String> serializer =
                 new StreamElementSerializer<String>(StringSerializer.INSTANCE);
 
         StreamRecord<String> withoutTimestamp = new StreamRecord<>("test 1 2 分享基督耶穌的愛給們，開拓雙贏!");
-        assertEquals(withoutTimestamp, serializeAndDeserialize(withoutTimestamp, serializer));
+        assertThat(serializeAndDeserialize(withoutTimestamp, serializer))
+                .isEqualTo(withoutTimestamp);
 
         StreamRecord<String> withTimestamp = new StreamRecord<>("one more test 拓 們 分", 77L);
-        assertEquals(withTimestamp, serializeAndDeserialize(withTimestamp, serializer));
+        assertThat(serializeAndDeserialize(withTimestamp, serializer)).isEqualTo(withTimestamp);
 
         StreamRecord<String> negativeTimestamp = new StreamRecord<>("他", Long.MIN_VALUE);
-        assertEquals(negativeTimestamp, serializeAndDeserialize(negativeTimestamp, serializer));
+        assertThat(serializeAndDeserialize(negativeTimestamp, serializer))
+                .isEqualTo(negativeTimestamp);
 
         Watermark positiveWatermark = new Watermark(13);
-        assertEquals(positiveWatermark, serializeAndDeserialize(positiveWatermark, serializer));
+        assertThat(serializeAndDeserialize(positiveWatermark, serializer))
+                .isEqualTo(positiveWatermark);
 
         Watermark negativeWatermark = new Watermark(-4647654567676555876L);
-        assertEquals(negativeWatermark, serializeAndDeserialize(negativeWatermark, serializer));
+        assertThat(serializeAndDeserialize(negativeWatermark, serializer))
+                .isEqualTo(negativeWatermark);
 
         Watermark internalWatermark = new InternalWatermark(13, 10);
-        assertEquals(internalWatermark, serializeAndDeserialize(internalWatermark, serializer));
+        assertThat(serializeAndDeserialize(internalWatermark, serializer))
+                .isEqualTo(internalWatermark);
 
         LatencyMarker latencyMarker =
                 new LatencyMarker(System.currentTimeMillis(), new OperatorID(-1, -1), 1);
-        assertEquals(latencyMarker, serializeAndDeserialize(latencyMarker, serializer));
+        assertThat(serializeAndDeserialize(latencyMarker, serializer)).isEqualTo(latencyMarker);
 
         RecordAttributes recordAttributes =
                 new RecordAttributesBuilder(Collections.emptyList()).setBacklog(true).build();
-        assertEquals(recordAttributes, serializeAndDeserialize(recordAttributes, serializer));
+        assertThat(serializeAndDeserialize(recordAttributes, serializer))
+                .isEqualTo(recordAttributes);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnableTest.java
@@ -34,20 +34,18 @@ import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.testutils.ExceptionallyDoneFuture;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link AsyncCheckpointRunnable}. */
-public class AsyncCheckpointRunnableTest {
+class AsyncCheckpointRunnableTest {
 
     @Test
-    public void testReportIncompleteStats() {
+    void testReportIncompleteStats() {
         long checkpointId = 1000L;
         TestEnvironment env = new TestEnvironment();
         new AsyncCheckpointRunnable(
@@ -63,18 +61,17 @@ public class AsyncCheckpointRunnableTest {
                         false,
                         () -> true)
                 .close();
-        assertEquals(
-                checkpointId,
-                ((TestTaskStateManager) env.getTaskStateManager()).getReportedCheckpointId());
+        assertThat(((TestTaskStateManager) env.getTaskStateManager()).getReportedCheckpointId())
+                .isEqualTo(checkpointId);
     }
 
     @Test
-    public void testDeclineWithAsyncCheckpointExceptionWhenRunning() {
+    void testDeclineWithAsyncCheckpointExceptionWhenRunning() {
         testAsyncCheckpointException(true);
     }
 
     @Test
-    public void testDeclineWithAsyncCheckpointExceptionWhenNotRunning() {
+    void testDeclineWithAsyncCheckpointExceptionWhenNotRunning() {
         testAsyncCheckpointException(false);
     }
 
@@ -97,16 +94,15 @@ public class AsyncCheckpointRunnableTest {
         runnable.run();
 
         if (isTaskRunning) {
-            Assert.assertSame(
-                    environment.getCause().getCheckpointFailureReason(),
-                    CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION);
+            assertThat(environment.getCause().getCheckpointFailureReason())
+                    .isSameAs(CheckpointFailureReason.CHECKPOINT_ASYNC_EXCEPTION);
         } else {
-            Assert.assertNull(environment.getCause());
+            assertThat(environment.getCause()).isNull();
         }
     }
 
     @Test
-    public void testDeclineAsyncCheckpoint() {
+    void testDeclineAsyncCheckpoint() {
         CheckpointFailureReason originalReason =
                 CheckpointFailureReason.CHECKPOINT_DECLINED_INPUT_END_OF_STREAM;
 
@@ -126,11 +122,11 @@ public class AsyncCheckpointRunnableTest {
                 createAsyncRunnable(snapshotsInProgress, environment, false, true);
         runnable.run();
 
-        Assert.assertSame(environment.getCause().getCheckpointFailureReason(), originalReason);
+        assertThat(environment.getCause().getCheckpointFailureReason()).isSameAs(originalReason);
     }
 
     @Test
-    public void testReportFinishedOnRestoreTaskSnapshots() {
+    void testReportFinishedOnRestoreTaskSnapshots() {
         TestEnvironment environment = new TestEnvironment();
         AsyncCheckpointRunnable asyncCheckpointRunnable =
                 createAsyncRunnable(new HashMap<>(), environment, true, true);
@@ -138,16 +134,13 @@ public class AsyncCheckpointRunnableTest {
         TestTaskStateManager testTaskStateManager =
                 (TestTaskStateManager) environment.getTaskStateManager();
 
-        assertEquals(
-                asyncCheckpointRunnable.getCheckpointId(),
-                testTaskStateManager.getReportedCheckpointId());
-        assertEquals(
-                TaskStateSnapshot.FINISHED_ON_RESTORE,
-                testTaskStateManager.getLastJobManagerTaskStateSnapshot());
-        assertEquals(
-                TaskStateSnapshot.FINISHED_ON_RESTORE,
-                testTaskStateManager.getLastTaskManagerTaskStateSnapshot());
-        assertTrue(asyncCheckpointRunnable.getFinishedFuture().isDone());
+        assertThat(testTaskStateManager.getReportedCheckpointId())
+                .isEqualTo(asyncCheckpointRunnable.getCheckpointId());
+        assertThat(testTaskStateManager.getLastJobManagerTaskStateSnapshot())
+                .isEqualTo(TaskStateSnapshot.FINISHED_ON_RESTORE);
+        assertThat(testTaskStateManager.getLastTaskManagerTaskStateSnapshot())
+                .isEqualTo(TaskStateSnapshot.FINISHED_ON_RESTORE);
+        assertThat(asyncCheckpointRunnable.getFinishedFuture()).isDone();
     }
 
     private AsyncCheckpointRunnable createAsyncRunnable(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CheckpointExceptionHandlerConfigurationTest.java
@@ -23,50 +23,49 @@ import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test that the configuration mechanism for how tasks react on checkpoint errors works correctly.
  */
-public class CheckpointExceptionHandlerConfigurationTest extends TestLogger {
+class CheckpointExceptionHandlerConfigurationTest {
 
     @Test
-    public void testCheckpointConfigDefault() {
+    void testCheckpointConfigDefault() {
         StreamExecutionEnvironment streamExecutionEnvironment =
                 StreamExecutionEnvironment.getExecutionEnvironment();
         CheckpointConfig checkpointConfig = streamExecutionEnvironment.getCheckpointConfig();
-        Assert.assertTrue(checkpointConfig.isFailOnCheckpointingErrors());
-        Assert.assertEquals(0, checkpointConfig.getTolerableCheckpointFailureNumber());
+        assertThat(checkpointConfig.isFailOnCheckpointingErrors()).isTrue();
+        assertThat(checkpointConfig.getTolerableCheckpointFailureNumber()).isZero();
     }
 
     @Test
-    public void testSetCheckpointConfig() {
+    void testSetCheckpointConfig() {
         StreamExecutionEnvironment streamExecutionEnvironment =
                 StreamExecutionEnvironment.getExecutionEnvironment();
         CheckpointConfig checkpointConfig = streamExecutionEnvironment.getCheckpointConfig();
 
         // use deprecated API to set not fail on checkpoint errors
         checkpointConfig.setFailOnCheckpointingErrors(false);
-        Assert.assertFalse(checkpointConfig.isFailOnCheckpointingErrors());
-        Assert.assertEquals(
-                CheckpointFailureManager.UNLIMITED_TOLERABLE_FAILURE_NUMBER,
-                checkpointConfig.getTolerableCheckpointFailureNumber());
+        assertThat(checkpointConfig.isFailOnCheckpointingErrors()).isFalse();
+        assertThat(checkpointConfig.getTolerableCheckpointFailureNumber())
+                .isEqualTo(CheckpointFailureManager.UNLIMITED_TOLERABLE_FAILURE_NUMBER);
 
         // use new API to set tolerable declined checkpoint number
         checkpointConfig.setTolerableCheckpointFailureNumber(5);
-        Assert.assertEquals(5, checkpointConfig.getTolerableCheckpointFailureNumber());
+        assertThat(checkpointConfig.getTolerableCheckpointFailureNumber()).isEqualTo(5);
 
         // after we configure the tolerable declined checkpoint number, deprecated API would not
         // take effect
         checkpointConfig.setFailOnCheckpointingErrors(true);
-        Assert.assertEquals(5, checkpointConfig.getTolerableCheckpointFailureNumber());
+        assertThat(checkpointConfig.getTolerableCheckpointFailureNumber()).isEqualTo(5);
     }
 
     @Test
-    public void testPropagationFailFromCheckpointConfig() {
+    void testPropagationFailFromCheckpointConfig() {
         try {
             doTestPropagationFromCheckpointConfig(true);
         } catch (IllegalArgumentException ignored) {
@@ -75,7 +74,7 @@ public class CheckpointExceptionHandlerConfigurationTest extends TestLogger {
     }
 
     @Test
-    public void testPropagationDeclineFromCheckpointConfig() {
+    void testPropagationDeclineFromCheckpointConfig() {
         doTestPropagationFromCheckpointConfig(false);
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase.java
@@ -99,7 +99,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * checkpoint completed before the failure is injected, and that there must be events sent from the
  * coordinator to its subtask during checkpoint.
  */
-public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
+class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
         extends CoordinatorEventsExactlyOnceITCase {
 
     private static final int NUM_EVENTS = 100;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -167,7 +167,7 @@ class InterruptSensitiveRestoreTest {
 
         assertThat(task.getExecutionState())
                 .as("Task is stuck and not canceling")
-                .isEqualTo(ExecutionState.CANCELED);
+                .isNotEqualTo(ExecutionState.CANCELING);
 
         assertThat(task.getExecutionState()).isEqualTo(ExecutionState.CANCELED);
         assertThat(task.getFailureCause()).isNull();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/InterruptSensitiveRestoreTest.java
@@ -80,7 +80,7 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.util.SerializedValue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -93,9 +93,8 @@ import java.util.Optional;
 import java.util.concurrent.Executor;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -105,7 +104,7 @@ import static org.mockito.Mockito.mock;
  * <p>In practice, reading from HDFS is interrupt sensitive: The HDFS code frequently deadlocks or
  * livelocks if it is interrupted.
  */
-public class InterruptSensitiveRestoreTest {
+class InterruptSensitiveRestoreTest {
 
     private static final OneShotLatch IN_RESTORE_LATCH = new OneShotLatch();
 
@@ -115,22 +114,22 @@ public class InterruptSensitiveRestoreTest {
     private static final int KEYED_RAW = 3;
 
     @Test
-    public void testRestoreWithInterruptOperatorManaged() throws Exception {
+    void testRestoreWithInterruptOperatorManaged() throws Exception {
         testRestoreWithInterrupt(OPERATOR_MANAGED);
     }
 
     @Test
-    public void testRestoreWithInterruptOperatorRaw() throws Exception {
+    void testRestoreWithInterruptOperatorRaw() throws Exception {
         testRestoreWithInterrupt(OPERATOR_RAW);
     }
 
     @Test
-    public void testRestoreWithInterruptKeyedManaged() throws Exception {
+    void testRestoreWithInterruptKeyedManaged() throws Exception {
         testRestoreWithInterrupt(KEYED_MANAGED);
     }
 
     @Test
-    public void testRestoreWithInterruptKeyedRaw() throws Exception {
+    void testRestoreWithInterruptKeyedRaw() throws Exception {
         testRestoreWithInterrupt(KEYED_RAW);
     }
 
@@ -166,12 +165,12 @@ public class InterruptSensitiveRestoreTest {
 
         task.getExecutingThread().join(30000);
 
-        if (task.getExecutionState() == ExecutionState.CANCELING) {
-            fail("Task is stuck and not canceling");
-        }
+        assertThat(task.getExecutionState())
+                .as("Task is stuck and not canceling")
+                .isEqualTo(ExecutionState.CANCELED);
 
-        assertEquals(ExecutionState.CANCELED, task.getExecutionState());
-        assertNull(task.getFailureCause());
+        assertThat(task.getExecutionState()).isEqualTo(ExecutionState.CANCELED);
+        assertThat(task.getFailureCause()).isNull();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LifeCycleMonitor.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LifeCycleMonitor.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** A utility class to record the number of calls for each phase. */
 class LifeCycleMonitor implements Serializable {
@@ -48,10 +48,9 @@ class LifeCycleMonitor implements Serializable {
 
     public void assertCallTimes(int expectedTimes, LifeCyclePhase... phases) {
         for (LifeCyclePhase phase : phases) {
-            assertEquals(
-                    String.format("The phase %s has unexpected call times", phase),
-                    expectedTimes,
-                    callTimes.getOrDefault(phase, 0).intValue());
+            assertThat(callTimes.getOrDefault(phase, 0))
+                    .as("The phase %s has unexpected call times", phase)
+                    .isEqualTo(expectedTimes);
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -50,17 +50,16 @@ import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 import org.apache.flink.runtime.state.changelog.inmemory.InMemoryStateChangelogStorage;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.concurrent.Executors;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nullable;
 
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -70,15 +69,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
  * Test for forwarding of state reporting to and from {@link
  * org.apache.flink.runtime.state.TaskStateManager}.
  */
-public class LocalStateForwardingTest extends TestLogger {
+class LocalStateForwardingTest {
 
-    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir private Path temporaryFolder;
 
     /**
      * This tests the forwarding of jm and tm-local state from the futures reported by the backends,
@@ -86,7 +86,7 @@ public class LocalStateForwardingTest extends TestLogger {
      * org.apache.flink.runtime.state.TaskStateManager}.
      */
     @Test
-    public void testReportingFromSnapshotToTaskStateManager() throws Exception {
+    void testReportingFromSnapshotToTaskStateManager() throws Exception {
 
         TestTaskStateManager taskStateManager = new TestTaskStateManager();
 
@@ -181,8 +181,7 @@ public class LocalStateForwardingTest extends TestLogger {
      * TaskLocalStateStoreImpl}.
      */
     @Test
-    public void testReportingFromTaskStateManagerToResponderAndTaskLocalStateStore()
-            throws Exception {
+    void testReportingFromTaskStateManagerToResponderAndTaskLocalStateStore() throws Exception {
 
         final JobID jobID = new JobID();
         final AllocationID allocationID = new AllocationID();
@@ -210,10 +209,10 @@ public class LocalStateForwardingTest extends TestLogger {
                             CheckpointMetrics lCheckpointMetrics,
                             TaskStateSnapshot lSubtaskState) {
 
-                        Assert.assertEquals(jobID, lJobID);
-                        Assert.assertEquals(executionAttemptID, lExecutionAttemptID);
-                        Assert.assertEquals(checkpointMetaData.getCheckpointId(), lCheckpointId);
-                        Assert.assertEquals(checkpointMetrics, lCheckpointMetrics);
+                        assertThat(lJobID).isEqualTo(jobID);
+                        assertThat(lExecutionAttemptID).isEqualTo(executionAttemptID);
+                        assertThat(lCheckpointId).isEqualTo(checkpointMetaData.getCheckpointId());
+                        assertThat(lCheckpointMetrics).isEqualTo(checkpointMetrics);
                         jmReported.set(true);
                     }
                 };
@@ -222,7 +221,7 @@ public class LocalStateForwardingTest extends TestLogger {
 
         LocalSnapshotDirectoryProviderImpl directoryProvider =
                 new LocalSnapshotDirectoryProviderImpl(
-                        temporaryFolder.newFolder(), jobID, jobVertexID, subtaskIdx);
+                        TempDirUtils.newFolder(temporaryFolder), jobID, jobVertexID, subtaskIdx);
 
         LocalRecoveryConfig localRecoveryConfig =
                 LocalRecoveryConfig.backupAndRecoveryEnabled(directoryProvider);
@@ -240,7 +239,7 @@ public class LocalStateForwardingTest extends TestLogger {
                             @Nonnegative long checkpointId,
                             @Nullable TaskStateSnapshot localState) {
 
-                        Assert.assertEquals(tmSnapshot, localState);
+                        assertThat(localState).isEqualTo(tmSnapshot);
                         tmReported.set(true);
                     }
                 };
@@ -261,8 +260,8 @@ public class LocalStateForwardingTest extends TestLogger {
         taskStateManager.reportTaskStateSnapshots(
                 checkpointMetaData, checkpointMetrics, jmSnapshot, tmSnapshot);
 
-        Assert.assertTrue("Reporting for JM state was not called.", jmReported.get());
-        Assert.assertTrue("Reporting for TM state was not called.", tmReported.get());
+        assertThat(jmReported).as("Reporting for JM state was not called.").isTrue();
+        assertThat(tmReported).as("Reporting for TM state was not called.").isTrue();
     }
 
     private static <T extends StateObject> void performCheck(
@@ -277,9 +276,9 @@ public class LocalStateForwardingTest extends TestLogger {
             throw new RuntimeException(e);
         }
 
-        Assert.assertEquals(snapshotResult.getJobManagerOwnedSnapshot(), jmState.iterator().next());
-
-        Assert.assertEquals(snapshotResult.getTaskLocalSnapshot(), tmState.iterator().next());
+        assertThat(jmState.iterator().next())
+                .isEqualTo(snapshotResult.getJobManagerOwnedSnapshot());
+        assertThat(tmState.iterator().next()).isEqualTo(snapshotResult.getTaskLocalSnapshot());
     }
 
     private static <T extends StateObject> void performCollectionCheck(
@@ -294,8 +293,8 @@ public class LocalStateForwardingTest extends TestLogger {
             throw new RuntimeException(e);
         }
 
-        Assert.assertEquals(snapshotResult.getJobManagerOwnedSnapshot(), jmState);
-        Assert.assertEquals(snapshotResult.getTaskLocalSnapshot(), tmState);
+        assertThat(jmState).isEqualTo(snapshotResult.getJobManagerOwnedSnapshot());
+        assertThat(tmState).isEqualTo(snapshotResult.getTaskLocalSnapshot());
     }
 
     private static <T extends StateObject> RunnableFuture<SnapshotResult<T>> createSnapshotResult(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -59,16 +59,18 @@ import org.apache.flink.streaming.runtime.tasks.LifeCycleMonitor.LifeCyclePhase;
 import org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.MapToStringMultipleInputOperatorFactory;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.CompletingCheckpointResponder;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -78,31 +80,23 @@ import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTe
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.applyObjectReuse;
 import static org.apache.flink.streaming.runtime.tasks.MultipleInputStreamTaskTest.buildTestHarness;
 import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.triggerCheckpoint;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link MultipleInputStreamTask} combined with {@link
  * org.apache.flink.streaming.api.operators.SourceOperator} chaining.
  */
-@RunWith(Parameterized.class)
-public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
 
     private static final int MAX_STEPS = 100;
 
     @Parameters(name = "objectReuse = {0}")
-    public static Boolean[] parameters() {
-        return new Boolean[] {true, false};
+    private static Collection<Boolean> parameters() {
+        return Arrays.asList(true, false);
     }
 
-    @Parameter public boolean objectReuse;
+    @Parameter private boolean objectReuse;
 
     private final CheckpointMetaData metaData =
             new CheckpointMetaData(1L, System.currentTimeMillis());
@@ -111,8 +105,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
      * In this scenario: 1. checkpoint is triggered via RPC and source is blocked 2. network inputs
      * are processed until CheckpointBarriers are processed 3. aligned checkpoint is performed
      */
-    @Test
-    public void testSourceCheckpointFirst() throws Exception {
+    @TestTemplate
+    void testSourceCheckpointFirst() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness(objectReuse)) {
             testHarness.setAutoProcess(false);
             ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
@@ -132,10 +126,9 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
 
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
 
-            assertThat(
-                    actualOutput.subList(0, expectedOutput.size()),
-                    containsInAnyOrder(expectedOutput.toArray()));
-            assertThat(actualOutput.get(expectedOutput.size()), equalTo(barrier));
+            assertThat(actualOutput.subList(0, expectedOutput.size()))
+                    .containsExactlyInAnyOrder(expectedOutput.toArray());
+            assertThat(actualOutput.get(expectedOutput.size())).isEqualTo(barrier);
         }
     }
 
@@ -143,8 +136,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
      * In this scenario: 1. checkpoint is triggered via RPC and source is blocked 2. unaligned
      * checkpoint is performed 3. all data from network inputs are processed
      */
-    @Test
-    public void testSourceCheckpointFirstUnaligned() throws Exception {
+    @TestTemplate
+    void testSourceCheckpointFirstUnaligned() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 buildTestHarness(true, objectReuse)) {
             testHarness.setAutoProcess(false);
@@ -158,7 +151,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                             .triggerCheckpointAsync(metaData, barrier.getCheckpointOptions());
             processSingleStepUntil(testHarness, checkpointFuture::isDone);
 
-            assertThat(testHarness.getOutput(), contains(barrier));
+            assertThat(testHarness.getOutput()).contains(barrier);
 
             testHarness.processAll();
 
@@ -168,9 +161,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
 
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
-            assertThat(
-                    actualOutput.subList(1, expectedOutput.size() + 1),
-                    containsInAnyOrder(expectedOutput.toArray()));
+            assertThat(actualOutput.subList(1, expectedOutput.size() + 1))
+                    .containsExactlyInAnyOrder(expectedOutput.toArray());
         }
     }
 
@@ -179,8 +171,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
      * source records are processed at the same time 2. checkpoint is triggered via RPC 3. aligned
      * checkpoint is performed
      */
-    @Test
-    public void testSourceCheckpointLast() throws Exception {
+    @TestTemplate
+    void testSourceCheckpointLast() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness(objectReuse)) {
             testHarness.setAutoProcess(false);
             ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
@@ -205,10 +197,9 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
 
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
 
-            assertThat(
-                    actualOutput.subList(0, expectedOutput.size()),
-                    containsInAnyOrder(expectedOutput.toArray()));
-            assertThat(actualOutput.get(expectedOutput.size()), equalTo(barrier));
+            assertThat(actualOutput.subList(0, expectedOutput.size()))
+                    .containsExactlyInAnyOrder(expectedOutput.toArray());
+            assertThat(actualOutput.get(expectedOutput.size())).isEqualTo(barrier);
         }
     }
 
@@ -218,8 +209,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
      * CheckpointBarrier 4. unaligned checkpoint is performed at some point of time blocking the
      * source 5. more source records are added, that shouldn't be processed
      */
-    @Test
-    public void testSourceCheckpointLastUnaligned() throws Exception {
+    @TestTemplate
+    void testSourceCheckpointLastUnaligned() throws Exception {
         boolean unaligned = true;
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 buildTestHarness(unaligned, objectReuse)) {
@@ -240,7 +231,7 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
             expectedOutput.add(barrier);
 
-            assertThat(testHarness.getOutput(), containsInAnyOrder(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).containsExactlyInAnyOrder(expectedOutput.toArray());
         }
     }
 
@@ -255,8 +246,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
      *   <li>Synchronous savepoint is triggered
      * </ul>
      */
-    @Test
-    public void testStopWithSavepointDrainWaitsForSourcesFinish() throws Exception {
+    @TestTemplate
+    void testStopWithSavepointDrainWaitsForSourcesFinish() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
@@ -308,17 +299,15 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             expectedOutput.add(new StreamRecord<>("2", TimestampAssigner.NO_TIMESTAMP));
 
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
-            assertThat(
-                    actualOutput.subList(0, expectedOutput.size()),
-                    containsInAnyOrder(expectedOutput.toArray()));
-            assertThat(
-                    actualOutput.subList(actualOutput.size() - 3, actualOutput.size()),
-                    contains(new StreamRecord<>("FINISH"), new EndOfData(StopMode.DRAIN), barrier));
+            assertThat(actualOutput.subList(0, expectedOutput.size()))
+                    .containsExactlyInAnyOrder(expectedOutput.toArray());
+            assertThat(actualOutput.subList(actualOutput.size() - 3, actualOutput.size()))
+                    .contains(new StreamRecord<>("FINISH"), new EndOfData(StopMode.DRAIN), barrier);
         }
     }
 
-    @Test
-    public void testOnlyOneSource() throws Exception {
+    @TestTemplate
+    void testOnlyOneSource() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
@@ -347,15 +336,14 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             processSingleStepUntil(testHarness, checkpointFuture::isDone);
 
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
-            assertThat(
-                    actualOutput.subList(0, expectedOutput.size()),
-                    containsInAnyOrder(expectedOutput.toArray()));
-            assertThat(actualOutput.get(expectedOutput.size()), equalTo(barrier));
+            assertThat(actualOutput.subList(0, expectedOutput.size()))
+                    .containsExactlyInAnyOrder(expectedOutput.toArray());
+            assertThat(actualOutput.get(expectedOutput.size())).isEqualTo(barrier);
         }
     }
 
-    @Test
-    public void testTriggerAlignedNoTimeoutCheckpointWithFinishedChannelsAndSourceChain()
+    @TestTemplate
+    void testTriggerAlignedNoTimeoutCheckpointWithFinishedChannelsAndSourceChain()
             throws Exception {
         testTriggerCheckpointWithFinishedChannelsAndSourceChain(
                 CheckpointOptions.alignedNoTimeout(
@@ -363,17 +351,16 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                         CheckpointStorageLocationReference.getDefault()));
     }
 
-    @Test
-    public void testTriggerUnalignedCheckpointWithFinishedChannelsAndSourceChain()
-            throws Exception {
+    @TestTemplate
+    void testTriggerUnalignedCheckpointWithFinishedChannelsAndSourceChain() throws Exception {
         testTriggerCheckpointWithFinishedChannelsAndSourceChain(
                 CheckpointOptions.unaligned(
                         CheckpointType.CHECKPOINT,
                         CheckpointStorageLocationReference.getDefault()));
     }
 
-    @Test
-    public void testTriggerAlignedWithTimeoutCheckpointWithFinishedChannelsAndSourceChain()
+    @TestTemplate
+    void testTriggerAlignedWithTimeoutCheckpointWithFinishedChannelsAndSourceChain()
             throws Exception {
         testTriggerCheckpointWithFinishedChannelsAndSourceChain(
                 CheckpointOptions.alignedWithTimeout(
@@ -441,7 +428,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                 testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
                 testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 1, 0);
                 testHarness.getTaskStateManager().getWaitForReportLatch().await();
-                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(2);
 
                 // Tests triggering checkpoint after all the inputs have received EndOfPartition.
                 checkpointFuture = triggerCheckpoint(testHarness, 4, checkpointOptions);
@@ -458,13 +446,14 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                 // The checkpoint 4 would be triggered successfully.
                 testHarness.processAll();
                 testHarness.finishProcessing();
-                assertTrue(checkpointFuture.isDone());
+                assertThat(checkpointFuture).isDone();
                 testHarness.getTaskStateManager().getWaitForReportLatch().await();
-                assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(4);
 
                 // Each result partition should have emitted 2 barriers and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {
-                    assertEquals(3, resultPartition.getNumberOfQueuedBuffers());
+                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(3);
                 }
             }
         } finally {
@@ -476,8 +465,8 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
         }
     }
 
-    @Test
-    public void testSkipExecutionsIfFinishedOnRestoreWithSourceChained() throws Exception {
+    @TestTemplate
+    void testSkipExecutionsIfFinishedOnRestoreWithSourceChained() throws Exception {
         OperatorID firstSourceOperatorId = new OperatorID();
         OperatorID secondSourceOperatorId = new OperatorID();
         OperatorID nonSourceOperatorId = new OperatorID();
@@ -521,9 +510,9 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                         .build()) {
 
             testHarness.processElement(Watermark.MAX_WATERMARK);
-            assertThat(output, is(empty()));
+            assertThat(output).isEmpty();
             testHarness.waitForTaskCompletion();
-            assertThat(output, contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN)));
+            assertThat(output).contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
 
             for (StreamOperatorWrapper<?, ?> wrapper :
                     testHarness.getStreamTask().operatorChain.getAllOperators()) {
@@ -592,11 +581,11 @@ public class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
     private void processSingleStepUntil(
             StreamTaskMailboxTestHarness<String> testHarness, Supplier<Boolean> condition)
             throws Exception {
-        assertFalse(condition.get());
+        assertThat(condition.get()).isFalse();
         for (int i = 0; i < MAX_STEPS && !condition.get(); i++) {
             testHarness.processSingleStep();
         }
-        assertTrue(condition.get());
+        assertThat(condition.get()).isTrue();
     }
 
     static class LifeCycleMonitorMultipleInputOperator extends TestFinishedOnRestoreStreamOperator

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskChainedSourcesCheckpointingTest.java
@@ -127,7 +127,7 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
 
             assertThat(actualOutput.subList(0, expectedOutput.size()))
-                    .containsExactlyInAnyOrder(expectedOutput.toArray());
+                    .containsExactlyInAnyOrderElementsOf(expectedOutput);
             assertThat(actualOutput.get(expectedOutput.size())).isEqualTo(barrier);
         }
     }
@@ -151,7 +151,7 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
                             .triggerCheckpointAsync(metaData, barrier.getCheckpointOptions());
             processSingleStepUntil(testHarness, checkpointFuture::isDone);
 
-            assertThat(testHarness.getOutput()).contains(barrier);
+            assertThat(testHarness.getOutput()).containsExactly(barrier);
 
             testHarness.processAll();
 
@@ -162,7 +162,7 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
 
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
             assertThat(actualOutput.subList(1, expectedOutput.size() + 1))
-                    .containsExactlyInAnyOrder(expectedOutput.toArray());
+                    .containsExactlyInAnyOrderElementsOf(expectedOutput);
         }
     }
 
@@ -198,7 +198,7 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
 
             assertThat(actualOutput.subList(0, expectedOutput.size()))
-                    .containsExactlyInAnyOrder(expectedOutput.toArray());
+                    .containsExactlyInAnyOrderElementsOf(expectedOutput);
             assertThat(actualOutput.get(expectedOutput.size())).isEqualTo(barrier);
         }
     }
@@ -231,7 +231,7 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             expectedOutput.add(new StreamRecord<>("47.0", TimestampAssigner.NO_TIMESTAMP));
             expectedOutput.add(barrier);
 
-            assertThat(testHarness.getOutput()).containsExactlyInAnyOrder(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyInAnyOrderElementsOf(expectedOutput);
         }
     }
 
@@ -300,9 +300,10 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
 
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
             assertThat(actualOutput.subList(0, expectedOutput.size()))
-                    .containsExactlyInAnyOrder(expectedOutput.toArray());
+                    .containsExactlyInAnyOrderElementsOf(expectedOutput);
             assertThat(actualOutput.subList(actualOutput.size() - 3, actualOutput.size()))
-                    .contains(new StreamRecord<>("FINISH"), new EndOfData(StopMode.DRAIN), barrier);
+                    .containsExactly(
+                            new StreamRecord<>("FINISH"), new EndOfData(StopMode.DRAIN), barrier);
         }
     }
 
@@ -337,7 +338,7 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
 
             ArrayList<Object> actualOutput = new ArrayList<>(testHarness.getOutput());
             assertThat(actualOutput.subList(0, expectedOutput.size()))
-                    .containsExactlyInAnyOrder(expectedOutput.toArray());
+                    .containsExactlyInAnyOrderElementsOf(expectedOutput);
             assertThat(actualOutput.get(expectedOutput.size())).isEqualTo(barrier);
         }
     }
@@ -512,7 +513,8 @@ class MultipleInputStreamTaskChainedSourcesCheckpointingTest {
             testHarness.processElement(Watermark.MAX_WATERMARK);
             assertThat(output).isEmpty();
             testHarness.waitForTaskCompletion();
-            assertThat(output).contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
+            assertThat(output)
+                    .containsExactly(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
 
             for (StreamOperatorWrapper<?, ?> wrapper :
                     testHarness.getStreamTask().operatorChain.getAllOperators()) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -175,7 +175,7 @@ class MultipleInputStreamTaskTest {
             testHarness.endInput();
             testHarness.waitForTaskCompletion();
 
-            assertThat(testHarness.getOutput()).containsExactlyInAnyOrder(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyInAnyOrderElementsOf(expectedOutput);
         }
     }
 
@@ -245,7 +245,7 @@ class MultipleInputStreamTaskTest {
             expectedOutput.add(new StreamRecord<>("11", initialTime));
             expectedOutput.add(new StreamRecord<>("1.0", initialTime));
 
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             testHarness.processEvent(
                     new CheckpointBarrier(
@@ -278,7 +278,7 @@ class MultipleInputStreamTaskTest {
                     new CheckpointBarrier(
                             0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()));
 
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
         }
     }
 
@@ -320,7 +320,7 @@ class MultipleInputStreamTaskTest {
 
             // we should not yet see the barrier, only the two elements from non-blocked input
 
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // Now give a later barrier to all inputs, this should unblock the first channel
             testHarness.processEvent(
@@ -359,7 +359,7 @@ class MultipleInputStreamTaskTest {
                     new CheckpointBarrier(
                             1, 1, CheckpointOptions.forCheckpointWithDefaultLocation()));
 
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // Then give the earlier barrier, these should be ignored
             testHarness.processEvent(
@@ -389,7 +389,7 @@ class MultipleInputStreamTaskTest {
                     1);
 
             testHarness.waitForTaskCompletion();
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
         }
     }
 
@@ -588,7 +588,7 @@ class MultipleInputStreamTaskTest {
             expectedOutput.add(new StreamRecord<>("2"));
             expectedOutput.add(new StreamRecord<>("3"));
 
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
         }
     }
 
@@ -609,13 +609,13 @@ class MultipleInputStreamTaskTest {
 
             testHarness.processElement(new Watermark(initialTime), 1, 0);
 
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             testHarness.processElement(new Watermark(initialTime), 1, 1);
 
             // now the watermark should have propagated, Map simply forward Watermarks
             expectedOutput.add(new Watermark(initialTime));
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // contrary to checkpoint barriers these elements are not blocked by watermarks
             testHarness.processElement(new StreamRecord<>("Hello", initialTime), 0, 0);
@@ -623,7 +623,7 @@ class MultipleInputStreamTaskTest {
             expectedOutput.add(new StreamRecord<>("Hello", initialTime));
             expectedOutput.add(new StreamRecord<>("42.0", initialTime));
 
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             testHarness.processElement(new Watermark(initialTime + 4), 0, 0);
             testHarness.processElement(new Watermark(initialTime + 3), 0, 1);
@@ -638,13 +638,13 @@ class MultipleInputStreamTaskTest {
             // check whether we get the minimum of all the watermarks, this must also only occur in
             // the output after the two StreamRecords
             expectedOutput.add(new Watermark(initialTime + 2));
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // advance watermark from one of the inputs, now we should get a new one since the
             // minimum increases
             testHarness.processElement(new Watermark(initialTime + 4), 1, 1);
             expectedOutput.add(new Watermark(initialTime + 3));
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // advance the other inputs, now we should get a new one since the minimum increases
             // again
@@ -656,7 +656,7 @@ class MultipleInputStreamTaskTest {
 
             testHarness.processElement(new Watermark(initialTime + 4), 1, 0);
             expectedOutput.add(new Watermark(initialTime + 4));
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             List<String> resultElements =
                     TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
@@ -684,17 +684,17 @@ class MultipleInputStreamTaskTest {
             testHarness.processElement(new Watermark(initialTime + 5), 1, 1);
             testHarness.processElement(WatermarkStatus.IDLE, 1, 0); // once this is acknowledged,
             expectedOutput.add(new Watermark(initialTime + 5));
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // We make the second input idle, which should forward W=6 from the first input
             testHarness.processElement(WatermarkStatus.IDLE, 1, 1);
             expectedOutput.add(new Watermark(initialTime + 6));
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // Make the first input idle
             testHarness.processElement(WatermarkStatus.IDLE, 0, 0);
             expectedOutput.add(WatermarkStatus.IDLE);
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // make source active once again, emit a watermark and go idle again.
             addSourceRecords(testHarness, 1, initialTime + 10);
@@ -705,12 +705,12 @@ class MultipleInputStreamTaskTest {
             expectedOutput.add(new Watermark(initialTime + 10)); // forward W from source
             expectedOutput.add(WatermarkStatus.IDLE); // go idle after reading all records
             testHarness.processAll();
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // make some network input channel active again
             testHarness.processElement(WatermarkStatus.ACTIVE, 0, 1);
             expectedOutput.add(WatermarkStatus.ACTIVE);
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
         }
     }
 
@@ -728,7 +728,7 @@ class MultipleInputStreamTaskTest {
             assertThat(testHarness.getOutput()).doesNotContain(Watermark.MAX_WATERMARK);
 
             testHarness.processElement(Watermark.MAX_WATERMARK, 1, 1);
-            assertThat(testHarness.getOutput()).contains(Watermark.MAX_WATERMARK);
+            assertThat(testHarness.getOutput()).containsExactly(Watermark.MAX_WATERMARK);
         }
     }
 
@@ -958,7 +958,7 @@ class MultipleInputStreamTaskTest {
             testHarness.processElement(latencyMarker);
             expectedOutput.add(latencyMarker);
 
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             testHarness.endInput();
             testHarness.waitForTaskCompletion();
@@ -1104,7 +1104,7 @@ class MultipleInputStreamTaskTest {
             testHarness.processElement(Watermark.MAX_WATERMARK, 2);
             testHarness.waitForTaskCompletion();
             assertThat(testHarness.getOutput())
-                    .contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
+                    .containsExactly(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -100,20 +100,18 @@ import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTest.Watermark
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.CompletingCheckpointResponder;
 import org.apache.flink.streaming.util.TestHarnessUtil;
-import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.testutils.junit.SharedObjectsExtension;
 import org.apache.flink.testutils.junit.SharedReference;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.SerializedValue;
 
-import org.hamcrest.collection.IsMapContaining;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -121,6 +119,7 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -132,40 +131,35 @@ import java.util.function.Consumer;
 import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.processMailTillCheckpointSucceeds;
 import static org.apache.flink.streaming.runtime.tasks.StreamTaskFinalCheckpointsTest.triggerCheckpoint;
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link MultipleInputStreamTask}. Theses tests implicitly also test the {@link
  * StreamMultipleInputProcessor}.
  */
 @SuppressWarnings("serial")
-@RunWith(Parameterized.class)
-public class MultipleInputStreamTaskTest {
+@ExtendWith(ParameterizedTestExtension.class)
+class MultipleInputStreamTaskTest {
 
     private static final List<String> LIFE_CYCLE_EVENTS = new ArrayList<>();
 
     @Parameters(name = "objectReuse = {0}")
-    public static Boolean[] parameters() {
-        return new Boolean[] {true, false};
+    private static Collection<Boolean> parameters() {
+        return Arrays.asList(true, false);
     }
 
-    @Parameter public boolean objectReuse;
+    @Parameter private boolean objectReuse;
 
-    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+    @RegisterExtension
+    private final SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         LIFE_CYCLE_EVENTS.clear();
     }
 
-    @Test
-    public void testBasicProcessing() throws Exception {
+    @TestTemplate
+    void testBasicProcessing() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness = buildTestHarness(objectReuse)) {
             long initialTime = 0L;
             ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
@@ -181,12 +175,12 @@ public class MultipleInputStreamTaskTest {
             testHarness.endInput();
             testHarness.waitForTaskCompletion();
 
-            assertThat(testHarness.getOutput(), containsInAnyOrder(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).containsExactlyInAnyOrder(expectedOutput.toArray());
         }
     }
 
-    @Test
-    public void testCopyForObjectReuse() throws Exception {
+    @TestTemplate
+    void testCopyForObjectReuse() throws Exception {
         SharedReference<List<Integer>> copiedElementsRef = sharedObjects.add(new ArrayList<>());
         CopyProxySerializer proxySerializer = new CopyProxySerializer(copiedElementsRef);
 
@@ -211,16 +205,16 @@ public class MultipleInputStreamTaskTest {
             testHarness.waitForTaskCompletion();
 
             if (objectReuse) {
-                assertTrue(copiedElementsRef.get().isEmpty());
+                assertThat(copiedElementsRef.get()).isEmpty();
             } else {
-                assertThat(copiedElementsRef.get(), containsInAnyOrder(42, 43));
+                assertThat(copiedElementsRef.get()).containsExactlyInAnyOrder(42, 43);
             }
         }
     }
 
     /** This test verifies that checkpoint barriers are correctly forwarded. */
-    @Test
-    public void testCheckpointBarriers() throws Exception {
+    @TestTemplate
+    void testCheckpointBarriers() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
@@ -251,7 +245,7 @@ public class MultipleInputStreamTaskTest {
             expectedOutput.add(new StreamRecord<>("11", initialTime));
             expectedOutput.add(new StreamRecord<>("1.0", initialTime));
 
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             testHarness.processEvent(
                     new CheckpointBarrier(
@@ -284,7 +278,7 @@ public class MultipleInputStreamTaskTest {
                     new CheckpointBarrier(
                             0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()));
 
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
         }
     }
 
@@ -294,8 +288,8 @@ public class MultipleInputStreamTaskTest {
      * some inputs receive barriers from an earlier checkpoint, thereby blocking, then all inputs
      * receive barriers from a later checkpoint.
      */
-    @Test
-    public void testOvertakingCheckpointBarriers() throws Exception {
+    @TestTemplate
+    void testOvertakingCheckpointBarriers() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
@@ -326,7 +320,7 @@ public class MultipleInputStreamTaskTest {
 
             // we should not yet see the barrier, only the two elements from non-blocked input
 
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // Now give a later barrier to all inputs, this should unblock the first channel
             testHarness.processEvent(
@@ -365,7 +359,7 @@ public class MultipleInputStreamTaskTest {
                     new CheckpointBarrier(
                             1, 1, CheckpointOptions.forCheckpointWithDefaultLocation()));
 
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // Then give the earlier barrier, these should be ignored
             testHarness.processEvent(
@@ -395,7 +389,7 @@ public class MultipleInputStreamTaskTest {
                     1);
 
             testHarness.waitForTaskCompletion();
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
         }
     }
 
@@ -406,8 +400,8 @@ public class MultipleInputStreamTaskTest {
      * should on the other hand report all records from all of the inputs (regardless if it's a
      * network or chained input).
      */
-    @Test
-    public void testMetrics() throws Exception {
+    @TestTemplate
+    void testMetrics() throws Exception {
 
         HashMap<String, OperatorMetricGroup> operatorMetrics = new HashMap<>();
 
@@ -453,7 +447,7 @@ public class MultipleInputStreamTaskTest {
                         .setTaskMetricGroup(taskMetricGroup)
                         .build()) {
 
-            assertTrue(operatorMetrics.containsKey(mainOperatorName));
+            assertThat(operatorMetrics).containsKey(mainOperatorName);
             OperatorMetricGroup mainOperatorMetrics = operatorMetrics.get(mainOperatorName);
             Counter numRecordsInCounter =
                     taskMetricGroup.getIOMetricGroup().getNumRecordsInCounter();
@@ -482,11 +476,10 @@ public class MultipleInputStreamTaskTest {
                             * 2
                             * 2
                             * 2; // there are three operators duplicating the records
-            assertEquals(
-                    mainOperatorRecordsIn,
-                    mainOperatorMetrics.getIOMetricGroup().getNumRecordsInCounter().getCount());
-            assertEquals(networkRecordsIn, numRecordsInCounter.getCount());
-            assertEquals(totalRecordsOut, numRecordsOutCounter.getCount());
+            assertThat(mainOperatorMetrics.getIOMetricGroup().getNumRecordsInCounter().getCount())
+                    .isEqualTo(mainOperatorRecordsIn);
+            assertThat(numRecordsInCounter.getCount()).isEqualTo(networkRecordsIn);
+            assertThat(numRecordsOutCounter.getCount()).isEqualTo(totalRecordsOut);
             testHarness.waitForTaskCompletion();
         }
     }
@@ -519,8 +512,8 @@ public class MultipleInputStreamTaskTest {
         }
     }
 
-    @Test
-    public void testLifeCycleOrder() throws Exception {
+    @TestTemplate
+    void testLifeCycleOrder() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
@@ -543,9 +536,8 @@ public class MultipleInputStreamTaskTest {
 
             testHarness.waitForTaskCompletion();
         }
-        assertThat(
-                LIFE_CYCLE_EVENTS,
-                contains(
+        assertThat(LIFE_CYCLE_EVENTS)
+                .contains(
                         LifeCycleTrackingMap.OPEN,
                         LifeCycleTrackingMapToStringMultipleInputOperator.OPEN,
                         LifeCycleTrackingMockSourceReader.START,
@@ -556,11 +548,11 @@ public class MultipleInputStreamTaskTest {
                         LifeCycleTrackingMap.END_INPUT,
                         LifeCycleTrackingMap.CLOSE,
                         LifeCycleTrackingMapToStringMultipleInputOperator.CLOSE,
-                        LifeCycleTrackingMockSourceReader.CLOSE));
+                        LifeCycleTrackingMockSourceReader.CLOSE);
     }
 
-    @Test
-    public void testInputFairness() throws Exception {
+    @TestTemplate
+    void testInputFairness() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
@@ -596,12 +588,12 @@ public class MultipleInputStreamTaskTest {
             expectedOutput.add(new StreamRecord<>("2"));
             expectedOutput.add(new StreamRecord<>("3"));
 
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
         }
     }
 
-    @Test
-    public void testWatermark() throws Exception {
+    @TestTemplate
+    void testWatermark() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 buildWatermarkTestHarness(2, false)) {
             ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
@@ -617,13 +609,13 @@ public class MultipleInputStreamTaskTest {
 
             testHarness.processElement(new Watermark(initialTime), 1, 0);
 
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             testHarness.processElement(new Watermark(initialTime), 1, 1);
 
             // now the watermark should have propagated, Map simply forward Watermarks
             expectedOutput.add(new Watermark(initialTime));
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // contrary to checkpoint barriers these elements are not blocked by watermarks
             testHarness.processElement(new StreamRecord<>("Hello", initialTime), 0, 0);
@@ -631,7 +623,7 @@ public class MultipleInputStreamTaskTest {
             expectedOutput.add(new StreamRecord<>("Hello", initialTime));
             expectedOutput.add(new StreamRecord<>("42.0", initialTime));
 
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             testHarness.processElement(new Watermark(initialTime + 4), 0, 0);
             testHarness.processElement(new Watermark(initialTime + 3), 0, 1);
@@ -646,13 +638,13 @@ public class MultipleInputStreamTaskTest {
             // check whether we get the minimum of all the watermarks, this must also only occur in
             // the output after the two StreamRecords
             expectedOutput.add(new Watermark(initialTime + 2));
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // advance watermark from one of the inputs, now we should get a new one since the
             // minimum increases
             testHarness.processElement(new Watermark(initialTime + 4), 1, 1);
             expectedOutput.add(new Watermark(initialTime + 3));
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // advance the other inputs, now we should get a new one since the minimum increases
             // again
@@ -664,11 +656,11 @@ public class MultipleInputStreamTaskTest {
 
             testHarness.processElement(new Watermark(initialTime + 4), 1, 0);
             expectedOutput.add(new Watermark(initialTime + 4));
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             List<String> resultElements =
                     TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
-            assertEquals(5, resultElements.size());
+            assertThat(resultElements).hasSize(5);
         }
     }
 
@@ -677,8 +669,8 @@ public class MultipleInputStreamTaskTest {
      * checks whether watermarks are forwarded only when we have received watermarks from all
      * inputs. The forwarded watermark must be the minimum of the watermarks of all active inputs.
      */
-    @Test
-    public void testWatermarkAndWatermarkStatusForwarding() throws Exception {
+    @TestTemplate
+    void testWatermarkAndWatermarkStatusForwarding() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 buildWatermarkTestHarness(2, true)) {
             ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
@@ -692,17 +684,17 @@ public class MultipleInputStreamTaskTest {
             testHarness.processElement(new Watermark(initialTime + 5), 1, 1);
             testHarness.processElement(WatermarkStatus.IDLE, 1, 0); // once this is acknowledged,
             expectedOutput.add(new Watermark(initialTime + 5));
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // We make the second input idle, which should forward W=6 from the first input
             testHarness.processElement(WatermarkStatus.IDLE, 1, 1);
             expectedOutput.add(new Watermark(initialTime + 6));
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // Make the first input idle
             testHarness.processElement(WatermarkStatus.IDLE, 0, 0);
             expectedOutput.add(WatermarkStatus.IDLE);
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // make source active once again, emit a watermark and go idle again.
             addSourceRecords(testHarness, 1, initialTime + 10);
@@ -713,17 +705,17 @@ public class MultipleInputStreamTaskTest {
             expectedOutput.add(new Watermark(initialTime + 10)); // forward W from source
             expectedOutput.add(WatermarkStatus.IDLE); // go idle after reading all records
             testHarness.processAll();
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // make some network input channel active again
             testHarness.processElement(WatermarkStatus.ACTIVE, 0, 1);
             expectedOutput.add(WatermarkStatus.ACTIVE);
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
         }
     }
 
-    @Test
-    public void testAdvanceToEndOfEventTime() throws Exception {
+    @TestTemplate
+    void testAdvanceToEndOfEventTime() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 buildWatermarkTestHarness(2, false)) {
             testHarness.processElement(Watermark.MAX_WATERMARK, 0, 0);
@@ -733,16 +725,16 @@ public class MultipleInputStreamTaskTest {
 
             testHarness.processElement(Watermark.MAX_WATERMARK, 1, 0);
 
-            assertThat(testHarness.getOutput(), not(contains(Watermark.MAX_WATERMARK)));
+            assertThat(testHarness.getOutput()).doesNotContain(Watermark.MAX_WATERMARK);
 
             testHarness.processElement(Watermark.MAX_WATERMARK, 1, 1);
-            assertThat(testHarness.getOutput(), contains(Watermark.MAX_WATERMARK));
+            assertThat(testHarness.getOutput()).contains(Watermark.MAX_WATERMARK);
         }
     }
 
-    @Test
+    @TestTemplate
     @SuppressWarnings("unchecked")
-    public void testWatermarkMetrics() throws Exception {
+    void testWatermarkMetrics() throws Exception {
         OperatorID mainOperatorId = new OperatorID();
         OperatorID chainedOperatorId = new OperatorID();
 
@@ -812,57 +804,58 @@ public class MultipleInputStreamTaskTest {
                     (Gauge<Long>)
                             chainedOperatorMetricGroup.get(MetricNames.IO_CURRENT_OUTPUT_WATERMARK);
 
-            assertEquals(Long.MIN_VALUE, taskInputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainInputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainInput1WatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainInput2WatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainInput3WatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainOutputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+            assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainInput1WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainInput2WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainInput3WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
 
             testHarness.processElement(new Watermark(1L), 0);
-            assertEquals(Long.MIN_VALUE, taskInputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainInputWatermarkGauge.getValue().longValue());
-            assertEquals(1L, mainInput1WatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainInput2WatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainInput3WatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainOutputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+            assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainInput1WatermarkGauge.getValue()).isOne();
+            assertThat(mainInput2WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainInput3WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
 
             addSourceRecords(testHarness, 1, 2);
             testHarness.processAll();
-            assertEquals(Long.MIN_VALUE, taskInputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainInputWatermarkGauge.getValue().longValue());
-            assertEquals(1L, mainInput1WatermarkGauge.getValue().longValue());
-            assertEquals(2L, mainInput2WatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainInput3WatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, mainOutputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
-            assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+            assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainInput1WatermarkGauge.getValue()).isOne();
+            assertThat(mainInput2WatermarkGauge.getValue()).isEqualTo(2L);
+            assertThat(mainInput3WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(mainOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+            assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
 
             testHarness.processElement(new Watermark(2L), 1);
-            assertEquals(1L, taskInputWatermarkGauge.getValue().longValue());
-            assertEquals(1L, mainInputWatermarkGauge.getValue().longValue());
-            assertEquals(1L, mainInput1WatermarkGauge.getValue().longValue());
-            assertEquals(2L, mainInput2WatermarkGauge.getValue().longValue());
-            assertEquals(2L, mainInput3WatermarkGauge.getValue().longValue());
-            assertEquals(1L, mainOutputWatermarkGauge.getValue().longValue());
-            assertEquals(1L, chainedInputWatermarkGauge.getValue().longValue());
-            assertEquals(2L, chainedOutputWatermarkGauge.getValue().longValue());
+            assertThat(taskInputWatermarkGauge.getValue()).isOne();
+            assertThat(mainInputWatermarkGauge.getValue()).isOne();
+            assertThat(mainInput1WatermarkGauge.getValue()).isOne();
+            assertThat(mainInput2WatermarkGauge.getValue()).isEqualTo(2L);
+            assertThat(mainInput3WatermarkGauge.getValue()).isEqualTo(2L);
+            assertThat(mainOutputWatermarkGauge.getValue()).isOne();
+            assertThat(chainedInputWatermarkGauge.getValue()).isOne();
+            assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(2L);
 
             testHarness.processElement(new Watermark(4L), 0);
             addSourceRecords(testHarness, 1, 3);
             testHarness.processAll();
-            assertEquals(2L, taskInputWatermarkGauge.getValue().longValue());
-            assertEquals(2L, mainInputWatermarkGauge.getValue().longValue());
-            assertEquals(4L, mainInput1WatermarkGauge.getValue().longValue());
-            assertEquals(3L, mainInput2WatermarkGauge.getValue().longValue());
-            assertEquals(2L, mainInput3WatermarkGauge.getValue().longValue());
-            assertEquals(2L, mainOutputWatermarkGauge.getValue().longValue());
-            assertEquals(2L, chainedInputWatermarkGauge.getValue().longValue());
-            assertEquals(4L, chainedOutputWatermarkGauge.getValue().longValue());
+            assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(2L);
+            assertThat(mainInputWatermarkGauge.getValue()).isEqualTo(2L);
+            assertThat(mainInput1WatermarkGauge.getValue()).isEqualTo(4L);
+            assertThat(mainInput2WatermarkGauge.getValue()).isEqualTo(3L);
+            assertThat(mainInput3WatermarkGauge.getValue()).isEqualTo(2L);
+            assertThat(mainOutputWatermarkGauge.getValue()).isEqualTo(2L);
+            assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(2L);
+            assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(4L);
 
             finishAddingRecords(testHarness, 1);
             testHarness.endInput();
@@ -875,8 +868,8 @@ public class MultipleInputStreamTaskTest {
      * Tests the checkpoint related metrics are registered into {@link TaskIOMetricGroup} correctly
      * while generating the {@link TwoInputStreamTask}.
      */
-    @Test
-    public void testCheckpointBarrierMetrics() throws Exception {
+    @TestTemplate
+    void testCheckpointBarrierMetrics() throws Exception {
         final Map<String, Metric> metrics = new ConcurrentHashMap<>();
         final TaskMetricGroup taskMetricGroup =
                 StreamTaskTestHarness.createTaskMetricGroup(metrics);
@@ -892,8 +885,9 @@ public class MultipleInputStreamTaskTest {
                         .setTaskMetricGroup(taskMetricGroup)
                         .build()) {
 
-            assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_ALIGNMENT_TIME));
-            assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_START_DELAY_TIME));
+            assertThat(metrics)
+                    .containsKey(MetricNames.CHECKPOINT_ALIGNMENT_TIME)
+                    .containsKey(MetricNames.CHECKPOINT_START_DELAY_TIME);
 
             testHarness.endInput();
             testHarness.waitForTaskCompletion();
@@ -901,8 +895,8 @@ public class MultipleInputStreamTaskTest {
     }
 
     /** The CanEmitBatchOfRecords should always be false for {@link MultipleInputStreamTask}. */
-    @Test
-    public void testCanEmitBatchOfRecords() throws Exception {
+    @TestTemplate
+    void testCanEmitBatchOfRecords() throws Exception {
         AvailabilityProvider.AvailabilityHelper availabilityHelper =
                 new AvailabilityProvider.AvailabilityHelper();
         try (StreamTaskMailboxTestHarness<String> testHarness =
@@ -921,28 +915,28 @@ public class MultipleInputStreamTaskTest {
             testHarness.processAll();
 
             availabilityHelper.resetAvailable();
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             // The canEmitBatchOfRecordsChecker should be the false after the record writer is
             // unavailable.
             availabilityHelper.resetUnavailable();
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             // Restore record writer to available
             availabilityHelper.resetAvailable();
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             // The canEmitBatchOfRecordsChecker should be the false after add the mail to mail box.
             testHarness.streamTask.mainMailboxExecutor.execute(() -> {}, "mail");
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             testHarness.processAll();
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
         }
     }
 
-    @Test
-    public void testLatencyMarker() throws Exception {
+    @TestTemplate
+    void testLatencyMarker() throws Exception {
         final Map<String, Metric> metrics = new ConcurrentHashMap<>();
         final TaskMetricGroup taskMetricGroup =
                 StreamTaskTestHarness.createTaskMetricGroup(metrics);
@@ -964,31 +958,31 @@ public class MultipleInputStreamTaskTest {
             testHarness.processElement(latencyMarker);
             expectedOutput.add(latencyMarker);
 
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             testHarness.endInput();
             testHarness.waitForTaskCompletion();
         }
     }
 
-    @Test
-    public void testTriggeringAlignedNoTimeoutCheckpointWithFinishedChannels() throws Exception {
+    @TestTemplate
+    void testTriggeringAlignedNoTimeoutCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
                 CheckpointOptions.alignedNoTimeout(
                         CheckpointType.CHECKPOINT,
                         CheckpointStorageLocationReference.getDefault()));
     }
 
-    @Test
-    public void testTriggeringUnalignedCheckpointWithFinishedChannels() throws Exception {
+    @TestTemplate
+    void testTriggeringUnalignedCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
                 CheckpointOptions.unaligned(
                         CheckpointType.CHECKPOINT,
                         CheckpointStorageLocationReference.getDefault()));
     }
 
-    @Test
-    public void testTriggeringAlignedWithTimeoutCheckpointWithFinishedChannels() throws Exception {
+    @TestTemplate
+    void testTriggeringAlignedWithTimeoutCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
                 CheckpointOptions.alignedWithTimeout(
                         CheckpointType.CHECKPOINT,
@@ -1035,14 +1029,16 @@ public class MultipleInputStreamTaskTest {
                 CompletableFuture<Boolean> checkpointFuture =
                         triggerCheckpoint(testHarness, 2, checkpointOptions);
                 processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(2);
 
                 // Tests triggering checkpoint after some inputs have received EndOfPartition.
                 testHarness.processEvent(new EndOfData(StopMode.DRAIN), 0, 0);
                 testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
                 checkpointFuture = triggerCheckpoint(testHarness, 4, checkpointOptions);
                 processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-                assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(4);
 
                 // Tests triggering checkpoint after all the inputs have received EndOfPartition.
                 testHarness.processEvent(new EndOfData(StopMode.DRAIN), 1, 0);
@@ -1063,13 +1059,14 @@ public class MultipleInputStreamTaskTest {
                 // The checkpoint 6 would be triggered successfully.
                 testHarness.processAll();
                 testHarness.finishProcessing();
-                assertTrue(checkpointFuture.isDone());
+                assertThat(checkpointFuture).isDone();
                 testHarness.getTaskStateManager().getWaitForReportLatch().await();
-                assertEquals(6, testHarness.getTaskStateManager().getReportedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(6);
 
                 // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {
-                    assertEquals(4, resultPartition.getNumberOfQueuedBuffers());
+                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(4);
                 }
             }
         } finally {
@@ -1081,8 +1078,8 @@ public class MultipleInputStreamTaskTest {
         }
     }
 
-    @Test
-    public void testSkipExecutionsIfFinishedOnRestore() throws Exception {
+    @TestTemplate
+    void testSkipExecutionsIfFinishedOnRestore() throws Exception {
         OperatorID nonSourceOperatorId = new OperatorID();
 
         try (StreamTaskMailboxTestHarness<String> testHarness =
@@ -1106,14 +1103,13 @@ public class MultipleInputStreamTaskTest {
             testHarness.processElement(Watermark.MAX_WATERMARK, 1);
             testHarness.processElement(Watermark.MAX_WATERMARK, 2);
             testHarness.waitForTaskCompletion();
-            assertThat(
-                    testHarness.getOutput(),
-                    contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN)));
+            assertThat(testHarness.getOutput())
+                    .contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
         }
     }
 
-    @Test
-    public void testTriggeringStopWithSavepointWithDrain() throws Exception {
+    @TestTemplate
+    void testTriggeringStopWithSavepointWithDrain() throws Exception {
         SourceOperatorFactory<Integer> sourceOperatorFactory =
                 new SourceOperatorFactory<>(
                         new MockSource(Boundedness.CONTINUOUS_UNBOUNDED, 2),
@@ -1165,9 +1161,8 @@ public class MultipleInputStreamTaskTest {
             testHarness.waitForTaskCompletion();
             testHarness.finishProcessing();
 
-            assertTrue(triggerResult.isDone());
-            assertTrue(triggerResult.get());
-            assertTrue(checkpointCompleted.isDone());
+            assertThat(triggerResult).isCompletedWithValue(true);
+            assertThat(checkpointCompleted).isDone();
         }
     }
 
@@ -1198,9 +1193,7 @@ public class MultipleInputStreamTaskTest {
         @Override
         public void open() throws Exception {
             super.open();
-            if (closeCalled) {
-                Assert.fail("Close called before open.");
-            }
+            assertThat(openCalled).as("Close called before open.").isFalse();
             openCalled = true;
         }
 
@@ -1214,9 +1207,7 @@ public class MultipleInputStreamTaskTest {
         @Override
         public void close() throws Exception {
             super.close();
-            if (!openCalled) {
-                Assert.fail("Open was not called before close.");
-            }
+            assertThat(openCalled).as("Open was not called before close.").isTrue();
             closeCalled = true;
         }
 
@@ -1243,9 +1234,7 @@ public class MultipleInputStreamTaskTest {
 
             @Override
             public void processElement(StreamRecord<T> element) throws Exception {
-                if (!openCalled) {
-                    Assert.fail("Open was not called before run.");
-                }
+                assertThat(openCalled).as("Open was not called before run.").isTrue();
                 if (element.hasTimestamp()) {
                     output.collect(
                             new StreamRecord<>(
@@ -1396,8 +1385,8 @@ public class MultipleInputStreamTaskTest {
                         new SerializedValue<>(new NoMoreSplitsEvent()));
     }
 
-    @Test
-    public void testTaskSideOutputStatistics() throws Exception {
+    @TestTemplate
+    void testTaskSideOutputStatistics() throws Exception {
         TaskMetricGroup taskMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
 
@@ -1466,12 +1455,13 @@ public class MultipleInputStreamTaskTest {
             final int oddEvenOperatorOutputsWithOddTag = totalOddRecords;
             final int oddEvenOperatorOutputsWithoutTag = totalOddRecords + totalEvenRecords;
             final int duplicatingOperatorOutput = (totalOddRecords + totalEvenRecords) * 2;
-            assertEquals(totalOddRecords + totalEvenRecords, numRecordsInCounter.getCount());
-            assertEquals(
-                    oddEvenOperatorOutputsWithOddTag
-                            + oddEvenOperatorOutputsWithoutTag
-                            + duplicatingOperatorOutput,
-                    numRecordsOutCounter.getCount());
+            assertThat(numRecordsInCounter.getCount())
+                    .isEqualTo(totalOddRecords + totalEvenRecords);
+            assertThat(numRecordsOutCounter.getCount())
+                    .isEqualTo(
+                            oddEvenOperatorOutputsWithOddTag
+                                    + oddEvenOperatorOutputsWithoutTag
+                                    + duplicatingOperatorOutput);
             testHarness.waitForTaskCompletion();
         } finally {
             for (ResultPartitionWriter partitionWriter : partitionWriters) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -74,11 +74,8 @@ import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.TestLogger;
 
-import org.hamcrest.collection.IsMapContaining;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayDeque;
@@ -94,12 +91,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link OneInputStreamTask}.
@@ -109,7 +101,7 @@ import static org.junit.Assert.fail;
  * used as a representative to test OneInputStreamTask, since OneInputStreamTask is used for all
  * OneInputStreamOperators.
  */
-public class OneInputStreamTaskTest extends TestLogger {
+class OneInputStreamTaskTest {
 
     private static final ListStateDescriptor<Integer> TEST_DESCRIPTOR =
             new ListStateDescriptor<>("test", new IntSerializer());
@@ -120,7 +112,7 @@ public class OneInputStreamTaskTest extends TestLogger {
      * emitted elements.
      */
     @Test
-    public void testOpenCloseAndTimestamps() throws Exception {
+    void testOpenCloseAndTimestamps() throws Exception {
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
                         OneInputStreamTask::new,
@@ -151,7 +143,9 @@ public class OneInputStreamTaskTest extends TestLogger {
 
         testHarness.waitForTaskCompletion();
 
-        assertTrue("RichFunction methods where not called.", TestOpenCloseMapFunction.closeCalled);
+        assertThat(TestOpenCloseMapFunction.closeCalled)
+                .as("RichFunction methods where not called.")
+                .isTrue();
 
         TestHarnessUtil.assertOutputEquals(
                 "Output was not correct.", expectedOutput, testHarness.getOutput());
@@ -163,7 +157,7 @@ public class OneInputStreamTaskTest extends TestLogger {
      * inputs. The forwarded watermark must be the minimum of the watermarks of all active inputs.
      */
     @Test
-    public void testWatermarkAndWatermarkStatusForwarding() throws Exception {
+    void testWatermarkAndWatermarkStatusForwarding() throws Exception {
 
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
@@ -273,7 +267,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 
         List<String> resultElements =
                 TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
-        assertEquals(2, resultElements.size());
+        assertThat(resultElements).hasSize(2);
     }
 
     /**
@@ -286,7 +280,7 @@ public class OneInputStreamTaskTest extends TestLogger {
      * were forwarded watermarks when the task is idle.
      */
     @Test
-    public void testWatermarksNotForwardedWithinChainWhenIdle() throws Exception {
+    void testWatermarksNotForwardedWithinChainWhenIdle() throws Exception {
 
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
@@ -406,12 +400,12 @@ public class OneInputStreamTaskTest extends TestLogger {
 
         List<String> resultElements =
                 TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
-        assertEquals(12, resultElements.size());
+        assertThat(resultElements).hasSize(12);
     }
 
     /** This test verifies that checkpoint barriers are correctly forwarded. */
     @Test
-    public void testCheckpointBarriers() throws Exception {
+    void testCheckpointBarriers() throws Exception {
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
                         OneInputStreamTask::new,
@@ -485,7 +479,7 @@ public class OneInputStreamTaskTest extends TestLogger {
      * receive barriers from a later checkpoint.
      */
     @Test
-    public void testOvertakingCheckpointBarriers() throws Exception {
+    void testOvertakingCheckpointBarriers() throws Exception {
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
                         OneInputStreamTask::new,
@@ -581,7 +575,7 @@ public class OneInputStreamTaskTest extends TestLogger {
      * operators.
      */
     @Test
-    public void testSnapshottingAndRestoring() throws Exception {
+    void testSnapshottingAndRestoring() throws Exception {
         final Deadline deadline = Deadline.fromNow(Duration.ofMinutes(2));
 
         final OneInputStreamTaskTestHarness<String, String> testHarness =
@@ -621,11 +615,11 @@ public class OneInputStreamTaskTest extends TestLogger {
                 .get();
 
         // since no state was set, there shouldn't be restore calls
-        assertEquals(0, TestingStreamOperator.numberRestoreCalls);
+        assertThat(TestingStreamOperator.numberRestoreCalls).isZero();
 
         taskStateManager.getWaitForReportLatch().await();
 
-        assertEquals(checkpointId, taskStateManager.getReportedCheckpointId());
+        assertThat(taskStateManager.getReportedCheckpointId()).isEqualTo(checkpointId);
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion(deadline.timeLeft().toMillis());
@@ -646,7 +640,7 @@ public class OneInputStreamTaskTest extends TestLogger {
         configureChainedTestingStreamOperator(restoredTaskStreamConfig, numberChainedTasks);
 
         TaskStateSnapshot stateHandles = taskStateManager.getLastJobManagerTaskStateSnapshot();
-        Assert.assertEquals(numberChainedTasks, stateHandles.getSubtaskStateMappings().size());
+        assertThat(stateHandles.getSubtaskStateMappings()).hasSize(numberChainedTasks);
 
         TestingStreamOperator.numberRestoreCalls = 0;
 
@@ -658,14 +652,14 @@ public class OneInputStreamTaskTest extends TestLogger {
         restoredTaskHarness.waitForTaskCompletion(deadline.timeLeft().toMillis());
 
         // restore of every chained operator should have been called
-        assertEquals(numberChainedTasks, TestingStreamOperator.numberRestoreCalls);
+        assertThat(TestingStreamOperator.numberRestoreCalls).isEqualTo(numberChainedTasks);
 
         TestingStreamOperator.numberRestoreCalls = 0;
         TestingStreamOperator.numberSnapshotCalls = 0;
     }
 
     @Test
-    public void testQuiesceTimerServiceAfterOpClose() throws Exception {
+    void testQuiesceTimerServiceAfterOpClose() throws Exception {
 
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
@@ -687,7 +681,7 @@ public class OneInputStreamTaskTest extends TestLogger {
                 (SystemProcessingTimeService) testHarness.getTimerService();
 
         // verify that the timer service is running
-        Assert.assertTrue(timeService.isAlive());
+        assertThat(timeService.isAlive()).isTrue();
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
@@ -695,7 +689,7 @@ public class OneInputStreamTaskTest extends TestLogger {
     }
 
     @Test
-    public void testClosingAllOperatorsOnChainProperly() throws Exception {
+    void testClosingAllOperatorsOnChainProperly() throws Exception {
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
                         OneInputStreamTask::new,
@@ -728,7 +722,7 @@ public class OneInputStreamTaskTest extends TestLogger {
                 new StreamRecord<>("[Operator1]: End of input"),
                 new StreamRecord<>("[Operator1]: Finish"));
 
-        assertThat(testHarness.getOutput(), containsInAnyOrder(expected.toArray()));
+        assertThat(testHarness.getOutput()).containsExactlyInAnyOrder(expected.toArray());
     }
 
     private static class TestOperator extends AbstractStreamOperator<String>
@@ -745,15 +739,16 @@ public class OneInputStreamTaskTest extends TestLogger {
         public void finish() throws Exception {
 
             // verify that the timer service is still running
-            Assert.assertTrue(
-                    ((SystemProcessingTimeService) getContainingTask().getTimerService())
-                            .isAlive());
+            assertThat(
+                            ((SystemProcessingTimeService) getContainingTask().getTimerService())
+                                    .isAlive())
+                    .isTrue();
             super.close();
         }
     }
 
     @Test
-    public void testOperatorMetricReuse() throws Exception {
+    void testOperatorMetricReuse() throws Exception {
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
                         OneInputStreamTask::new,
@@ -807,8 +802,8 @@ public class OneInputStreamTaskTest extends TestLogger {
         }
         testHarness.waitForInputProcessing();
 
-        assertEquals(numRecords, numRecordsInCounter.getCount());
-        assertEquals(numRecords * 2 * 2 * 2, numRecordsOutCounter.getCount());
+        assertThat(numRecordsInCounter.getCount()).isEqualTo(numRecords);
+        assertThat(numRecordsOutCounter.getCount()).isEqualTo(numRecords * 2 * 2 * 2);
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
@@ -825,7 +820,7 @@ public class OneInputStreamTaskTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testWatermarkMetrics() throws Exception {
+    void testWatermarkMetrics() throws Exception {
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
                         OneInputStreamTask::new,
@@ -895,39 +890,38 @@ public class OneInputStreamTaskTest extends TestLogger {
                 (Gauge<Long>)
                         chainedOperatorMetricGroup.get(MetricNames.IO_CURRENT_OUTPUT_WATERMARK);
 
-        Assert.assertEquals(
-                "A metric was registered multiple times.",
-                5,
-                new HashSet<>(
+        assertThat(
+                        new HashSet<>(
                                 Arrays.asList(
                                         taskInputWatermarkGauge,
                                         headInputWatermarkGauge,
                                         headOutputWatermarkGauge,
                                         chainedInputWatermarkGauge,
-                                        chainedOutputWatermarkGauge))
-                        .size());
+                                        chainedOutputWatermarkGauge)))
+                .as("A metric was registered multiple times.")
+                .hasSize(5);
 
-        Assert.assertEquals(Long.MIN_VALUE, taskInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, headInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, headOutputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+        assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(headInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(headOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
 
         testHarness.processElement(new Watermark(1L));
         testHarness.waitForInputProcessing();
-        Assert.assertEquals(1L, taskInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(1L, headInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(2L, headOutputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(2L, chainedInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(4L, chainedOutputWatermarkGauge.getValue().longValue());
+        assertThat(taskInputWatermarkGauge.getValue()).isOne();
+        assertThat(headInputWatermarkGauge.getValue()).isOne();
+        assertThat(headOutputWatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(4L);
 
         testHarness.processElement(new Watermark(2L));
         testHarness.waitForInputProcessing();
-        Assert.assertEquals(2L, taskInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(2L, headInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(4L, headOutputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(4L, chainedInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(8L, chainedOutputWatermarkGauge.getValue().longValue());
+        assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(headInputWatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(headOutputWatermarkGauge.getValue()).isEqualTo(4L);
+        assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(4L);
+        assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(8L);
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
@@ -938,7 +932,7 @@ public class OneInputStreamTaskTest extends TestLogger {
      * while generating the {@link OneInputStreamTask}.
      */
     @Test
-    public void testCheckpointBarrierMetrics() throws Exception {
+    void testCheckpointBarrierMetrics() throws Exception {
         final OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
                         OneInputStreamTask::new,
@@ -958,15 +952,16 @@ public class OneInputStreamTaskTest extends TestLogger {
         testHarness.invoke(environment);
         testHarness.waitForTaskRunning();
 
-        assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_ALIGNMENT_TIME));
-        assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_START_DELAY_TIME));
+        assertThat(metrics)
+                .containsKey(MetricNames.CHECKPOINT_ALIGNMENT_TIME)
+                .containsKey(MetricNames.CHECKPOINT_START_DELAY_TIME);
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
     }
 
     @Test
-    public void testCanEmitBatchOfRecords() throws Exception {
+    void testCanEmitBatchOfRecords() throws Exception {
         AvailabilityProvider.AvailabilityHelper availabilityHelper =
                 new AvailabilityProvider.AvailabilityHelper();
         try (StreamTaskMailboxTestHarness<Integer> testHarness =
@@ -983,28 +978,28 @@ public class OneInputStreamTaskTest extends TestLogger {
             testHarness.processAll();
 
             availabilityHelper.resetAvailable();
-            assertTrue(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isTrue();
 
             // The canEmitBatchOfRecordsChecker should be the false after the record writer is
             // unavailable.
             availabilityHelper.resetUnavailable();
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             // Restore record writer to available
             availabilityHelper.resetAvailable();
-            assertTrue(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isTrue();
 
             // The canEmitBatchOfRecordsChecker should be the false after add the mail to mail box.
             testHarness.streamTask.mainMailboxExecutor.execute(() -> {}, "mail");
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             testHarness.processAll();
-            assertTrue(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isTrue();
         }
     }
 
     @Test
-    public void testTaskSideOutputStatistics() throws Exception {
+    void testTaskSideOutputStatistics() throws Exception {
         TaskMetricGroup taskMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
 
@@ -1061,12 +1056,12 @@ public class OneInputStreamTaskTest extends TestLogger {
             final int oddEvenOperatorOutputsWithOddTag = numOddRecords;
             final int oddEvenOperatorOutputsWithoutTag = numOddRecords + numEvenRecords;
             final int duplicatingOperatorOutput = (numOddRecords + numEvenRecords) * 2;
-            assertEquals(numOddRecords + numEvenRecords, numRecordsInCounter.getCount());
-            assertEquals(
-                    oddEvenOperatorOutputsWithOddTag
-                            + oddEvenOperatorOutputsWithoutTag
-                            + duplicatingOperatorOutput,
-                    numRecordsOutCounter.getCount());
+            assertThat(numRecordsInCounter.getCount()).isEqualTo(numOddRecords + numEvenRecords);
+            assertThat(numRecordsOutCounter.getCount())
+                    .isEqualTo(
+                            oddEvenOperatorOutputsWithOddTag
+                                    + oddEvenOperatorOutputsWithoutTag
+                                    + duplicatingOperatorOutput);
             testHarness.waitForTaskCompletion();
         } finally {
             for (ResultPartitionWriter partitionWriter : partitionWriters) {
@@ -1206,18 +1201,15 @@ public class OneInputStreamTaskTest extends TestLogger {
                     context.getOperatorStateStore().getListState(TEST_DESCRIPTOR);
 
             if (numberSnapshotCalls == 0) {
-                for (Integer v : partitionableState.get()) {
-                    fail();
-                }
+                assertThat(partitionableState.get()).isEmpty();
             } else {
                 Set<Integer> result = new HashSet<>();
                 for (Integer v : partitionableState.get()) {
                     result.add(v);
                 }
 
-                assertEquals(2, result.size());
-                assertTrue(result.contains(42));
-                assertTrue(result.contains(4711));
+                assertThat(result).hasSize(2);
+                assertThat(result).contains(42, 4711);
             }
         }
 
@@ -1243,26 +1235,20 @@ public class OneInputStreamTaskTest extends TestLogger {
         @Override
         public void open(OpenContext openContext) throws Exception {
             super.open(openContext);
-            if (closeCalled) {
-                Assert.fail("Close called before open.");
-            }
+            assertThat(openCalled).as("Close called before open.").isFalse();
             openCalled = true;
         }
 
         @Override
         public void close() throws Exception {
             super.close();
-            if (!openCalled) {
-                Assert.fail("Open was not called before close.");
-            }
+            assertThat(openCalled).as("Open was not called before close.").isTrue();
             closeCalled = true;
         }
 
         @Override
         public String map(String value) throws Exception {
-            if (!openCalled) {
-                Assert.fail("Open was not called before run.");
-            }
+            assertThat(openCalled).as("Open was not called before run.").isTrue();
             return value;
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -1208,8 +1208,7 @@ class OneInputStreamTaskTest {
                     result.add(v);
                 }
 
-                assertThat(result).hasSize(2);
-                assertThat(result).contains(42, 4711);
+                assertThat(result).containsExactlyInAnyOrder(42, 4711);
             }
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.SetupableStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
-import org.apache.flink.streaming.runtime.operators.StreamOperatorChainingTest;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 
@@ -48,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * This class test the {@link OperatorChain}.
  *
  * <p>It takes a different (simpler) approach at testing the operator chain than {@link
- * StreamOperatorChainingTest}.
+ * org.apache.flink.streaming.runtime.operators.StreamOperatorChainingTest}.
  */
 class OperatorChainTest {
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -33,7 +33,7 @@ import org.apache.flink.streaming.runtime.operators.StreamOperatorChainingTest;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,7 +42,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This class test the {@link OperatorChain}.
@@ -50,10 +50,10 @@ import static org.junit.Assert.assertEquals;
  * <p>It takes a different (simpler) approach at testing the operator chain than {@link
  * StreamOperatorChainingTest}.
  */
-public class OperatorChainTest {
+class OperatorChainTest {
 
     @Test
-    public void testPrepareCheckpointPreBarrier() throws Exception {
+    void testPrepareCheckpointPreBarrier() throws Exception {
         final AtomicInteger intRef = new AtomicInteger();
 
         final OneInputStreamOperator<String, String> one = new ValidatingOperator(intRef, 0);
@@ -63,7 +63,7 @@ public class OperatorChainTest {
         final OperatorChain<?, ?> chain = setupOperatorChain(one, two, three);
         chain.prepareSnapshotPreBarrier(ValidatingOperator.CHECKPOINT_ID);
 
-        assertEquals(3, intRef.get());
+        assertThat(intRef).hasValue(3);
     }
 
     // ------------------------------------------------------------------------
@@ -71,7 +71,7 @@ public class OperatorChainTest {
     // ------------------------------------------------------------------------
 
     @SafeVarargs
-    public static <T, OP extends StreamOperator<T>> OperatorChain<T, OP> setupOperatorChain(
+    static <T, OP extends StreamOperator<T>> OperatorChain<T, OP> setupOperatorChain(
             OneInputStreamOperator<T, T>... operators) throws Exception {
 
         checkNotNull(operators);
@@ -148,8 +148,8 @@ public class OperatorChainTest {
 
         @Override
         public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
-            assertEquals("wrong checkpointId", CHECKPOINT_ID, checkpointId);
-            assertEquals("wrong order", expected, toUpdate.getAndIncrement());
+            assertThat(checkpointId).as("wrong checkpointId").isEqualTo(CHECKPOINT_ID);
+            assertThat(toUpdate.getAndIncrement()).as("wrong order").isEqualTo(expected);
         }
 
         @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
@@ -37,38 +37,32 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestHarnessUtil;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests ensuring correct behaviour of {@link
  * org.apache.flink.runtime.state.ManagedInitializationContext#isRestored} method.
  */
-public class RestoreStreamTaskTest extends TestLogger {
+class RestoreStreamTaskTest {
 
     private static final Map<OperatorID, Long> RESTORED_OPERATORS = new ConcurrentHashMap();
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         RESTORED_OPERATORS.clear();
     }
 
     @Test
-    public void testRestore() throws Exception {
+    void testRestore() throws Exception {
 
         OperatorID headOperatorID = new OperatorID(42L, 42L);
         OperatorID tailOperatorID = new OperatorID(44L, 44L);
@@ -83,7 +77,7 @@ public class RestoreStreamTaskTest extends TestLogger {
 
         TaskStateSnapshot stateHandles = restore.getTaskStateSnapshot();
 
-        assertEquals(2, stateHandles.getSubtaskStateMappings().size());
+        assertThat(stateHandles.getSubtaskStateMappings()).hasSize(2);
 
         createRunAndCheckpointOperatorChain(
                 headOperatorID,
@@ -92,16 +86,13 @@ public class RestoreStreamTaskTest extends TestLogger {
                 new CounterOperator(),
                 Optional.of(restore));
 
-        assertEquals(
-                new HashSet<>(Arrays.asList(headOperatorID, tailOperatorID)),
-                RESTORED_OPERATORS.keySet());
-        assertThat(
-                new HashSet<>(RESTORED_OPERATORS.values()),
-                contains(restore.getRestoreCheckpointId()));
+        assertThat(RESTORED_OPERATORS)
+                .containsOnlyKeys(headOperatorID, tailOperatorID)
+                .containsValue(restore.getRestoreCheckpointId());
     }
 
     @Test
-    public void testRestoreHeadWithNewId() throws Exception {
+    void testRestoreHeadWithNewId() throws Exception {
 
         OperatorID tailOperatorID = new OperatorID(44L, 44L);
 
@@ -115,7 +106,7 @@ public class RestoreStreamTaskTest extends TestLogger {
 
         TaskStateSnapshot stateHandles = restore.getTaskStateSnapshot();
 
-        assertEquals(2, stateHandles.getSubtaskStateMappings().size());
+        assertThat(stateHandles.getSubtaskStateMappings()).hasSize(2);
 
         createRunAndCheckpointOperatorChain(
                 new OperatorID(4242L, 4242L),
@@ -124,14 +115,13 @@ public class RestoreStreamTaskTest extends TestLogger {
                 new CounterOperator(),
                 Optional.of(restore));
 
-        assertEquals(Collections.singleton(tailOperatorID), RESTORED_OPERATORS.keySet());
-        assertThat(
-                new HashSet<>(RESTORED_OPERATORS.values()),
-                contains(restore.getRestoreCheckpointId()));
+        assertThat(RESTORED_OPERATORS)
+                .containsOnlyKeys(tailOperatorID)
+                .containsValue(restore.getRestoreCheckpointId());
     }
 
     @Test
-    public void testRestoreTailWithNewId() throws Exception {
+    void testRestoreTailWithNewId() throws Exception {
         OperatorID headOperatorID = new OperatorID(42L, 42L);
 
         JobManagerTaskRestore restore =
@@ -143,7 +133,7 @@ public class RestoreStreamTaskTest extends TestLogger {
                         Optional.empty());
 
         TaskStateSnapshot stateHandles = restore.getTaskStateSnapshot();
-        assertEquals(2, stateHandles.getSubtaskStateMappings().size());
+        assertThat(stateHandles.getSubtaskStateMappings()).hasSize(2);
 
         createRunAndCheckpointOperatorChain(
                 headOperatorID,
@@ -152,14 +142,13 @@ public class RestoreStreamTaskTest extends TestLogger {
                 new CounterOperator(),
                 Optional.of(restore));
 
-        assertEquals(Collections.singleton(headOperatorID), RESTORED_OPERATORS.keySet());
-        assertThat(
-                new HashSet<>(RESTORED_OPERATORS.values()),
-                contains(restore.getRestoreCheckpointId()));
+        assertThat(RESTORED_OPERATORS)
+                .containsOnlyKeys(headOperatorID)
+                .containsValue(restore.getRestoreCheckpointId());
     }
 
     @Test
-    public void testRestoreAfterScaleUp() throws Exception {
+    void testRestoreAfterScaleUp() throws Exception {
         OperatorID headOperatorID = new OperatorID(42L, 42L);
         OperatorID tailOperatorID = new OperatorID(44L, 44L);
 
@@ -173,7 +162,7 @@ public class RestoreStreamTaskTest extends TestLogger {
 
         TaskStateSnapshot stateHandles = restore.getTaskStateSnapshot();
 
-        assertEquals(2, stateHandles.getSubtaskStateMappings().size());
+        assertThat(stateHandles.getSubtaskStateMappings()).hasSize(2);
 
         // test empty state in case of scale up
 
@@ -188,16 +177,13 @@ public class RestoreStreamTaskTest extends TestLogger {
                 new CounterOperator(),
                 Optional.of(restore));
 
-        assertEquals(
-                new HashSet<>(Arrays.asList(headOperatorID, tailOperatorID)),
-                RESTORED_OPERATORS.keySet());
-        assertThat(
-                new HashSet<>(RESTORED_OPERATORS.values()),
-                contains(restore.getRestoreCheckpointId()));
+        assertThat(RESTORED_OPERATORS)
+                .containsOnlyKeys(headOperatorID, tailOperatorID)
+                .containsValue(restore.getRestoreCheckpointId());
     }
 
     @Test
-    public void testRestoreWithoutState() throws Exception {
+    void testRestoreWithoutState() throws Exception {
         OperatorID headOperatorID = new OperatorID(42L, 42L);
         OperatorID tailOperatorID = new OperatorID(44L, 44L);
 
@@ -210,7 +196,7 @@ public class RestoreStreamTaskTest extends TestLogger {
                         Optional.empty());
 
         TaskStateSnapshot stateHandles = restore.getTaskStateSnapshot();
-        assertEquals(2, stateHandles.getSubtaskStateMappings().size());
+        assertThat(stateHandles.getSubtaskStateMappings()).hasSize(2);
 
         createRunAndCheckpointOperatorChain(
                 headOperatorID,
@@ -219,12 +205,9 @@ public class RestoreStreamTaskTest extends TestLogger {
                 new CounterOperator(),
                 Optional.of(restore));
 
-        assertEquals(
-                new HashSet<>(Arrays.asList(headOperatorID, tailOperatorID)),
-                RESTORED_OPERATORS.keySet());
-        assertThat(
-                new HashSet<>(RESTORED_OPERATORS.values()),
-                contains(restore.getRestoreCheckpointId()));
+        assertThat(RESTORED_OPERATORS)
+                .containsOnlyKeys(headOperatorID, tailOperatorID)
+                .containsValue(restore.getRestoreCheckpointId());
     }
 
     private JobManagerTaskRestore createRunAndCheckpointOperatorChain(
@@ -298,7 +281,7 @@ public class RestoreStreamTaskTest extends TestLogger {
         testHarness.taskStateManager.getWaitForReportLatch().await();
         long reportedCheckpointId = testHarness.taskStateManager.getReportedCheckpointId();
 
-        assertEquals(checkpointId, reportedCheckpointId);
+        assertThat(reportedCheckpointId).isEqualTo(checkpointId);
     }
 
     private void processRecords(OneInputStreamTaskTestHarness<String, String> testHarness)
@@ -323,10 +306,9 @@ public class RestoreStreamTaskTest extends TestLogger {
 
         @Override
         public void initializeState(StateInitializationContext context) throws Exception {
-            assertEquals(
-                    "Restored context id should be set iff is restored",
-                    context.isRestored(),
-                    context.getRestoredCheckpointId().isPresent());
+            assertThat(context.getRestoredCheckpointId().isPresent())
+                    .as("Restored context id should be set iff is restored")
+                    .isEqualTo(context.isRestored());
             if (context.isRestored()) {
                 RESTORED_OPERATORS.put(
                         getOperatorID(), context.getRestoredCheckpointId().getAsLong());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceExternalCheckpointTriggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceExternalCheckpointTriggerTest.java
@@ -32,33 +32,33 @@ import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.BlockingQueue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * These tests verify the behavior of a source function that triggers checkpoints in response to
  * received events.
  */
 @SuppressWarnings("serial")
-public class SourceExternalCheckpointTriggerTest {
+class SourceExternalCheckpointTriggerTest {
 
     private static OneShotLatch ready = new OneShotLatch();
     private static MultiShotLatch sync = new MultiShotLatch();
 
-    @Before
-    public void resetLatches() {
+    @BeforeEach
+    void resetLatches() {
         ready = new OneShotLatch();
         sync = new MultiShotLatch();
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testCheckpointsTriggeredBySource() throws Exception {
+    void testCheckpointsTriggeredBySource() throws Exception {
         // set up the basic test harness
         final StreamTaskTestHarness<Long> testHarness =
                 new StreamTaskTestHarness<>(SourceStreamTask::new, BasicTypeInfo.LONG_TYPE_INFO);
@@ -85,12 +85,12 @@ public class SourceExternalCheckpointTriggerTest {
         ready.await();
 
         // now send an external trigger that should be ignored
-        assertTrue(
-                sourceTask
-                        .triggerCheckpointAsync(
+        assertThatFuture(
+                        sourceTask.triggerCheckpointAsync(
                                 new CheckpointMetaData(32, 829),
-                                CheckpointOptions.forCheckpointWithDefaultLocation())
-                        .get());
+                                CheckpointOptions.forCheckpointWithDefaultLocation()))
+                .eventuallySucceeds()
+                .isEqualTo(true);
 
         // step by step let the source thread emit elements
         sync.trigger();
@@ -106,12 +106,12 @@ public class SourceExternalCheckpointTriggerTest {
         verifyNextElement(testHarness.getOutput(), 4L);
 
         // now send an regular trigger command that should be ignored
-        assertTrue(
-                sourceTask
-                        .triggerCheckpointAsync(
+        assertThatFuture(
+                        sourceTask.triggerCheckpointAsync(
                                 new CheckpointMetaData(34, 900),
-                                CheckpointOptions.forCheckpointWithDefaultLocation())
-                        .get());
+                                CheckpointOptions.forCheckpointWithDefaultLocation()))
+                .eventuallySucceeds()
+                .isEqualTo(true);
 
         sync.trigger();
         verifyNextElement(testHarness.getOutput(), 5L);
@@ -138,16 +138,21 @@ public class SourceExternalCheckpointTriggerTest {
     private void verifyNextElement(BlockingQueue<Object> output, long expectedElement)
             throws InterruptedException {
         Object next = output.take();
-        assertTrue("next element is not an event", next instanceof StreamRecord);
-        assertEquals(
-                "wrong event", expectedElement, ((StreamRecord<Long>) next).getValue().longValue());
+        assertThat(next).as("next element is not an event").isInstanceOf(StreamRecord.class);
+        assertThat(((StreamRecord<Long>) next).getValue())
+                .as("wrong event")
+                .isEqualTo(expectedElement);
     }
 
     private void verifyCheckpointBarrier(BlockingQueue<Object> output, long checkpointId)
             throws InterruptedException {
         Object next = output.take();
-        assertTrue("next element is not a checkpoint barrier", next instanceof CheckpointBarrier);
-        assertEquals("wrong checkpoint id", checkpointId, ((CheckpointBarrier) next).getId());
+        assertThat(next)
+                .as("next element is not a checkpoint barrier")
+                .isInstanceOf(CheckpointBarrier.class);
+        assertThat(((CheckpointBarrier) next).getId())
+                .as("wrong checkpoint id")
+                .isEqualTo(checkpointId);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceOperatorStreamTaskTest.java
@@ -151,7 +151,7 @@ class SourceOperatorStreamTaskTest extends SourceStreamTaskTestBase {
             Queue<Object> expectedOutput = new LinkedList<>();
             expectedOutput.add(Watermark.MAX_WATERMARK);
             expectedOutput.add(new EndOfData(StopMode.DRAIN));
-            assertThat(testHarness.getOutput().toArray()).isEqualTo(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -79,7 +79,7 @@ import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 /** Mock {@link Environment}. */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapperTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapperTest.java
@@ -28,14 +28,12 @@ import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
-import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,17 +44,13 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link StreamOperatorWrapper}. */
-public class StreamOperatorWrapperTest extends TestLogger {
+class StreamOperatorWrapperTest {
 
     private static SystemProcessingTimeService timerService;
 
@@ -68,19 +62,19 @@ public class StreamOperatorWrapperTest extends TestLogger {
 
     private volatile StreamTask<?, ?> containingTask;
 
-    @BeforeClass
-    public static void startTimeService() {
+    @BeforeAll
+    static void startTimeService() {
         CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
         timerService = new SystemProcessingTimeService(errorFuture::complete);
     }
 
-    @AfterClass
-    public static void shutdownTimeService() {
+    @AfterAll
+    static void shutdownTimeService() {
         timerService.shutdownService();
     }
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() throws Exception {
         this.operatorWrappers = new ArrayList<>();
         this.output = new ConcurrentLinkedQueue<>();
 
@@ -127,13 +121,13 @@ public class StreamOperatorWrapperTest extends TestLogger {
         }
     }
 
-    @After
-    public void teardown() throws Exception {
+    @AfterEach
+    void teardown() throws Exception {
         containingTask.cleanUpInternal();
     }
 
     @Test
-    public void testFinish() throws Exception {
+    void testFinish() throws Exception {
         output.clear();
         operatorWrappers.get(0).finish(containingTask.getActionExecutor(), StopMode.DRAIN);
 
@@ -148,14 +142,13 @@ public class StreamOperatorWrapperTest extends TestLogger {
                     prefix + ": Mail to put in mailbox when finishing operator");
         }
 
-        assertArrayEquals(
-                "Output was not correct.",
-                expected.subList(2, expected.size()).toArray(),
-                output.toArray());
+        assertThat(output.toArray())
+                .as("Output was not correct.")
+                .isEqualTo(expected.subList(2, expected.size()).toArray());
     }
 
     @Test
-    public void testFinishingOperatorWithException() {
+    void testFinishingOperatorWithException() {
         AbstractStreamOperator<Void> streamOperator =
                 new AbstractStreamOperator<Void>() {
                     @Override
@@ -173,46 +166,43 @@ public class StreamOperatorWrapperTest extends TestLogger {
                                 .createExecutor(Integer.MAX_VALUE - 1),
                         true);
 
-        try {
-            operatorWrapper.finish(containingTask.getActionExecutor(), StopMode.DRAIN);
-            fail("should throw an exception");
-        } catch (Throwable t) {
-            Optional<Throwable> optional =
-                    ExceptionUtils.findThrowableWithMessage(t, "test exception at finishing");
-            assertTrue(optional.isPresent());
-        }
+        assertThatThrownBy(
+                        () ->
+                                operatorWrapper.finish(
+                                        containingTask.getActionExecutor(), StopMode.DRAIN))
+                .hasMessageContaining("test exception at finishing");
     }
 
     @Test
-    public void testReadIterator() {
+    void testReadIterator() {
         // traverse operators in forward order
         Iterator<StreamOperatorWrapper<?, ?>> it =
                 new StreamOperatorWrapper.ReadIterator(operatorWrappers.get(0), false);
         for (int i = 0; i < operatorWrappers.size(); i++) {
-            assertTrue(it.hasNext());
+            assertThat(it).hasNext();
 
             StreamOperatorWrapper<?, ?> next = it.next();
-            assertNotNull(next);
+            assertThat(next).isNotNull();
 
             TestOneInputStreamOperator operator = getStreamOperatorFromWrapper(next);
-            assertEquals("Operator" + i, operator.getName());
+            assertThat(operator.getName()).isEqualTo("Operator" + i);
         }
-        assertFalse(it.hasNext());
+        assertThat(it).isExhausted();
 
         // traverse operators in reverse order
         it =
                 new StreamOperatorWrapper.ReadIterator(
                         operatorWrappers.get(operatorWrappers.size() - 1), true);
         for (int i = operatorWrappers.size() - 1; i >= 0; i--) {
-            assertTrue(it.hasNext());
+            assertThat(it).hasNext();
 
             StreamOperatorWrapper<?, ?> next = it.next();
-            assertNotNull(next);
+            assertThat(next).isNotNull();
 
             TestOneInputStreamOperator operator = getStreamOperatorFromWrapper(next);
-            assertEquals("Operator" + i, operator.getName());
+            assertThat(operator.getName()).isEqualTo("Operator" + i);
         }
-        assertFalse(it.hasNext());
+        assertThat(it).isExhausted();
     }
 
     private TestOneInputStreamOperator getStreamOperatorFromWrapper(
@@ -322,8 +312,8 @@ public class StreamOperatorWrapperTest extends TestLogger {
                                     "["
                                             + name
                                             + "]: Timer to put in mailbox when finishing operator");
-            assertNotNull(processingTimeService.registerTimer(0, callback));
-            assertNull(timerMailController.getPuttingLatch(callback));
+            assertThat((Future<?>) processingTimeService.registerTimer(0, callback)).isNotNull();
+            assertThat(timerMailController.getPuttingLatch(callback)).isNull();
 
             mailboxExecutor.submit(
                     () ->

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapperTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamOperatorWrapperTest.java
@@ -142,9 +142,9 @@ class StreamOperatorWrapperTest {
                     prefix + ": Mail to put in mailbox when finishing operator");
         }
 
-        assertThat(output.toArray())
+        assertThat(output)
                 .as("Output was not correct.")
-                .isEqualTo(expected.subList(2, expected.size()).toArray());
+                .containsExactlyElementsOf(expected.subList(2, expected.size()));
     }
 
     @Test

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -27,16 +28,15 @@ import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.co.CoStreamMap;
-import org.apache.flink.streaming.runtime.io.checkpointing.AlignedCheckpointsTest;
-import org.apache.flink.streaming.runtime.io.checkpointing.AlignedCheckpointsTest.CheckpointExceptionMatcher;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -44,9 +44,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 /** Test checkpoint cancellation barrier. */
-public class StreamTaskCancellationBarrierTest {
-
-    @Rule public final Timeout timeoutPerTest = Timeout.seconds(10);
+@Timeout(value = 10, unit = TimeUnit.SECONDS)
+class StreamTaskCancellationBarrierTest {
 
     /**
      * This test verifies (for onw input tasks) that the Stream tasks react the following way to
@@ -54,7 +53,7 @@ public class StreamTaskCancellationBarrierTest {
      * (to the JobManager) - emit a cancellation barrier downstream.
      */
     @Test
-    public void testDeclineCallOnCancelBarrierOneInput() throws Exception {
+    void testDeclineCallOnCancelBarrierOneInput() throws Exception {
 
         OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
@@ -92,10 +91,11 @@ public class StreamTaskCancellationBarrierTest {
 
         // a cancellation barrier should be downstream
         Object result = testHarness.getOutput().poll();
-        assertNotNull("nothing emitted", result);
-        assertTrue("wrong type emitted", result instanceof CancelCheckpointMarker);
-        assertEquals(
-                "wrong checkpoint id", 2L, ((CancelCheckpointMarker) result).getCheckpointId());
+        assertThat(result).as("nothing emitted").isNotNull();
+        assertThat(result).as("wrong type emitted").isInstanceOf(CancelCheckpointMarker.class);
+        assertThat(((CancelCheckpointMarker) result).getCheckpointId())
+                .as("wrong checkpoint id")
+                .isEqualTo(2L);
 
         // cancel and shutdown
         testHarness.endInput();
@@ -108,7 +108,7 @@ public class StreamTaskCancellationBarrierTest {
      * (to the JobManager) - emit a cancellation barrier downstream.
      */
     @Test
-    public void testDeclineCallOnCancelBarrierTwoInputs() throws Exception {
+    void testDeclineCallOnCancelBarrierTwoInputs() throws Exception {
 
         TwoInputStreamTaskTestHarness<String, String, String> testHarness =
                 new TwoInputStreamTaskTestHarness<>(
@@ -139,16 +139,17 @@ public class StreamTaskCancellationBarrierTest {
                 .declineCheckpoint(
                         eq(2L),
                         argThat(
-                                new AlignedCheckpointsTest.CheckpointExceptionMatcher(
+                                new CheckpointExceptionMatcher(
                                         CheckpointFailureReason
                                                 .CHECKPOINT_DECLINED_ON_CANCELLATION_BARRIER)));
 
         // a cancellation barrier should be downstream
         Object result = testHarness.getOutput().poll();
-        assertNotNull("nothing emitted", result);
-        assertTrue("wrong type emitted", result instanceof CancelCheckpointMarker);
-        assertEquals(
-                "wrong checkpoint id", 2L, ((CancelCheckpointMarker) result).getCheckpointId());
+        assertThat(result).as("nothing emitted").isNotNull();
+        assertThat(result).as("wrong type emitted").isInstanceOf(CancelCheckpointMarker.class);
+        assertThat(((CancelCheckpointMarker) result).getCheckpointId())
+                .as("wrong checkpoint id")
+                .isEqualTo(2L);
 
         // cancel and shutdown
         testHarness.endInput();
@@ -175,6 +176,28 @@ public class StreamTaskCancellationBarrierTest {
         @Override
         public String map2(String value) throws Exception {
             return value;
+        }
+    }
+
+    /** A validation matcher for checkpoint exception against failure reason. */
+    private static class CheckpointExceptionMatcher extends BaseMatcher<CheckpointException> {
+
+        private final CheckpointFailureReason failureReason;
+
+        public CheckpointExceptionMatcher(CheckpointFailureReason failureReason) {
+            this.failureReason = failureReason;
+        }
+
+        @Override
+        public boolean matches(Object o) {
+            return o != null
+                    && o.getClass() == CheckpointException.class
+                    && ((CheckpointException) o).getCheckpointFailureReason().equals(failureReason);
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("CheckpointException - reason = " + failureReason);
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
@@ -184,7 +184,7 @@ class StreamTaskCancellationBarrierTest {
 
         private final CheckpointFailureReason failureReason;
 
-        public CheckpointExceptionMatcher(CheckpointFailureReason failureReason) {
+        private CheckpointExceptionMatcher(CheckpointFailureReason failureReason) {
             this.failureReason = failureReason;
         }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -58,7 +58,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.CompletingCheckpointResponder;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -69,20 +69,15 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests the behavior of {@link StreamTask} related to final checkpoint. */
-public class StreamTaskFinalCheckpointsTest {
+class StreamTaskFinalCheckpointsTest {
 
     private static final long CONCURRENT_EVENT_WAIT_PERIOD_MS = 500L;
 
     @Test
-    public void testCheckpointDoneOnFinishedOperator() throws Exception {
+    void testCheckpointDoneOnFinishedOperator() throws Exception {
         FinishingOperator finishingOperator = new FinishingOperator();
         StreamTaskMailboxTestHarnessBuilder<Integer> builder =
                 new StreamTaskMailboxTestHarnessBuilder<>(
@@ -96,7 +91,7 @@ public class StreamTaskFinalCheckpointsTest {
 
         harness.streamTask.operatorChain.finishOperators(
                 harness.streamTask.getActionExecutor(), StopMode.DRAIN);
-        assertTrue(FinishingOperator.finished);
+        assertThat(FinishingOperator.finished).isTrue();
 
         harness.getTaskStateManager().getWaitForReportLatch().reset();
         harness.streamTask.triggerCheckpointOnBarrier(
@@ -106,11 +101,11 @@ public class StreamTaskFinalCheckpointsTest {
                         .setBytesProcessedDuringAlignment(0L)
                         .setAlignmentDurationNanos(0L));
         harness.getTaskStateManager().getWaitForReportLatch().await();
-        assertEquals(2, harness.getTaskStateManager().getReportedCheckpointId());
+        assertThat(harness.getTaskStateManager().getReportedCheckpointId()).isEqualTo(2);
     }
 
     @Test
-    public void testNotWaitingForAllRecordsProcessedIfCheckpointNotEnabled() throws Exception {
+    void testNotWaitingForAllRecordsProcessedIfCheckpointNotEnabled() throws Exception {
         ResultPartitionWriter[] partitionWriters = new ResultPartitionWriter[2];
         try {
             for (int i = 0; i < partitionWriters.length; ++i) {
@@ -133,7 +128,8 @@ public class StreamTaskFinalCheckpointsTest {
 
                 // In this case the result partition should not emit EndOfUserRecordsEvent.
                 for (ResultPartitionWriter writer : partitionWriters) {
-                    assertEquals(0, ((PipelinedResultPartition) writer).getNumberOfQueuedBuffers());
+                    assertThat(((PipelinedResultPartition) writer).getNumberOfQueuedBuffers())
+                            .isZero();
                 }
             }
         } finally {
@@ -146,7 +142,7 @@ public class StreamTaskFinalCheckpointsTest {
     }
 
     @Test
-    public void testWaitingForFinalCheckpoint() throws Exception {
+    void testWaitingForFinalCheckpoint() throws Exception {
         ResultPartition[] partitionWriters = new ResultPartition[2];
         try {
             for (int i = 0; i < partitionWriters.length; ++i) {
@@ -162,14 +158,16 @@ public class StreamTaskFinalCheckpointsTest {
                 // Tests triggering checkpoint when all the inputs are alive.
                 CompletableFuture<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
                 processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(2);
 
                 // Tests triggering checkpoint after some inputs have received EndOfPartition.
                 testHarness.processEvent(new EndOfData(StopMode.DRAIN), 0, 0);
                 testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
                 checkpointFuture = triggerCheckpoint(testHarness, 4);
                 processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-                assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(4);
 
                 // Tests triggering checkpoint after received all the inputs have received
                 // EndOfPartition.
@@ -190,15 +188,16 @@ public class StreamTaskFinalCheckpointsTest {
 
                 // The checkpoint 6 would be triggered successfully.
                 testHarness.finishProcessing();
-                assertTrue(checkpointFuture.isDone());
+                assertThat(checkpointFuture).isDone();
                 testHarness.getTaskStateManager().getWaitForReportLatch().await();
-                assertEquals(6, testHarness.getTaskStateManager().getReportedCheckpointId());
-                assertEquals(
-                        6, testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(6);
+                assertThat(testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId())
+                        .isEqualTo(6);
 
                 // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {
-                    assertEquals(4, resultPartition.getNumberOfQueuedBuffers());
+                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(4);
                 }
             }
         } finally {
@@ -247,7 +246,7 @@ public class StreamTaskFinalCheckpointsTest {
     }
 
     @Test
-    public void testWaitingForFinalCheckpointNotTheFirsNotifiedComplete() throws Exception {
+    void testWaitingForFinalCheckpointNotTheFirsNotifiedComplete() throws Exception {
         ResultPartition[] partitionWriters = new ResultPartition[2];
         try {
             for (int i = 0; i < partitionWriters.length; ++i) {
@@ -288,13 +287,14 @@ public class StreamTaskFinalCheckpointsTest {
 
                 testHarness.finishProcessing();
                 testHarness.getTaskStateManager().getWaitForReportLatch().await();
-                assertEquals(3L, testHarness.getTaskStateManager().getReportedCheckpointId());
-                assertEquals(
-                        3L, testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(3);
+                assertThat(testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId())
+                        .isEqualTo(3);
 
                 // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {
-                    assertEquals(4, resultPartition.getNumberOfQueuedBuffers());
+                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(4);
                 }
             }
         } finally {
@@ -307,7 +307,7 @@ public class StreamTaskFinalCheckpointsTest {
     }
 
     @Test
-    public void testTriggerStopWithSavepointWhenWaitingForFinalCheckpoint() throws Exception {
+    void testTriggerStopWithSavepointWhenWaitingForFinalCheckpoint() throws Exception {
         ResultPartition[] partitionWriters = new ResultPartition[2];
         try {
             for (int i = 0; i < partitionWriters.length; ++i) {
@@ -378,19 +378,17 @@ public class StreamTaskFinalCheckpointsTest {
 
                 // The checkpoint 6 would be triggered successfully.
                 testHarness.finishProcessing();
-                assertTrue(checkpointFuture.isDone());
-                assertTrue(savepointFuture.isDone());
+                assertThat(checkpointFuture).isDone();
+                assertThat(savepointFuture).isDone();
                 testHarness.getTaskStateManager().getWaitForReportLatch().await();
-                assertEquals(
-                        syncSavepointId,
-                        testHarness.getTaskStateManager().getReportedCheckpointId());
-                assertEquals(
-                        syncSavepointId,
-                        testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(syncSavepointId);
+                assertThat(testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId())
+                        .isEqualTo(syncSavepointId);
 
                 // Each result partition should have emitted 2 barriers and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {
-                    assertEquals(3, resultPartition.getNumberOfQueuedBuffers());
+                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(3);
                 }
             }
         } finally {
@@ -403,13 +401,12 @@ public class StreamTaskFinalCheckpointsTest {
     }
 
     @Test
-    public void testTriggerStopWithSavepointWhenWaitingForFinalCheckpointOnSourceTask()
-            throws Exception {
+    void testTriggerStopWithSavepointWhenWaitingForFinalCheckpointOnSourceTask() throws Exception {
         doTestTriggerStopWithSavepointWhenWaitingForFinalCheckpointOnSourceTask(true);
     }
 
     @Test
-    public void testTriggerStopWithSavepointNoDrainWhenWaitingForFinalCheckpointOnSourceTask()
+    void testTriggerStopWithSavepointNoDrainWhenWaitingForFinalCheckpointOnSourceTask()
             throws Exception {
         doTestTriggerStopWithSavepointWhenWaitingForFinalCheckpointOnSourceTask(false);
     }
@@ -485,19 +482,18 @@ public class StreamTaskFinalCheckpointsTest {
 
             // The checkpoint 6 would be triggered successfully.
             testHarness.finishProcessing();
-            assertTrue(checkpointFuture.isDone());
-            assertTrue(savepointFuture.isDone());
+            assertThat(checkpointFuture).isDone();
+            assertThat(savepointFuture).isDone();
             testHarness.getTaskStateManager().getWaitForReportLatch().await();
-            assertEquals(
-                    syncSavepointId, testHarness.getTaskStateManager().getReportedCheckpointId());
-            assertEquals(
-                    syncSavepointId,
-                    testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId());
+            assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                    .isEqualTo(syncSavepointId);
+            assertThat(testHarness.getTaskStateManager().getNotifiedCompletedCheckpointId())
+                    .isEqualTo(syncSavepointId);
         }
     }
 
     @Test
-    public void testTriggeringAlignedNoTimeoutCheckpointWithFinishedChannels() throws Exception {
+    void testTriggeringAlignedNoTimeoutCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
                 CheckpointOptions.alignedNoTimeout(
                         CheckpointType.CHECKPOINT,
@@ -505,7 +501,7 @@ public class StreamTaskFinalCheckpointsTest {
     }
 
     @Test
-    public void testTriggeringUnalignedCheckpointWithFinishedChannels() throws Exception {
+    void testTriggeringUnalignedCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
                 CheckpointOptions.unaligned(
                         CheckpointType.CHECKPOINT,
@@ -513,7 +509,7 @@ public class StreamTaskFinalCheckpointsTest {
     }
 
     @Test
-    public void testTriggeringAlignedWithTimeoutCheckpointWithFinishedChannels() throws Exception {
+    void testTriggeringAlignedWithTimeoutCheckpointWithFinishedChannels() throws Exception {
         testTriggeringCheckpointWithFinishedChannels(
                 CheckpointOptions.alignedWithTimeout(
                         CheckpointType.CHECKPOINT,
@@ -553,16 +549,18 @@ public class StreamTaskFinalCheckpointsTest {
                 CompletableFuture<Boolean> checkpointFuture =
                         triggerCheckpoint(testHarness, 2, checkpointOptions);
                 processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
-                assertArrayEquals(new int[] {0, 0, 0}, resumedCount);
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(2);
+                assertThat(resumedCount).containsExactly(0, 0, 0);
 
                 // Tests triggering checkpoint after some inputs have received EndOfPartition.
                 testHarness.processEvent(new EndOfData(StopMode.DRAIN), 0, 0);
                 testHarness.processEvent(EndOfPartitionEvent.INSTANCE, 0, 0);
                 checkpointFuture = triggerCheckpoint(testHarness, 4, checkpointOptions);
                 processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-                assertEquals(4, testHarness.getTaskStateManager().getReportedCheckpointId());
-                assertArrayEquals(new int[] {0, 0, 0}, resumedCount);
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(4);
+                assertThat(resumedCount).containsExactly(0, 0, 0);
 
                 // Tests triggering checkpoint after received all the inputs have received
                 // EndOfPartition.
@@ -583,14 +581,15 @@ public class StreamTaskFinalCheckpointsTest {
 
                 // The checkpoint 6 would be triggered successfully.
                 testHarness.finishProcessing();
-                assertTrue(checkpointFuture.isDone());
+                assertThat(checkpointFuture).isDone();
                 testHarness.getTaskStateManager().getWaitForReportLatch().await();
-                assertEquals(6, testHarness.getTaskStateManager().getReportedCheckpointId());
-                assertArrayEquals(new int[] {0, 0, 0}, resumedCount);
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(6);
+                assertThat(resumedCount).containsExactly(0, 0, 0);
 
                 // Each result partition should have emitted 3 barriers and 1 EndOfUserRecordsEvent.
                 for (ResultPartition resultPartition : partitionWriters) {
-                    assertEquals(4, resultPartition.getNumberOfQueuedBuffers());
+                    assertThat(resultPartition.getNumberOfQueuedBuffers()).isEqualTo(4);
                 }
             }
         } finally {
@@ -603,7 +602,7 @@ public class StreamTaskFinalCheckpointsTest {
     }
 
     @Test
-    public void testReportOperatorsFinishedInCheckpoint() throws Exception {
+    void testReportOperatorsFinishedInCheckpoint() throws Exception {
         ResultPartition[] partitionWriters = new ResultPartition[2];
         try {
             for (int i = 0; i < partitionWriters.length; ++i) {
@@ -632,13 +631,15 @@ public class StreamTaskFinalCheckpointsTest {
                 // Trigger the first checkpoint before we call operators' finish method.
                 CompletableFuture<Boolean> checkpointFuture = triggerCheckpoint(testHarness, 2);
                 processMailTillCheckpointSucceeds(testHarness, checkpointFuture);
-                assertEquals(2, testHarness.getTaskStateManager().getReportedCheckpointId());
-                assertFalse(
-                        testHarness
-                                .getTaskStateManager()
-                                .getJobManagerTaskStateSnapshotsByCheckpointId()
-                                .get(2L)
-                                .isTaskFinished());
+                assertThat(testHarness.getTaskStateManager().getReportedCheckpointId())
+                        .isEqualTo(2);
+                assertThat(
+                                testHarness
+                                        .getTaskStateManager()
+                                        .getJobManagerTaskStateSnapshotsByCheckpointId()
+                                        .get(2L)
+                                        .isTaskFinished())
+                        .isFalse();
 
                 // Trigger the first checkpoint after we call operators' finish method.
                 // The checkpoint is added to the mailbox and will be processed in the
@@ -654,14 +655,15 @@ public class StreamTaskFinalCheckpointsTest {
                         });
                 testHarness.processAll();
                 testHarness.finishProcessing();
-                assertTrue(checkpointFuture.isDone());
+                assertThat(checkpointFuture).isDone();
                 testHarness.getTaskStateManager().getWaitForReportLatch().await();
-                assertTrue(
-                        testHarness
-                                .getTaskStateManager()
-                                .getJobManagerTaskStateSnapshotsByCheckpointId()
-                                .get(4L)
-                                .isTaskFinished());
+                assertThat(
+                                testHarness
+                                        .getTaskStateManager()
+                                        .getJobManagerTaskStateSnapshotsByCheckpointId()
+                                        .get(4L)
+                                        .isTaskFinished())
+                        .isTrue();
             }
 
         } finally {
@@ -726,7 +728,7 @@ public class StreamTaskFinalCheckpointsTest {
     }
 
     @Test
-    public void testWaitingForPendingCheckpointsOnFinished() throws Exception {
+    void testWaitingForPendingCheckpointsOnFinished() throws Exception {
         long delayedCheckpointId = 2;
         CompletingCheckpointResponder responder =
                 new CompletingCheckpointResponder() {
@@ -778,13 +780,13 @@ public class StreamTaskFinalCheckpointsTest {
 
             harness.processAll();
             harness.finishProcessing();
-            assertEquals(
-                    delayedCheckpointId, harness.getTaskStateManager().getReportedCheckpointId());
+            assertThat(harness.getTaskStateManager().getReportedCheckpointId())
+                    .isEqualTo(delayedCheckpointId);
         }
     }
 
     @Test
-    public void testOperatorSkipLifeCycleIfFinishedOnRestore() throws Exception {
+    void testOperatorSkipLifeCycleIfFinishedOnRestore() throws Exception {
         try (StreamTaskMailboxTestHarness<String> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
@@ -810,7 +812,7 @@ public class StreamTaskFinalCheckpointsTest {
                             .setBytesProcessedDuringAlignment(0)
                             .setAlignmentDurationNanos(0));
             harness.getTaskStateManager().getWaitForReportLatch().await();
-            assertEquals(2, harness.getTaskStateManager().getReportedCheckpointId());
+            assertThat(harness.getTaskStateManager().getReportedCheckpointId()).isEqualTo(2);
 
             // Checkpoint notification.
             harness.streamTask.notifyCheckpointCompleteAsync(2);
@@ -824,15 +826,14 @@ public class StreamTaskFinalCheckpointsTest {
             harness.waitForTaskCompletion();
             harness.finishProcessing();
 
-            assertThat(
-                    harness.getOutput(),
-                    contains(
+            assertThat(harness.getOutput())
+                    .contains(
                             new CheckpointBarrier(
                                     checkpointMetaData.getCheckpointId(),
                                     checkpointMetaData.getTimestamp(),
                                     checkpointOptions),
                             Watermark.MAX_WATERMARK,
-                            new EndOfData(StopMode.DRAIN)));
+                            new EndOfData(StopMode.DRAIN));
         }
     }
 
@@ -842,7 +843,7 @@ public class StreamTaskFinalCheckpointsTest {
      * barriers are aligned.
      */
     @Test
-    public void testWaitingForUnalignedChannelStatesIfFinishedOnRestore() throws Exception {
+    void testWaitingForUnalignedChannelStatesIfFinishedOnRestore() throws Exception {
         OperatorID operatorId = new OperatorID();
         try (StreamTaskMailboxTestHarness<String> harness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
@@ -888,16 +889,17 @@ public class StreamTaskFinalCheckpointsTest {
                             checkpointResponder.getAcknowledgeLatch().isTriggered()
                                     || checkpointResponder.getDeclinedLatch().isTriggered());
 
-            assertEquals(
-                    Collections.singletonList(2L),
-                    checkpointResponder.getAcknowledgeReports().stream()
-                            .map(TestCheckpointResponder.AbstractReport::getCheckpointId)
-                            .collect(Collectors.toList()));
-            assertEquals(
-                    Collections.emptyList(),
-                    checkpointResponder.getDeclineReports().stream()
-                            .map(TestCheckpointResponder.AbstractReport::getCheckpointId)
-                            .collect(Collectors.toList()));
+            assertThat(
+                            checkpointResponder.getAcknowledgeReports().stream()
+                                    .map(TestCheckpointResponder.AbstractReport::getCheckpointId)
+                                    .collect(Collectors.toList()))
+                    .containsExactly(2L);
+
+            assertThat(
+                            checkpointResponder.getDeclineReports().stream()
+                                    .map(TestCheckpointResponder.AbstractReport::getCheckpointId)
+                                    .collect(Collectors.toList()))
+                    .isEmpty();
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskFinalCheckpointsTest.java
@@ -827,7 +827,7 @@ class StreamTaskFinalCheckpointsTest {
             harness.finishProcessing();
 
             assertThat(harness.getOutput())
-                    .contains(
+                    .containsExactly(
                             new CheckpointBarrier(
                                     checkpointMetaData.getCheckpointId(),
                                     checkpointMetaData.getTimestamp(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -29,7 +29,7 @@ import java.util.Queue;
 import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test harness for testing a {@link StreamTask}.
@@ -181,9 +181,9 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
         streamMockEnvironment.getIOManager().close();
         MemoryManager memMan = this.streamMockEnvironment.getMemoryManager();
         if (memMan != null) {
-            assertTrue(
-                    "Memory Manager managed memory was not completely freed.",
-                    memMan.verifyEmpty());
+            assertThat(memMan.verifyEmpty())
+                    .as("Memory Manager managed memory was not completely freed.")
+                    .isTrue();
             memMan.shutdown();
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
@@ -33,23 +33,20 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TestAnyModeMultipleInputStreamOperator;
 import org.apache.flink.streaming.util.TestAnyModeMultipleInputStreamOperator.ToStringInput;
 import org.apache.flink.streaming.util.TestSequentialMultipleInputStreamOperator;
-import org.apache.flink.util.ExceptionUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test selective reading. */
-public class StreamTaskMultipleInputSelectiveReadingTest {
+class StreamTaskMultipleInputSelectiveReadingTest {
 
     private static final StreamRecord<String>[] INPUT1 =
             new StreamRecord[] {
@@ -67,7 +64,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
             };
 
     @Test
-    public void testAnyOrderedReading() throws Exception {
+    void testAnyOrderedReading() throws Exception {
         ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
         expectedOutput.add(new StreamRecord<>("[1]: Hello-1"));
         expectedOutput.add(new StreamRecord<>("[2]: 1"));
@@ -82,7 +79,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
     }
 
     @Test
-    public void testAnyUnorderedReading() throws Exception {
+    void testAnyUnorderedReading() throws Exception {
         ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
         expectedOutput.add(new StreamRecord<>("[1]: Hello-1"));
         expectedOutput.add(new StreamRecord<>("[2]: 1"));
@@ -97,7 +94,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
     }
 
     @Test
-    public void testSequentialReading() throws Exception {
+    void testSequentialReading() throws Exception {
         ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
         expectedOutput.add(new StreamRecord<>("[1]: Hello-1"));
         expectedOutput.add(new StreamRecord<>("[1]: Hello-2"));
@@ -115,7 +112,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
     }
 
     @Test
-    public void testSpecialRuleReading() throws Exception {
+    void testSpecialRuleReading() throws Exception {
         ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
         expectedOutput.add(new StreamRecord<>("[1]: Hello-1"));
         expectedOutput.add(new StreamRecord<>("[1]: Hello-2"));
@@ -130,21 +127,17 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
     }
 
     @Test
-    public void testReadFinishedInput() throws Exception {
-        try {
-            testInputSelection(
-                    new TestReadFinishedInputStreamOperatorFactory(),
-                    true,
-                    new ArrayDeque<>(),
-                    true);
-            fail("should throw an IOException");
-        } catch (Exception t) {
-            if (!ExceptionUtils.findThrowableWithMessage(
-                            t, "Can not make a progress: all selected inputs are already finished")
-                    .isPresent()) {
-                throw t;
-            }
-        }
+    void testReadFinishedInput() throws Exception {
+        assertThatThrownBy(
+                        () ->
+                                testInputSelection(
+                                        new TestReadFinishedInputStreamOperatorFactory(),
+                                        true,
+                                        new ArrayDeque<>(),
+                                        true))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining(
+                        "Can not make a progress: all selected inputs are already finished");
     }
 
     private void testInputSelection(
@@ -177,9 +170,10 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
             testHarness.waitForTaskCompletion();
 
             if (orderedCheck) {
-                assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+                assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
             } else {
-                assertThat(testHarness.getOutput(), containsInAnyOrder(expectedOutput.toArray()));
+                assertThat(testHarness.getOutput())
+                        .containsExactlyInAnyOrder(expectedOutput.toArray());
             }
         }
     }
@@ -189,7 +183,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
      * when one has some data all the time, but the other only rarely.
      */
     @Test
-    public void testInputStarvation() throws Exception {
+    void testInputStarvation() throws Exception {
         try (StreamTaskMailboxTestHarness<String> testHarness =
                 new StreamTaskMailboxTestHarnessBuilder<>(
                                 MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
@@ -208,7 +202,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
             // StreamMultipleInputProcessor starts with all inputs available. Let it rotate and
             // refresh properly.
             testHarness.processSingleStep();
-            assertTrue(testHarness.getOutput().isEmpty());
+            assertThat(testHarness.getOutput()).isEmpty();
 
             testHarness.processElement(new StreamRecord<>("NOT_SELECTED"), 0);
 
@@ -221,7 +215,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
             expectedOutput.add(new StreamRecord<>("[2]: 1"));
             testHarness.processSingleStep();
             expectedOutput.add(new StreamRecord<>("[2]: 2"));
-            assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
 
             // InputGate 2 was not available in previous steps, so let's check if we are not
             // starving it
@@ -234,7 +228,7 @@ public class StreamTaskMultipleInputSelectiveReadingTest {
             expectedOutput.add(new StreamRecord<>("[3]: 1"));
             expectedOutput.add(new StreamRecord<>("[2]: 3"));
 
-            assertThat(testHarness.getOutput(), containsInAnyOrder(expectedOutput.toArray()));
+            assertThat(testHarness.getOutput()).containsExactlyInAnyOrder(expectedOutput.toArray());
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
@@ -170,10 +170,10 @@ class StreamTaskMultipleInputSelectiveReadingTest {
             testHarness.waitForTaskCompletion();
 
             if (orderedCheck) {
-                assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+                assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
             } else {
                 assertThat(testHarness.getOutput())
-                        .containsExactlyInAnyOrder(expectedOutput.toArray());
+                        .containsExactlyInAnyOrderElementsOf(expectedOutput);
             }
         }
     }
@@ -215,7 +215,7 @@ class StreamTaskMultipleInputSelectiveReadingTest {
             expectedOutput.add(new StreamRecord<>("[2]: 1"));
             testHarness.processSingleStep();
             expectedOutput.add(new StreamRecord<>("[2]: 2"));
-            assertThat(testHarness.getOutput()).contains(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyElementsOf(expectedOutput);
 
             // InputGate 2 was not available in previous steps, so let's check if we are not
             // starving it
@@ -228,7 +228,7 @@ class StreamTaskMultipleInputSelectiveReadingTest {
             expectedOutput.add(new StreamRecord<>("[3]: 1"));
             expectedOutput.add(new StreamRecord<>("[2]: 3"));
 
-            assertThat(testHarness.getOutput()).containsExactlyInAnyOrder(expectedOutput.toArray());
+            assertThat(testHarness.getOutput()).containsExactlyInAnyOrderElementsOf(expectedOutput);
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
@@ -32,19 +32,19 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
 import org.apache.flink.streaming.util.TestAnyModeReadingStreamOperator;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.streaming.util.TestSequentialReadingStreamOperator;
-import org.apache.flink.util.ExceptionUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test selective reading. */
-public class StreamTaskSelectiveReadingTest {
+class StreamTaskSelectiveReadingTest {
 
     private static String elementToString(Object record) {
         return record instanceof StreamRecord
@@ -53,7 +53,7 @@ public class StreamTaskSelectiveReadingTest {
     }
 
     @Test
-    public void testAnyOrderedReading() throws Exception {
+    void testAnyOrderedReading() throws Exception {
         ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
         expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
         expectedOutput.add(new StreamRecord<>("[Operator0-2]: 1"));
@@ -67,7 +67,7 @@ public class StreamTaskSelectiveReadingTest {
     }
 
     @Test
-    public void testAnyUnorderedReading() throws Exception {
+    void testAnyUnorderedReading() throws Exception {
         ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
         expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
         expectedOutput.add(new StreamRecord<>("[Operator0-2]: 1"));
@@ -81,7 +81,7 @@ public class StreamTaskSelectiveReadingTest {
     }
 
     @Test
-    public void testSequentialReading() throws Exception {
+    void testSequentialReading() throws Exception {
         ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
         expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
         expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-2"));
@@ -95,7 +95,7 @@ public class StreamTaskSelectiveReadingTest {
     }
 
     @Test
-    public void testSpecialRuleReading() throws Exception {
+    void testSpecialRuleReading() throws Exception {
         ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
         expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
         expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-2"));
@@ -113,21 +113,17 @@ public class StreamTaskSelectiveReadingTest {
     }
 
     @Test
-    public void testReadFinishedInput() throws Exception {
-        try {
-            testBase(
-                    new TestReadFinishedInputStreamOperator(),
-                    false,
-                    new ConcurrentLinkedQueue<>(),
-                    true);
-            fail("should throw an IOException");
-        } catch (Exception t) {
-            if (!ExceptionUtils.findThrowableWithMessage(
-                            t, "all selected inputs are already finished")
-                    .isPresent()) {
-                throw t;
-            }
-        }
+    void testReadFinishedInput() {
+        assertThatThrownBy(
+                        () ->
+                                testBase(
+                                        new TestReadFinishedInputStreamOperator(),
+                                        false,
+                                        new ConcurrentLinkedQueue<>(),
+                                        true))
+                .hasCauseInstanceOf(IOException.class)
+                .rootCause()
+                .hasMessageContaining("all selected inputs are already finished");
     }
 
     private void testBase(
@@ -196,7 +192,7 @@ public class StreamTaskSelectiveReadingTest {
                             .toArray(String[]::new);
             Arrays.sort(result);
 
-            assertArrayEquals("Output was not correct.", expectedResult, result);
+            assertThat(result).as("Output was not correct.").isEqualTo(expectedResult);
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -142,7 +142,6 @@ import org.apache.flink.util.CloseableIterable;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
 import org.apache.flink.util.FlinkRuntimeException;
-import org.apache.flink.util.TestLoggerExtension;
 import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.TestingUncaughtExceptionHandler;
@@ -151,7 +150,6 @@ import org.apache.flink.util.function.RunnableWithException;
 import org.apache.flink.util.function.SupplierWithException;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
@@ -216,7 +214,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /** Tests for {@link StreamTask}. */
-@ExtendWith(TestLoggerExtension.class)
 public class StreamTaskTest {
 
     @RegisterExtension

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -68,8 +68,6 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.SupplierWithException;
 
-import org.junit.Assert;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -85,6 +83,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test harness for testing a {@link StreamTask}.
@@ -401,9 +400,9 @@ public class StreamTaskTestHarness<OUT> {
         if (this.memorySize > 0) {
             MemoryManager memMan = this.mockEnv.getMemoryManager();
             if (memMan != null) {
-                Assert.assertTrue(
-                        "Memory Manager managed memory was not completely freed.",
-                        memMan.verifyEmpty());
+                assertThat(memMan.verifyEmpty())
+                        .as("Memory Manager managed memory was not completely freed.")
+                        .isTrue();
                 memMan.shutdown();
             }
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarnessTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarnessTest.java
@@ -26,97 +26,76 @@ import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link StreamTaskTestHarness}. */
-public class StreamTaskTestHarnessTest {
+class StreamTaskTestHarnessTest {
 
     @Test
-    public void testMultipleSetupsThrowsException() {
-        StreamTaskTestHarness<String> harness;
+    void testMultipleSetupsThrowsException() {
 
-        harness =
+        StreamTaskTestHarness<String> harness =
                 new StreamTaskTestHarness<>(
                         OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO);
         harness.setupOutputForSingletonOperatorChain();
 
-        try {
-            harness.setupOutputForSingletonOperatorChain();
-            Assert.fail();
-        } catch (IllegalStateException expected) {
-            // expected
-        }
-        try {
-            harness.setupOperatorChain(new OperatorID(), new TestOperator());
-            Assert.fail();
-        } catch (IllegalStateException expected) {
-            // expected
-        }
-        try {
-            harness.setupOperatorChain(new OperatorID(), new TwoInputTestOperator());
-            Assert.fail();
-        } catch (IllegalStateException expected) {
-            // expected
-        }
+        assertThatThrownBy(harness::setupOutputForSingletonOperatorChain)
+                .isInstanceOf(IllegalStateException.class);
 
-        harness =
+        assertThatThrownBy(() -> harness.setupOperatorChain(new OperatorID(), new TestOperator()))
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(
+                        () ->
+                                harness.setupOperatorChain(
+                                        new OperatorID(), new TwoInputTestOperator()))
+                .isInstanceOf(IllegalStateException.class);
+
+        StreamTaskTestHarness<String> harness1 =
                 new StreamTaskTestHarness<>(
                         OneInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO);
-        harness.setupOperatorChain(new OperatorID(), new TestOperator())
+        harness1.setupOperatorChain(new OperatorID(), new TestOperator())
                 .chain(
                         new OperatorID(),
                         new TestOperator(),
                         BasicTypeInfo.STRING_TYPE_INFO.createSerializer(
                                 new SerializerConfigImpl()));
 
-        try {
-            harness.setupOutputForSingletonOperatorChain();
-            Assert.fail();
-        } catch (IllegalStateException expected) {
-            // expected
-        }
-        try {
-            harness.setupOperatorChain(new OperatorID(), new TestOperator());
-            Assert.fail();
-        } catch (IllegalStateException expected) {
-            // expected
-        }
-        try {
-            harness.setupOperatorChain(new OperatorID(), new TwoInputTestOperator());
-            Assert.fail();
-        } catch (IllegalStateException expected) {
-            // expected
-        }
+        assertThatThrownBy(harness1::setupOutputForSingletonOperatorChain)
+                .isInstanceOf(IllegalStateException.class);
 
-        harness =
+        assertThatThrownBy(() -> harness1.setupOperatorChain(new OperatorID(), new TestOperator()))
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(
+                        () ->
+                                harness1.setupOperatorChain(
+                                        new OperatorID(), new TwoInputTestOperator()))
+                .isInstanceOf(IllegalStateException.class);
+
+        StreamTaskTestHarness<String> harness2 =
                 new StreamTaskTestHarness<>(
                         TwoInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO);
-        harness.setupOperatorChain(new OperatorID(), new TwoInputTestOperator())
+        harness2.setupOperatorChain(new OperatorID(), new TwoInputTestOperator())
                 .chain(
                         new OperatorID(),
                         new TestOperator(),
                         BasicTypeInfo.STRING_TYPE_INFO.createSerializer(
                                 new SerializerConfigImpl()));
 
-        try {
-            harness.setupOutputForSingletonOperatorChain();
-            Assert.fail();
-        } catch (IllegalStateException expected) {
-            // expected
-        }
-        try {
-            harness.setupOperatorChain(new OperatorID(), new TestOperator());
-            Assert.fail();
-        } catch (IllegalStateException expected) {
-            // expected
-        }
-        try {
-            harness.setupOperatorChain(new OperatorID(), new TwoInputTestOperator());
-            Assert.fail();
-        } catch (IllegalStateException expected) {
-            // expected
-        }
+        assertThatThrownBy(harness2::setupOutputForSingletonOperatorChain)
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> harness2.setupOperatorChain(new OperatorID(), new TestOperator()))
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(
+                        () ->
+                                harness2.setupOperatorChain(
+                                        new OperatorID(), new TwoInputTestOperator()))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     private static class TestOperator extends AbstractStreamOperator<String>

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -69,7 +69,7 @@ import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 import org.apache.flink.util.ExceptionUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -86,22 +86,19 @@ import java.util.function.Supplier;
 
 import static org.apache.flink.runtime.checkpoint.CheckpointType.CHECKPOINT;
 import static org.apache.flink.shaded.guava31.com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
-import static org.apache.flink.util.ExceptionUtils.findThrowable;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for {@link SubtaskCheckpointCoordinator}. */
-public class SubtaskCheckpointCoordinatorTest {
+class SubtaskCheckpointCoordinatorTest {
 
     @Test
-    public void testInitCheckpoint() throws IOException, CheckpointException {
-        assertTrue(initCheckpoint(true, CHECKPOINT));
-        assertFalse(initCheckpoint(false, CHECKPOINT));
-        assertFalse(initCheckpoint(false, SavepointType.savepoint(SavepointFormatType.CANONICAL)));
+    void testInitCheckpoint() throws IOException, CheckpointException {
+        assertThat(initCheckpoint(true, CHECKPOINT)).isTrue();
+        assertThat(initCheckpoint(false, CHECKPOINT)).isFalse();
+        assertThat(initCheckpoint(false, SavepointType.savepoint(SavepointFormatType.CANONICAL)))
+                .isFalse();
     }
 
     private boolean initCheckpoint(boolean unalignedCheckpointEnabled, SnapshotType checkpointType)
@@ -128,7 +125,7 @@ public class SubtaskCheckpointCoordinatorTest {
     }
 
     @Test
-    public void testNotifyCheckpointComplete() throws Exception {
+    void testNotifyCheckpointComplete() throws Exception {
         TestTaskStateManager stateManager = new TestTaskStateManager();
         MockEnvironment mockEnvironment =
                 MockEnvironment.builder().setTaskStateManager(stateManager).build();
@@ -143,7 +140,7 @@ public class SubtaskCheckpointCoordinatorTest {
             {
                 subtaskCheckpointCoordinator.notifyCheckpointComplete(
                         checkpointId, operatorChain, () -> true);
-                assertEquals(checkpointId, stateManager.getNotifiedCompletedCheckpointId());
+                assertThat(stateManager.getNotifiedCompletedCheckpointId()).isEqualTo(checkpointId);
             }
 
             long newCheckpointId = checkpointId + 1;
@@ -151,13 +148,14 @@ public class SubtaskCheckpointCoordinatorTest {
                 subtaskCheckpointCoordinator.notifyCheckpointComplete(
                         newCheckpointId, operatorChain, () -> false);
                 // even task is not running, state manager could still receive the notification.
-                assertEquals(newCheckpointId, stateManager.getNotifiedCompletedCheckpointId());
+                assertThat(stateManager.getNotifiedCompletedCheckpointId())
+                        .isEqualTo(newCheckpointId);
             }
         }
     }
 
     @Test
-    public void testSavepointNotResultingInPriorityEvents() throws Exception {
+    void testSavepointNotResultingInPriorityEvents() throws Exception {
         MockEnvironment mockEnvironment = MockEnvironment.builder().build();
 
         try (SubtaskCheckpointCoordinator coordinator =
@@ -188,12 +186,12 @@ public class SubtaskCheckpointCoordinatorTest {
                     false,
                     () -> true);
 
-            assertEquals(false, broadcastedPriorityEvent.get());
+            assertThat(broadcastedPriorityEvent.get()).isFalse();
         }
     }
 
     @Test
-    public void testForceAlignedCheckpointResultingInPriorityEvents() throws Exception {
+    void testForceAlignedCheckpointResultingInPriorityEvents() throws Exception {
         final long checkpointId = 42L;
         MockEnvironment mockEnvironment = MockEnvironment.builder().build();
 
@@ -237,12 +235,12 @@ public class SubtaskCheckpointCoordinatorTest {
                     false,
                     () -> true);
 
-            assertEquals(true, broadcastedPriorityEvent.get());
+            assertThat(broadcastedPriorityEvent.get()).isTrue();
         }
     }
 
     @Test
-    public void testSkipChannelStateForSavepoints() throws Exception {
+    void testSkipChannelStateForSavepoints() throws Exception {
         try (SubtaskCheckpointCoordinator coordinator =
                 new MockSubtaskCheckpointCoordinatorBuilder()
                         .setUnalignedCheckpointEnabled(true)
@@ -266,7 +264,7 @@ public class SubtaskCheckpointCoordinatorTest {
     }
 
     @Test
-    public void testNotifyCheckpointSubsumed() throws Exception {
+    void testNotifyCheckpointSubsumed() throws Exception {
         TestTaskStateManager stateManager = new TestTaskStateManager();
         MockEnvironment mockEnvironment =
                 MockEnvironment.builder().setTaskStateManager(stateManager).build();
@@ -304,15 +302,16 @@ public class SubtaskCheckpointCoordinatorTest {
             // notify checkpoint aborted before execution.
             subtaskCheckpointCoordinator.notifyCheckpointSubsumed(
                     notifySubsumeCheckpointId, operatorChain, () -> true);
-            assertEquals(
-                    notifySubsumeCheckpointId,
-                    ((TestStateBackend.TestKeyedStateBackend<?>) streamMap.getKeyedStateBackend())
-                            .getSubsumeCheckpointId());
+            assertThat(
+                            ((TestStateBackend.TestKeyedStateBackend<?>)
+                                            streamMap.getKeyedStateBackend())
+                                    .getSubsumeCheckpointId())
+                    .isEqualTo(notifySubsumeCheckpointId);
         }
     }
 
     @Test
-    public void testNotifyCheckpointAbortedManyTimes() throws Exception {
+    void testNotifyCheckpointAbortedManyTimes() throws Exception {
         MockEnvironment mockEnvironment = MockEnvironment.builder().build();
         int maxRecordAbortedCheckpoints = 256;
 
@@ -327,15 +326,14 @@ public class SubtaskCheckpointCoordinatorTest {
             long notifyAbortedTimes = maxRecordAbortedCheckpoints + 42;
             for (int i = 1; i < notifyAbortedTimes; i++) {
                 subtaskCheckpointCoordinator.notifyCheckpointAborted(i, operatorChain, () -> true);
-                assertEquals(
-                        Math.min(maxRecordAbortedCheckpoints, i),
-                        subtaskCheckpointCoordinator.getAbortedCheckpointSize());
+                assertThat(subtaskCheckpointCoordinator.getAbortedCheckpointSize())
+                        .isEqualTo(Math.min(maxRecordAbortedCheckpoints, i));
             }
         }
     }
 
     @Test
-    public void testNotifyCheckpointAbortedBeforeAsyncPhase() throws Exception {
+    void testNotifyCheckpointAbortedBeforeAsyncPhase() throws Exception {
         TestTaskStateManager stateManager = new TestTaskStateManager();
         MockEnvironment mockEnvironment =
                 MockEnvironment.builder().setTaskStateManager(stateManager).build();
@@ -356,7 +354,7 @@ public class SubtaskCheckpointCoordinatorTest {
             // notify checkpoint aborted before execution.
             subtaskCheckpointCoordinator.notifyCheckpointAborted(
                     checkpointId, operatorChain, () -> true);
-            assertEquals(1, subtaskCheckpointCoordinator.getAbortedCheckpointSize());
+            assertThat(subtaskCheckpointCoordinator.getAbortedCheckpointSize()).isOne();
 
             subtaskCheckpointCoordinator
                     .getChannelStateWriter()
@@ -368,15 +366,15 @@ public class SubtaskCheckpointCoordinatorTest {
                     operatorChain,
                     false,
                     () -> false);
-            assertFalse(checkpointOperator.isCheckpointed());
-            assertEquals(-1, stateManager.getReportedCheckpointId());
-            assertEquals(0, subtaskCheckpointCoordinator.getAbortedCheckpointSize());
-            assertEquals(0, subtaskCheckpointCoordinator.getAsyncCheckpointRunnableSize());
+            assertThat(checkpointOperator.isCheckpointed()).isFalse();
+            assertThat(stateManager.getReportedCheckpointId()).isEqualTo(-1);
+            assertThat(subtaskCheckpointCoordinator.getAbortedCheckpointSize()).isZero();
+            assertThat(subtaskCheckpointCoordinator.getAsyncCheckpointRunnableSize()).isZero();
         }
     }
 
     @Test
-    public void testBroadcastCancelCheckpointMarkerOnAbortingFromCoordinator() throws Exception {
+    void testBroadcastCancelCheckpointMarkerOnAbortingFromCoordinator() throws Exception {
         OneInputStreamTaskTestHarness<String, String> testHarness =
                 new OneInputStreamTaskTestHarness<>(
                         OneInputStreamTask::new,
@@ -429,11 +427,12 @@ public class SubtaskCheckpointCoordinatorTest {
                     false,
                     () -> false);
 
-            assertEquals(1, recordOrEvents.size());
+            assertThat(recordOrEvents).hasSize(1);
             Object recordOrEvent = recordOrEvents.get(0);
             // ensure CancelCheckpointMarker is broadcast downstream.
-            assertTrue(recordOrEvent instanceof CancelCheckpointMarker);
-            assertEquals(checkpointId, ((CancelCheckpointMarker) recordOrEvent).getCheckpointId());
+            assertThat(recordOrEvent).isInstanceOf(CancelCheckpointMarker.class);
+            assertThat(((CancelCheckpointMarker) recordOrEvent).getCheckpointId())
+                    .isEqualTo(checkpointId);
             testHarness.endInput();
             testHarness.waitForTaskCompletion();
         }
@@ -451,7 +450,7 @@ public class SubtaskCheckpointCoordinatorTest {
     }
 
     @Test
-    public void testNotifyCheckpointAbortedDuringAsyncPhase() throws Exception {
+    void testNotifyCheckpointAbortedDuringAsyncPhase() throws Exception {
         MockEnvironment mockEnvironment = MockEnvironment.builder().build();
 
         try (SubtaskCheckpointCoordinatorImpl subtaskCheckpointCoordinator =
@@ -486,21 +485,21 @@ public class SubtaskCheckpointCoordinatorTest {
                     false,
                     () -> false);
             rawKeyedStateHandleFuture.awaitRun();
-            assertEquals(1, subtaskCheckpointCoordinator.getAsyncCheckpointRunnableSize());
-            assertFalse(rawKeyedStateHandleFuture.isCancelled());
+            assertThat(subtaskCheckpointCoordinator.getAsyncCheckpointRunnableSize()).isOne();
+            assertThat(rawKeyedStateHandleFuture.isCancelled()).isFalse();
 
             subtaskCheckpointCoordinator.notifyCheckpointAborted(
                     checkpointId, operatorChain, () -> true);
             while (!rawKeyedStateHandleFuture.isDone()) {
                 Thread.sleep(10L);
             }
-            assertTrue(rawKeyedStateHandleFuture.isCancelled());
-            assertEquals(0, subtaskCheckpointCoordinator.getAsyncCheckpointRunnableSize());
+            assertThat(rawKeyedStateHandleFuture.isCancelled()).isTrue();
+            assertThat(subtaskCheckpointCoordinator.getAbortedCheckpointSize()).isZero();
         }
     }
 
     @Test
-    public void testNotifyCheckpointAbortedAfterAsyncPhase() throws Exception {
+    void testNotifyCheckpointAbortedAfterAsyncPhase() throws Exception {
         TestTaskStateManager stateManager = new TestTaskStateManager();
         MockEnvironment mockEnvironment =
                 MockEnvironment.builder().setTaskStateManager(stateManager).build();
@@ -522,13 +521,13 @@ public class SubtaskCheckpointCoordinatorTest {
                     () -> false);
             subtaskCheckpointCoordinator.notifyCheckpointAborted(
                     checkpointId, operatorChain, () -> true);
-            assertEquals(0, subtaskCheckpointCoordinator.getAbortedCheckpointSize());
-            assertEquals(checkpointId, stateManager.getNotifiedAbortedCheckpointId());
+            assertThat(subtaskCheckpointCoordinator.getAbortedCheckpointSize()).isZero();
+            assertThat(stateManager.getNotifiedAbortedCheckpointId()).isEqualTo(checkpointId);
         }
     }
 
     @Test
-    public void testTimeoutableAlignedBarrierNotPriorityAndChannelStateResult() throws Exception {
+    void testTimeoutableAlignedBarrierNotPriorityAndChannelStateResult() throws Exception {
         long checkpointId = 66;
         MockEnvironment mockEnvironment = MockEnvironment.builder().build();
 
@@ -578,13 +577,13 @@ public class SubtaskCheckpointCoordinatorTest {
                     false,
                     () -> true);
 
-            assertEquals(false, broadcastedPriorityEvent.get());
-            assertNotNull(channelStateResult.get());
+            assertThat(broadcastedPriorityEvent.get()).isFalse();
+            assertThat(channelStateResult.get()).isNotNull();
         }
     }
 
     @Test
-    public void testChannelStateWriteResultLeakAndNotFailAfterCheckpointAborted() throws Exception {
+    void testChannelStateWriteResultLeakAndNotFailAfterCheckpointAborted() throws Exception {
         String taskName = "test";
         DummyEnvironment env = new DummyEnvironment();
         ChannelStateWriterImpl writer =
@@ -621,7 +620,7 @@ public class SubtaskCheckpointCoordinatorTest {
                             CheckpointStorageLocationReference.getDefault()));
             ChannelStateWriter.ChannelStateWriteResult writeResult =
                     writer.getWriteResult(checkpointId);
-            assertNotNull(writeResult);
+            assertThat(writeResult).isNotNull();
 
             coordinator.checkpointState(
                     new CheckpointMetaData(checkpointId, System.currentTimeMillis()),
@@ -630,16 +629,18 @@ public class SubtaskCheckpointCoordinatorTest {
                     operatorChain,
                     false,
                     () -> true);
-            assertNull(writer.getWriteResult(checkpointId));
+            assertThat(writer.getWriteResult(checkpointId)).isNull();
             writeResult.waitForDone();
-            assertTrue(writeResult.isDone());
-            assertTrue(writeResult.getInputChannelStateHandles().isCompletedExceptionally());
-            assertTrue(writeResult.getResultSubpartitionStateHandles().isCompletedExceptionally());
+            assertThat(writeResult.isDone()).isTrue();
+            assertThat(writeResult.getInputChannelStateHandles().isCompletedExceptionally())
+                    .isTrue();
+            assertThat(writeResult.getResultSubpartitionStateHandles().isCompletedExceptionally())
+                    .isTrue();
         }
     }
 
     @Test
-    public void testAbortOldAndStartNewCheckpoint() throws Exception {
+    void testAbortOldAndStartNewCheckpoint() throws Exception {
         String taskName = "test";
         CheckpointOptions unalignedOptions =
                 CheckpointOptions.unaligned(
@@ -674,7 +675,7 @@ public class SubtaskCheckpointCoordinatorTest {
             coordinator.initInputsCheckpoint(checkpoint42, unalignedOptions);
             ChannelStateWriter.ChannelStateWriteResult result42 =
                     writer.getWriteResult(checkpoint42);
-            assertNotNull(result42);
+            assertThat(result42).isNotNull();
 
             coordinator.notifyCheckpointAborted(checkpoint42, operatorChain, () -> true);
             coordinator.initInputsCheckpoint(checkpoint43, unalignedOptions);
@@ -682,13 +683,10 @@ public class SubtaskCheckpointCoordinatorTest {
                     writer.getWriteResult(checkpoint43);
 
             result42.waitForDone();
-            assertTrue(result42.isDone());
-            try {
-                result42.getInputChannelStateHandles().get();
-                fail("The result should have failed.");
-            } catch (Throwable throwable) {
-                assertTrue(findThrowable(throwable, CancellationException.class).isPresent());
-            }
+            assertThat(result42.isDone()).isTrue();
+
+            assertThatThrownBy(() -> result42.getInputChannelStateHandles().get())
+                    .isInstanceOf(CancellationException.class);
 
             // test the new checkpoint can be completed
             coordinator.checkpointState(
@@ -699,10 +697,11 @@ public class SubtaskCheckpointCoordinatorTest {
                     false,
                     () -> true);
             result43.waitForDone();
-            assertNotNull(result43);
-            assertTrue(result43.isDone());
-            assertFalse(result43.getInputChannelStateHandles().isCompletedExceptionally());
-            assertFalse(result43.getResultSubpartitionStateHandles().isCompletedExceptionally());
+            assertThat(result43).isNotNull();
+            assertThat(result43.isDone()).isTrue();
+            assertThat(result43.getInputChannelStateHandles().isCompletedExceptionally()).isFalse();
+            assertThat(result43.getResultSubpartitionStateHandles().isCompletedExceptionally())
+                    .isFalse();
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeServiceTest.java
@@ -18,40 +18,36 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
-import org.apache.flink.api.common.operators.ProcessingTimeService.ProcessingTimeCallback;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for {@link SystemProcessingTimeService}. */
-public class SystemProcessingTimeServiceTest extends TestLogger {
+class SystemProcessingTimeServiceTest {
 
     /**
      * Tests that SystemProcessingTimeService#scheduleAtFixedRate is actually triggered multiple
      * times.
      */
-    @Test(timeout = 10000)
-    public void testScheduleAtFixedRate() throws Exception {
+    @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+    @Test
+    void testScheduleAtFixedRate() throws Exception {
         final AtomicReference<Throwable> errorRef = new AtomicReference<>();
         final long period = 10L;
         final int countDown = 3;
@@ -61,22 +57,11 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
         final CountDownLatch countDownLatch = new CountDownLatch(countDown);
 
         try {
-            timer.scheduleAtFixedRate(
-                    new ProcessingTimeCallback() {
-                        @Override
-                        public void onProcessingTime(long timestamp) throws Exception {
-                            countDownLatch.countDown();
-                        }
-                    },
-                    0L,
-                    period);
+            timer.scheduleAtFixedRate(timestamp -> countDownLatch.countDown(), 0L, period);
 
             countDownLatch.await();
 
-            if (errorRef.get() != null) {
-                throw new Exception(errorRef.get());
-            }
-
+            assertThat(errorRef.get()).isNull();
         } finally {
             timer.shutdownService();
         }
@@ -87,23 +72,16 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
      * fix rate future.
      */
     @Test
-    public void testQuiesceAndAwaitingCancelsScheduledAtFixRateFuture() throws Exception {
+    void testQuiesceAndAwaitingCancelsScheduledAtFixRateFuture() throws Exception {
         final AtomicReference<Throwable> errorRef = new AtomicReference<>();
         final long period = 10L;
 
         final SystemProcessingTimeService timer = createSystemProcessingTimeService(errorRef);
 
         try {
-            ScheduledFuture<?> scheduledFuture =
-                    timer.scheduleAtFixedRate(
-                            new ProcessingTimeCallback() {
-                                @Override
-                                public void onProcessingTime(long timestamp) throws Exception {}
-                            },
-                            0L,
-                            period);
+            Future<?> scheduledFuture = timer.scheduleAtFixedRate(timestamp -> {}, 0L, period);
 
-            assertFalse(scheduledFuture.isDone());
+            assertThat(scheduledFuture).isNotDone();
 
             // this should cancel our future
             timer.quiesce().get();
@@ -111,45 +89,36 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
             // it may be that the cancelled status is not immediately visible after the
             // termination (not necessary a volatile update), so we need to "get()" the cancellation
             // exception to be on the safe side
-            try {
-                scheduledFuture.get();
-                fail("scheduled future is not cancelled");
-            } catch (CancellationException ignored) {
-                // expected
-            }
+            assertThatThrownBy(scheduledFuture::get)
+                    .as("scheduled future is not cancelled")
+                    .isInstanceOf(CancellationException.class);
 
             scheduledFuture =
                     timer.scheduleAtFixedRate(
-                            new ProcessingTimeCallback() {
-                                @Override
-                                public void onProcessingTime(long timestamp) throws Exception {
-                                    throw new Exception("Test exception.");
-                                }
+                            timestamp -> {
+                                throw new Exception("Test exception.");
                             },
                             0L,
                             100L);
 
-            assertNotNull(scheduledFuture);
+            assertThat(scheduledFuture).isNotNull();
 
-            assertEquals(0, timer.getNumTasksScheduled());
+            assertThat(timer.getNumTasksScheduled()).isZero();
 
-            if (errorRef.get() != null) {
-                throw new Exception(errorRef.get());
-            }
-
+            assertThat(errorRef.get()).isNull();
         } finally {
             timer.shutdownService();
         }
     }
 
     @Test
-    public void testImmediateShutdown() throws Exception {
+    void testImmediateShutdown() throws Exception {
         final CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
 
         final SystemProcessingTimeService timer = createSystemProcessingTimeService(errorFuture);
 
         try {
-            assertFalse(timer.isTerminated());
+            assertThat(timer.isTerminated()).isFalse();
 
             final OneShotLatch latch = new OneShotLatch();
 
@@ -164,37 +133,32 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
             latch.await();
             timer.shutdownService();
 
-            assertTrue(timer.isTerminated());
-            assertEquals(0, timer.getNumTasksScheduled());
+            assertThat(timer.isTerminated()).isTrue();
+            assertThat(timer.getNumTasksScheduled()).isZero();
 
-            try {
-                timer.registerTimer(
-                        System.currentTimeMillis() + 1000,
-                        timestamp -> fail("should not be called"));
+            assertThatThrownBy(
+                            () ->
+                                    timer.registerTimer(
+                                            System.currentTimeMillis() + 1000,
+                                            timestamp -> fail("should not be called")))
+                    .isInstanceOf(IllegalStateException.class);
 
-                fail("should result in an exception");
-            } catch (IllegalStateException e) {
-                // expected
-            }
-
-            try {
-                timer.scheduleAtFixedRate(timestamp -> fail("should not be called"), 0L, 100L);
-
-                fail("should result in an exception");
-            } catch (IllegalStateException e) {
-                // expected
-            }
+            assertThatThrownBy(
+                            () ->
+                                    timer.scheduleAtFixedRate(
+                                            timestamp -> fail("should not be called"), 0L, 100L))
+                    .isInstanceOf(IllegalStateException.class);
 
             // check that the task eventually responded to interruption
-            assertThat(
-                    errorFuture.get(30L, TimeUnit.SECONDS), instanceOf(InterruptedException.class));
+            assertThat(errorFuture.get(30L, TimeUnit.SECONDS))
+                    .isInstanceOf(InterruptedException.class);
         } finally {
             timer.shutdownService();
         }
     }
 
     @Test
-    public void testQuiescing() throws Exception {
+    void testQuiescing() throws Exception {
 
         final AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
@@ -207,17 +171,14 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 
             timer.registerTimer(
                     timer.getCurrentProcessingTime() + 20L,
-                    new ProcessingTimeCallback() {
-                        @Override
-                        public void onProcessingTime(long timestamp) throws Exception {
-                            scopeLock.lock();
-                            try {
-                                latch.trigger();
-                                // delay a bit before leaving the method
-                                Thread.sleep(5);
-                            } finally {
-                                scopeLock.unlock();
-                            }
+                    timestamp -> {
+                        scopeLock.lock();
+                        try {
+                            latch.trigger();
+                            // delay a bit before leaving the method
+                            Thread.sleep(5);
+                        } finally {
+                            scopeLock.unlock();
                         }
                     });
 
@@ -227,71 +188,64 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 
             // should be able to immediately acquire the lock, since the task must have exited by
             // now
-            assertTrue(scopeLock.tryLock());
+            assertThat(scopeLock.tryLock()).isTrue();
 
             // should be able to schedule more tasks (that never get executed)
-            ScheduledFuture<?> future =
+            Future<?> future =
                     timer.registerTimer(
                             timer.getCurrentProcessingTime() - 5L,
-                            new ProcessingTimeCallback() {
-                                @Override
-                                public void onProcessingTime(long timestamp) throws Exception {
-                                    throw new Exception("test");
-                                }
+                            timestamp -> {
+                                throw new Exception("test");
                             });
-            assertNotNull(future);
+            assertThat(future).isNotNull();
 
             // nothing should be scheduled right now
-            assertEquals(0L, timer.getNumTasksScheduled());
+            assertThat(timer.getNumTasksScheduled()).isZero();
 
             // check that no asynchronous error was reported - that ensures that the newly scheduled
             // triggerable did, in fact, not trigger
-            if (errorRef.get() != null) {
-                throw new Exception(errorRef.get());
-            }
+            assertThat(errorRef.get()).isNull();
         } finally {
             timer.shutdownService();
         }
     }
 
     @Test
-    public void testFutureCancellation() throws Exception {
+    void testFutureCancellation() {
 
         final AtomicReference<Throwable> errorRef = new AtomicReference<>();
 
         final SystemProcessingTimeService timer = createSystemProcessingTimeService(errorRef);
 
         try {
-            assertEquals(0, timer.getNumTasksScheduled());
+            assertThat(timer.getNumTasksScheduled()).isZero();
 
             // schedule something
             ScheduledFuture<?> future =
                     timer.registerTimer(System.currentTimeMillis() + 100000000, timestamp -> {});
-            assertEquals(1, timer.getNumTasksScheduled());
+            assertThat(timer.getNumTasksScheduled()).isOne();
 
             future.cancel(false);
 
-            assertEquals(0, timer.getNumTasksScheduled());
+            assertThat(timer.getNumTasksScheduled()).isZero();
 
             future = timer.scheduleAtFixedRate(timestamp -> {}, 10000000000L, 50L);
 
-            assertEquals(1, timer.getNumTasksScheduled());
+            assertThat(timer.getNumTasksScheduled()).isOne();
 
             future.cancel(false);
 
-            assertEquals(0, timer.getNumTasksScheduled());
+            assertThat(timer.getNumTasksScheduled()).isZero();
 
             // check that no asynchronous error was reported
-            if (errorRef.get() != null) {
-                throw new Exception(errorRef.get());
-            }
+            assertThat(errorRef.get()).isNull();
         } finally {
             timer.shutdownService();
         }
     }
 
     @Test
-    public void testShutdownAndWaitPending() {
+    void testShutdownAndWaitPending() throws Exception {
 
         final OneShotLatch blockUntilTriggered = new OneShotLatch();
         final AtomicBoolean timerExecutionFinished = new AtomicBoolean(false);
@@ -300,39 +254,31 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
                 createBlockingSystemProcessingTimeService(
                         blockUntilTriggered, timerExecutionFinished);
 
-        Assert.assertFalse(timeService.isTerminated());
+        assertThat(timeService.isTerminated()).isFalse();
 
         // Check that we wait for the timer to terminate. As the timer blocks on the second latch,
         // this should time out.
-        try {
-            Assert.assertFalse(timeService.shutdownAndAwaitPending(1, TimeUnit.SECONDS));
-        } catch (InterruptedException e) {
-            Assert.fail("Unexpected interruption.");
-        }
+        assertThat(timeService.shutdownAndAwaitPending(1, TimeUnit.SECONDS)).isFalse();
 
         // Let the timer proceed.
         blockUntilTriggered.trigger();
 
         // Now we should succeed in terminating the timer.
-        try {
-            Assert.assertTrue(timeService.shutdownAndAwaitPending(60, TimeUnit.SECONDS));
-        } catch (InterruptedException e) {
-            Assert.fail("Unexpected interruption.");
-        }
+        assertThat(timeService.shutdownAndAwaitPending(60, TimeUnit.SECONDS)).isTrue();
 
-        Assert.assertTrue(timerExecutionFinished.get());
-        Assert.assertTrue(timeService.isTerminated());
+        assertThat(timerExecutionFinished).isTrue();
+        assertThat(timeService.isTerminated()).isTrue();
     }
 
     @Test
-    public void testShutdownServiceUninterruptible() {
+    void testShutdownServiceUninterruptible() {
         final OneShotLatch blockUntilTriggered = new OneShotLatch();
         final AtomicBoolean timerFinished = new AtomicBoolean(false);
 
         final SystemProcessingTimeService timeService =
                 createBlockingSystemProcessingTimeService(blockUntilTriggered, timerFinished);
 
-        Assert.assertFalse(timeService.isTerminated());
+        assertThat(timeService.isTerminated()).isFalse();
 
         final Thread interruptTarget = Thread.currentThread();
         final AtomicBoolean runInterrupts = new AtomicBoolean(true);
@@ -352,15 +298,15 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
 
         final long timeoutMs = 50L;
         final long startTime = System.nanoTime();
-        Assert.assertFalse(timeService.isTerminated());
+        assertThat(timeService.isTerminated()).isFalse();
         // check that termination did not succeed (because of blocking timer execution)
-        Assert.assertFalse(timeService.shutdownServiceUninterruptible(timeoutMs));
+        assertThat(timeService.shutdownServiceUninterruptible(timeoutMs)).isFalse();
         // check that termination flag was set.
-        Assert.assertTrue(timeService.isTerminated());
+        assertThat(timeService.isTerminated()).isTrue();
         // check that the blocked timer is still in flight.
-        Assert.assertFalse(timerFinished.get());
+        assertThat(timerFinished).isFalse();
         // check that we waited until timeout
-        Assert.assertTrue((System.nanoTime() - startTime) >= (1_000_000L * timeoutMs));
+        assertThat(System.nanoTime() - startTime).isGreaterThanOrEqualTo(1_000_000L * timeoutMs);
 
         runInterrupts.set(false);
 
@@ -375,8 +321,8 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
         final boolean ignored = Thread.interrupted();
 
         blockUntilTriggered.trigger();
-        Assert.assertTrue(timeService.shutdownServiceUninterruptible(timeoutMs));
-        Assert.assertTrue(timerFinished.get());
+        assertThat(timeService.shutdownServiceUninterruptible(timeoutMs)).isTrue();
+        assertThat(timerFinished).isTrue();
     }
 
     private static SystemProcessingTimeService createSystemProcessingTimeService(
@@ -425,7 +371,7 @@ public class SystemProcessingTimeServiceTest extends TestLogger {
         try {
             waitUntilTimerStarted.await();
         } catch (InterruptedException e) {
-            Assert.fail("Problem while starting up service.");
+            fail("Problem while starting up service.");
         }
 
         return timeService;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -89,11 +89,9 @@ import org.apache.flink.streaming.api.operators.StreamFilter;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
 import org.apache.flink.util.SerializedValue;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.Executors;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -104,8 +102,7 @@ import java.util.HashMap;
 import java.util.concurrent.RunnableFuture;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -113,12 +110,12 @@ import static org.mockito.Mockito.mock;
  * checks correct working of different policies how tasks deal with checkpoint failures (fail task,
  * decline checkpoint and continue).
  */
-public class TaskCheckpointingBehaviourTest extends TestLogger {
+class TaskCheckpointingBehaviourTest {
 
     private static final OneShotLatch IN_CHECKPOINT_LATCH = new OneShotLatch();
 
     @Test
-    public void testDeclineOnCheckpointErrorInSyncPart() throws Exception {
+    void testDeclineOnCheckpointErrorInSyncPart() throws Exception {
         TestDeclinedCheckpointResponder checkpointResponder = new TestDeclinedCheckpointResponder();
         Task task =
                 createTask(
@@ -129,7 +126,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
     }
 
     @Test
-    public void testDeclineOnCheckpointErrorInAsyncPart() throws Exception {
+    void testDeclineOnCheckpointErrorInAsyncPart() throws Exception {
         TestDeclinedCheckpointResponder checkpointResponder = new TestDeclinedCheckpointResponder();
         Task task =
                 createTask(
@@ -140,7 +137,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
     }
 
     @Test
-    public void testBlockingNonInterruptibleCheckpoint() throws Exception {
+    void testBlockingNonInterruptibleCheckpoint() throws Exception {
 
         StateBackend lockingStateBackend = new BackendForTestStream(LockingOutputStream::new);
 
@@ -157,8 +154,8 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
         task.cancelExecution();
         task.getExecutingThread().join();
 
-        assertEquals(ExecutionState.CANCELED, task.getExecutionState());
-        assertNull(task.getFailureCause());
+        assertThat(task.getExecutionState()).isEqualTo(ExecutionState.CANCELED);
+        assertThat(task.getFailureCause()).isNull();
     }
 
     private void runTaskExpectCheckpointDeclined(
@@ -168,7 +165,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 
         checkpointResponder.declinedLatch.await();
 
-        Assert.assertEquals(ExecutionState.RUNNING, task.getExecutionState());
+        assertThat(task.getExecutionState()).isEqualTo(ExecutionState.RUNNING);
 
         task.cancelExecution();
         task.getExecutingThread().join();
@@ -177,7 +174,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
     private void runTaskExpectFailure(Task task) throws Exception {
         task.startTaskThread();
         task.getExecutingThread().join();
-        Assert.assertEquals(ExecutionState.FAILED, task.getExecutionState());
+        assertThat(task.getExecutionState()).isEqualTo(ExecutionState.FAILED);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -547,7 +547,7 @@ class TwoInputStreamTaskTest {
             testHarness.processElement(Watermark.MAX_WATERMARK, 1);
             testHarness.waitForTaskCompletion();
             assertThat(testHarness.getOutput())
-                    .contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
+                    .containsExactly(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
         }
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -66,14 +66,10 @@ import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.OutputTag;
 
-import org.hamcrest.collection.IsMapContaining;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -81,11 +77,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link TwoInputStreamTask}.
@@ -95,7 +87,7 @@ import static org.junit.Assert.assertFalse;
  * used as a representative to test {@link TwoInputStreamTask}, since {@link TwoInputStreamTask} is
  * used for all {@link TwoInputStreamOperator}s.
  */
-public class TwoInputStreamTaskTest {
+class TwoInputStreamTaskTest {
 
     /**
      * This test verifies that open() and close() are correctly called. This test also verifies that
@@ -103,7 +95,7 @@ public class TwoInputStreamTaskTest {
      * to emitted elements.
      */
     @Test
-    public void testOpenCloseAndTimestamps() throws Exception {
+    void testOpenCloseAndTimestamps() throws Exception {
         final TwoInputStreamTaskTestHarness<String, Integer, String> testHarness =
                 new TwoInputStreamTaskTestHarness<>(
                         TwoInputStreamTask::new,
@@ -140,8 +132,9 @@ public class TwoInputStreamTaskTest {
 
         testHarness.waitForTaskCompletion();
 
-        Assert.assertTrue(
-                "RichFunction methods were not called.", TestOpenCloseMapFunction.closeCalled);
+        assertThat(TestOpenCloseMapFunction.closeCalled)
+                .as("RichFunction methods were not called.")
+                .isTrue();
 
         TestHarnessUtil.assertOutputEquals(
                 "Output was not correct.", expectedOutput, testHarness.getOutput());
@@ -153,7 +146,7 @@ public class TwoInputStreamTaskTest {
      * inputs. The forwarded watermark must be the minimum of the watermarks of all active inputs.
      */
     @Test
-    public void testWatermarkAndWatermarkStatusForwarding() throws Exception {
+    void testWatermarkAndWatermarkStatusForwarding() throws Exception {
 
         final TwoInputStreamTaskTestHarness<String, Integer, String> testHarness =
                 new TwoInputStreamTaskTestHarness<>(
@@ -270,12 +263,12 @@ public class TwoInputStreamTaskTest {
 
         List<String> resultElements =
                 TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
-        Assert.assertEquals(2, resultElements.size());
+        assertThat(resultElements).hasSize(2);
     }
 
     /** This test verifies that checkpoint barriers are correctly forwarded. */
     @Test
-    public void testCheckpointBarriers() throws Exception {
+    void testCheckpointBarriers() throws Exception {
 
         final TwoInputStreamTaskTestHarness<String, Integer, String> testHarness =
                 new TwoInputStreamTaskTestHarness<>(
@@ -360,7 +353,7 @@ public class TwoInputStreamTaskTest {
 
         List<String> resultElements =
                 TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
-        Assert.assertEquals(3, resultElements.size());
+        assertThat(resultElements).hasSize(3);
     }
 
     /**
@@ -370,7 +363,7 @@ public class TwoInputStreamTaskTest {
      * receive barriers from a later checkpoint.
      */
     @Test
-    public void testOvertakingCheckpointBarriers() throws Exception {
+    void testOvertakingCheckpointBarriers() throws Exception {
 
         final TwoInputStreamTaskTestHarness<String, Integer, String> testHarness =
                 new TwoInputStreamTaskTestHarness<>(
@@ -465,7 +458,7 @@ public class TwoInputStreamTaskTest {
     }
 
     @Test
-    public void testOperatorMetricReuse() throws Exception {
+    void testOperatorMetricReuse() throws Exception {
         final TwoInputStreamTaskTestHarness<String, String, String> testHarness =
                 new TwoInputStreamTaskTestHarness<>(
                         TwoInputStreamTask::new,
@@ -525,15 +518,16 @@ public class TwoInputStreamTaskTest {
         }
         testHarness.waitForInputProcessing();
 
-        assertEquals(numRecords1 + numRecords2, numRecordsInCounter.getCount());
-        assertEquals((numRecords1 + numRecords2) * 2 * 2 * 2, numRecordsOutCounter.getCount());
+        assertThat(numRecordsInCounter.getCount()).isEqualTo(numRecords1 + numRecords2);
+        assertThat(numRecordsOutCounter.getCount())
+                .isEqualTo((numRecords1 + numRecords2) * 2 * 2 * 2);
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
     }
 
     @Test
-    public void testSkipExecutionsIfFinishedOnRestore() throws Exception {
+    void testSkipExecutionsIfFinishedOnRestore() throws Exception {
         OperatorID nonSourceOperatorId = new OperatorID();
 
         try (StreamTaskMailboxTestHarness<String> testHarness =
@@ -552,9 +546,8 @@ public class TwoInputStreamTaskTest {
             testHarness.processElement(Watermark.MAX_WATERMARK, 0);
             testHarness.processElement(Watermark.MAX_WATERMARK, 1);
             testHarness.waitForTaskCompletion();
-            assertThat(
-                    testHarness.getOutput(),
-                    contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN)));
+            assertThat(testHarness.getOutput())
+                    .contains(Watermark.MAX_WATERMARK, new EndOfData(StopMode.DRAIN));
         }
     }
 
@@ -581,7 +574,7 @@ public class TwoInputStreamTaskTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testWatermarkMetrics() throws Exception {
+    void testWatermarkMetrics() throws Exception {
         final TwoInputStreamTaskTestHarness<String, Integer, String> testHarness =
                 new TwoInputStreamTaskTestHarness<>(
                         TwoInputStreamTask::new,
@@ -657,10 +650,8 @@ public class TwoInputStreamTaskTest {
                 (Gauge<Long>)
                         chainedOperatorMetricGroup.get(MetricNames.IO_CURRENT_OUTPUT_WATERMARK);
 
-        Assert.assertEquals(
-                "A metric was registered multiple times.",
-                7,
-                new HashSet<>(
+        assertThat(
+                        new HashSet<>(
                                 Arrays.asList(
                                         taskInputWatermarkGauge,
                                         headInput1WatermarkGauge,
@@ -668,53 +659,54 @@ public class TwoInputStreamTaskTest {
                                         headInputWatermarkGauge,
                                         headOutputWatermarkGauge,
                                         chainedInputWatermarkGauge,
-                                        chainedOutputWatermarkGauge))
-                        .size());
+                                        chainedOutputWatermarkGauge)))
+                .as("A metric was registered multiple times.")
+                .hasSize(7);
 
-        Assert.assertEquals(Long.MIN_VALUE, taskInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, headInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, headInput1WatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, headInput2WatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, headOutputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+        assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(headInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(headInput1WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(headInput2WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(headOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
 
         testHarness.processElement(new Watermark(1L), 0, 0);
         testHarness.waitForInputProcessing();
-        Assert.assertEquals(Long.MIN_VALUE, taskInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, headInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(1L, headInput1WatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, headInput2WatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, headOutputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+        assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(headInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(headInput1WatermarkGauge.getValue()).isOne();
+        assertThat(headInput2WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(headOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
+        assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
 
         testHarness.processElement(new Watermark(2L), 1, 0);
         testHarness.waitForInputProcessing();
-        Assert.assertEquals(1L, taskInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(1L, headInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(1L, headInput1WatermarkGauge.getValue().longValue());
-        Assert.assertEquals(2L, headInput2WatermarkGauge.getValue().longValue());
-        Assert.assertEquals(1L, headOutputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(1L, chainedInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(2L, chainedOutputWatermarkGauge.getValue().longValue());
+        assertThat(taskInputWatermarkGauge.getValue()).isOne();
+        assertThat(headInputWatermarkGauge.getValue()).isOne();
+        assertThat(headInput1WatermarkGauge.getValue()).isOne();
+        assertThat(headInput2WatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(headOutputWatermarkGauge.getValue()).isOne();
+        assertThat(chainedInputWatermarkGauge.getValue()).isOne();
+        assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(2L);
 
         testHarness.processElement(new Watermark(3L), 0, 0);
         testHarness.waitForInputProcessing();
-        Assert.assertEquals(2L, taskInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(2L, headInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(3L, headInput1WatermarkGauge.getValue().longValue());
-        Assert.assertEquals(2L, headInput2WatermarkGauge.getValue().longValue());
-        Assert.assertEquals(2L, headOutputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(2L, chainedInputWatermarkGauge.getValue().longValue());
-        Assert.assertEquals(4L, chainedOutputWatermarkGauge.getValue().longValue());
+        assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(headInputWatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(headInput1WatermarkGauge.getValue()).isEqualTo(3L);
+        assertThat(headInput2WatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(headOutputWatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(2L);
+        assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(4L);
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
     }
 
     @Test
-    public void testClosingAllOperatorsOnChainProperly() throws Exception {
+    void testClosingAllOperatorsOnChainProperly() throws Exception {
         final TwoInputStreamTaskTestHarness<String, String, String> testHarness =
                 new TwoInputStreamTaskTestHarness<>(
                         TwoInputStreamTask::new,
@@ -743,19 +735,19 @@ public class TwoInputStreamTaskTest {
 
         testHarness.waitForTaskCompletion();
 
-        ArrayList<Object> expected = new ArrayList<>();
-        Collections.addAll(
-                expected,
-                new StreamRecord<>("[Operator0-1]: Hello-1"),
-                new StreamRecord<>("[Operator0-1]: End of input"),
-                new StreamRecord<>("[Operator0-2]: Hello-2"),
-                new StreamRecord<>("[Operator0-2]: End of input"),
-                new StreamRecord<>("[Operator0]: Finish"),
-                new StreamRecord<>("[Operator1]: End of input"),
-                new StreamRecord<>("[Operator1]: Finish"));
+        Object[] expected =
+                new StreamRecord[] {
+                    new StreamRecord<>("[Operator0-1]: Hello-1"),
+                    new StreamRecord<>("[Operator0-1]: End of input"),
+                    new StreamRecord<>("[Operator0-2]: Hello-2"),
+                    new StreamRecord<>("[Operator0-2]: End of input"),
+                    new StreamRecord<>("[Operator0]: Finish"),
+                    new StreamRecord<>("[Operator1]: End of input"),
+                    new StreamRecord<>("[Operator1]: Finish")
+                };
 
         final Object[] output = testHarness.getOutput().toArray();
-        assertArrayEquals("Output was not correct.", expected.toArray(), output);
+        assertThat(output).as("Output was not correct.").isEqualTo(expected);
     }
 
     /**
@@ -763,7 +755,7 @@ public class TwoInputStreamTaskTest {
      * while generating the {@link TwoInputStreamTask}.
      */
     @Test
-    public void testCheckpointBarrierMetrics() throws Exception {
+    void testCheckpointBarrierMetrics() throws Exception {
         final TwoInputStreamTaskTestHarness<String, Integer, String> testHarness =
                 new TwoInputStreamTaskTestHarness<>(
                         TwoInputStreamTask::new,
@@ -785,8 +777,10 @@ public class TwoInputStreamTaskTest {
         testHarness.invoke(environment);
         testHarness.waitForTaskRunning();
 
-        assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_ALIGNMENT_TIME));
-        assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_START_DELAY_TIME));
+        assertThat(metrics)
+                .containsKeys(
+                        MetricNames.CHECKPOINT_ALIGNMENT_TIME,
+                        MetricNames.CHECKPOINT_START_DELAY_TIME);
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
@@ -794,7 +788,7 @@ public class TwoInputStreamTaskTest {
 
     /** The CanEmitBatchOfRecords should always be false for {@link TwoInputStreamTask}. */
     @Test
-    public void testCanEmitBatchOfRecords() throws Exception {
+    void testCanEmitBatchOfRecords() throws Exception {
         AvailabilityProvider.AvailabilityHelper availabilityHelper =
                 new AvailabilityProvider.AvailabilityHelper();
         try (StreamTaskMailboxTestHarness<String> testHarness =
@@ -812,28 +806,28 @@ public class TwoInputStreamTaskTest {
             testHarness.processAll();
 
             availabilityHelper.resetAvailable();
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             // The canEmitBatchOfRecordsChecker should be the false after the record writer is
             // unavailable.
             availabilityHelper.resetUnavailable();
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             // Restore record writer to available
             availabilityHelper.resetAvailable();
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             // The canEmitBatchOfRecordsChecker should be the false after add the mail to mail box.
             testHarness.streamTask.mainMailboxExecutor.execute(() -> {}, "mail");
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
 
             testHarness.processAll();
-            assertFalse(canEmitBatchOfRecordsChecker.check());
+            assertThat(canEmitBatchOfRecordsChecker.check()).isFalse();
         }
     }
 
     @Test
-    public void testTaskSideOutputStatistics() throws Exception {
+    void testTaskSideOutputStatistics() throws Exception {
         TaskMetricGroup taskMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
 
@@ -895,12 +889,12 @@ public class TwoInputStreamTaskTest {
             final int oddEvenOperatorOutputsWithOddTag = numOddRecords;
             final int oddEvenOperatorOutputsWithoutTag = numOddRecords + numEvenRecords;
             final int duplicatingOperatorOutput = (numOddRecords + numEvenRecords) * 2;
-            assertEquals(numOddRecords + numEvenRecords, numRecordsInCounter.getCount());
-            assertEquals(
-                    oddEvenOperatorOutputsWithOddTag
-                            + oddEvenOperatorOutputsWithoutTag
-                            + duplicatingOperatorOutput,
-                    numRecordsOutCounter.getCount());
+            assertThat(numRecordsInCounter.getCount()).isEqualTo(numOddRecords + numEvenRecords);
+            assertThat(numRecordsOutCounter.getCount())
+                    .isEqualTo(
+                            oddEvenOperatorOutputsWithOddTag
+                                    + oddEvenOperatorOutputsWithoutTag
+                                    + duplicatingOperatorOutput);
             testHarness.waitForTaskCompletion();
         } finally {
             for (ResultPartitionWriter partitionWriter : partitionWriters) {
@@ -967,34 +961,26 @@ public class TwoInputStreamTaskTest {
         @Override
         public void open(OpenContext openContext) throws Exception {
             super.open(openContext);
-            if (closeCalled) {
-                Assert.fail("Close called before open.");
-            }
+            assertThat(openCalled).as("Close called before open.").isFalse();
             openCalled = true;
         }
 
         @Override
         public void close() throws Exception {
             super.close();
-            if (!openCalled) {
-                Assert.fail("Open was not called before close.");
-            }
+            assertThat(openCalled).as("Open was not called before close.").isTrue();
             closeCalled = true;
         }
 
         @Override
         public String map1(String value) {
-            if (!openCalled) {
-                Assert.fail("Open was not called before run.");
-            }
+            assertThat(openCalled).as("Open was not called before run.").isTrue();
             return value;
         }
 
         @Override
         public String map2(Integer value) {
-            if (!openCalled) {
-                Assert.fail("Open was not called before run.");
-            }
+            assertThat(openCalled).as("Open was not called before run.").isTrue();
             return value.toString();
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/WatermarkStatusTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/watermarkstatus/WatermarkStatusTest.java
@@ -18,63 +18,47 @@
 
 package org.apache.flink.streaming.runtime.watermarkstatus;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link WatermarkStatus}. */
-public class WatermarkStatusTest {
+class WatermarkStatusTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalCreationThrowsException() {
-        new WatermarkStatus(32);
+    @Test
+    void testIllegalCreationThrowsException() {
+        assertThatThrownBy(() -> new WatermarkStatus(32))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         WatermarkStatus idleStatus = new WatermarkStatus(WatermarkStatus.IDLE_STATUS);
         WatermarkStatus activeStatus = new WatermarkStatus(WatermarkStatus.ACTIVE_STATUS);
 
-        assertEquals(WatermarkStatus.IDLE, idleStatus);
-        assertTrue(idleStatus.isIdle());
-        assertFalse(idleStatus.isActive());
+        assertThat(idleStatus).isEqualTo(WatermarkStatus.IDLE);
+        assertThat(idleStatus.isIdle()).isTrue();
+        assertThat(idleStatus.isActive()).isFalse();
 
-        assertEquals(WatermarkStatus.ACTIVE, activeStatus);
-        assertTrue(activeStatus.isActive());
-        assertFalse(activeStatus.isIdle());
+        assertThat(activeStatus).isEqualTo(WatermarkStatus.ACTIVE);
+        assertThat(activeStatus.isActive()).isTrue();
+        assertThat(activeStatus.isIdle()).isFalse();
     }
 
     @Test
-    public void testTypeCasting() {
+    void testTypeCasting() {
         WatermarkStatus status = WatermarkStatus.ACTIVE;
 
-        assertTrue(status.isWatermarkStatus());
-        assertFalse(status.isRecord());
-        assertFalse(status.isWatermark());
-        assertFalse(status.isLatencyMarker());
+        assertThat(status.isWatermarkStatus()).isTrue();
+        assertThat(status.isRecord()).isFalse();
+        assertThat(status.isWatermark()).isFalse();
+        assertThat(status.isLatencyMarker()).isFalse();
 
-        try {
-            status.asWatermark();
-            fail("should throw an exception");
-        } catch (Exception e) {
-            // expected
-        }
+        assertThatThrownBy(status::asWatermark).isInstanceOf(ClassCastException.class);
 
-        try {
-            status.asRecord();
-            fail("should throw an exception");
-        } catch (Exception e) {
-            // expected
-        }
+        assertThatThrownBy(status::asRecord).isInstanceOf(ClassCastException.class);
 
-        try {
-            status.asLatencyMarker();
-            fail("should throw an exception");
-        } catch (Exception e) {
-            // expected
-        }
+        assertThatThrownBy(status::asLatencyMarker).isInstanceOf(ClassCastException.class);
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-25544][streaming][JUnit5 Migration] The runtime package of module flink-stream-java

## Brief change log


**1. Migrate Junit4 annotations to JUnit5**

JUnit 4 | JUnit 5
-- | --
`@Test` | `@Test`
`@Test(expected=XXX)` | `@Test + assertThatThrownBy(() -> { ...}).isInstanceOf(XXX.class)`
`@Test(timeout=XXX)` | `@Test + @Timeout(XXX)`
`@Before` | `@BeforeEach`
`@After` | `@AfterEach`
`@BeforeClass` | `@BeforeAll`
`@AfterClass` | `@AfterAll`
`@Ignore` | `@Disabled`
`@Category` | `@Tag`

**2. Migrate Junit4 Assertion & Assumption to AssertJ**
**3. Migrate Junit4 `@Rule` and `@ClassRule` to `@ExtendWith` and `@RegisterExtension`**
**4. Migrate Parameterized Test from `@RunWith(Parameterized.class)` to `@ExtendWith(ParameterizedTestExtension.class)` and `@TestTemplate`**
**4. Minimize Test classes and Methods visibility**

https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit?pli=1

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
