### PR TITLE
[FLINK-34660][checkpoint] Avoid randomizing changelog-related config when it's pre-defined

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -124,15 +124,17 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
         }
 
         // randomize ITTests for enabling state change log
-        if (STATE_CHANGE_LOG_CONFIG.equalsIgnoreCase(STATE_CHANGE_LOG_CONFIG_ON)) {
-            if (!conf.contains(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)) {
+        if (!conf.contains(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)) {
+            if (STATE_CHANGE_LOG_CONFIG.equalsIgnoreCase(STATE_CHANGE_LOG_CONFIG_ON)) {
                 conf.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, true);
-                miniCluster.overrideRestoreModeForChangelogStateBackend();
+            } else if (STATE_CHANGE_LOG_CONFIG.equalsIgnoreCase(STATE_CHANGE_LOG_CONFIG_RAND)) {
+                randomize(conf, StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, true, false);
             }
-        } else if (STATE_CHANGE_LOG_CONFIG.equalsIgnoreCase(STATE_CHANGE_LOG_CONFIG_RAND)) {
-            boolean enabled =
-                    randomize(conf, StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, true, false);
-            if (enabled) {
+        }
+
+        // randomize periodic materialization when enabling state change log
+        if (conf.get(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)) {
+            if (!conf.contains(StateChangelogOptions.PERIODIC_MATERIALIZATION_ENABLED)) {
                 // More situations about enabling periodic materialization should be tested
                 randomize(
                         conf,
@@ -141,6 +143,8 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
                         true,
                         true,
                         false);
+            }
+            if (!conf.contains(StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL)) {
                 randomize(
                         conf,
                         StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL,
@@ -148,8 +152,8 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
                         Duration.ofMillis(500),
                         Duration.ofSeconds(1),
                         Duration.ofSeconds(5));
-                miniCluster.overrideRestoreModeForChangelogStateBackend();
             }
+            miniCluster.overrideRestoreModeForChangelogStateBackend();
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

AutoRescalingITCase#testCheckpointRescalingInKeyedState AssertionError:

```
expected:<[(0,8000), (0,32000), (0,48000), (0,72000), (1,78000), (1,30000), (1,54000), (0,2000), (0,10000), (0,50000), (0,66000), (0,74000), (0,82000), (1,80000), (1,0), (1,16000), (1,24000), (1,40000), (1,56000), (1,64000), (0,12000), (0,28000), (0,52000), (0,60000), (0,68000), (0,76000), (1,18000), (1,26000), (1,34000), (1,42000), (1,58000), (0,6000), (0,14000), (0,22000), (0,38000), (0,46000), (0,62000), (0,70000), (1,4000), (1,20000), (1,36000), (1,44000)]> but was:<[(0,8000), (0,32000), (0,48000), (0,72000), (1,78000), (1,30000), (1,54000), (0,2000), (0,10000), (0,50000), (0,66000), (0,74000), (0,82000), (0,23000), (0,31000), (1,80000), (1,0), (1,16000), (1,24000), (1,40000), (1,56000), (1,64000), (0,12000), (0,28000), (0,52000), (0,60000), (0,68000), (0,76000), (1,18000), (1,26000), (1,34000), (1,42000), (1,58000), (0,6000), (0,14000), (0,22000), (0,19000), (0,35000), (1,4000), (1,20000), (1,36000), (1,44000)]> 
```
 

This maybe related to [FLINK-34624](https://issues.apache.org/jira/browse/FLINK-34624) as we could see from the log:

```
03:31:02,073 [ main] INFO org.apache.flink.runtime.testutils.PseudoRandomValueSelector [] - Randomly selected true for state.changelog.enabled
03:31:02,163 [jobmanager-io-thread-2] INFO org.apache.flink.state.changelog.AbstractChangelogStateBackend [] - ChangelogStateBackend is used, delegating EmbeddedRocksDBStateBackend. 
[FLINK-34624](https://issues.apache.org/jira/browse/FLINK-34624) disables changelog since it doesn't support local rescaling currently.

```
Even if disabling changelog for AutoRescalingITCase manually,  randomization may still be applied to it.
We should apply randomization only when it's not pre-defined.


## Brief change log

  - Modify TestStreamEnvironment to apply randomization only when it's not pre-defined.


## Verifying this change

This change is a trivial rework to reconstruct the test util.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
