### PR TITLE
[FLINK-34227][runtime] Fixes concurrency issue in JobMaster shutdown

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -883,14 +883,29 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
     public void disconnectResourceManager(
             final ResourceManagerId resourceManagerId, final Exception cause) {
 
-        if (isConnectingToResourceManager(resourceManagerId)) {
+        if (resourceManagerAddress == null) {
+            log.debug(
+                    "Disconnecting ResourceManager {} was triggered with no ResourceManager address "
+                            + "being set (anymore). That either indicates that the ResourceManager "
+                            + "lost leadership in the mean time or the message was received while "
+                            + "shutting down the JobMaster. No reconnect will be initiated.",
+                    resourceManagerId);
+        } else if (!resourceManagerAddress.getResourceManagerId().equals(resourceManagerId)) {
+            log.debug(
+                    "Disconnecting ResourceManager {} was received while this instance is currently "
+                            + "connected to another ResourceManager {} indicating that a ResourceManager "
+                            + "leader change happened. No reconnect will be initiated.",
+                    resourceManagerId,
+                    resourceManagerAddress.getResourceManagerId());
+        } else {
             reconnectToResourceManager(cause);
         }
     }
 
-    private boolean isConnectingToResourceManager(ResourceManagerId resourceManagerId) {
-        return resourceManagerAddress != null
-                && resourceManagerAddress.getResourceManagerId().equals(resourceManagerId);
+    private void shutdownResourceManagerConnection(Exception cause) {
+        // unsetting the resourceManagerAddress will prevent reconnection
+        resourceManagerAddress = null;
+        closeResourceManagerConnection(cause);
     }
 
     @Override
@@ -1213,8 +1228,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
             disconnectTaskManager(taskManagerResourceId, cause);
         }
 
-        // disconnect from resource manager:
-        closeResourceManagerConnection(cause);
+        shutdownResourceManagerConnection(cause);
     }
 
     private void stopHeartbeatServices() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -1194,13 +1194,14 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
 
         final CompletableFuture<Void> terminationFuture = stopScheduling();
 
-        return FutureUtils.runAfterwards(
+        return FutureUtils.runAfterwardsAsync(
                 terminationFuture,
                 () -> {
                     shuffleMaster.unregisterJob(executionPlan.getJobID());
                     disconnectTaskManagerResourceManagerConnections(cause);
                     stopJobMasterServices();
-                });
+                },
+                getMainThreadExecutor());
     }
 
     private void disconnectTaskManagerResourceManagerConnections(Exception cause) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolServiceBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolServiceBuilder.java
@@ -92,6 +92,11 @@ public class TestingSlotPoolServiceBuilder implements SlotPoolServiceFactory {
         return this;
     }
 
+    public TestingSlotPoolServiceBuilder setCloseRunnable(Runnable closeRunnable) {
+        this.closeRunnable = closeRunnable;
+        return this;
+    }
+
     public static TestingSlotPoolServiceBuilder newBuilder() {
         return new TestingSlotPoolServiceBuilder();
     }


### PR DESCRIPTION
## What is the purpose of the change

The `SchedulerNG#closeAsync` might return a future that's completed in a IO thread because both, the [AdaptiveScheduler:581](https://github.com/apache/flink/blob/d4e0084649c019c536ee1e44bab15c8eca01bf13/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java#L581) and the [SchedulerBase:674](https://github.com/apache/flink/blob/d4e0084649c019c536ee1e44bab15c8eca01bf13/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java#L674) compose the result future of the checkpointsCleaner. This can result in the connection close operation being executed concurrently while the `JobMaster` is shut down. There's a race condition where the `ResourceManager` might be able to sent a `JobMaster#disconnectResourceManager` back to the `JobMaster` in the end. If that RPC call is still handled because the `RPCEndpoint` isn't stopped, yet, it will trigger a reconnect because the `JobMaster#resourceManagerAddress` is never reset.

The only changes that happened in the `AdaptiveScheduler` around the time where the test instability became more frequent were FLINK-34371 and FLINK-34518:
* FLINK-34371 changes behavior of the `stopWithSavepoint` method that isn't relevant for FLINK-34227.
* FLINK-34518 touches the `JobStatus` when the job fails while being in restart state which is also not relevant for FLINK-34227 because the cases where the test instability appeared have the scheduler in `Finished` state.

On the `JobMaster` side there's only FLINK-34417 added which integrates the `MdcUtils`. No shutdown logic is touched.

So, we don't have a conclusion for why this test instability started to appear more regularely in March and why it only manifests itself in GitHub Actions with the `AdaptiveScheduler` test profile enabled.

## Brief change log

* Removes the concurrency in the `JobMaster`'s shutdown logic by forcing the execution in the main thread
* Resets the `JobMaster#resourceManagerAddress` during shutdown to make the implementation more explicit

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable