### PR TITLE
[FLINK-18255][state] Add API annotations to RocksDB user-facing classes

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/ConfigurableRocksDBOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/ConfigurableRocksDBOptionsFactory.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ReadableConfig;
 
 /** An interface for options factory that pick up additional parameters from a configuration. */
+@PublicEvolving
 public interface ConfigurableRocksDBOptionsFactory extends RocksDBOptionsFactory {
 
     /**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBConfigurableOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
@@ -53,6 +54,7 @@ import static org.rocksdb.InfoLogLevel.INFO_LEVEL;
  * PredefinedOptions}, and then a user-defined {@link RocksDBOptionsFactory} may override the
  * configurations here.
  */
+@PublicEvolving
 public class RocksDBConfigurableOptions implements Serializable {
 
     // --------------------------------------------------------------------------

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBNativeMetricOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -46,6 +47,7 @@ import java.util.Set;
  * href="https://github.com/facebook/rocksdb/blob/64324e329eb0a9b4e77241a425a1615ff524c7f1/include/rocksdb/db.h#L429">
  * db.h</a> for more information.
  */
+@PublicEvolving
 public class RocksDBNativeMetricOptions implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.ConfigOption;
@@ -33,6 +34,7 @@ import static org.apache.flink.contrib.streaming.state.PredefinedOptions.SPINNIN
 import static org.apache.flink.contrib.streaming.state.PredefinedOptions.SPINNING_DISK_OPTIMIZED_HIGH_MEM;
 
 /** Configuration options for the RocksDB backend. */
+@PublicEvolving
 public class RocksDBOptions {
 
     /** The local directory (on the TaskManager) where RocksDB puts its files. */

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptionsFactory.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.contrib.streaming.state;
 
+import org.apache.flink.annotation.PublicEvolving;
+
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.ReadOptions;
@@ -50,6 +52,7 @@ import java.util.Collection;
  * });
  * }</pre>
  */
+@PublicEvolving
 public interface RocksDBOptionsFactory extends java.io.Serializable {
 
     /**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackendFactory.java
@@ -29,6 +29,7 @@ import java.io.IOException;
  * A factory that creates an {@link org.apache.flink.contrib.streaming.state.RocksDBStateBackend}
  * from a configuration.
  */
+@Deprecated
 public class RocksDBStateBackendFactory implements StateBackendFactory<RocksDBStateBackend> {
 
     @Override

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/SingleStateIterator.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/iterator/SingleStateIterator.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.contrib.streaming.state.iterator;
 
+import org.apache.flink.annotation.Internal;
+
 import java.io.Closeable;
 
 /** An interface for iterating over a single state in a RocksDB state backend. */
+@Internal
 public interface SingleStateIterator extends Closeable {
     void next();
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBRestoreOperation.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.contrib.streaming.state.restore;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.state.RestoreOperation;
 
 /** Interface for RocksDB restore. */
+@Internal
 public interface RocksDBRestoreOperation
         extends RestoreOperation<RocksDBRestoreResult>, AutoCloseable {
     /** Restores state that was previously snapshot-ed from the provided state handles. */


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds API annotations for Rocksdb StateBackend user-facing classes

## Brief change log
  - add PublicEvolving annotation for ConfigurableRocksDBOptionsFactory/RocksDBConfigurableOptions/RocksDBNativeMetricOptions/RocksDBOptions/RocksDBOptionsFactory
  - add Deprecated annotation for RocksDBStateBackendFactory
  - add Internal annotation for SingleStateIterator/RocksDBRestoreOperation

## Verifying this change

This change adds annotations for classes without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no