### PR TITLE
[FLINK-32074][checkpoint] Merge file across checkpoints

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManager.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.filemerging;
+
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+
+/** A {@link FileMergingSnapshotManager} that merging files across checkpoints. */
+public class AcrossCheckpointFileMergingSnapshotManager extends FileMergingSnapshotManagerBase {
+
+    private final PhysicalFilePool filePool;
+
+    public AcrossCheckpointFileMergingSnapshotManager(
+            String id, long maxFileSize, PhysicalFilePool.Type filePoolType, Executor ioExecutor) {
+        super(id, maxFileSize, filePoolType, ioExecutor);
+        filePool = createPhysicalPool();
+    }
+
+    @Override
+    @Nonnull
+    protected PhysicalFile getOrCreatePhysicalFileForCheckpoint(
+            SubtaskKey subtaskKey, long checkpointID, CheckpointedStateScope scope)
+            throws IOException {
+        return filePool.pollFile(subtaskKey, scope);
+    }
+
+    @Override
+    protected void discardCheckpoint(long checkpointId) {}
+
+    @Override
+    protected void returnPhysicalFileForNextReuse(
+            SubtaskKey subtaskKey, long checkpointId, PhysicalFile physicalFile)
+            throws IOException {
+
+        if (shouldSyncAfterClosingLogicalFile) {
+            FSDataOutputStream os = physicalFile.getOutputStream();
+            if (os != null) {
+                os.sync();
+            }
+        }
+
+        if (!filePool.tryPutFile(subtaskKey, physicalFile)) {
+            physicalFile.close();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingType.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.filemerging;
+
+/** How the checkpoint files can be segmented. */
+public enum FileMergingType {
+    // merge checkpoint files within checkpoint boundaries
+    MERGE_WITHIN_CHECKPOINT,
+    // merge checkpoint files across checkpoint boundaries
+    MERGE_ACROSS_CHECKPOINT
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorFileMergingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorFileMergingManager.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManagerBuilder;
+import org.apache.flink.runtime.checkpoint.filemerging.FileMergingType;
 import org.apache.flink.util.ShutdownHookUtil;
 
 import org.slf4j.Logger;
@@ -78,7 +79,9 @@ public class TaskExecutorFileMergingManager {
             if (fileMergingSnapshotManager == null) {
                 // TODO FLINK-32440: choose different FileMergingSnapshotManager by configuration
                 fileMergingSnapshotManager =
-                        new FileMergingSnapshotManagerBuilder(jobId.toString()).build();
+                        new FileMergingSnapshotManagerBuilder(
+                                        jobId.toString(), FileMergingType.MERGE_WITHIN_CHECKPOINT)
+                                .build();
                 fileMergingSnapshotManagerByJobId.put(jobId, fileMergingSnapshotManager);
                 LOG.info("Registered new file merging snapshot manager for job {}.", jobId);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManagerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.filemerging;
+
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.filesystem.FileMergingCheckpointStateOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link AcrossCheckpointFileMergingSnapshotManager}. */
+public class AcrossCheckpointFileMergingSnapshotManagerTest
+        extends FileMergingSnapshotManagerTestBase {
+    @Override
+    FileMergingType getFileMergingType() {
+        return FileMergingType.MERGE_ACROSS_CHECKPOINT;
+    }
+
+    @Test
+    void testCreateAndReuseFiles() throws IOException {
+        try (FileMergingSnapshotManagerBase fmsm =
+                (FileMergingSnapshotManagerBase)
+                        createFileMergingSnapshotManager(checkpointBaseDir)) {
+            fmsm.registerSubtaskForSharedStates(subtaskKey1);
+            fmsm.registerSubtaskForSharedStates(subtaskKey2);
+            // firstly, we try shared state.
+            PhysicalFile file1 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
+            assertThat(file1.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            // allocate another
+            PhysicalFile file2 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
+            assertThat(file2.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(file2).isNotEqualTo(file1);
+
+            // return for reuse
+            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file1);
+
+            // allocate for another subtask
+            PhysicalFile file3 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey2, 0, CheckpointedStateScope.SHARED);
+            assertThat(file3.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.SHARED));
+            assertThat(file3).isNotEqualTo(file1);
+
+            // allocate for another checkpoint
+            PhysicalFile file4 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 1, CheckpointedStateScope.SHARED);
+            assertThat(file4.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(file4).isEqualTo(file1);
+
+            // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
+            file4.incSize(fmsm.maxPhysicalFileSize);
+            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 1, file4);
+            PhysicalFile file5 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 1, CheckpointedStateScope.SHARED);
+            assertThat(file5.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(file5).isNotEqualTo(file4);
+
+            // Secondly, we try private state
+            PhysicalFile file6 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 1, CheckpointedStateScope.EXCLUSIVE);
+            assertThat(file6.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+
+            // allocate another
+            PhysicalFile file7 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 1, CheckpointedStateScope.EXCLUSIVE);
+            assertThat(file7.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+            assertThat(file7).isNotEqualTo(file5);
+
+            // return for reuse
+            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file6);
+
+            // allocate for another checkpoint
+            PhysicalFile file8 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 2, CheckpointedStateScope.EXCLUSIVE);
+            assertThat(file8.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+            assertThat(file8).isEqualTo(file6);
+
+            // return for reuse
+            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file8);
+
+            // allocate for this checkpoint but another subtask
+            PhysicalFile file9 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey2, 2, CheckpointedStateScope.EXCLUSIVE);
+            assertThat(file9.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE));
+            assertThat(file9).isEqualTo(file6);
+
+            // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
+            file9.incSize(fmsm.maxPhysicalFileSize);
+            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 2, file9);
+            PhysicalFile file10 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 2, CheckpointedStateScope.SHARED);
+            assertThat(file10.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(file10).isNotEqualTo(file9);
+
+            assertThat(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE))
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+        }
+    }
+
+    @Test
+    public void testCheckpointNotification() throws Exception {
+        try (FileMergingSnapshotManager fmsm = createFileMergingSnapshotManager(checkpointBaseDir);
+                CloseableRegistry closeableRegistry = new CloseableRegistry()) {
+            FileMergingCheckpointStateOutputStream cp1Stream =
+                    writeCheckpointAndGetStream(1, fmsm, closeableRegistry);
+            SegmentFileStateHandle cp1StateHandle = cp1Stream.closeAndGetHandle();
+            fmsm.notifyCheckpointComplete(subtaskKey1, 1);
+            assertFileInManagedDir(fmsm, cp1StateHandle);
+
+            // complete checkpoint-2
+            FileMergingCheckpointStateOutputStream cp2Stream =
+                    writeCheckpointAndGetStream(2, fmsm, closeableRegistry);
+            SegmentFileStateHandle cp2StateHandle = cp2Stream.closeAndGetHandle();
+            fmsm.notifyCheckpointComplete(subtaskKey1, 2);
+            assertFileInManagedDir(fmsm, cp2StateHandle);
+
+            // subsume checkpoint-1
+            assertThat(fileExists(cp1StateHandle)).isTrue();
+            fmsm.notifyCheckpointSubsumed(subtaskKey1, 1);
+            assertThat(fileExists(cp1StateHandle)).isTrue();
+
+            // abort checkpoint-3
+            FileMergingCheckpointStateOutputStream cp3Stream =
+                    writeCheckpointAndGetStream(3, fmsm, closeableRegistry);
+            SegmentFileStateHandle cp3StateHandle = cp3Stream.closeAndGetHandle();
+            assertFileInManagedDir(fmsm, cp3StateHandle);
+            fmsm.notifyCheckpointAborted(subtaskKey1, 3);
+            assertThat(fileExists(cp3StateHandle)).isTrue();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
@@ -43,18 +43,20 @@ import java.util.concurrent.Future;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link FileMergingSnapshotManager}. */
-public class FileMergingSnapshotManagerTest {
+public abstract class FileMergingSnapshotManagerTestBase {
 
-    private final String tmId = "Testing";
+    final String tmId = "Testing";
 
-    private final OperatorID operatorID = new OperatorID(289347923L, 75893479L);
+    final OperatorID operatorID = new OperatorID(289347923L, 75893479L);
 
-    private SubtaskKey subtaskKey1;
-    private SubtaskKey subtaskKey2;
+    SubtaskKey subtaskKey1;
+    SubtaskKey subtaskKey2;
 
-    private Path checkpointBaseDir;
+    Path checkpointBaseDir;
 
-    private int writeBufferSize;
+    int writeBufferSize;
+
+    abstract FileMergingType getFileMergingType();
 
     @BeforeEach
     public void setup(@TempDir java.nio.file.Path tempFolder) {
@@ -87,113 +89,6 @@ public class FileMergingSnapshotManagerTest {
                                     AbstractFsCheckpointStorageAccess.CHECKPOINT_SHARED_STATE_DIR
                                             + "/"
                                             + subtaskKey1.getManagedDirName()));
-        }
-    }
-
-    @Test
-    void testCreateAndReuseFiles() throws IOException {
-        try (FileMergingSnapshotManagerBase fmsm =
-                (FileMergingSnapshotManagerBase)
-                        createFileMergingSnapshotManager(checkpointBaseDir)) {
-            fmsm.registerSubtaskForSharedStates(subtaskKey1);
-            fmsm.registerSubtaskForSharedStates(subtaskKey2);
-            // firstly, we try shared state.
-            PhysicalFile file1 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
-            assertThat(file1.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
-            // allocate another
-            PhysicalFile file2 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
-            assertThat(file2.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
-            assertThat(file2).isNotEqualTo(file1);
-
-            // return for reuse
-            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file1);
-
-            // allocate for another subtask
-            PhysicalFile file3 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey2, 0, CheckpointedStateScope.SHARED);
-            assertThat(file3.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.SHARED));
-            assertThat(file3).isNotEqualTo(file1);
-
-            // allocate for another checkpoint
-            PhysicalFile file4 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey1, 1, CheckpointedStateScope.SHARED);
-            assertThat(file4.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
-            assertThat(file4).isNotEqualTo(file1);
-
-            // allocate for this checkpoint
-            PhysicalFile file5 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
-            assertThat(file5.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
-            assertThat(file5).isEqualTo(file1);
-
-            // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
-            file5.incSize(fmsm.maxPhysicalFileSize);
-            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file5);
-            PhysicalFile file6 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
-            assertThat(file6.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
-            assertThat(file6).isNotEqualTo(file5);
-
-            // Secondly, we try private state
-            PhysicalFile file7 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey1, 0, CheckpointedStateScope.EXCLUSIVE);
-            assertThat(file7.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
-
-            // allocate another
-            PhysicalFile file8 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey1, 0, CheckpointedStateScope.EXCLUSIVE);
-            assertThat(file8.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
-            assertThat(file8).isNotEqualTo(file6);
-
-            // return for reuse
-            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file7);
-
-            // allocate for another checkpoint
-            PhysicalFile file9 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey1, 1, CheckpointedStateScope.EXCLUSIVE);
-            assertThat(file9.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
-            assertThat(file9).isNotEqualTo(file7);
-
-            // allocate for this checkpoint but another subtask
-            PhysicalFile file10 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey2, 0, CheckpointedStateScope.EXCLUSIVE);
-            assertThat(file10.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE));
-            assertThat(file10).isEqualTo(file7);
-
-            // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
-            file10.incSize(fmsm.maxPhysicalFileSize);
-            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file10);
-            PhysicalFile file11 =
-                    fmsm.getOrCreatePhysicalFileForCheckpoint(
-                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
-            assertThat(file11.getFilePath().getParent())
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
-            assertThat(file11).isNotEqualTo(file10);
-
-            assertThat(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE))
-                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
         }
     }
 
@@ -379,38 +274,6 @@ public class FileMergingSnapshotManagerTest {
     }
 
     @Test
-    public void testCheckpointNotification() throws Exception {
-        try (FileMergingSnapshotManager fmsm = createFileMergingSnapshotManager(checkpointBaseDir);
-                CloseableRegistry closeableRegistry = new CloseableRegistry()) {
-            FileMergingCheckpointStateOutputStream cp1Stream =
-                    writeCheckpointAndGetStream(1, fmsm, closeableRegistry);
-            SegmentFileStateHandle cp1StateHandle = cp1Stream.closeAndGetHandle();
-            fmsm.notifyCheckpointComplete(subtaskKey1, 1);
-            assertFileInManagedDir(fmsm, cp1StateHandle);
-
-            // complete checkpoint-2
-            FileMergingCheckpointStateOutputStream cp2Stream =
-                    writeCheckpointAndGetStream(2, fmsm, closeableRegistry);
-            SegmentFileStateHandle cp2StateHandle = cp2Stream.closeAndGetHandle();
-            fmsm.notifyCheckpointComplete(subtaskKey1, 2);
-            assertFileInManagedDir(fmsm, cp2StateHandle);
-
-            // subsume checkpoint-1
-            assertThat(fileExists(cp1StateHandle)).isTrue();
-            fmsm.notifyCheckpointSubsumed(subtaskKey1, 1);
-            assertThat(fileExists(cp1StateHandle)).isFalse();
-
-            // abort checkpoint-3
-            FileMergingCheckpointStateOutputStream cp3Stream =
-                    writeCheckpointAndGetStream(3, fmsm, closeableRegistry);
-            SegmentFileStateHandle cp3StateHandle = cp3Stream.closeAndGetHandle();
-            assertFileInManagedDir(fmsm, cp3StateHandle);
-            fmsm.notifyCheckpointAborted(subtaskKey1, 3);
-            assertThat(fileExists(cp3StateHandle)).isFalse();
-        }
-    }
-
-    @Test
     public void testConcurrentFileReusingWithBlockingPool() throws Exception {
         try (FileMergingSnapshotManagerBase fmsm =
                 (FileMergingSnapshotManagerBase)
@@ -455,13 +318,13 @@ public class FileMergingSnapshotManagerTest {
         }
     }
 
-    private FileMergingSnapshotManager createFileMergingSnapshotManager(Path checkpointBaseDir)
+    FileMergingSnapshotManager createFileMergingSnapshotManager(Path checkpointBaseDir)
             throws IOException {
         return createFileMergingSnapshotManager(
                 checkpointBaseDir, 32 * 1024 * 1024, PhysicalFilePool.Type.NON_BLOCKING);
     }
 
-    private FileMergingSnapshotManager createFileMergingSnapshotManager(
+    FileMergingSnapshotManager createFileMergingSnapshotManager(
             Path checkpointBaseDir, long maxFileSize, PhysicalFilePool.Type filePoolType)
             throws IOException {
         FileSystem fs = LocalFileSystem.getSharedInstance();
@@ -479,7 +342,7 @@ public class FileMergingSnapshotManagerTest {
             fs.mkdirs(taskOwnedStateDir);
         }
         FileMergingSnapshotManager fmsm =
-                new FileMergingSnapshotManagerBuilder(tmId)
+                new FileMergingSnapshotManagerBuilder(tmId, getFileMergingType())
                         .setMaxFileSize(maxFileSize)
                         .setFilePoolType(filePoolType)
                         .build();
@@ -493,13 +356,13 @@ public class FileMergingSnapshotManagerTest {
         return fmsm;
     }
 
-    private FileMergingCheckpointStateOutputStream writeCheckpointAndGetStream(
+    FileMergingCheckpointStateOutputStream writeCheckpointAndGetStream(
             long checkpointId, FileMergingSnapshotManager fmsm, CloseableRegistry closeableRegistry)
             throws IOException {
         return writeCheckpointAndGetStream(checkpointId, fmsm, closeableRegistry, 32);
     }
 
-    private FileMergingCheckpointStateOutputStream writeCheckpointAndGetStream(
+    FileMergingCheckpointStateOutputStream writeCheckpointAndGetStream(
             long checkpointId,
             FileMergingSnapshotManager fmsm,
             CloseableRegistry closeableRegistry,
@@ -515,7 +378,7 @@ public class FileMergingSnapshotManagerTest {
         return stream;
     }
 
-    private void assertFileInManagedDir(
+    void assertFileInManagedDir(
             FileMergingSnapshotManager fmsm, SegmentFileStateHandle stateHandle) {
         assertThat(fmsm instanceof FileMergingSnapshotManagerBase).isTrue();
         assertThat(stateHandle).isNotNull();
@@ -524,7 +387,7 @@ public class FileMergingSnapshotManagerTest {
         assertThat(((FileMergingSnapshotManagerBase) fmsm).isResponsibleForFile(filePath)).isTrue();
     }
 
-    private boolean fileExists(SegmentFileStateHandle stateHandle) throws IOException {
+    boolean fileExists(SegmentFileStateHandle stateHandle) throws IOException {
         assertThat(stateHandle).isNotNull();
         Path filePath = stateHandle.getFilePath();
         assertThat(filePath).isNotNull();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManagerTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.filemerging;
+
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.filesystem.FileMergingCheckpointStateOutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link WithinCheckpointFileMergingSnapshotManager}. */
+public class WithinCheckpointFileMergingSnapshotManagerTest
+        extends FileMergingSnapshotManagerTestBase {
+    @Override
+    FileMergingType getFileMergingType() {
+        return FileMergingType.MERGE_WITHIN_CHECKPOINT;
+    }
+
+    @Test
+    void testCreateAndReuseFiles() throws IOException {
+        try (FileMergingSnapshotManagerBase fmsm =
+                (FileMergingSnapshotManagerBase)
+                        createFileMergingSnapshotManager(checkpointBaseDir)) {
+            fmsm.registerSubtaskForSharedStates(subtaskKey1);
+            fmsm.registerSubtaskForSharedStates(subtaskKey2);
+            // firstly, we try shared state.
+            PhysicalFile file1 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
+            assertThat(file1.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            // allocate another
+            PhysicalFile file2 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
+            assertThat(file2.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(file2).isNotEqualTo(file1);
+
+            // return for reuse
+            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file1);
+
+            // allocate for another subtask
+            PhysicalFile file3 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey2, 0, CheckpointedStateScope.SHARED);
+            assertThat(file3.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.SHARED));
+            assertThat(file3).isNotEqualTo(file1);
+
+            // allocate for another checkpoint
+            PhysicalFile file4 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 1, CheckpointedStateScope.SHARED);
+            assertThat(file4.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(file4).isNotEqualTo(file1);
+
+            // allocate for this checkpoint
+            PhysicalFile file5 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
+            assertThat(file5.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(file5).isEqualTo(file1);
+
+            // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
+            file5.incSize(fmsm.maxPhysicalFileSize);
+            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file5);
+            PhysicalFile file6 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
+            assertThat(file6.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(file6).isNotEqualTo(file5);
+
+            // Secondly, we try private state
+            PhysicalFile file7 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 0, CheckpointedStateScope.EXCLUSIVE);
+            assertThat(file7.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+
+            // allocate another
+            PhysicalFile file8 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 0, CheckpointedStateScope.EXCLUSIVE);
+            assertThat(file8.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+            assertThat(file8).isNotEqualTo(file6);
+
+            // return for reuse
+            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file7);
+
+            // allocate for another checkpoint
+            PhysicalFile file9 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 1, CheckpointedStateScope.EXCLUSIVE);
+            assertThat(file9.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+            assertThat(file9).isNotEqualTo(file7);
+
+            // allocate for this checkpoint but another subtask
+            PhysicalFile file10 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey2, 0, CheckpointedStateScope.EXCLUSIVE);
+            assertThat(file10.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE));
+            assertThat(file10).isEqualTo(file7);
+
+            // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
+            file10.incSize(fmsm.maxPhysicalFileSize);
+            fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file10);
+            PhysicalFile file11 =
+                    fmsm.getOrCreatePhysicalFileForCheckpoint(
+                            subtaskKey1, 0, CheckpointedStateScope.SHARED);
+            assertThat(file11.getFilePath().getParent())
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(file11).isNotEqualTo(file10);
+
+            assertThat(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE))
+                    .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+        }
+    }
+
+    @Test
+    public void testCheckpointNotification() throws Exception {
+        try (FileMergingSnapshotManager fmsm = createFileMergingSnapshotManager(checkpointBaseDir);
+                CloseableRegistry closeableRegistry = new CloseableRegistry()) {
+            FileMergingCheckpointStateOutputStream cp1Stream =
+                    writeCheckpointAndGetStream(1, fmsm, closeableRegistry);
+            SegmentFileStateHandle cp1StateHandle = cp1Stream.closeAndGetHandle();
+            fmsm.notifyCheckpointComplete(subtaskKey1, 1);
+            assertFileInManagedDir(fmsm, cp1StateHandle);
+
+            // complete checkpoint-2
+            FileMergingCheckpointStateOutputStream cp2Stream =
+                    writeCheckpointAndGetStream(2, fmsm, closeableRegistry);
+            SegmentFileStateHandle cp2StateHandle = cp2Stream.closeAndGetHandle();
+            fmsm.notifyCheckpointComplete(subtaskKey1, 2);
+            assertFileInManagedDir(fmsm, cp2StateHandle);
+
+            // subsume checkpoint-1
+            assertThat(fileExists(cp1StateHandle)).isTrue();
+            fmsm.notifyCheckpointSubsumed(subtaskKey1, 1);
+            assertThat(fileExists(cp1StateHandle)).isFalse();
+
+            // abort checkpoint-3
+            FileMergingCheckpointStateOutputStream cp3Stream =
+                    writeCheckpointAndGetStream(3, fmsm, closeableRegistry);
+            SegmentFileStateHandle cp3StateHandle = cp3Stream.closeAndGetHandle();
+            assertFileInManagedDir(fmsm, cp3StateHandle);
+            fmsm.notifyCheckpointAborted(subtaskKey1, 3);
+            assertThat(fileExists(cp3StateHandle)).isFalse();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocationTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManagerBuilder;
+import org.apache.flink.runtime.checkpoint.filemerging.FileMergingType;
 import org.apache.flink.runtime.checkpoint.filemerging.SegmentFileStateHandle;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
@@ -220,7 +221,9 @@ public class FsMergingCheckpointStorageLocationTest {
 
     private FileMergingSnapshotManager createFileMergingSnapshotManager(long maxFileSize) {
         FileMergingSnapshotManager mgr =
-                new FileMergingSnapshotManagerBuilder(SNAPSHOT_MGR_ID).build();
+                new FileMergingSnapshotManagerBuilder(
+                                SNAPSHOT_MGR_ID, FileMergingType.MERGE_WITHIN_CHECKPOINT)
+                        .build();
 
         mgr.initFileSystem(
                 getSharedInstance(),


### PR DESCRIPTION
## What is the purpose of the change

  As one part of FLIP-306, this PR enables the file merging across checkpoints.


## Brief change log

 - Added new type of file merging manager
 - Add corresponding tests


## Verifying this change

Added `AcrossCheckpointFileMergingSnapshotManagerTest` for new manager.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), **Checkpointing**, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
