### PR TITLE
[FLINK-34546] Emit span with failure labels on failure in AdaptiveScheduler.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandler.java
@@ -32,8 +32,6 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.throwable.ThrowableClassifier;
 import org.apache.flink.runtime.throwable.ThrowableType;
-import org.apache.flink.traces.Span;
-import org.apache.flink.traces.SpanBuilder;
 import org.apache.flink.util.IterableUtils;
 
 import javax.annotation.Nullable;
@@ -180,28 +178,6 @@ public class ExecutionFailureHandler {
         }
 
         return failureHandlingResult;
-    }
-
-    private void reportFailureHandling(
-            FailureHandlingResult failureHandlingResult, Map<String, String> failureLabels) {
-
-        // Add base attributes
-        SpanBuilder spanBuilder =
-                Span.builder(ExecutionFailureHandler.class, "JobFailure")
-                        .setStartTsMillis(failureHandlingResult.getTimestamp())
-                        .setEndTsMillis(failureHandlingResult.getTimestamp())
-                        .setAttribute(
-                                "canRestart", String.valueOf(failureHandlingResult.canRestart()))
-                        .setAttribute(
-                                "isGlobalFailure",
-                                String.valueOf(failureHandlingResult.isGlobalFailure()));
-
-        // Add all failure labels
-        for (Map.Entry<String, String> entry : failureLabels.entrySet()) {
-            spanBuilder.setAttribute(
-                    FAILURE_LABEL_ATTRIBUTE_PREFIX + entry.getKey(), entry.getValue());
-        }
-        metricGroup.addSpan(spanBuilder);
     }
 
     private FailureHandlingResult handleFailure(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Canceling.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Canceling.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /** State which describes a job which is currently being canceled. */
 class Canceling extends StateWithExecutionGraph {
@@ -66,7 +68,7 @@ class Canceling extends StateWithExecutionGraph {
     }
 
     @Override
-    void onFailure(Throwable failure) {
+    void onFailure(Throwable failure, CompletableFuture<Map<String, String>> failureLabels) {
         // Execution graph is already cancelling, so there is nothing more we can do.
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
@@ -106,8 +107,9 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
     }
 
     @Override
-    void onFailure(Throwable cause) {
-        FailureResultUtil.restartOrFail(context.howToHandleFailure(cause), context, this);
+    void onFailure(Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
+        FailureResultUtil.restartOrFail(
+                context.howToHandleFailure(cause, failureLabels), context, this);
     }
 
     @Override
@@ -255,9 +257,11 @@ class Executing extends StateWithExecutionGraph implements ResourceListener {
          * Asks how to handle the failure.
          *
          * @param failure failure describing the failure cause
+         * @param failureLabels future of labels from error classification.
          * @return {@link FailureResult} which describes how to handle the failure
          */
-        FailureResult howToHandleFailure(Throwable failure);
+        FailureResult howToHandleFailure(
+                Throwable failure, CompletableFuture<Map<String, String>> failureLabels);
 
         /**
          * Asks if we should rescale the currently executing job.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Failing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Failing.java
@@ -29,6 +29,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 /** State which describes a failing job which is currently being canceled. */
 class Failing extends StateWithExecutionGraph {
@@ -71,7 +73,7 @@ class Failing extends StateWithExecutionGraph {
     }
 
     @Override
-    void onFailure(Throwable failure) {
+    void onFailure(Throwable failure, CompletableFuture<Map<String, String>> failureLabels) {
         // We've already failed the execution graph, so there is noting else we can do.
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/JobFailureMetricReporter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/JobFailureMetricReporter.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.executiongraph.failover.FailureHandlingResult;
+import org.apache.flink.traces.Span;
+import org.apache.flink.traces.SpanBuilder;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Map;
+
+/** Helper class to simplify job failure reporting through a metric group. */
+public class JobFailureMetricReporter {
+
+    public static final String FAILURE_LABEL_ATTRIBUTE_PREFIX = "failureLabel.";
+
+    private final MetricGroup metricGroup;
+
+    public JobFailureMetricReporter(MetricGroup metricGroup) {
+        this.metricGroup = Preconditions.checkNotNull(metricGroup);
+    }
+
+    public void reportJobFailure(
+            FailureHandlingResult failureHandlingResult, Map<String, String> failureLabels) {
+        reportJobFailure(
+                failureHandlingResult.getTimestamp(),
+                failureHandlingResult.canRestart(),
+                failureHandlingResult.isGlobalFailure(),
+                failureLabels);
+    }
+
+    public void reportJobFailure(
+            FailureResult failureHandlingResult, Map<String, String> failureLabels) {
+        reportJobFailure(
+                System.currentTimeMillis(),
+                failureHandlingResult.canRestart(),
+                null,
+                failureLabels);
+    }
+
+    private void reportJobFailure(
+            long timestamp,
+            Boolean canRestart,
+            Boolean isGlobal,
+            Map<String, String> failureLabels) {
+        // Add base attributes
+        SpanBuilder spanBuilder =
+                Span.builder(JobFailureMetricReporter.class, "JobFailure")
+                        .setStartTsMillis(timestamp)
+                        .setEndTsMillis(timestamp);
+
+        if (canRestart != null) {
+            spanBuilder.setAttribute("canRestart", String.valueOf(canRestart));
+        }
+
+        if (isGlobal != null) {
+            spanBuilder.setAttribute("isGlobalFailure", String.valueOf(isGlobal));
+        }
+
+        // Add all failure labels
+        for (Map.Entry<String, String> entry : failureLabels.entrySet()) {
+            spanBuilder.setAttribute(
+                    FAILURE_LABEL_ATTRIBUTE_PREFIX + entry.getKey(), entry.getValue());
+        }
+        metricGroup.addSpan(spanBuilder);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Restarting.java
@@ -31,6 +31,8 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 
 /** State which describes a job which is currently being restarted. */
@@ -94,7 +96,7 @@ class Restarting extends StateWithExecutionGraph {
     }
 
     @Override
-    void onFailure(Throwable failure) {
+    void onFailure(Throwable failure, CompletableFuture<Map<String, String>> failureLabels) {
         // We've already cancelled the execution graph, so there is noting else we can do.
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
@@ -377,7 +377,7 @@ abstract class StateWithExecutionGraph implements State {
     }
 
     /** Transition to different state when failure occurs. Stays in the same state by default. */
-    abstract void onFailure(Throwable cause);
+    abstract void onFailure(Throwable cause, CompletableFuture<Map<String, String>> failureLabels);
 
     /**
      * Transition to different state when the execution graph reaches a globally terminal state.
@@ -390,7 +390,7 @@ abstract class StateWithExecutionGraph implements State {
     public void handleGlobalFailure(
             Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         failureCollection.add(ExceptionHistoryEntry.createGlobal(cause, failureLabels));
-        onFailure(cause);
+        onFailure(cause, failureLabels);
     }
 
     /**
@@ -422,7 +422,8 @@ abstract class StateWithExecutionGraph implements State {
                         ExceptionHistoryEntry.create(execution, taskName, failureLabels));
                 onFailure(
                         ErrorInfo.handleMissingThrowable(
-                                taskExecutionStateTransition.getError(userCodeClassLoader)));
+                                taskExecutionStateTransition.getError(userCodeClassLoader)),
+                        failureLabels);
             }
         }
         return successfulUpdate;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepoint.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 
@@ -209,7 +210,7 @@ class StopWithSavepoint extends StateWithExecutionGraph {
     }
 
     @Override
-    void onFailure(Throwable cause) {
+    void onFailure(Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         if (hasPendingStateTransition) {
             // the error handling remains the same independent of how many tasks have failed
             // we don't want to initiate the same state transition multiple times, so we exit early
@@ -231,7 +232,7 @@ class StopWithSavepoint extends StateWithExecutionGraph {
                                                     savepoint, getJobId(), cause);
                             operationFailureCause = ex;
                             FailureResultUtil.restartOrFail(
-                                    context.howToHandleFailure(ex), context, this);
+                                    context.howToHandleFailure(ex, failureLabels), context, this);
                             return null;
                         }));
     }
@@ -279,9 +280,11 @@ class StopWithSavepoint extends StateWithExecutionGraph {
          * Asks how to handle the failure.
          *
          * @param failure failure describing the failure cause
+         * @param failureLabels future of labels from error classification.
          * @return {@link FailureResult} which describes how to handle the failure
          */
-        FailureResult howToHandleFailure(Throwable failure);
+        FailureResult howToHandleFailure(
+                Throwable failure, CompletableFuture<Map<String, String>> failureLabels);
 
         /**
          * Runs the given action after the specified delay if the state is the expected state at

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/ExecutionFailureHandlerTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAda
 import org.apache.flink.runtime.execution.SuppressRestartsException;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.adaptive.JobFailureMetricReporter;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
@@ -339,7 +340,8 @@ class ExecutionFailureHandlerTest {
     private void checkMetrics(List<Span> results, boolean global, boolean canRestart) {
         assertThat(results).isNotEmpty();
         for (Span span : results) {
-            assertThat(span.getScope()).isEqualTo(ExecutionFailureHandler.class.getCanonicalName());
+            assertThat(span.getScope())
+                    .isEqualTo(JobFailureMetricReporter.class.getCanonicalName());
             assertThat(span.getName()).isEqualTo("JobFailure");
             Map<String, Object> attributes = span.getAttributes();
             assertThat(attributes).containsEntry("failureLabel.failKey", "failValue");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -57,7 +57,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
-import org.apache.flink.runtime.executiongraph.failover.ExecutionFailureHandler;
 import org.apache.flink.runtime.executiongraph.failover.FixedDelayRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.failover.NoRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.failover.TestRestartBackoffTimeStrategy;
@@ -2560,7 +2559,8 @@ public class AdaptiveSchedulerTest {
     private static void checkMetrics(List<Span> results, boolean canRestart) {
         assertThat(results).isNotEmpty();
         for (Span span : results) {
-            assertThat(span.getScope()).isEqualTo(ExecutionFailureHandler.class.getCanonicalName());
+            assertThat(span.getScope())
+                    .isEqualTo(JobFailureMetricReporter.class.getCanonicalName());
             assertThat(span.getName()).isEqualTo("JobFailure");
             Map<String, Object> attributes = span.getAttributes();
             assertThat(attributes).containsEntry("failureLabel.failKey", "failValue");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -703,7 +703,8 @@ public class ExecutingTest extends TestLogger {
         }
 
         @Override
-        public FailureResult howToHandleFailure(Throwable failure) {
+        public FailureResult howToHandleFailure(
+                Throwable failure, CompletableFuture<Map<String, String>> failureLabels) {
             return howToHandleFailure.apply(failure);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraphTest.java
@@ -218,7 +218,7 @@ public class StateWithExecutionGraphTest extends TestLogger {
         }
 
         @Override
-        void onFailure(Throwable cause) {}
+        void onFailure(Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {}
 
         @Override
         void onGloballyTerminalState(JobStatus globallyTerminalState) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
@@ -41,7 +41,9 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -381,7 +383,9 @@ class StopWithSavepointTest {
 
             ctx.setHowToHandleFailure(failure -> FailureResult.canRestart(failure, Duration.ZERO));
 
-            sws.onFailure(new Exception("task failure"));
+            sws.onFailure(
+                    new Exception("task failure"),
+                    CompletableFuture.completedFuture(Collections.emptyMap()));
             // this is a sanity check that we haven't scheduled a state transition
             ctx.triggerExecutors();
 
@@ -404,7 +408,9 @@ class StopWithSavepointTest {
 
             ctx.setHowToHandleFailure(failure -> FailureResult.canRestart(failure, Duration.ZERO));
 
-            sws.onFailure(new Exception("task failure"));
+            sws.onFailure(
+                    new Exception("task failure"),
+                    CompletableFuture.completedFuture(Collections.emptyMap()));
             // this is a sanity check that we haven't scheduled a state transition
             ctx.triggerExecutors();
 
@@ -538,7 +544,8 @@ class StopWithSavepointTest {
         }
 
         @Override
-        public FailureResult howToHandleFailure(Throwable failure) {
+        public FailureResult howToHandleFailure(
+                Throwable failure, CompletableFuture<Map<String, String>> failureLabels) {
             return howToHandleFailure.apply(failure);
         }
 


### PR DESCRIPTION
## Contribution Checklist

## What is the purpose of the change

Adding span for job failure with failure label to adaptive scheduler as well.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (already documented)
