### PR TITLE
[FLINK-34670][checkpoint] Use FixedThreadPool to create asyncOperationsThreadPool…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -138,10 +138,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_PERIOD;
 import static org.apache.flink.runtime.metrics.MetricNames.GATE_RESTORE_DURATION;
@@ -441,12 +438,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
             this.asyncOperationsThreadPool =
                     MdcUtils.scopeToJob(
                             getEnvironment().getJobID(),
-                            new ThreadPoolExecutor(
-                                    0,
+                            Executors.newFixedThreadPool(
                                     configuration.getMaxConcurrentCheckpoints() + 1,
-                                    60L,
-                                    TimeUnit.SECONDS,
-                                    new SynchronousQueue<>(),
                                     new ExecutorThreadFactory(
                                             "AsyncOperations", uncaughtExceptionHandler)));
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -137,8 +137,8 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -446,7 +446,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                                     configuration.getMaxConcurrentCheckpoints() + 1,
                                     60L,
                                     TimeUnit.SECONDS,
-                                    new LinkedBlockingQueue<>(),
+                                    new SynchronousQueue<>(),
                                     new ExecutorThreadFactory(
                                             "AsyncOperations", uncaughtExceptionHandler)));
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -68,6 +68,8 @@ import org.apache.flink.streaming.runtime.tasks.StreamTaskITCase.NoOpStreamTask;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.MockStreamTaskBuilder;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FatalExitExceptionHandler;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import org.junit.jupiter.api.Test;
 
@@ -78,8 +80,9 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -452,12 +455,20 @@ class SubtaskCheckpointCoordinatorTest {
     @Test
     void testNotifyCheckpointAbortedDuringAsyncPhase() throws Exception {
         MockEnvironment mockEnvironment = MockEnvironment.builder().build();
-
         try (SubtaskCheckpointCoordinatorImpl subtaskCheckpointCoordinator =
                 (SubtaskCheckpointCoordinatorImpl)
                         new MockSubtaskCheckpointCoordinatorBuilder()
                                 .setEnvironment(mockEnvironment)
-                                .setExecutor(Executors.newFixedThreadPool(2))
+                                .setExecutor(
+                                        new ThreadPoolExecutor(
+                                                0,
+                                                2,
+                                                60L,
+                                                TimeUnit.SECONDS,
+                                                new SynchronousQueue<>(),
+                                                new ExecutorThreadFactory(
+                                                        "AsyncOperations",
+                                                        FatalExitExceptionHandler.INSTANCE)))
                                 .setUnalignedCheckpointEnabled(true)
                                 .build()) {
             final BlockingRunnableFuture rawKeyedStateHandleFuture = new BlockingRunnableFuture();


### PR DESCRIPTION
… for SubtaskCheckpointCoordinatorImpl

## What is the purpose of the change

This pull request replaces the LinkedBlockingQueue with SynchronousQueue for the asyncOperations ThreadPoolExecutor in SubtaskCheckpointCoordinatorImpl.


## Brief change log

*(for example:)*
  - use SynchronousQueue to create ThreadPoolExecutor in StreamTask
 

## Verifying this change


This change is already covered by existing tests, such as SubtaskCheckpointCoordinatorTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
