### PR TITLE
[table] Add support for temporal join on rolling aggregates

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -13,7 +13,7 @@
             <td style="word-wrap: break-word;">"AUTO"</td>
             <td>String</td>
             <td>Strategy for aggregate phase. Only AUTO, TWO_PHASE or ONE_PHASE can be set.
-AUTO: No special enforcer for aggregate stage. Whether to choose two stage aggregate or one stage aggregate depends on cost. 
+AUTO: No special enforcer for aggregate stage. Whether to choose two stage aggregate or one stage aggregate depends on cost.
 TWO_PHASE: Enforce to use two stage aggregate which has localAggregate and globalAggregate. Note that if aggregate call does not support optimize into two phase, we will still use one stage aggregate.
 ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggregate.</td>
         </tr>
@@ -124,6 +124,12 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>If set to true, it will merge projects when converting SqlNode to RelNode.<br />Note: it is not recommended to turn on unless you are aware of possible side effects, such as causing the output of certain non-deterministic expressions to not meet expectations(see FLINK-20887).</td>
+        </tr>
+        <tr>
+            <td><h5>table.optimizer.temporal-join-on-rolling-aggregate-enabled</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>When it is true, the planner will support temporal join where the right side is a rolling aggregate.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -274,6 +274,15 @@ public class OptimizerConfigOptions {
                                                     + "such as causing the output of certain non-deterministic expressions to not meet expectations(see FLINK-20887).")
                                     .build());
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<Boolean>
+            TABLE_OPTIMIZER_TEMPORAL_JOIN_ON_ROLLING_AGGREGATE_ENABLED =
+                    key("table.optimizer.temporal-join-on-rolling-aggregate-enabled")
+                            .booleanType()
+                            .defaultValue(true)
+                            .withDescription(
+                                    "When it is true, the planner will support temporal join where the right side is a rolling aggregate.");
+
     /** Strategy for handling non-deterministic updates. */
     @PublicEvolving
     public enum NonDeterministicUpdateStrategy {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -581,7 +581,8 @@ class AggFunctionFactory(
     val valueType = argTypes(0)
     if (aggCallNeedRetractions(index)) {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+            TIMESTAMP_WITH_LOCAL_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE =>
           new LastValueWithRetractAggFunction(valueType)
         case t =>
           throw new TableException(
@@ -590,7 +591,8 @@ class AggFunctionFactory(
       }
     } else {
       valueType.getTypeRoot match {
-        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL =>
+        case TINYINT | SMALLINT | INTEGER | BIGINT | FLOAT | DOUBLE | BOOLEAN | VARCHAR | DECIMAL |
+            TIMESTAMP_WITH_LOCAL_TIME_ZONE | TIMESTAMP_WITHOUT_TIME_ZONE =>
           new LastValueAggFunction(valueType)
         case t =>
           throw new TableException(

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
@@ -534,6 +534,41 @@ Calc(select=[currency, currency0, rate1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testEventTimeTemporalJoinWithRollingAggregate">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM Orders AS o JOIN rates_last_value_agg FOR SYSTEM_TIME AS OF o.rowtime AS r on o.currency = r.currency]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(amount=[$0], currency=[$1], rowtime=[$2], proctime=[$3], currency0=[$4], rate=[$5], updated_at=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 2}])
+   :- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
+   :  +- LogicalProject(amount=[$0], currency=[$1], rowtime=[$2], proctime=[PROCTIME()])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
+   +- LogicalFilter(condition=[=($cor0.currency, $0)])
+      +- LogicalSnapshot(period=[$cor0.rowtime])
+         +- LogicalAggregate(group=[{0}], rate=[LAST_VALUE($1)], updated_at=[LAST_VALUE($2)])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
+               +- LogicalTableScan(table=[[default_catalog, default_database, RatesHistory]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[amount, currency, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, currency0, rate, updated_at])
++- TemporalJoin(joinType=[InnerJoin], where=[((currency = currency0) AND __TEMPORAL_JOIN_CONDITION(rowtime, updated_at, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(currency0), __TEMPORAL_JOIN_LEFT_KEY(currency), __TEMPORAL_JOIN_RIGHT_KEY(currency0)))], select=[amount, currency, rowtime, proctime, currency0, rate, updated_at])
+   :- Exchange(distribution=[hash[currency]])
+   :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+   :     +- Calc(select=[amount, currency, rowtime, PROCTIME() AS proctime])
+   :        +- TableSourceScan(table=[[default_catalog, default_database, Orders]], fields=[amount, currency, rowtime])
+   +- Exchange(distribution=[hash[currency]])
+      +- GroupAggregate(groupBy=[currency], select=[currency, LAST_VALUE(rate) AS rate, LAST_VALUE(rowtime) AS updated_at])
+         +- Exchange(distribution=[hash[currency]])
+            +- Calc(select=[currency, rate, CAST(rowtime AS TIMESTAMP(3)) AS rowtime])
+               +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+                  +- TableSourceScan(table=[[default_catalog, default_database, RatesHistory]], fields=[currency, rate, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProcTimeTemporalJoinWithLastRowView">
     <Resource name="sql">
       <![CDATA[SELECT * FROM Orders AS o JOIN rates_last_row_proctime FOR SYSTEM_TIME AS OF o.proctime AS r on o.currency = r.currency]]>


### PR DESCRIPTION
## What is the purpose of the change

This is more of a proposal to demonstrate a possible fix. I am looking for feedback for people that are more knowledgeable.

Following this thread on the mailing list: https://lists.apache.org/thread/9q7sjyqptcnw1371wc190496nwpdv1tz 

Given an order table:

```sql
CREATE TABLE orders (
    order_id INT,
    price DECIMAL(6, 2),
    currency_id INT,
    order_time AS NOW(),
    WATERMARK FOR order_time AS order_time - INTERVAL '2' SECOND
) WITH (…)
```

and a currency rate table:

```sql
CREATE TABLE currency_rates (
    currency_id INT,
    conversion_rate DECIMAL(4, 3),
    created_at AS NOW(),
    WATERMARK FOR created_at AS created_at - INTERVAL '2' SECOND
    PRIMARY KEY (currency_id) NOT ENFORCED
) WITH (…)
```

that we would aggregate in an unbounded way like this:

```sql
CREATE TEMPORARY VIEW max_rates AS (
    SELECT
        currency_id,
        MAX(conversion_rate) AS max_rate
    FROM currency_rates
    GROUP BY currency_id
);
```

It's not possible to do a temporal join between `orders` and `max_rates` and it fails with the following error:

```
Exception in thread "main" org.apache.flink.table.api.ValidationException:
Event-Time Temporal Table Join  requires both primary key and row time 
attribute in versioned table, but no row time attribute can be found.
```

After some investigation we realised the way the temporal join checks for event/proc time is by looking if the row types contains some timing information, so we added to `max_rates` another columns like this:

```sql
CREATE TEMPORARY VIEW max_rates AS (
    SELECT
        currency_id,
        MAX(conversion_rate) AS max_rate,
        LAST_VALUE(created_at) AS updated_at
    FROM currency_rates
    GROUP BY currency_id
);
```

However, `LAST_VALUE` does not support timestamp type ([FLINK-15867](https://issues.apache.org/jira/browse/FLINK-15867)). We added that and we ended up with a Planner assertion error:

```
java.lang.AssertionError: Sql optimization: Assertion error: type mismatch:
ref:
TIMESTAMP_LTZ(3) *ROWTIME* NOT NULL
input:
TIMESTAMP_WITH_LOCAL_TIME_ZONE(3) NOT NULL

	at org.apache.flink.table.planner.plan.optimize.program.FlinkVolcanoProgram.optimize(FlinkVolcanoProgram.scala:79)
	at org.apache.flink.table.planner.plan.optimize.program.FlinkChainedProgram.$anonfun$optimize$1(FlinkChainedProgram.scala:59)
```

We understood the issue was in the way `RelTimeIndicatorConverter` rewrites the FlinkLogicalJoin. Left and right input expressions get their `TimeIndicatorRelDataType` types replaced by normal timestamps but in the temporal join case, the `condition` is not rewritten (but in the `else` it's actually done).

However, I thought it might not be the solution to the problem. So I also compared if I replaced `max_rates` definition with a simple `SELECT` like in:

```sql
CREATE TEMPORARY VIEW max_rates AS (
       SELECT
        currency_id,
        conversion_rate AS max_rate,
        created_at AS updated_at
    FROM currency_rates
);
```

What I've noticed is that the timestamp on the `right` side of the join is not replaced and stay a `TimeIndicatorRelDataType`. This is because the graph of `RelNode` on the right side is:

```
FlinkLogicalTableSourceScan -> FlinkLogicalCalc -> FlinkLogicalWatermarkAssigner -> FlinkLogicalSnapshot -> FlinkLogicalJoin
```

and `WatermarkAssigner` overrides `deriveRowType` which actually force the `TimeIndicatorRelDataType` to be there, whereas for the `FlinkLogicalAggregate` it simply gets converted into a normal timestamp.

So the use of `LAST_VALUE(…)` here is a bit of a hack to keep having the time information in the query. It actually would not even work depending on the aggregation ones want to write.

However, it seems that supporting temporal join with rolling aggregate would be a good idea.

Looking forward to discuss more on this with you.

## Brief change log

## Verifying this change

  - *Added test that execute the type of queries we wanted to support*
  - *Added tests that checks that with the new feature disabled, the join is not supported*
  - 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't no / no (it's part of the planner)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented

