### PR TITLE
[FLINK-34703][ORC Format][Scaladocs] Update filesystem.md to increment VectorizedRowBatch's row property in the Scala example

### DIFF
--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -711,10 +711,13 @@ import org.apache.hadoop.hive.ql.exec.vector.{BytesColumnVector, LongColumnVecto
 class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
 
   override def vectorize(element: Person, batch: VectorizedRowBatch): Unit = {
+    val row = batch.row
+    batch.row = batch.row + 1
+
     val nameColVector = batch.cols(0).asInstanceOf[BytesColumnVector]
     val ageColVector = batch.cols(1).asInstanceOf[LongColumnVector]
-    nameColVector.setVal(batch.size + 1, element.getName.getBytes(StandardCharsets.UTF_8))
-    ageColVector.vector(batch.size + 1) = element.getAge
+    nameColVector.setVal(row, element.getName.getBytes(StandardCharsets.UTF_8))
+    ageColVector.vector(row) = element.getAge
   }
 
 }

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -711,8 +711,8 @@ import org.apache.hadoop.hive.ql.exec.vector.{BytesColumnVector, LongColumnVecto
 class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
 
   override def vectorize(element: Person, batch: VectorizedRowBatch): Unit = {
-    val row = batch.row
-    batch.row = batch.row + 1
+    val row = batch.size
+    batch.size = batch.size + 1
 
     val nameColVector = batch.cols(0).asInstanceOf[BytesColumnVector]
     val ageColVector = batch.cols(1).asInstanceOf[LongColumnVector]


### PR DESCRIPTION
## What is the purpose of the change

Corrected the Scala example for ORC Vectorizer. If you do not increment the row in VectorizedRowBatch, the first row in the batch will be the only row written for the output orc file.

## Brief change log

- The filesystem.md documentation had a incorrect example for creating an ORC Vectorizer using Scala, I corrected the docs to reflect how to utilize this feature correctly.

## Verifying this change

This change is a trivial rework / docs cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
