### PR TITLE
[FLINK-34668][checkpoint] Report state handle of file merging directory to JM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.TaskStateManager;
+import org.apache.flink.runtime.state.filemerging.DirectoryStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileMergingCheckpointStateOutputStream;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageAccess;
 
@@ -116,6 +117,17 @@ public interface FileMergingSnapshotManager extends Closeable {
      * @return the managed directory for one subtask in specified checkpoint scope.
      */
     Path getManagedDir(SubtaskKey subtaskKey, CheckpointedStateScope scope);
+
+    /**
+     * Get the {@link DirectoryStreamStateHandle} of the managed directory, created in {@link
+     * #initFileSystem} or {@link #registerSubtaskForSharedStates}.
+     *
+     * @param subtaskKey the subtask key identifying the subtask.
+     * @param scope the checkpoint scope.
+     * @return the {@link DirectoryStreamStateHandle} for one subtask in specified checkpoint scope.
+     */
+    DirectoryStreamStateHandle getManagedDirStateHandle(
+            SubtaskKey subtaskKey, CheckpointedStateScope scope);
 
     /**
      * Notifies the manager that the checkpoint with the given {@code checkpointId} completed and

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/DefaultOperatorStateBackendSnapshotStrategy.java
@@ -21,6 +21,9 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.filemerging.EmptyFileMergingOperatorStreamStateHandle;
+import org.apache.flink.runtime.state.filemerging.FileMergingOperatorStreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.FsMergingCheckpointStorageLocation;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.CollectionUtil;
 
@@ -121,7 +124,17 @@ class DefaultOperatorStateBackendSnapshotStrategy
 
         if (registeredBroadcastStatesDeepCopies.isEmpty()
                 && registeredOperatorStatesDeepCopies.isEmpty()) {
-            return snapshotCloseableRegistry -> SnapshotResult.empty();
+            if (streamFactory instanceof FsMergingCheckpointStorageLocation) {
+                FsMergingCheckpointStorageLocation location =
+                        (FsMergingCheckpointStorageLocation) streamFactory;
+                return snapshotCloseableRegistry ->
+                        SnapshotResult.of(
+                                EmptyFileMergingOperatorStreamStateHandle.create(
+                                        location.getExclusiveStateHandle(),
+                                        location.getSharedStateHandle()));
+            } else {
+                return snapshotCloseableRegistry -> SnapshotResult.empty();
+            }
         }
 
         return (snapshotCloseableRegistry) -> {
@@ -204,7 +217,17 @@ class DefaultOperatorStateBackendSnapshotStrategy
             if (snapshotCloseableRegistry.unregisterCloseable(localOut)) {
                 StreamStateHandle stateHandle = localOut.closeAndGetHandle();
                 if (stateHandle != null) {
-                    retValue = new OperatorStreamStateHandle(writtenStatesMetaData, stateHandle);
+                    retValue =
+                            streamFactory instanceof FsMergingCheckpointStorageLocation
+                                    ? new FileMergingOperatorStreamStateHandle(
+                                            ((FsMergingCheckpointStorageLocation) streamFactory)
+                                                    .getExclusiveStateHandle(),
+                                            ((FsMergingCheckpointStorageLocation) streamFactory)
+                                                    .getSharedStateHandle(),
+                                            writtenStatesMetaData,
+                                            stateHandle)
+                                    : new OperatorStreamStateHandle(
+                                            writtenStatesMetaData, stateHandle);
                 }
                 return SnapshotResult.of(retValue);
             } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/DirectoryStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/DirectoryStreamStateHandle.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filemerging;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.runtime.state.DirectoryStateHandle;
+import org.apache.flink.runtime.state.PhysicalStateHandleID;
+import org.apache.flink.runtime.state.SharedStateRegistryKey;
+import org.apache.flink.runtime.state.StreamStateHandle;
+
+import javax.annotation.Nonnull;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+/** Wrap {@link DirectoryStateHandle} to a {@link StreamStateHandle}. */
+public class DirectoryStreamStateHandle extends DirectoryStateHandle implements StreamStateHandle {
+
+    private static final long serialVersionUID = 1L;
+
+    public DirectoryStreamStateHandle(@Nonnull Path directory, long directorySize) {
+        super(directory, directorySize);
+    }
+
+    @Override
+    public FSDataInputStream openInputStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<byte[]> asBytesIfInMemory() {
+        return Optional.empty();
+    }
+
+    @Override
+    public PhysicalStateHandleID getStreamStateHandleID() {
+        return new PhysicalStateHandleID(getDirectory().toString());
+    }
+
+    public SharedStateRegistryKey createStateRegistryKey() {
+        return new SharedStateRegistryKey(getDirectory().toUri().toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DirectoryStreamStateHandle that = (DirectoryStreamStateHandle) o;
+
+        return getDirectory().equals(that.getDirectory());
+    }
+
+    @Override
+    public String toString() {
+        return "DirectoryStreamStateHandle{" + "directory=" + getDirectory() + '}';
+    }
+
+    /**
+     * Return a {@link DirectoryStreamStateHandle} with zero size, which usually used to be
+     * registered to {@link org.apache.flink.runtime.state.SharedStateRegistry} to track the life
+     * cycle of the directory, therefore a fake size is provided.
+     *
+     * @param directory the directory.
+     * @return DirectoryStreamStateHandle with zero size.
+     */
+    public static DirectoryStreamStateHandle forPathWithZeroSize(@Nonnull Path directory) {
+        return new DirectoryStreamStateHandle(directory, 0);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/EmptyFileMergingOperatorStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/EmptyFileMergingOperatorStreamStateHandle.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state.filemerging;
+
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.StreamStateHandle;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * An empty {@link FileMergingOperatorStreamStateHandle} that is only used as a placeholder to
+ * prevent file merging directory from being deleted.
+ */
+public class EmptyFileMergingOperatorStreamStateHandle
+        extends FileMergingOperatorStreamStateHandle {
+
+    private static final long serialVersionUID = 1L;
+
+    public EmptyFileMergingOperatorStreamStateHandle(
+            DirectoryStreamStateHandle taskOwnedDirHandle,
+            DirectoryStreamStateHandle sharedDirHandle,
+            Map<String, StateMetaInfo> stateNameToPartitionOffsets,
+            StreamStateHandle delegateStateHandle) {
+        super(
+                taskOwnedDirHandle,
+                sharedDirHandle,
+                stateNameToPartitionOffsets,
+                delegateStateHandle);
+    }
+
+    /**
+     * Create an empty {@link EmptyFileMergingOperatorStreamStateHandle}.
+     *
+     * @param taskownedDirHandle the directory where operator state is stored.
+     * @param sharedDirHandle the directory where shared state is stored.
+     */
+    public static EmptyFileMergingOperatorStreamStateHandle create(
+            DirectoryStreamStateHandle taskownedDirHandle,
+            DirectoryStreamStateHandle sharedDirHandle) {
+        final Map<String, OperatorStateHandle.StateMetaInfo> writtenStatesMetaData =
+                Collections.emptyMap();
+        return new EmptyFileMergingOperatorStreamStateHandle(
+                taskownedDirHandle,
+                sharedDirHandle,
+                writtenStatesMetaData,
+                EmptySegmentFileStateHandle.INSTANCE);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/EmptySegmentFileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/EmptySegmentFileStateHandle.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filemerging;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+/** An empty {@link SegmentFileStateHandle} that is only used as a placeholder. */
+public class EmptySegmentFileStateHandle extends SegmentFileStateHandle {
+    private static final long serialVersionUID = 1L;
+
+    public static final EmptySegmentFileStateHandle INSTANCE =
+            new EmptySegmentFileStateHandle(
+                    new Path("empty"), 0, 0, CheckpointedStateScope.EXCLUSIVE);
+
+    private EmptySegmentFileStateHandle(
+            Path filePath, long startPos, long stateSize, CheckpointedStateScope scope) {
+        super(filePath, startPos, stateSize, scope);
+    }
+
+    @Override
+    public FSDataInputStream openInputStream() throws IOException {
+        throw new UnsupportedEncodingException(
+                "Cannot open input stream from an EmptySegmentFileStateHandle.");
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/FileMergingOperatorStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/FileMergingOperatorStreamStateHandle.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filemerging;
+
+import org.apache.flink.runtime.state.CompositeStateHandle;
+import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.SharedStateRegistryKey;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A {@link OperatorStreamStateHandle} that works for file merging checkpoints.
+ *
+ * <p>Operator states are stored in `taskownd/` dir when file merging is enabled. When an operator
+ * state dir is not referenced by any checkpoint, {@link SharedStateRegistry} will discard it. The
+ * shared subtask dir of fire merging is also tracked by {@link
+ * FileMergingOperatorStreamStateHandle}.
+ *
+ * <p>The shared subtask dir of file merging is created when task initialization, which will be
+ * discarded when no checkpoint refer to it.
+ */
+public class FileMergingOperatorStreamStateHandle extends OperatorStreamStateHandle
+        implements CompositeStateHandle {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG =
+            LoggerFactory.getLogger(FileMergingOperatorStreamStateHandle.class);
+
+    /** The directory handle of file merging under 'taskowed/', one for each job. */
+    private final DirectoryStreamStateHandle taskOwnedDirHandle;
+
+    /**
+     * The directory handle of file merging under 'shared/', one for each subtask.
+     *
+     * @see org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager the layout of
+     *     file merging checkpoint directory.
+     */
+    private final DirectoryStreamStateHandle sharedDirHandle;
+
+    private transient SharedStateRegistry sharedStateRegistry;
+
+    public FileMergingOperatorStreamStateHandle(
+            DirectoryStreamStateHandle taskOwnedDirHandle,
+            DirectoryStreamStateHandle sharedDirHandle,
+            Map<String, StateMetaInfo> stateNameToPartitionOffsets,
+            StreamStateHandle delegateStateHandle) {
+        super(stateNameToPartitionOffsets, delegateStateHandle);
+        this.taskOwnedDirHandle = taskOwnedDirHandle;
+        this.sharedDirHandle = sharedDirHandle;
+    }
+
+    @Override
+    public void registerSharedStates(SharedStateRegistry stateRegistry, long checkpointId) {
+        Preconditions.checkState(
+                sharedStateRegistry != stateRegistry,
+                "The state handle has already registered its shared states to the given registry.");
+
+        sharedStateRegistry = Preconditions.checkNotNull(stateRegistry);
+
+        LOG.trace(
+                "Registering FileMergingOperatorStreamStateHandle for checkpoint {} from backend.",
+                checkpointId);
+        stateRegistry.registerReference(
+                new SharedStateRegistryKey(
+                        getDelegateStateHandle().getStreamStateHandleID().getKeyString()),
+                getDelegateStateHandle(),
+                checkpointId);
+
+        stateRegistry.registerReference(
+                taskOwnedDirHandle.createStateRegistryKey(), taskOwnedDirHandle, checkpointId);
+        stateRegistry.registerReference(
+                sharedDirHandle.createStateRegistryKey(), sharedDirHandle, checkpointId);
+    }
+
+    @Override
+    public void discardState() throws Exception {
+        SharedStateRegistry registry = this.sharedStateRegistry;
+        final boolean isRegistered = (registry != null);
+
+        LOG.trace(
+                "Discarding FileMergingOperatorStreamStateHandle (registered = {}) from backend.",
+                isRegistered);
+
+        try {
+            getDelegateStateHandle().discardState();
+        } catch (Exception e) {
+            LOG.warn("Could not properly discard directory state handle.", e);
+        }
+    }
+
+    @Override
+    public long getCheckpointedSize() {
+        return getDelegateStateHandle().getStateSize();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        FileMergingOperatorStreamStateHandle that = (FileMergingOperatorStreamStateHandle) o;
+
+        return super.equals(that)
+                && taskOwnedDirHandle.equals(that.taskOwnedDirHandle)
+                && sharedDirHandle.equals(that.sharedDirHandle);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Objects.hashCode(taskOwnedDirHandle);
+        result = 31 * result + Objects.hashCode(sharedDirHandle);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "FileMergingOperatorStreamStateHandle{"
+                + super.toString()
+                + ", taskOwnedDirHandle="
+                + taskOwnedDirHandle
+                + ", sharedDirHandle="
+                + sharedDirHandle
+                + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/SegmentFileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/SegmentFileStateHandle.java
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.checkpoint.filemerging;
+package org.apache.flink.runtime.state.filemerging;
 
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.filemerging.LogicalFile;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.PhysicalStateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -138,7 +139,7 @@ public class SegmentFileStateHandle implements StreamStateHandle {
 
         SegmentFileStateHandle that = (SegmentFileStateHandle) o;
 
-        return super.equals(that)
+        return filePath.equals(that.filePath)
                 && startPos == that.startPos
                 && stateSize == that.stateSize
                 && scope.equals(that.scope);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileMergingCheckpointStateOutputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FileMergingCheckpointStateOutputStream.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
-import org.apache.flink.runtime.checkpoint.filemerging.SegmentFileStateHandle;
 import org.apache.flink.runtime.state.CheckpointStateOutputStream;
+import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocation.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filemerging.DirectoryStreamStateHandle;
 
 import java.io.IOException;
 import java.util.List;
@@ -82,6 +83,16 @@ public class FsMergingCheckpointStorageLocation extends FsCheckpointStorageLocat
 
     public CheckpointStreamFactory toNonFileMerging() {
         return backwardsConvertor.get();
+    }
+
+    public DirectoryStreamStateHandle getExclusiveStateHandle() {
+        return fileMergingSnapshotManager.getManagedDirStateHandle(
+                subtaskKey, CheckpointedStateScope.EXCLUSIVE);
+    }
+
+    public DirectoryStreamStateHandle getSharedStateHandle() {
+        return fileMergingSnapshotManager.getManagedDirStateHandle(
+                subtaskKey, CheckpointedStateScope.SHARED);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManagerTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.checkpoint.filemerging;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileMergingCheckpointStateOutputStream;
 
 import org.junit.jupiter.api.Test;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager.SubtaskKey;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
 import org.apache.flink.runtime.state.filesystem.FileMergingCheckpointStateOutputStream;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManagerTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.checkpoint.filemerging;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileMergingCheckpointStateOutputStream;
 
 import org.junit.jupiter.api.Test;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileMergingCheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileMergingCheckpointStateOutputStreamTest.java
@@ -25,9 +25,9 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.OutputStreamAndPath;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.filemerging.PhysicalFile;
-import org.apache.flink.runtime.checkpoint.filemerging.SegmentFileStateHandle;
 import org.apache.flink.runtime.state.CheckpointStateOutputStream;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 import org.apache.flink.util.Preconditions;
 
 import org.junit.Before;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocationTest.java
@@ -25,9 +25,9 @@ import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManagerBuilder;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingType;
-import org.apache.flink.runtime.checkpoint.filemerging.SegmentFileStateHandle;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 
 import org.junit.Before;
 import org.junit.Rule;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Operator states are stored in `taskownd/` dir when file merging is enabled, this PR reports the operator state handle of file merging directory to JM `SharedStateRegistry`. 

## Brief change log
  - Introduce `FileMergingOperatorStreamStateHandle` , `EmptyFileMergingOperatorStreamStateHandle` and `DirectoryStreamStateHandle`.
  - Still report file merging directory to JM even if operator state is empty.

## Verifying this change

This change added tests and can be verified as follows:
- `OperatorStateBackendTest#testFileMergingSnapshotEmpty`
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( checkpointing )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
