### PR TITLE
[FLINK-34727][REST]fix rest request writer future not return

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractRestHandler.java
@@ -85,7 +85,7 @@ public abstract class AbstractRestHandler<
             response = FutureUtils.completedExceptionally(e);
         }
 
-        return response.thenAccept(
+        return response.thenCompose(
                 resp ->
                         HandlerUtils.sendResponse(
                                 ctx,


### PR DESCRIPTION
## What is the purpose of the change

 "thenAccept()" did not return sendResponse's future, causing the server shutdown process before the request was sent complete. 


## Brief change log

change AbstractRestHandler respondToRequest return sendRequest inner future


## Verifying this change

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable


[FLINK-34727][REST]fix rest request writer future not return