### PR TITLE
[FLINK-31664] Implement ARRAY_INTERSECT function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -688,6 +688,9 @@ collection:
   - sql: ARRAY_EXCEPT(array1, array2)
     table: arrayOne.arrayExcept(arrayTwo)
     description: Returns an ARRAY that contains the elements from array1 that are not in array2. If no elements remain after excluding the elements in array2 from array1, the function returns an empty ARRAY. If one or both arguments are NULL, the function returns NULL. The order of the elements from array1 is kept.
+  - sql: ARRAY_INTERSECT(array1, array2)
+    table: array1.arrayIntersect(array2)
+    description: Returns an ARRAY that contains the elements from array1 that are also in array2, without duplicates. If no elements that are both in array1 and array2, the function returns an empty ARRAY. If any of the array is null, the function will return null. The order of the elements from array1 is kept.
   - sql: SPLIT(string, delimiter)
     table: string.split(delimiter)
     description: Returns an array of substrings by splitting the input string based on the given delimiter. If the delimiter is not found in the string, the original string is returned as the only element in the array. If the delimiter is empty, every character in the string is split. If the string or delimiter is null, a null value is returned. If the delimiter is found at the beginning or end of the string, or there are contiguous delimiters, then an empty string is added to the array.

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -243,8 +243,8 @@ advanced type helper functions
     Expression.map_union
     Expression.map_values
     Expression.array_except
+    Expression.array_intersect
     Expression.split
-
 
 time definition functions
 -------------------------

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1618,6 +1618,15 @@ class Expression(Generic[T]):
         """
         return _binary_op("arrayExcept")(self, array)
 
+    def array_intersect(self, array) -> 'Expression':
+        """
+        Returns an ARRAY that contains the elements from array1 that are also in array2,
+        without duplicates. If no elements are both in array1 and array2, the function
+        returns an empty ARRAY. If one or both arguments are NULL, the function returns NULL.
+        The order of the elements from array1 is kept.
+        """
+        return _binary_op("arrayIntersect")(self, array)
+
     def split(self, delimiter) -> 'Expression':
         """
         Returns an array of substrings by splitting the input string based on the given delimiter.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -60,6 +60,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_DISTINCT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_ELEMENT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_EXCEPT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_INTERSECT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_MAX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_MIN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_POSITION;
@@ -244,6 +245,19 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType arrayExcept(InType array) {
         return toApiSpecificExpression(
                 unresolvedCall(ARRAY_EXCEPT, toExpr(), objectToExpression(array)));
+    }
+
+    /**
+     * Returns an ARRAY that contains the elements from array1 that are also in array2, without
+     * duplicates. If no elements that are both in array1 and array2, the function returns an empty
+     * ARRAY.
+     *
+     * <p>If one or both arguments are NULL, the function returns NULL. The order of the elements
+     * from array1 is kept.
+     */
+    public OutType arrayIntersect(InType array) {
+        return toApiSpecificExpression(
+                unresolvedCall(ARRAY_INTERSECT, toExpr(), objectToExpression(array)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -471,6 +471,16 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.ArrayExceptFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition ARRAY_INTERSECT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ARRAY_INTERSECT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(commonArrayType(2))
+                    .outputTypeStrategy(nullableIfArgs(COMMON))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ArrayIntersectFunction")
+                    .build();
+
     // --------------------------------------------------------------------------------------------
     // Logic functions
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -56,6 +56,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         arrayMinTestCases(),
                         arraySortTestCases(),
                         arrayExceptTestCases(),
+                        arrayIntersectTestCases(),
                         splitTestCases())
                 .flatMap(s -> s);
     }
@@ -1721,6 +1722,83 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").arrayExcept(new String[] {"hi", "there"}),
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "ARRAY_EXCEPT(<COMMON>, <COMMON>)"));
+    }
+
+    private Stream<TestSetSpec> arrayIntersectTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_INTERSECT)
+                        .onFieldsWithData(
+                                new Integer[] {1, 1, 2},
+                                null,
+                                new Row[] {Row.of(true, 1), Row.of(true, 2), null},
+                                new Integer[] {null, null, 1},
+                                new Map[] {
+                                    CollectionUtil.map(entry(1, "a"), entry(2, "b")),
+                                    CollectionUtil.map(entry(3, "c"), entry(4, "d"))
+                                },
+                                new Integer[][] {new Integer[] {1, 2, 3}})
+                        .andDataTypes(
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.INT())),
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())),
+                                DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT())))
+                        // ARRAY<INT>
+                        .testResult(
+                                $("f0").arrayIntersect(new Integer[] {1, null, 4}),
+                                "ARRAY_INTERSECT(f0, ARRAY[1, NULL, 4])",
+                                new Integer[] {1, 1},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f0").arrayIntersect(new Integer[] {3, 4}),
+                                "ARRAY_INTERSECT(f0, ARRAY[3, 4])",
+                                new Integer[] {},
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        .testResult(
+                                $("f1").arrayIntersect(new Integer[] {1, null, 4}),
+                                "ARRAY_INTERSECT(f1, ARRAY[1, NULL, 4])",
+                                null,
+                                DataTypes.ARRAY(DataTypes.INT()))
+                        // ARRAY<ROW<BOOLEAN, DATE>>
+                        .testResult(
+                                $("f2").arrayIntersect(
+                                                new Row[] {
+                                                    null, Row.of(true, 2),
+                                                }),
+                                "ARRAY_INTERSECT(f2, ARRAY[NULL, ROW(TRUE, 2)])",
+                                new Row[] {Row.of(true, 2), null},
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.INT())))
+                        // arrayOne contains null elements
+                        .testResult(
+                                $("f3").arrayIntersect(new Integer[] {null, 42}),
+                                "ARRAY_INTERSECT(f3, ARRAY[null, 42])",
+                                new Integer[] {null, null},
+                                DataTypes.ARRAY(DataTypes.INT()).nullable())
+                        .testResult(
+                                $("f4").arrayIntersect(
+                                                new Map[] {
+                                                    CollectionUtil.map(entry(1, "a"), entry(2, "b"))
+                                                }),
+                                "ARRAY_INTERSECT(f4, ARRAY[MAP[1, 'a', 2, 'b']])",
+                                new Map[] {CollectionUtil.map(entry(1, "a"), entry(2, "b"))},
+                                DataTypes.ARRAY(DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())))
+                        .testResult(
+                                $("f5").arrayIntersect(new Integer[][] {new Integer[] {1, 2, 3}}),
+                                "ARRAY_INTERSECT(f5, ARRAY[ARRAY[1, 2, 3]])",
+                                new Integer[][] {new Integer[] {1, 2, 3}},
+                                DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.INT())))
+                        // invalid signatures
+                        .testSqlValidationError(
+                                "ARRAY_INTERSECT(f3, TRUE)",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_INTERSECT(<COMMON>, <COMMON>)")
+                        .testTableApiValidationError(
+                                $("f3").arrayIntersect(true),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ARRAY_INTERSECT(<COMMON>, <COMMON>)"));
     }
 
     private Stream<TestSetSpec> splitTestCases() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -1749,7 +1749,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f0").arrayIntersect(new Integer[] {1, null, 4}),
                                 "ARRAY_INTERSECT(f0, ARRAY[1, NULL, 4])",
-                                new Integer[] {1, 1},
+                                new Integer[] {1},
                                 DataTypes.ARRAY(DataTypes.INT()))
                         .testResult(
                                 $("f0").arrayIntersect(new Integer[] {3, 4}),
@@ -1775,7 +1775,7 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 $("f3").arrayIntersect(new Integer[] {null, 42}),
                                 "ARRAY_INTERSECT(f3, ARRAY[null, 42])",
-                                new Integer[] {null, null},
+                                new Integer[] {null},
                                 DataTypes.ARRAY(DataTypes.INT()).nullable())
                         .testResult(
                                 $("f4").arrayIntersect(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayIntersectFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayIntersectFunction.java
@@ -32,9 +32,8 @@ import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_INTERSECT}. */
@@ -64,21 +63,26 @@ public class ArrayIntersectFunction extends BuiltInScalarFunction {
                 return null;
             }
 
-            List<Object> list = new ArrayList<>();
             Set<ObjectContainer> set = new HashSet<>();
             for (int pos = 0; pos < arrayTwo.size(); pos++) {
                 final Object element = elementGetter.getElementOrNull(arrayTwo, pos);
                 final ObjectContainer objectContainer = createObjectContainer(element);
                 set.add(objectContainer);
             }
+
+            Set<ObjectContainer> res = new LinkedHashSet<>();
             for (int pos = 0; pos < arrayOne.size(); pos++) {
                 final Object element = elementGetter.getElementOrNull(arrayOne, pos);
                 final ObjectContainer objectContainer = createObjectContainer(element);
                 if (set.contains(objectContainer)) {
-                    list.add(element);
+                    res.add(objectContainer);
                 }
             }
-            return new GenericArrayData(list.toArray());
+
+            return new GenericArrayData(
+                    res.stream()
+                            .map(element -> element != null ? element.getObject() : null)
+                            .toArray());
         } catch (Throwable t) {
             throw new FlinkRuntimeException(t);
         }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayIntersectFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayIntersectFunction.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.runtime.util.EqualityAndHashcodeProvider;
+import org.apache.flink.table.runtime.util.ObjectContainer;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ARRAY_INTERSECT}. */
+@Internal
+public class ArrayIntersectFunction extends BuiltInScalarFunction {
+    private final ArrayData.ElementGetter elementGetter;
+    private final EqualityAndHashcodeProvider equalityAndHashcodeProvider;
+
+    public ArrayIntersectFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ARRAY_INTERSECT, context);
+        final DataType dataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType()
+                        .toInternal();
+        elementGetter = ArrayData.createElementGetter(dataType.toInternal().getLogicalType());
+        this.equalityAndHashcodeProvider = new EqualityAndHashcodeProvider(context, dataType);
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        equalityAndHashcodeProvider.open(context);
+    }
+
+    public @Nullable ArrayData eval(ArrayData arrayOne, ArrayData arrayTwo) {
+        try {
+            if (arrayOne == null || arrayTwo == null) {
+                return null;
+            }
+
+            List<Object> list = new ArrayList<>();
+            Set<ObjectContainer> set = new HashSet<>();
+            for (int pos = 0; pos < arrayTwo.size(); pos++) {
+                final Object element = elementGetter.getElementOrNull(arrayTwo, pos);
+                final ObjectContainer objectContainer = createObjectContainer(element);
+                set.add(objectContainer);
+            }
+            for (int pos = 0; pos < arrayOne.size(); pos++) {
+                final Object element = elementGetter.getElementOrNull(arrayOne, pos);
+                final ObjectContainer objectContainer = createObjectContainer(element);
+                if (set.contains(objectContainer)) {
+                    list.add(element);
+                }
+            }
+            return new GenericArrayData(list.toArray());
+        } catch (Throwable t) {
+            throw new FlinkRuntimeException(t);
+        }
+    }
+
+    private ObjectContainer createObjectContainer(Object element) {
+        if (element == null) {
+            return null;
+        }
+        return new ObjectContainer(
+                element,
+                equalityAndHashcodeProvider::equals,
+                equalityAndHashcodeProvider::hashCode);
+    }
+
+    @Override
+    public void close() throws Exception {
+        equalityAndHashcodeProvider.close();
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/ObjectContainer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/ObjectContainer.java
@@ -31,19 +31,23 @@ import java.util.function.Function;
 @Internal
 public class ObjectContainer {
 
-    private final Object o;
+    private final Object object;
 
     private final BiFunction<Object, Object, Boolean> equalsMethod;
 
     private final Function<Object, Integer> hashCodeMethod;
 
     public ObjectContainer(
-            Object o,
+            Object object,
             BiFunction<Object, Object, Boolean> equalsMethod,
             Function<Object, Integer> hashCodeMethod) {
-        this.o = o;
+        this.object = object;
         this.equalsMethod = equalsMethod;
         this.hashCodeMethod = hashCodeMethod;
+    }
+
+    public Object getObject() {
+        return object;
     }
 
     @Override
@@ -55,11 +59,11 @@ public class ObjectContainer {
             return false;
         }
         ObjectContainer that = (ObjectContainer) other;
-        return equalsMethod.apply(this.o, that.o);
+        return equalsMethod.apply(this.object, that.object);
     }
 
     @Override
     public int hashCode() {
-        return hashCodeMethod.apply(o);
+        return hashCodeMethod.apply(object);
     }
 }


### PR DESCRIPTION
- What is the purpose of the change
This is an implementation of ARRAY_INTERSECT

- Brief change log
ARRAY_INTERSECT for Table API and SQL
    
```
Returns an array of the elements in the intersection of array1 and array2, with duplicates.

Syntax:
array_intersect(array1, array2)

Arguments:
array: An ARRAY to be handled.

Returns:
An ARRAY. If any of the array is null, the function will return null.
Examples:

> SELECT array_intersect(array(1, 1, 3), array(1, 3, 5));
 [1,1,3]

```

- Verifying this change
This change added tests in CollectionFunctionsITCase.

- Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): ( no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes )
The serializers: (no)
The runtime per-record code paths (performance sensitive): ( no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
The S3 file system connector: ( no)
- Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)
