### PR TITLE
[FLINK-34733] [filesystem] Fix oss filesystem ClassNotFoundException when configure 'fs.oss.credentials.provider'.

### DIFF
--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/java/org/apache/flink/fs/osshadoop/OSSFileSystemFactory.java
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/java/org/apache/flink/fs/osshadoop/OSSFileSystemFactory.java
@@ -33,8 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.Set;
 
 /** Simple factory for the OSS file system. */
 public class OSSFileSystemFactory implements FileSystemFactory {
@@ -43,11 +41,6 @@ public class OSSFileSystemFactory implements FileSystemFactory {
     private Configuration flinkConfig;
 
     private org.apache.hadoop.conf.Configuration hadoopConfig;
-
-    private static final Set<String> CONFIG_KEYS_TO_SHADE =
-            Collections.singleton("fs.oss.credentials.provider");
-
-    private static final String FLINK_SHADING_PREFIX = "org.apache.flink.fs.osshadoop.shaded.";
 
     /**
      * In order to simplify, we make flink oss configuration keys same with hadoop oss module. So,
@@ -125,9 +118,6 @@ public class OSSFileSystemFactory implements FileSystemFactory {
                 if (key.startsWith(prefix)) {
                     String value = flinkConfig.getString(key, null);
                     conf.set(key, value);
-                    if (CONFIG_KEYS_TO_SHADE.contains(key)) {
-                        conf.set(key, FLINK_SHADING_PREFIX + value);
-                    }
 
                     LOG.debug(
                             "Adding Flink config entry for {} as {} to Hadoop config",


### PR DESCRIPTION

 ## What is the purpose of the change

Fixing the exception in Alibaba Cloud OSS file system.


## Brief change log

  - *Remove the oss filesystem hard-coded shaded prefix of 'fs.oss.credentials.provider'.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

