### PR TITLE
[FLINK-34718][tests] Exclude operators not meant for adaptive scheduler

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/KeyedPartitionWindowedStreamITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/KeyedPartitionWindowedStreamITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.util.Collector;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Integration tests for {@link KeyedPartitionWindowedStream}. */
+@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler") // FLINK-34718
 class KeyedPartitionWindowedStreamITCase {
 
     private static final int EVENT_NUMBER = 100;

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/NonKeyedPartitionWindowedStreamITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/NonKeyedPartitionWindowedStreamITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.util.Collector;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Integration tests for {@link NonKeyedPartitionWindowedStream}. */
+@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler") // FLINK-34718
 class NonKeyedPartitionWindowedStreamITCase {
 
     private static final int EVENT_NUMBER = 100;


### PR DESCRIPTION
## What is the purpose of the change

* Some of the new tests for the unit tests introduced in FLINK-34543 are failing in the **adaptive scheduler** stage.  These operators are not suitable for the adaptive scheduler and should be excluded.

## Brief change log

Add `@Tag` to exclude the `KeyedPartitionWindowedStreamITCase` and `NonKeyedPartitionWindowedStreamITCase`.

## Verifying this change

This change can be verified in the Azure and GitHub Actions pipeline by verifying the execution of a full build: they should be run in stages that don't have the system property "flink.tests.enable-adaptive-scheduler" set to true (and definitely excluded from the **adaptive scheduler** stage)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
