### PR TITLE
[FLINK-34745] Improve validations for a period in Time Travel

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -233,7 +233,7 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
 
             RexLiteral rexLiteral = (RexLiteral) reducedNode;
             final RelDataType sqlType = rexLiteral.getType();
-            if (!SqlTypeUtil.isTimestamp(rexLiteral.getType())) {
+            if (!SqlTypeUtil.isTimestamp(sqlType)) {
                 throw newValidationError(
                         periodNode,
                         Static.RESOURCE.illegalExpressionForTemporal(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -59,7 +59,7 @@ import org.apache.calcite.sql.SqlTableFunction;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWindowTableFunction;
 import org.apache.calcite.sql.parser.SqlParserPos;
-import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.sql.validate.DelegatingScope;
 import org.apache.calcite.sql.validate.IdentifierNamespace;
 import org.apache.calcite.sql.validate.IdentifierSnapshotNamespace;
@@ -232,12 +232,12 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
             }
 
             RexLiteral rexLiteral = (RexLiteral) reducedNode;
-            final SqlTypeName sqlTypeName = rexLiteral.getTypeName();
-            if (!(sqlTypeName == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
-                    || sqlTypeName == SqlTypeName.TIMESTAMP)) {
+            final RelDataType sqlType = rexLiteral.getType();
+            if (!SqlTypeUtil.isTimestamp(rexLiteral.getType())) {
                 throw newValidationError(
                         periodNode,
-                        Static.RESOURCE.illegalExpressionForTemporal(sqlTypeName.getName()));
+                        Static.RESOURCE.illegalExpressionForTemporal(
+                                sqlType.getSqlTypeName().getName()));
             }
 
             TimestampString timestampString = rexLiteral.getValueAs(TimestampString.class);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -231,7 +231,8 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
                                 periodNode));
             }
 
-            final SqlTypeName sqlTypeName = ((RexLiteral) reducedNode).getTypeName();
+            RexLiteral rexLiteral = (RexLiteral) reducedNode;
+            final SqlTypeName sqlTypeName = rexLiteral.getTypeName();
             if (!(sqlTypeName == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
                     || sqlTypeName == SqlTypeName.TIMESTAMP)) {
                 throw newValidationError(
@@ -239,9 +240,7 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
                         Static.RESOURCE.illegalExpressionForTemporal(sqlTypeName.getName()));
             }
 
-            RexLiteral rexLiteral = (RexLiteral) reducedNode;
-            TimestampString timestampString =
-                    ((RexLiteral) reducedNode).getValueAs(TimestampString.class);
+            TimestampString timestampString = rexLiteral.getValueAs(TimestampString.class);
             checkNotNull(
                     timestampString,
                     "The time travel expression %s can not reduce to a valid timestamp string. This is a bug. Please file an issue.",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
@@ -508,6 +508,27 @@ class TemporalJoinTest extends TableTestBase {
         " table, but the rowtime types are TIMESTAMP_LTZ(3) *ROWTIME* and TIMESTAMP(3) *ROWTIME*.",
       classOf[ValidationException]
     )
+
+    val sqlQuery9 = "SELECT * " +
+      "FROM Orders AS o JOIN " +
+      "RatesHistoryWithPK FOR SYSTEM_TIME AS OF 'o.rowtime' AS r " +
+      "ON o.currency = r.currency"
+    expectExceptionThrown(
+      sqlQuery9,
+      "The system time period specification expects Timestamp type but is 'CHAR'",
+      classOf[ValidationException]
+    )
+
+    val sqlQuery10 = "SELECT * " +
+      "FROM Orders AS o JOIN " +
+      "RatesHistoryWithPK FOR SYSTEM_TIME AS OF o.rowtime + INTERVAL '1' SECOND AS r " +
+      "ON o.currency = r.currency"
+    expectExceptionThrown(
+      sqlQuery10,
+      "Temporal table join currently only supports 'FOR SYSTEM_TIME AS OF' left table's time" +
+        " attribute field'",
+      classOf[ValidationException]
+    )
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change

The provided SQLs are invalid, however the current code base fails on unexpected locations giving unhelpful messages. This PR improves the validation which results in proper error messages.

## Verifying this change

Added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
