### PR TITLE
[hotfix] Fix maven property typo in root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1021,7 +1021,7 @@ under the License.
 							<excludedGroups>
 								${surefire.excludedGroups.github-actions},
 								${surefire.excludedGroups.adaptive-scheduler},
-								${surefire.excludedGroups.jdk,
+								${surefire.excludedGroups.jdk}
 							</excludedGroups>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
## What is the purpose of the change

There's a missing brace in the root `pom.xml` that would ignore any tests that should be excluded on a specific JDK version (`FailsOnJavaXxx`) when the `enable-adaptive-scheduler` profile is enabled.  There currently aren't any, but this should be corrected (and maybe backported)?

## Brief change log

Add the missing brace.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not documented**
