### PR TITLE
[FLINK-34526][runtime] Actively disconnect the TM in RM to reduce restart time

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -543,12 +543,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
     @Override
     public CompletableFuture<Acknowledge> disconnectTaskManager(
             final ResourceID resourceID, final Exception cause) {
-        log.info(
-                "Disconnect TaskExecutor {} because: {}",
-                resourceID.getStringWithMetadata(),
-                cause.getMessage(),
-                ExceptionUtils.returnExceptionIfUnexpected(cause.getCause()));
-        ExceptionUtils.logExceptionIfExcepted(cause.getCause(), log);
 
         taskManagerHeartbeatManager.unmonitorTarget(resourceID);
         slotPoolService.releaseTaskManager(resourceID, cause);
@@ -557,6 +551,13 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
         TaskManagerRegistration taskManagerRegistration = registeredTaskManagers.remove(resourceID);
 
         if (taskManagerRegistration != null) {
+            log.info(
+                    "Disconnect TaskExecutor {} because: {}",
+                    resourceID.getStringWithMetadata(),
+                    cause.getMessage(),
+                    ExceptionUtils.returnExceptionIfUnexpected(cause.getCause()));
+            ExceptionUtils.logExceptionIfExcepted(cause.getCause(), log);
+
             taskManagerRegistration
                     .getTaskExecutorGateway()
                     .disconnectJobManager(jobGraph.getJobID(), cause);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1179,6 +1179,14 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
             slotManager.unregisterTaskManager(workerRegistration.getInstanceID(), cause);
             clusterPartitionTracker.processTaskExecutorShutdown(resourceID);
 
+            jobManagerRegistrations
+                    .values()
+                    .forEach(
+                            jobManagerRegistration ->
+                                    jobManagerRegistration
+                                            .getJobManagerGateway()
+                                            .disconnectTaskManager(resourceID, cause));
+
             workerRegistration.getTaskExecutorGateway().disconnectResourceManager(cause);
         } else {
             log.debug(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -29,11 +29,14 @@ import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElection;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
+import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import org.junit.jupiter.api.AfterEach;
@@ -44,8 +47,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
+import static org.apache.flink.runtime.resourcemanager.ResourceManagerPartitionLifecycleTest.registerTaskExecutor;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the interaction between the {@link ResourceManager} and the {@link JobMaster}. */
 class ResourceManagerJobMasterTest {
@@ -144,6 +150,59 @@ class ResourceManagerJobMasterTest {
         assertThatFuture(successfulFuture)
                 .succeedsWithin(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS)
                 .isInstanceOf(JobMasterRegistrationSuccess.class);
+    }
+
+    @Test
+    void testDisconnectTaskManagerInResourceManager()
+            throws ExecutionException, InterruptedException, TimeoutException {
+        final ResourceID taskExecutorId = ResourceID.generate();
+        final CompletableFuture<Exception> disconnectRMFuture = new CompletableFuture<>();
+        final CompletableFuture<ResourceID> disconnectTMFuture = new CompletableFuture<>();
+
+        TestingJobMasterGateway jobMasterGateway =
+                new TestingJobMasterGatewayBuilder()
+                        .setDisconnectTaskManagerFunction(
+                                resourceID -> {
+                                    disconnectTMFuture.complete(resourceID);
+                                    return CompletableFuture.completedFuture(Acknowledge.get());
+                                })
+                        .setAddress("pekko.tcp://flink@localhost:6130/user/jobmanager2")
+                        .build();
+        rpcService.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
+        ResourceManagerGateway resourceManagerGateway =
+                resourceManagerService
+                        .getResourceManagerGateway()
+                        .orElseThrow(
+                                () ->
+                                        new AssertionError(
+                                                "RM not available after confirming leadership."));
+
+        // test response successful
+        CompletableFuture<RegistrationResponse> successfulFuture =
+                resourceManagerGateway.registerJobMaster(
+                        jobMasterGateway.getFencingToken(),
+                        jobMasterResourceId,
+                        jobMasterGateway.getAddress(),
+                        jobId,
+                        TIMEOUT);
+        assertThatFuture(successfulFuture)
+                .succeedsWithin(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS)
+                .isInstanceOf(JobMasterRegistrationSuccess.class);
+
+        final TaskExecutorGateway taskExecutorGateway =
+                new TestingTaskExecutorGatewayBuilder()
+                        .setAddress(UUID.randomUUID().toString())
+                        .setDisconnectResourceManagerConsumer(disconnectRMFuture::complete)
+                        .createTestingTaskExecutorGateway();
+        rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
+        registerTaskExecutor(
+                resourceManagerGateway, taskExecutorId, taskExecutorGateway.getAddress());
+
+        resourceManagerGateway.disconnectTaskManager(taskExecutorId, new Exception("for test"));
+        assertThatFuture(disconnectRMFuture).succeedsWithin(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+        final ResourceID resourceId =
+                disconnectTMFuture.get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+        assertThat(resourceId).isEqualTo(taskExecutorId);
     }
 
     /** Test receive registration with unmatched leadershipId from job master. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -199,7 +199,8 @@ class ResourceManagerJobMasterTest {
                 resourceManagerGateway, taskExecutorId, taskExecutorGateway.getAddress());
 
         resourceManagerGateway.disconnectTaskManager(taskExecutorId, new Exception("for test"));
-        assertThatFuture(disconnectRMFuture).succeedsWithin(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+        assertThatFuture(disconnectRMFuture)
+                .succeedsWithin(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
         final ResourceID resourceId =
                 disconnectTMFuture.get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
         assertThat(resourceId).isEqualTo(taskExecutorId);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

* This pull request makes job restart more quickly by `disconnectTaskManager` actively in ResourceManager.


## Brief change log

  - *Disconnect TaskManager in ResourceManager actively*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - Add new unit test `testDisconnectTaskManagerInResourceManager()`
  - *Manually verified the change by running a datagen print job, verifying that recovery is faster than before.*  
    - ![image](https://github.com/apache/flink/assets/1277293/6128b07b-f988-4958-a515-e57fbe20ec89)
    - parallelism = 100 && taskmanager.numberOfTaskSlots = 2 && disable checkpoint


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
