### PR TITLE
 [FLINK-34893] Bump checkstyle to 9.3 

### DIFF
--- a/docs/content.zh/docs/flinkDev/ide_setup.md
+++ b/docs/content.zh/docs/flinkDev/ide_setup.md
@@ -103,7 +103,7 @@ IntelliJ 使用 Checkstyle-IDEA 插件在 IDE 中支持 checkstyle。
 1. 从 IntelliJ 插件存储库中安装 "Checkstyle-IDEA" 插件。
 2. 通过 Settings → Tools → Checkstyle 配置插件。
 3. 将 "Scan Scope" 设置为仅 Java 源（包括测试）。
-4. 在 "Checkstyle Version" 下拉菜单中选择 _8.14_ 版本，然后单击 "apply"。**此步骤很重要，请勿跳过！**
+4. 在 "Checkstyle Version" 下拉菜单中选择 _9.3_ 版本，然后单击 "apply"。**此步骤很重要，请勿跳过！**
 5. 在 "Configuration File" 窗格中，点击 "+" 图标添加新配置：
     1. 将 "Description" 设置为 Flink。
     2. 选择 "Use a local Checkstyle file" ，然后将其指向你存储库中 `"tools/maven/checkstyle.xml"` 文件。

--- a/docs/content/docs/flinkDev/ide_setup.md
+++ b/docs/content/docs/flinkDev/ide_setup.md
@@ -169,7 +169,7 @@ any of these modules.
 
 1. Go to "Settings" → "Tools" → "Checkstyle".
 2. Set "Scan Scope" to "Only Java sources (including tests)".
-3. For "Checkstyle Version" select "8.14".
+3. For "Checkstyle Version" select "9.3".
 4. Under "Configuration File" click the "+" icon to add a new configuration.
 5. Set "Description" to "Flink".
 6. Select "Use a local Checkstyle file" and point it to `tools/maven/checkstyle.xml` located within

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/util/ListKeyGroupedIterator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/util/ListKeyGroupedIterator.java
@@ -64,7 +64,7 @@ public final class ListKeyGroupedIterator<E> {
         this.serializer = serializer;
         this.comparator = comparator;
 
-        this.done = input.isEmpty() ? true : false;
+        this.done = input.isEmpty();
     }
 
     /**

--- a/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/ByteArrayOutputStreamWithPos.java
@@ -88,7 +88,7 @@ public class ByteArrayOutputStreamWithPos extends OutputStream {
         count = 0;
     }
 
-    public byte toByteArray()[] {
+    public byte[] toByteArray() {
         return Arrays.copyOf(buffer, count);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReader.java
@@ -1,4 +1,3 @@
-package org.apache.flink.runtime.checkpoint.channel;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +14,8 @@ package org.apache.flink.runtime.checkpoint.channel;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.flink.runtime.checkpoint.channel;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobPlanHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobPlanHandler.java
@@ -1,4 +1,3 @@
-package org.apache.flink.runtime.rest.handler.job;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -16,6 +15,8 @@ package org.apache.flink.runtime.rest.handler.job;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.flink.runtime.rest.handler.job;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogState.java
@@ -1,4 +1,3 @@
-package org.apache.flink.state.changelog;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -15,6 +14,8 @@ package org.apache.flink.state.changelog;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.flink.state.changelog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.state.changelog.restore.ChangelogApplierFactory;

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -783,7 +783,7 @@ public class OperationExecutor {
      * @param handle the specified operation handle
      * @param clusterAction the cluster action to run against the retrieved {@link ClusterClient}.
      * @param <ClusterID> type of the cluster id
-     * @param <Result>> type of the result
+     * @param <Result> type of the result
      * @throws SqlExecutionException if something goes wrong
      */
     private <ClusterID, Result> Result runClusterAction(

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@ under the License.
 		<orc.version>1.5.6</orc.version>
 		<japicmp.referenceVersion>1.18.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
+		<checkstyle.version>8.14</checkstyle.version>
 		<!-- can be removed with maven-spotless-plugin:2.38+ -->
 		<spotless.skip>false</spotless.skip>
 		<spotless.version>2.27.1</spotless.version>
@@ -2175,7 +2176,7 @@ under the License.
 							<groupId>com.puppycrawl.tools</groupId>
 							<artifactId>checkstyle</artifactId>
 							<!-- Note: match version with docs/flinkDev/ide_setup.md -->
-							<version>8.14</version>
+							<version>${checkstyle.version}</version>
 						</dependency>
 					</dependencies>
 					<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@ under the License.
 		<orc.version>1.5.6</orc.version>
 		<japicmp.referenceVersion>1.18.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
-		<checkstyle.version>8.14</checkstyle.version>
+		<checkstyle.version>9.3</checkstyle.version>
 		<!-- can be removed with maven-spotless-plugin:2.38+ -->
 		<spotless.skip>false</spotless.skip>
 		<spotless.version>2.27.1</spotless.version>
@@ -2170,7 +2170,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>3.1.2</version>
+					<version>3.3.1</version>
 					<dependencies>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -208,7 +208,7 @@ This file is based on the checkstyle file of Apache Beam.
 
 		<module name="RedundantModifier">
 			<!-- Checks for redundant modifiers on various symbol definitions.
-			  See: http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier
+			  See: https://checkstyle.sourceforge.io/checks/modifier/redundantmodifier.html#RedundantModifier
 
 			  We exclude METHOD_DEF to allow final methods in final classes to make them more future-proof.
 			-->
@@ -236,18 +236,12 @@ This file is based on the checkstyle file of Apache Beam.
 		-->
 
 		<!-- Checks for Javadoc comments.                     -->
-		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
+		<!-- See https://checkstyle.sourceforge.io/checks/javadoc/javadocmethod.html -->
 		<module name="JavadocMethod">
-			<property name="scope" value="protected"/>
+			<property name="accessModifiers" value="protected"/>
 			<property name="severity" value="error"/>
-			<property name="allowMissingJavadoc" value="true"/>
 			<property name="allowMissingParamTags" value="true"/>
 			<property name="allowMissingReturnTag" value="true"/>
-			<property name="allowMissingThrowsTags" value="true"/>
-			<property name="allowThrowsTagsForSubclasses" value="true"/>
-			<property name="allowUndeclaredRTE" value="true"/>
-			<!-- This check sometimes failed for with "Unable to get class information for @throws tag" for custom exceptions -->
-			<property name="suppressLoadErrors" value="true"/>
 		</module>
 
 		<!-- Check that paragraph tags are used correctly in Javadoc. -->


### PR DESCRIPTION

## What is the purpose of the change


The issue with current checkstyle is that there is checkstyle IntellijIdea plugin

And recently it dropped checkstyle 8 support [1]

At the same time we can not move to Checkstyle 10 since 10.x requires java 11+

Also it moves version to properties to allow build with different checkstyle versions
for instance after this PR it would be possible to build with checkstyle 10 as well (leveraging jdk11+)
like `mvn clean install -DskipTests -Dcheckstyle.version=10.14.2`

[1] https://github.com/jshiell/checkstyle-idea/blob/main/CHANGELOG.md


## Verifying this change


This change is a trivial rework 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
