### PR TITLE
[FLINK-34897][test] Enables JobMasterServiceLeadershipRunnerTest#testJobMasterServiceLeadershipRunnerCloseWhenElectionServiceGrantLeaderShip again.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -45,18 +45,19 @@ import org.apache.flink.runtime.leaderelection.TestingLeaderElectionDriver;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.TestingJobResultStore;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.SupplierWithException;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
@@ -676,25 +677,24 @@ class JobMasterServiceLeadershipRunnerTest {
         }
     }
 
-    @Disabled
     @Test
     void testJobMasterServiceLeadershipRunnerCloseWhenElectionServiceGrantLeaderShip()
             throws Exception {
         final AtomicReference<LeaderInformationRegister> storedLeaderInformation =
                 new AtomicReference<>(LeaderInformationRegister.empty());
+        final AtomicBoolean haBackendLeadershipFlag = new AtomicBoolean();
 
         final TestingLeaderElectionDriver.Factory driverFactory =
                 new TestingLeaderElectionDriver.Factory(
                         TestingLeaderElectionDriver.newBuilder(
-                                new AtomicBoolean(), storedLeaderInformation, new AtomicBoolean()));
+                                haBackendLeadershipFlag,
+                                storedLeaderInformation,
+                                new AtomicBoolean()));
 
         // we need to use DefaultLeaderElectionService here because JobMasterServiceLeadershipRunner
         // in connection with the DefaultLeaderElectionService generates the nested locking
         final DefaultLeaderElectionService defaultLeaderElectionService =
                 new DefaultLeaderElectionService(driverFactory, fatalErrorHandler);
-
-        final TestingLeaderElectionDriver currentLeaderDriver =
-                driverFactory.assertAndGetOnlyCreatedDriver();
 
         // latch to detect when we reached the first synchronized section having a lock on the
         // JobMasterServiceProcess#stop side
@@ -733,6 +733,7 @@ class JobMasterServiceLeadershipRunnerTest {
                                                         // before calling stop on the
                                                         // DefaultLeaderElectionService
                                                         triggerClassLoaderLeaseRelease.await();
+
                                                         // In order to reproduce the deadlock, we
                                                         // need to ensure that
                                                         // leaderContender#grantLeadership can be
@@ -770,13 +771,19 @@ class JobMasterServiceLeadershipRunnerTest {
             jobManagerRunner.start();
 
             // grant leadership to create jobMasterServiceProcess
+            haBackendLeadershipFlag.set(true);
             final UUID leaderSessionID = UUID.randomUUID();
             defaultLeaderElectionService.onGrantLeadership(leaderSessionID);
 
-            while (!currentLeaderDriver.hasLeadership()
-                    || !leaderElection.hasLeadership(leaderSessionID)) {
-                Thread.sleep(100);
-            }
+            final SupplierWithException<Boolean, Exception> confirmationForSessionIdReceived =
+                    () ->
+                            storedLeaderInformation
+                                    .get()
+                                    .forComponentId(componentId)
+                                    .map(LeaderInformation::getLeaderSessionID)
+                                    .map(sessionId -> sessionId.equals(leaderSessionID))
+                                    .orElse(false);
+            CommonTestUtils.waitUntilCondition(confirmationForSessionIdReceived);
 
             final CheckedThread contenderCloseThread = createCheckedThread(jobManagerRunner::close);
             contenderCloseThread.start();


### PR DESCRIPTION
## PR Chain

- [ ] *** THIS PR ***
- [ ] https://github.com/apache/flink/pull/24562
- [ ] https://github.com/apache/flink/pull/24568
- [ ] https://github.com/apache/flink/pull/24561

## What is the purpose of the change

It seems like I disabled the test accidentally with FLINK-31783. This PR re-enables the test (and fixes it).

## Brief change log

* Enables test again
* Makes the test wait for the leadership being confirmed by polling the leader information in the HA backend rather than relying on `hasLeadership`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable