### PR TITLE
[FLINK-34706][docs] Deprecates 1.17 docs.

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -27,7 +27,7 @@ pygmentsUseClasses = true
   IsStable = true
 
   # Flag to indicate whether an outdated warning should be shown.
-  ShowOutDatedWarning = false
+  ShowOutDatedWarning = true
 
   # This are the version referenced in the docs. Please only use these variables
   # to reference a specific Flink version, because this is the only place where


### PR DESCRIPTION
Enable `ShowOutDatedWarning` 