### PR TITLE
[FLINK-34706][docs] Add 1.19 to PreviousDocs list.

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -76,6 +76,7 @@ pygmentsUseClasses = true
   ]
 
   PreviousDocs = [
+    ["1.19", "http://nightlies.apache.org/flink/flink-docs-release-1.19"],
     ["1.18", "http://nightlies.apache.org/flink/flink-docs-release-1.18"],
     ["1.17", "http://nightlies.apache.org/flink/flink-docs-release-1.17"],
     ["1.16", "http://nightlies.apache.org/flink/flink-docs-release-1.16"],


### PR DESCRIPTION
Currently 1.19 is not in PreviousDocs list.