### PR TITLE
[FLINK-34716][release] Build 1.19 docs in GitHub Action and mark 1.19 as stable in docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,6 @@ jobs:
           - release-1.19
           - release-1.18
           - release-1.17
-          - release-1.16
     steps:
       - uses: actions/checkout@v3
         with:
@@ -43,8 +42,8 @@ jobs:
           echo "flink_branch=${currentBranch}" >> ${GITHUB_ENV}
 
           if [ "${currentBranch}" = "master" ]; then
-            echo "flink_alias=release-1.19" >> ${GITHUB_ENV}
-          elif [ "${currentBranch}" = "release-1.18" ]; then
+            echo "flink_alias=release-1.20" >> ${GITHUB_ENV}
+          elif [ "${currentBranch}" = "release-1.19" ]; then
             echo "flink_alias=stable" >> ${GITHUB_ENV}
           fi
       - name: Build documentation


### PR DESCRIPTION
Sync the docs build changes with 1.19  https://github.com/apache/flink/pull/24518