### PR TITLE
[FLINK-34902][table] Fix column mismatch IndexOutOfBoundsException

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
@@ -33,7 +33,13 @@ class FlinkCalciteSqlValidatorTest {
     private final PlannerMocks plannerMocks =
             PlannerMocks.create()
                     .registerTemporaryTable(
-                            "t1", Schema.newBuilder().column("a", DataTypes.INT()).build());
+                            "t1", Schema.newBuilder().column("a", DataTypes.INT()).build())
+                    .registerTemporaryTable(
+                            "t2",
+                            Schema.newBuilder()
+                                    .column("a", DataTypes.INT())
+                                    .column("b", DataTypes.INT())
+                                    .build());
 
     @Test
     void testUpsertInto() {
@@ -41,6 +47,20 @@ class FlinkCalciteSqlValidatorTest {
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining(
                         "UPSERT INTO statement is not supported. Please use INSERT INTO instead.");
+    }
+
+    @Test
+    void testInsertInto1() {
+        assertThatThrownBy(() -> plannerMocks.getParser().parse("INSERT INTO t2 (a,b) VALUES(1)"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(" Number of columns must match number of query columns");
+    }
+
+    @Test
+    void testInsertInto2() {
+        assertThatThrownBy(() -> plannerMocks.getParser().parse("INSERT INTO t2 (a,b) SELECT 1"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(" Number of columns must match number of query columns");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Column mismatch validation error should not throw IndexOutOfBoundsException


## Brief change log

  - Check column mismatch for SELECT and VALUES clauses
  -  Add tests


## Verifying this change

`org.apache.flink.table.planner.calcite. FlinkCalciteSqlValidatorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
