### PR TITLE
[FLINK-34913][metrics][state] Fix ConcurrentModificationException in SubTaskInitializationMetricsBuilder.addDurationMetric

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.ReadableConfig;
@@ -122,6 +123,15 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
             randomize(conf, CheckpointingOptions.CLEANER_PARALLEL_MODE, true, false);
             randomize(conf, ExecutionOptions.SNAPSHOT_COMPRESSION, true, false);
         }
+
+        randomize(
+                conf,
+                // This config option is defined in the rocksdb module :(
+                ConfigOptions.key("state.backend.rocksdb.use-ingest-db-restore-mode")
+                        .booleanType()
+                        .noDefaultValue(),
+                true,
+                false);
 
         // randomize ITTests for enabling state change log
         if (!conf.contains(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)) {


### PR DESCRIPTION
## Verifying this change

This change is currently not tested, as the code path is permanently disabled waiting for FRocksDB release. In the future that will be covered by existing ITCases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
