### PR TITLE
[FLINK-33376][coordination] Extend ZooKeeper Curator configurations

### DIFF
--- a/docs/layouts/shortcodes/generated/high_availability_configuration.html
+++ b/docs/layouts/shortcodes/generated/high_availability_configuration.html
@@ -39,6 +39,12 @@
             <td>Defines the ACL (open|creator) to be configured on ZK node. The configuration value can be set to “creator” if the ZooKeeper server configuration has the “authProvider” property mapped to use SASLAuthenticationProvider and the cluster is configured to run in secure mode (Kerberos).</td>
         </tr>
         <tr>
+            <td><h5>high-availability.zookeeper.client.authorization</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Map</td>
+            <td>Add connection authorization Subsequent calls to this method overwrite the prior calls. In certain cases ZooKeeper requires additional Authorization information. For example list of valid names for ensemble in order to prevent accidentally connecting to a wrong ensemble. Each entry of type Map.Entry&lt;String, String&gt; will be transformed into an AuthInfo object with the constructor AuthInfo(String, byte[]). The field entry.key() will serve as the String scheme value, while the field entry.getValue() will be initially converted to a byte[] using the String#getBytes() method with UTF-8 encoding. If not set the default configuration for a Curator would be applied.</td>
+        </tr>
+        <tr>
             <td><h5>high-availability.zookeeper.client.connection-timeout</h5></td>
             <td style="word-wrap: break-word;">15000</td>
             <td>Integer</td>
@@ -49,6 +55,12 @@
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Defines whether Curator should enable ensemble tracker. This can be useful in certain scenarios in which CuratorFramework is accessing to ZK clusters via load balancer or Virtual IPs. Default Curator EnsembleTracking logic watches CuratorEventType.GET_CONFIG events and changes ZooKeeper connection string. It is not desired behaviour when ZooKeeper is running under the Virtual IPs. Under certain configurations EnsembleTracking can lead to setting of ZooKeeper connection string with unresolvable hostnames.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.max-close-wait</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Defines the time Curator should wait during close to join background threads. If not set the default configuration for a Curator would be applied.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.max-retry-attempts</h5></td>
@@ -67,6 +79,12 @@
             <td style="word-wrap: break-word;">60000</td>
             <td>Integer</td>
             <td>Defines the session timeout for the ZooKeeper session in ms.</td>
+        </tr>
+        <tr>
+            <td><h5>high-availability.zookeeper.client.simulated-session-expiration-percent</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The percentage set by this method determines how and if Curator will check for session expiration. See Curator documentation for <a href="https://curator.apache.org/apidocs/org/apache/curator/framework/CuratorFrameworkFactory.Builder.html#simulatedSessionExpirationPercent(int)">simulatedSessionExpirationPercent</a> property for more information.</td>
         </tr>
         <tr>
             <td><h5>high-availability.zookeeper.client.tolerate-suspended-connections</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -22,7 +22,12 @@ import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
+import java.time.Duration;
+import java.util.Map;
+
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.LinkElement.link;
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /** The set of configuration options relating to high-availability settings. */
 public class HighAvailabilityOptions {
@@ -218,6 +223,50 @@ public class HighAvailabilityOptions {
                                                     + "changes ZooKeeper connection string. It is not desired behaviour when ZooKeeper is running under the Virtual IPs. "
                                                     + "Under certain configurations EnsembleTracking can lead to setting of ZooKeeper connection string "
                                                     + "with unresolvable hostnames.")
+                                    .build());
+
+    public static final ConfigOption<Map<String, String>> ZOOKEEPER_CLIENT_AUTHORIZATION =
+            key("high-availability.zookeeper.client.authorization")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Add connection authorization Subsequent calls to this method overwrite the prior calls. "
+                                                    + "In certain cases ZooKeeper requires additional Authorization information. "
+                                                    + "For example list of valid names for ensemble in order to prevent accidentally connecting to a wrong ensemble. "
+                                                    + "Each entry of type Map.Entry<String, String> will be transformed "
+                                                    + "into an AuthInfo object with the constructor AuthInfo(String, byte[]). "
+                                                    + "The field entry.key() will serve as the String scheme value, while the field entry.getValue() "
+                                                    + "will be initially converted to a byte[] using the String#getBytes() method with %s encoding. "
+                                                    + "If not set the default configuration for a Curator would be applied.",
+                                            text(ConfigConstants.DEFAULT_CHARSET.displayName()))
+                                    .build());
+
+    public static final ConfigOption<Duration> ZOOKEEPER_MAX_CLOSE_WAIT =
+            key("high-availability.zookeeper.client.max-close-wait")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines the time Curator should wait during close to join background threads. "
+                                                    + "If not set the default configuration for a Curator would be applied.")
+                                    .build());
+
+    public static final ConfigOption<Integer> ZOOKEEPER_SIMULATED_SESSION_EXP_PERCENT =
+            key("high-availability.zookeeper.client.simulated-session-expiration-percent")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The percentage set by this method determines how and if Curator will check for session expiration. "
+                                                    + "See Curator documentation for %s property for more information.",
+                                            link(
+                                                    "https://curator.apache.org/apidocs/org/apache/curator/framework/"
+                                                            + "CuratorFrameworkFactory.Builder.html#simulatedSessionExpirationPercent(int)",
+                                                    "simulatedSessionExpirationPercent"))
                                     .build());
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR introduces new configuration options for Flink and Curator configurations, such as:
* authorization - option which expose to allow additional AuthInfo records as part of the connect
* maxCloseWaitMs - Ability that would enable the user to adjust to different network speeds.
* simulatedSessionExpirationPercent - Additional checking for Session expiration above what is provided by ZooKeeper.

Such configuration has been proposed as part of [FLIP-402](https://cwiki.apache.org/confluence/display/FLINK/FLIP-402%3A+Extend+ZooKeeper+Curator+configurations).

## Brief change log

* Adds a new configurations into HighAvailabilityOptions
* In case if newly added configs are configured, they are invoking appropriate builder method during Curator connection creation
* If no configuration are passed, no new configurations are being applied

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
The code path is executed in several test scenarios, e.g. ZooKeeperLeaderElectionITCase#testJobExecutionOnClusterWithLeaderChange.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs / JavaDocs
