### PR TITLE
[FLINK-34938] Fix incorrect behaviour for comparison functions

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -38,7 +38,8 @@ import static java.util.Objects.requireNonNull;
  * <p>FLINK modifications are at lines
  *
  * <ol>
- *   <li>Should be removed after fix of FLINK-31350: Lines 541 ~ 553.
+ *   <li>Should be removed after fixing CALCITE-6342: Lines 475-485
+ *   <li>Should be removed after fix of FLINK-31350: Lines 552 ~ 564.
  * </ol>
  */
 public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
@@ -470,9 +471,21 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
                                 resultType, nullCount > 0 || nullableCount > 0);
                     }
                 }
+
+                // FLINK MODIFICATION BEGIN
+                // in case we compare TIME(STAMP) and TIME(STAMP)_LTZ we should adjust the precision
+                // as well
+                if (type.getSqlTypeName().getFamily() == resultType.getSqlTypeName().getFamily()
+                        && type.getSqlTypeName().allowsPrec()
+                        && type.getPrecision() != resultType.getPrecision()) {
+                    final int precision =
+                            SqlTypeUtil.maxPrecision(
+                                    resultType.getPrecision(), type.getPrecision());
+
+                    resultType = createSqlType(type.getSqlTypeName(), precision);
+                }
+                // FLINK MODIFICATION END
             } else {
-                // TODO:  datetime precision details; for now we let
-                // leastRestrictiveByCast handle it
                 return null;
             }
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -37,6 +37,7 @@ import org.apache.flink.table.runtime.typeutils.TypeCheckUtils._
 import org.apache.flink.table.types.logical._
 import org.apache.flink.table.types.logical.LogicalTypeFamily.DATETIME
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldTypes
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging.findCommonType
 import org.apache.flink.table.utils.DateTimeUtils.MILLIS_PER_DAY
@@ -463,11 +464,7 @@ object ScalarOperatorGens {
       generateEqualAndNonEqual(
         ctx,
         newLeft,
-        if (newRight.literal) {
-          generateCastLiteral(ctx, newRight, newLeft.resultType)
-        } else {
-          generateCast(ctx, newRight, newLeft.resultType, nullOnFailure = true)
-        },
+        generateCastOrCastLiteral(ctx, newRight, newLeft.resultType),
         operator,
         resultType
       )
@@ -546,6 +543,36 @@ object ScalarOperatorGens {
       left: GeneratedExpression,
       right: GeneratedExpression,
       resultType: LogicalType): GeneratedExpression = {
+    // we compare TIMESTAMP with TIMESTAMP_LTZ, we don't care which type is which, we just need
+    // to cast to the type with the higher precision
+    if (
+      left.resultType.is(LogicalTypeFamily.TIMESTAMP)
+      && right.resultType.is(LogicalTypeFamily.TIMESTAMP)
+      && left.resultType.getTypeRoot != right.resultType.getTypeRoot
+    ) {
+      val (newLeft, newRight) =
+        if (
+          LogicalTypeChecks.getPrecision(left.resultType) > LogicalTypeChecks.getPrecision(
+            right.resultType)
+        ) {
+          (left, generateCastOrCastLiteral(ctx, right, left.resultType))
+        } else {
+          (generateCastOrCastLiteral(ctx, left, right.resultType), right)
+        }
+
+      generateComparisonSameType(ctx, operator, newLeft, newRight, resultType)
+    } else {
+      generateComparisonSameType(ctx, operator, left, right, resultType)
+    }
+  }
+
+  /** Generates comparison code for numeric types and comparable types of same type. */
+  private def generateComparisonSameType(
+      ctx: CodeGeneratorContext,
+      operator: String,
+      left: GeneratedExpression,
+      right: GeneratedExpression,
+      resultType: LogicalType): GeneratedExpression = {
     generateOperatorIfNotNull(ctx, resultType, left, right) {
       // either side is decimal
       if (isDecimal(left.resultType) || isDecimal(right.resultType)) {
@@ -559,10 +586,15 @@ object ScalarOperatorGens {
         (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm"
       }
 
-      // both sides are timestamp family (timestamp or timestamp_ltz)
+      // both sides are timestamp
+      else if (isTimestamp(left.resultType) && isTimestamp(right.resultType)) {
+        (leftTerm, rightTerm) => s"$leftTerm.compareTo($rightTerm) $operator 0"
+      }
+
+      // both sides are timestamp with local zone
       else if (
-        left.resultType.is(LogicalTypeFamily.TIMESTAMP) && right.resultType.is(
-          LogicalTypeFamily.TIMESTAMP)
+        isTimestampWithLocalZone(left.resultType) &&
+        isTimestampWithLocalZone(right.resultType)
       ) { (leftTerm, rightTerm) => s"$leftTerm.compareTo($rightTerm) $operator 0" }
 
       // both sides are temporal of same type
@@ -855,6 +887,17 @@ object ScalarOperatorGens {
           throw new CodeGenException(s"Unsupported reinterpret from '$from' to '$to'.")
         }
     }
+
+  private def generateCastOrCastLiteral(
+      ctx: CodeGeneratorContext,
+      expr: GeneratedExpression,
+      targetType: LogicalType): GeneratedExpression = {
+    if (expr.literal) {
+      generateCastLiteral(ctx, expr, targetType)
+    } else {
+      generateCast(ctx, expr, targetType, nullOnFailure = true)
+    }
+  }
 
   def generateCast(
       ctx: CodeGeneratorContext,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -384,6 +384,13 @@ object ScalarOperatorGens {
     else if (isNumeric(left.resultType) && isNumeric(right.resultType)) {
       generateComparison(ctx, operator, left, right, resultType)
     }
+    // both sides are timestamp family (timestamp or timestamp_ltz)
+    else if (
+      left.resultType.is(LogicalTypeFamily.TIMESTAMP) && right.resultType.is(
+        LogicalTypeFamily.TIMESTAMP)
+    ) {
+      generateComparison(ctx, operator, left, right, resultType)
+    }
     // array types
     else if (isArray(left.resultType) && canEqual) {
       wrapExpressionIfNonEq(
@@ -552,15 +559,10 @@ object ScalarOperatorGens {
         (leftTerm, rightTerm) => s"$leftTerm $operator $rightTerm"
       }
 
-      // both sides are timestamp
-      else if (isTimestamp(left.resultType) && isTimestamp(right.resultType)) {
-        (leftTerm, rightTerm) => s"$leftTerm.compareTo($rightTerm) $operator 0"
-      }
-
-      // both sides are timestamp with local zone
+      // both sides are timestamp family (timestamp or timestamp_ltz)
       else if (
-        isTimestampWithLocalZone(left.resultType) &&
-        isTimestampWithLocalZone(right.resultType)
+        left.resultType.is(LogicalTypeFamily.TIMESTAMP) && right.resultType.is(
+          LogicalTypeFamily.TIMESTAMP)
       ) { (leftTerm, rightTerm) => s"$leftTerm.compareTo($rightTerm) $operator 0" }
 
       // both sides are temporal of same type

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ComparisonFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ComparisonFunctionITCase.java
@@ -42,7 +42,7 @@ public class ComparisonFunctionITCase extends BuiltInFunctionTestBase {
     Configuration getConfiguration() {
         final Configuration config = new Configuration();
         // make the LTZ stable across all environments
-        config.set(TableConfigOptions.LOCAL_TIME_ZONE, "UTC");
+        config.set(TableConfigOptions.LOCAL_TIME_ZONE, "GMT-08:00");
         return config;
     }
 
@@ -50,7 +50,7 @@ public class ComparisonFunctionITCase extends BuiltInFunctionTestBase {
     Stream<TestSetSpec> getTestSetSpecs() {
         final Instant ltz3 = Instant.ofEpochMilli(1_123);
         final Instant ltz0 = Instant.ofEpochMilli(1_000);
-        final LocalDateTime tmstmp3 = ltz3.atOffset(ZoneOffset.UTC).toLocalDateTime();
+        final LocalDateTime tmstmp3 = ltz3.atOffset(ZoneOffset.ofHours(-8)).toLocalDateTime();
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.EQUALS)
                         .onFieldsWithData(ltz3, ltz0, tmstmp3)
@@ -89,5 +89,5 @@ public class ComparisonFunctionITCase extends BuiltInFunctionTestBase {
                         // compare different types, same precision
                         .testResult($("f0").isLess($("f2")), "f0 < f2", false, DataTypes.BOOLEAN())
                         .testResult($("f2").isLess($("f0")), "f2 < f0", true, DataTypes.BOOLEAN()));
-    };
+    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ComparisonFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ComparisonFunctionITCase.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.DataTypes.TIMESTAMP;
+import static org.apache.flink.table.api.DataTypes.TIMESTAMP_LTZ;
+import static org.apache.flink.table.api.Expressions.$;
+
+/**
+ * Tests for comparison functions such as {@link BuiltInFunctionDefinitions#EQUALS}, {@link
+ * BuiltInFunctionDefinitions#GREATER_THAN} etc.
+ */
+public class ComparisonFunctionITCase extends BuiltInFunctionTestBase {
+
+    @Override
+    Configuration getConfiguration() {
+        final Configuration config = new Configuration();
+        // make the LTZ stable across all environments
+        config.set(TableConfigOptions.LOCAL_TIME_ZONE, "UTC");
+        return config;
+    }
+
+    @Override
+    Stream<TestSetSpec> getTestSetSpecs() {
+        final Instant ltz3 = Instant.ofEpochMilli(1_123);
+        final Instant ltz0 = Instant.ofEpochMilli(1_000);
+        final LocalDateTime tmstmp3 = ltz3.atOffset(ZoneOffset.UTC).toLocalDateTime();
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.EQUALS)
+                        .onFieldsWithData(ltz3, ltz0, tmstmp3)
+                        .andDataTypes(TIMESTAMP_LTZ(3), TIMESTAMP_LTZ(0), TIMESTAMP(3))
+                        // compare same type, but different precision, should always adjust to the
+                        // higher precision
+                        .testResult($("f0").isEqual($("f1")), "f0 = f1", false, DataTypes.BOOLEAN())
+                        .testResult($("f1").isEqual($("f0")), "f1 = f0", false, DataTypes.BOOLEAN())
+                        // compare different types
+                        .testResult($("f0").isEqual($("f2")), "f0 = f2", true, DataTypes.BOOLEAN())
+                        .testResult($("f2").isEqual($("f0")), "f2 = f0", true, DataTypes.BOOLEAN())
+                        // compare different type and different precision, should always adjust to
+                        // the higher precision
+                        .testResult($("f1").isEqual($("f2")), "f1 = f2", false, DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f2").isEqual($("f1")), "f2 = f1", false, DataTypes.BOOLEAN()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.GREATER_THAN)
+                        .onFieldsWithData(ltz3, ltz0, tmstmp3.minusSeconds(1))
+                        .andDataTypes(TIMESTAMP_LTZ(3), TIMESTAMP_LTZ(0), TIMESTAMP(3))
+                        // compare same type, but different precision
+                        .testResult(
+                                $("f0").isGreater($("f1")), "f0 > f1", true, DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f1").isGreater($("f0")), "f1 > f0", false, DataTypes.BOOLEAN())
+                        // compare different types, same precision
+                        .testResult(
+                                $("f0").isGreater($("f2")), "f0 > f2", true, DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f2").isGreater($("f0")), "f2 > f0", false, DataTypes.BOOLEAN()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.LESS_THAN)
+                        .onFieldsWithData(ltz3, ltz0, tmstmp3.minusSeconds(1))
+                        .andDataTypes(TIMESTAMP_LTZ(3), TIMESTAMP_LTZ(0), TIMESTAMP(3))
+                        // compare same type, but different precision
+                        .testResult($("f0").isLess($("f1")), "f0 < f1", false, DataTypes.BOOLEAN())
+                        .testResult($("f1").isLess($("f0")), "f1 < f0", true, DataTypes.BOOLEAN())
+                        // compare different types, same precision
+                        .testResult($("f0").isLess($("f2")), "f0 < f2", false, DataTypes.BOOLEAN())
+                        .testResult($("f2").isLess($("f0")), "f2 < f0", true, DataTypes.BOOLEAN()));
+    };
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes how SQL comparison functions work for TIMESTAMP types.

## Verifying this change

Added tests in `ComparisonFunctionsITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
