### PR TITLE
[FLINK-34939][test] Hardens TestingLeaderElection

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderContender.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderContender.java
@@ -22,7 +22,13 @@ import java.util.UUID;
 
 /**
  * Interface which has to be implemented to take part in the leader election process of the {@link
- * LeaderElectionService}.
+ * LeaderElection}.
+ *
+ * <p>The event handling methods for granting and revoking leadership are meant to be called in an
+ * alternating fashion, i.e. no two leadership grants or revocation events can happen after each
+ * other. Two subsequent events of the same type would indicate that the current instance missed a
+ * state change of the HA backend resulting in an invalid state of the overall deployment
+ * (split-brain scenario possible).
  */
 public interface LeaderContender {
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
@@ -333,6 +333,7 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
         secondDispatcher.start();
 
         toTerminate.add(secondDispatcher);
+        leaderElection.notLeader();
         leaderElection.isLeader(UUID.randomUUID());
 
         CommonTestUtils.waitUntilCondition(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerTest.java
@@ -172,6 +172,7 @@ public class DefaultDispatcherRunnerTest extends TestLogger {
 
             assertFalse(dispatcherShutDownFuture.isDone());
 
+            leaderElection.notLeader();
             leaderElection.isLeader(secondLeaderSessionId);
 
             final ApplicationStatus finalApplicationStatus = ApplicationStatus.UNKNOWN;
@@ -231,6 +232,7 @@ public class DefaultDispatcherRunnerTest extends TestLogger {
 
             assertThat(firstTestingDispatcherLeaderProcess.isStarted(), is(true));
 
+            leaderElection.notLeader();
             leaderElection.isLeader(secondLeaderSessionId);
 
             assertThat(secondTestingDispatcherLeaderProcess.isStarted(), is(false));
@@ -315,8 +317,13 @@ public class DefaultDispatcherRunnerTest extends TestLogger {
 
         try {
             leaderElection.isLeader(firstLeaderSession);
+            leaderElection.notLeader();
+
             leaderElection.isLeader(secondLeaderSession);
+            leaderElection.notLeader();
+
             leaderElection.isLeader(thirdLeaderSession);
+            leaderElection.notLeader();
 
             firstDispatcherLeaderProcessTerminationFuture.complete(null);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -565,14 +565,13 @@ class JobMasterServiceLeadershipRunnerTest {
 
         jobManagerRunner.start();
 
-        final CompletableFuture<LeaderInformation> leaderFuture =
-                leaderElection.isLeader(UUID.randomUUID());
-
+        final UUID leaderSessionID = UUID.randomUUID();
+        leaderElection.isLeader(leaderSessionID);
         leaderElection.notLeader();
 
         leaderAddressFuture.complete("foobar");
 
-        assertThatFuture(leaderFuture).willNotCompleteWithin(Duration.ofMillis(5));
+        assertThat(leaderElection.hasLeadership(leaderSessionID)).isFalse();
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -499,11 +499,33 @@ class JobMasterServiceLeadershipRunnerTest {
 
         leaderElection.notLeader();
 
+        assertThat(jobManagerRunner.getResultFuture())
+                .as("The runner result should not be completed by the leadership revocation.")
+                .isNotDone();
+
         resultFuture.complete(
                 JobManagerRunnerResult.forSuccess(
                         createFailedExecutionGraphInfo(new FlinkException("test exception"))));
 
-        assertThatFuture(jobManagerRunner.getResultFuture()).eventuallyFails();
+        assertThat(jobManagerRunner.getResultFuture())
+                .as("The runner result should be completed if the leadership is lost.")
+                .isNotDone();
+
+        jobManagerRunner.closeAsync().get();
+
+        assertThatFuture(jobManagerRunner.getResultFuture())
+                .eventuallySucceeds()
+                .as(
+                        "The runner result should be completed with a SUSPENDED job status if the job didn't finish, yet.")
+                .satisfies(
+                        result -> {
+                            assertThat(result.isSuccess()).isTrue();
+                            assertThat(
+                                            result.getExecutionGraphInfo()
+                                                    .getArchivedExecutionGraph()
+                                                    .getState())
+                                    .isEqualTo(JobStatus.SUSPENDED);
+                        });
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunnerTest.java
@@ -45,18 +45,19 @@ import org.apache.flink.runtime.leaderelection.TestingLeaderElectionDriver;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.TestingJobResultStore;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.SupplierWithException;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
@@ -676,25 +677,24 @@ class JobMasterServiceLeadershipRunnerTest {
         }
     }
 
-    @Disabled
     @Test
     void testJobMasterServiceLeadershipRunnerCloseWhenElectionServiceGrantLeaderShip()
             throws Exception {
         final AtomicReference<LeaderInformationRegister> storedLeaderInformation =
                 new AtomicReference<>(LeaderInformationRegister.empty());
+        final AtomicBoolean haBackendLeadershipFlag = new AtomicBoolean();
 
         final TestingLeaderElectionDriver.Factory driverFactory =
                 new TestingLeaderElectionDriver.Factory(
                         TestingLeaderElectionDriver.newBuilder(
-                                new AtomicBoolean(), storedLeaderInformation, new AtomicBoolean()));
+                                haBackendLeadershipFlag,
+                                storedLeaderInformation,
+                                new AtomicBoolean()));
 
         // we need to use DefaultLeaderElectionService here because JobMasterServiceLeadershipRunner
         // in connection with the DefaultLeaderElectionService generates the nested locking
         final DefaultLeaderElectionService defaultLeaderElectionService =
                 new DefaultLeaderElectionService(driverFactory, fatalErrorHandler);
-
-        final TestingLeaderElectionDriver currentLeaderDriver =
-                driverFactory.assertAndGetOnlyCreatedDriver();
 
         // latch to detect when we reached the first synchronized section having a lock on the
         // JobMasterServiceProcess#stop side
@@ -733,6 +733,7 @@ class JobMasterServiceLeadershipRunnerTest {
                                                         // before calling stop on the
                                                         // DefaultLeaderElectionService
                                                         triggerClassLoaderLeaseRelease.await();
+
                                                         // In order to reproduce the deadlock, we
                                                         // need to ensure that
                                                         // leaderContender#grantLeadership can be
@@ -770,13 +771,19 @@ class JobMasterServiceLeadershipRunnerTest {
             jobManagerRunner.start();
 
             // grant leadership to create jobMasterServiceProcess
+            haBackendLeadershipFlag.set(true);
             final UUID leaderSessionID = UUID.randomUUID();
             defaultLeaderElectionService.onGrantLeadership(leaderSessionID);
 
-            while (!currentLeaderDriver.hasLeadership()
-                    || !leaderElection.hasLeadership(leaderSessionID)) {
-                Thread.sleep(100);
-            }
+            final SupplierWithException<Boolean, Exception> confirmationForSessionIdReceived =
+                    () ->
+                            storedLeaderInformation
+                                    .get()
+                                    .forComponentId(componentId)
+                                    .map(LeaderInformation::getLeaderSessionID)
+                                    .map(sessionId -> sessionId.equals(leaderSessionID))
+                                    .orElse(false);
+            CommonTestUtils.waitUntilCondition(confirmationForSessionIdReceived);
 
             final CheckedThread contenderCloseThread = createCheckedThread(jobManagerRunner::close);
             contenderCloseThread.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobMasterServiceProcess.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingJobMasterServiceProcess.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmaster;
 
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
+import org.apache.flink.util.concurrent.FutureUtils;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -87,7 +88,8 @@ public class TestingJobMasterServiceProcess implements JobMasterServiceProcess {
     public static final class Builder {
 
         private UUID leaderSessionId = UUID.randomUUID();
-        private Supplier<CompletableFuture<Void>> closeAsyncSupplier = unsupportedOperation();
+        private Supplier<CompletableFuture<Void>> closeAsyncSupplier =
+                FutureUtils::completedVoidFuture;
         private Supplier<Boolean> isInitializedAndRunningSupplier = unsupportedOperation();
         private Supplier<CompletableFuture<JobMasterGateway>> getJobMasterGatewayFutureSupplier =
                 () ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImplTest.java
@@ -182,6 +182,9 @@ class ResourceManagerServiceImplTest {
 
     @Test
     void grantLeadership_withExistingLeader_stopExistLeader() throws Exception {
+        leaderElection = TestingLeaderElection.createWithLeadershipConsistencyChecksDisabled();
+        haService.setResourceManagerLeaderElection(leaderElection);
+
         final UUID leaderSessionId1 = UUID.randomUUID();
         final UUID leaderSessionId2 = UUID.randomUUID();
         final CompletableFuture<UUID> startRmFuture1 = new CompletableFuture<>();
@@ -238,6 +241,7 @@ class ResourceManagerServiceImplTest {
 
         // first time grant leadership
         leaderElection.isLeader(leaderSessionId1).join();
+        leaderElection.notLeader();
 
         // second time grant leadership
         final CompletableFuture<LeaderInformation> confirmedLeaderInformation =


### PR DESCRIPTION
## PR Chain

- [ ] https://github.com/apache/flink/pull/24546
- [ ] https://github.com/apache/flink/pull/24562
- [ ] *** THIS PR ***
- [ ] https://github.com/apache/flink/pull/24561

## What is the purpose of the change

Hardens `TestingLeaderElection` to comply to the `LeaderContender` contract

## Brief change log

* Notifying the contender of the leadership revocation should only happen if the leadership was actually confirmed
* Revoking leadership in the `TestLeaderElection` should also reset the `confirmedLeaderInformation`
* Added Preconditions to check for the right order of grant and revoke events
* Updated the `LeaderContender` JavaDoc

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable