### PR TITLE
[BP-1.19][FLINK-26515][tests] Fix RetryingExecutorTest

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/RetryingExecutorTest.java
@@ -219,7 +219,7 @@ class RetryingExecutorTest {
                 Executors.newScheduledThreadPool(2));
         /* future completion can be delayed arbitrarily causing start delta be less than timeout */
         assertThat(((double) secondStart.get() - firstStart.get()) / 1_000_000)
-                .isCloseTo(timeout, Percentage.withPercentage(75));
+                .isGreaterThanOrEqualTo(timeout * .75);
     }
 
     private void testPolicy(


### PR DESCRIPTION
backport of https://github.com/apache/flink/pull/24569 to 1.19