### PR TITLE
[FLINK-34956][doc] Fix the config type wrong of Duration

### DIFF
--- a/docs/layouts/shortcodes/config_file.html
+++ b/docs/layouts/shortcodes/config_file.html
@@ -115,7 +115,7 @@ under the License.
         <td>Regular expression: <code>[0-9]+ (b | kb | kibibytes | m | mb | mebibytes | g | gb | gibibytes | t | tb | tebibytes)?</code><br><br>Example: <code>100 mb</code></td>
     </tr>
     <tr>
-        <td><h5>Boolean</h5></td>
+        <td><h5>Duration</h5></td>
         <td>Regular expression: <code>[0-9]+ (d | day | h | hour | m | min | minute | s | sec | second | ms | milli | millisecond | us | micro | microsecond | ns | nano | nanosecond)?</code><br><br>Example: <code>10 s</code></td>
     </tr>
     <tr>

--- a/docs/layouts/shortcodes/config_file_zh.html
+++ b/docs/layouts/shortcodes/config_file_zh.html
@@ -115,7 +115,7 @@ under the License.
             <td>正则表达式：<code>[0-9]+ (b | kb | kibibytes | m | mb | mebibytes | g | gb | gibibytes | t | tb | tebibytes)?</code><br><br>示例：<code>100 mb</code></td>
         </tr>
         <tr>
-            <td><h5>Boolean</h5></td>
+            <td><h5>Duration</h5></td>
             <td>正则表达式：<code>[0-9]+ (d | day | h | hour | m | min | minute | s | sec | second | ms | milli | millisecond | us | micro | microsecond | ns | nano | nanosecond)?</code><br><br>示例：<code>10 s</code></td>
         </tr>
         <tr>


### PR DESCRIPTION
## What is the purpose of the change

The Config type is Boolean, but it should be Duration.

https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/config/

![image](https://github.com/apache/flink/assets/38427477/f1156c3e-e3e2-4d36-88a0-ed2976a598f6)


## Brief change log

- [FLINK-34956][doc] Fix the config type wrong of Duration