### PR TITLE
[FLINK-34661][runtime] TaskExecutor supports retain partitions after JM crashed.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -972,7 +972,8 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
                                 allFutures.add(
                                         taskManager
                                                 .getTaskExecutorGateway()
-                                                .getPartitionWithMetrics(jobGraph.getJobID())));
+                                                .getAndRetainPartitionWithMetrics(
+                                                        jobGraph.getJobID())));
         return FutureUtils.combineAll(allFutures)
                 .thenApply(
                         partitions ->

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleServiceOptions.java
@@ -25,6 +25,9 @@ import org.apache.flink.configuration.ConfigOptions;
 @SuppressWarnings("WeakerAccess")
 public class ShuffleServiceOptions {
 
+    public static final String NETTY_SHUFFLE_SERVICE_FACTORY_CLASS =
+            "org.apache.flink.runtime.io.network.NettyShuffleServiceFactory";
+
     private ShuffleServiceOptions() {}
 
     /**
@@ -33,7 +36,7 @@ public class ShuffleServiceOptions {
     public static final ConfigOption<String> SHUFFLE_SERVICE_FACTORY_CLASS =
             ConfigOptions.key("shuffle-service-factory.class")
                     .stringType()
-                    .defaultValue("org.apache.flink.runtime.io.network.NettyShuffleServiceFactory")
+                    .defaultValue(NETTY_SHUFFLE_SERVICE_FACTORY_CLASS)
                     .withDescription(
                             "The full class name of the shuffle service factory implementation to be used by the cluster. "
                                     + "The default implementation uses Netty for network communication and local memory as well disk space "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.management.jmx.JMXService;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
@@ -189,6 +190,8 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.runtime.shuffle.ShuffleServiceOptions.NETTY_SHUFFLE_SERVICE_FACTORY_CLASS;
+import static org.apache.flink.runtime.shuffle.ShuffleServiceOptions.SHUFFLE_SERVICE_FACTORY_CLASS;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -313,6 +316,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
     private final ProfilingService profilingService;
 
+    private final Set<JobID> jobPartitionToCleanupSet = new HashSet<>();
+
     public TaskExecutor(
             RpcService rpcService,
             TaskManagerConfiguration taskManagerConfiguration,
@@ -407,6 +412,16 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                     HeartbeatServices heartbeatServices, ResourceID resourceId) {
         return heartbeatServices.createHeartbeatManager(
                 resourceId, new JobManagerHeartbeatListener(), getMainThreadExecutor(), log);
+    }
+
+    private boolean shouldRetainPartitionsOnJobManagerConnectionLost() {
+        return taskManagerConfiguration
+                        .getConfiguration()
+                        .get(BatchExecutionOptions.JOB_RECOVERY_ENABLED)
+                && taskManagerConfiguration
+                        .getConfiguration()
+                        .get(SHUFFLE_SERVICE_FACTORY_CLASS)
+                        .equals(NETTY_SHUFFLE_SERVICE_FACTORY_CLASS);
     }
 
     @Override
@@ -1365,15 +1380,15 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                     .ifPresent(
                             jobManagerConnection ->
                                     disconnectAndTryReconnectToJobManager(
-                                            jobManagerConnection, cause));
+                                            jobManagerConnection, cause, true));
         }
     }
 
     private void disconnectAndTryReconnectToJobManager(
-            JobTable.Connection jobManagerConnection, Exception cause) {
+            JobTable.Connection jobManagerConnection, Exception cause, boolean releasePartitions) {
         try (MdcCloseable ignored =
                 MdcUtils.withContext(MdcUtils.asContextData(jobManagerConnection.getJobId()))) {
-            disconnectJobManagerConnection(jobManagerConnection, cause);
+            disconnectJobManagerConnection(jobManagerConnection, cause, releasePartitions);
             jobLeaderService.reconnect(jobManagerConnection.getJobId());
         }
     }
@@ -1449,8 +1464,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     }
 
     @Override
-    public CompletableFuture<Collection<PartitionWithMetrics>> getPartitionWithMetrics(
+    public CompletableFuture<Collection<PartitionWithMetrics>> getAndRetainPartitionWithMetrics(
             JobID jobId) {
+        jobPartitionToCleanupSet.remove(jobId);
+
         Collection<TaskExecutorPartitionInfo> partitionInfoList =
                 partitionTracker.getTrackedPartitionsFor(jobId);
         List<PartitionWithMetrics> partitionWithMetrics = new ArrayList<>();
@@ -1825,7 +1842,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             } else {
                 disconnectJobManagerConnection(
                         oldJobManagerConnection,
-                        new Exception("Found new job leader for job id " + jobId + '.'));
+                        new Exception("Found new job leader for job id " + jobId + '.'),
+                        true);
             }
         }
 
@@ -1847,14 +1865,16 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         job.asConnection()
                 .ifPresent(
                         jobManagerConnection ->
-                                disconnectJobManagerConnection(jobManagerConnection, cause));
+                                disconnectJobManagerConnection(jobManagerConnection, cause, true));
 
         job.close();
     }
 
     private void disconnectJobManagerConnection(
-            JobTable.Connection jobManagerConnection, Exception cause) {
+            JobTable.Connection jobManagerConnection, Exception cause, boolean releasePartitions) {
         final JobID jobId = jobManagerConnection.getJobId();
+        jobPartitionToCleanupSet.add(jobId);
+
         log.info(
                 "Close JobManager connection for job {}.",
                 jobId,
@@ -1889,6 +1909,35 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             } catch (SlotNotFoundException e) {
                 log.debug("Could not mark the slot {} inactive.", activeSlotAllocationID, e);
             }
+        }
+
+        if (!releasePartitions) {
+            // this branch is for job recovery from master failures
+            final Duration maxRegistrationDuration =
+                    taskManagerConfiguration.getMaxRegistrationDuration();
+
+            if (maxRegistrationDuration != null) {
+                log.info(
+                        "Waiting for {} mills for job {} to recover. If the job manager is not reconnected, "
+                                + "the job's partitions will be cleaned up.",
+                        maxRegistrationDuration.toMillis(),
+                        jobId);
+                scheduleRunAsync(
+                        () -> {
+                            // If the job is not recovery after wait for a period of time, we will
+                            // clean up the partitions
+                            Optional<JobTable.Job> job = jobTable.getJob(jobId);
+                            if (!job.isPresent()
+                                    || !job.get().isConnected()
+                                    || jobPartitionToCleanupSet.contains(jobId)) {
+                                scheduleResultPartitionCleanup(jobId);
+                            }
+                        },
+                        maxRegistrationDuration);
+            }
+        } else {
+            // cleanup remaining partitions once all tasks for this job have completed
+            scheduleResultPartitionCleanup(jobId);
         }
 
         // 3. Disassociate from the JobManager
@@ -1934,9 +1983,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         checkNotNull(jobManagerConnection);
 
         final JobID jobId = jobManagerConnection.getJobId();
-
-        // cleanup remaining partitions once all tasks for this job have completed
-        scheduleResultPartitionCleanup(jobId);
 
         final KvStateRegistry kvStateRegistry = kvStateService.getKvStateRegistry();
 
@@ -2009,6 +2055,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                     .thenRunAsync(
                             () -> {
                                 partitionTracker.stopTrackingAndReleaseJobPartitionsFor(jobId);
+                                jobPartitionToCleanupSet.remove(jobId);
                             },
                             getMainThreadExecutor());
         }
@@ -2488,7 +2535,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                                                             new Exception(
                                                                     "Job leader for job id "
                                                                             + jobId
-                                                                            + " lost leadership."))));
+                                                                            + " lost leadership."),
+                                                            !shouldRetainPartitionsOnJobManagerConnectionLost())));
         }
 
         @Override
@@ -2659,7 +2707,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                     .ifPresent(
                             jobManagerConnection ->
                                     disconnectAndTryReconnectToJobManager(
-                                            jobManagerConnection, cause));
+                                            jobManagerConnection,
+                                            cause,
+                                            !shouldRetainPartitionsOnJobManagerConnectionLost()));
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -318,13 +318,13 @@ public interface TaskExecutorGateway
             ResourceManagerId resourceManagerId, byte[] tokens);
 
     /**
-     * Get all partitions and their metrics located on this task executor, the metrics mainly
-     * includes the meta information of partition(partition bytes, etc).
+     * Get and retain all partitions and their metrics located on this task executor, the metrics
+     * mainly includes the meta information of partition(partition bytes, etc).
      *
      * @param jobId ID of the target job
      * @return All partitions belong to the target job and their metrics
      */
-    default CompletableFuture<Collection<PartitionWithMetrics>> getPartitionWithMetrics(
+    default CompletableFuture<Collection<PartitionWithMetrics>> getAndRetainPartitionWithMetrics(
             JobID jobId) {
         throw new UnsupportedOperationException();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -20,7 +20,9 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.NoOpTaskExecutorBlobService;
@@ -33,7 +35,7 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
-import org.apache.flink.runtime.heartbeat.HeartbeatServicesImpl;
+import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
@@ -87,6 +89,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -96,8 +99,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
 
+import static org.apache.flink.configuration.TaskManagerOptions.SLOT_TIMEOUT;
 import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -116,6 +121,20 @@ class TaskExecutorPartitionLifecycleTest {
             new SettableLeaderRetrievalService();
     private final JobID jobId = new JobID();
 
+    private Configuration configuration;
+
+    private TestingHeartbeatServices heartbeatServices;
+
+    private ResourceID jmResourceId;
+
+    private Duration duration = Duration.ofSeconds(15);
+
+    private Duration longDuration = Duration.ofSeconds(30);
+
+    private CompletableFuture<Void> disconnectTaskManagerFuture;
+
+    private final String jobMasterAddress = "jm";
+
     @TempDir private Path tempDir;
 
     @RegisterExtension
@@ -126,6 +145,10 @@ class TaskExecutorPartitionLifecycleTest {
     void setup() {
         haServices.setResourceManagerLeaderRetriever(resourceManagerLeaderRetriever);
         haServices.setJobMasterLeaderRetriever(jobId, jobManagerLeaderRetriever);
+        configuration = new Configuration();
+        heartbeatServices = new TestingHeartbeatServices(50000L, 50000L);
+        jmResourceId = ResourceID.generate();
+        disconnectTaskManagerFuture = new CompletableFuture<>();
     }
 
     @AfterEach
@@ -321,6 +344,75 @@ class TaskExecutorPartitionLifecycleTest {
     }
 
     @Test
+    void testEnableBatchJobRecoveryAndNotRetainPartitions() throws Exception {
+        testJMCrashedAndPossibleRetainPartitions(
+                false,
+                true,
+                // the release action will delay
+                releasePartitionsForJobFuture ->
+                        assertThatFuture(releasePartitionsForJobFuture)
+                                .willNotCompleteWithin(duration)
+                                .eventuallySucceeds()
+                                .isEqualTo(jobId));
+    }
+
+    @Test
+    void testEnableBatchJobRecoveryAndRetainPartitions() throws Exception {
+        testJMCrashedAndPossibleRetainPartitions(
+                true,
+                true,
+                // will not trigger release
+                releasePartitionsForJobFuture ->
+                        assertThatFuture(releasePartitionsForJobFuture)
+                                .willNotCompleteWithin(longDuration));
+    }
+
+    @Test
+    void testDisableBatchJobRecoveryAndReleasePartitions() throws Exception {
+        Consumer<CompletableFuture<JobID>> verifyAction =
+                releasePartitionsForJobFuture ->
+                        assertThatFuture(releasePartitionsForJobFuture)
+                                .succeedsWithin(duration)
+                                .isEqualTo(jobId);
+
+        // the release action will complete intermediately although enable retain partition
+        testJMCrashedAndPossibleRetainPartitions(true, false, verifyAction);
+    }
+
+    private void testJMCrashedAndPossibleRetainPartitions(
+            boolean enableRetainPartitions,
+            boolean enableBatchJobRecovery,
+            Consumer<CompletableFuture<JobID>> verifyAction)
+            throws Exception {
+        configuration.set(BatchExecutionOptions.JOB_RECOVERY_ENABLED, enableBatchJobRecovery);
+        configuration.set(TaskManagerOptions.REGISTRATION_TIMEOUT, duration);
+        // the slot time out will try to release partition again, and we should avoid it
+        configuration.set(SLOT_TIMEOUT, Duration.ofMinutes(5));
+
+        final CompletableFuture<JobID> releasePartitionsForJobFuture = new CompletableFuture<>();
+
+        testPartitionRelease(
+                partitionTracker ->
+                        partitionTracker.setStopTrackingAndReleaseAllPartitionsConsumer(
+                                releasePartitionsForJobFuture::complete),
+                (jobId, resultPartitionDeploymentDescriptor, taskExecutor, taskExecutorGateway) -> {
+                    jobManagerLeaderRetriever.notifyListener(null, UUID.randomUUID());
+
+                    // wait trigger JM disconnect TM which means TM is waiting for JM to retain
+                    // partitions
+                    disconnectTaskManagerFuture.get();
+
+                    jobManagerLeaderRetriever.notifyListener(jobMasterAddress, UUID.randomUUID());
+
+                    if (enableRetainPartitions) {
+                        taskExecutor.getAndRetainPartitionWithMetrics(jobId);
+                    }
+
+                    verifyAction.accept(releasePartitionsForJobFuture);
+                });
+    }
+
+    @Test
     void testBlockingLocalPartitionReleaseDoesNotBlockTaskExecutor() throws Exception {
         BlockerSync sync = new BlockerSync();
         ResultPartitionManager blockingResultPartitionManager =
@@ -446,7 +538,7 @@ class TaskExecutorPartitionLifecycleTest {
                         .setRegisterTaskManagerFunction(
                                 (ignoredJobId, ignoredTaskManagerRegistrationInformation) ->
                                         CompletableFuture.completedFuture(
-                                                new JMTMRegistrationSuccess(ResourceID.generate())))
+                                                new JMTMRegistrationSuccess(jmResourceId)))
                         .setOfferSlotsFunction(
                                 (resourceID, slotOffers) -> {
                                     slotOfferedLatch.trigger();
@@ -458,6 +550,11 @@ class TaskExecutorPartitionLifecycleTest {
                                             == ExecutionState.FINISHED) {
                                         taskFinishedFuture.complete(null);
                                     }
+                                    return CompletableFuture.completedFuture(Acknowledge.get());
+                                })
+                        .setDisconnectTaskManagerFunction(
+                                ignored -> {
+                                    disconnectTaskManagerFuture.complete(null);
                                     return CompletableFuture.completedFuture(Acknowledge.get());
                                 })
                         .build();
@@ -490,7 +587,6 @@ class TaskExecutorPartitionLifecycleTest {
             final TaskExecutorGateway taskExecutorGateway =
                     taskExecutor.getSelfGateway(TaskExecutorGateway.class);
 
-            final String jobMasterAddress = "jm";
             rpc.registerGateway(jobMasterAddress, jobMasterGateway);
             rpc.registerGateway(
                     testingResourceManagerGateway.getAddress(), testingResourceManagerGateway);
@@ -584,7 +680,6 @@ class TaskExecutorPartitionLifecycleTest {
     private TestingTaskExecutor createTestingTaskExecutor(
             TaskManagerServices taskManagerServices, TaskExecutorPartitionTracker partitionTracker)
             throws IOException {
-        final Configuration configuration = new Configuration();
         return new TestingTaskExecutor(
                 rpc,
                 TaskManagerConfiguration.fromConfiguration(
@@ -596,7 +691,7 @@ class TaskExecutorPartitionLifecycleTest {
                 haServices,
                 taskManagerServices,
                 ExternalResourceInfoProvider.NO_EXTERNAL_RESOURCES,
-                new HeartbeatServicesImpl(10_000L, 30_000L),
+                heartbeatServices,
                 UnregisteredMetricGroups.createUnregisteredTaskManagerMetricGroup(),
                 null,
                 NoOpTaskExecutorBlobService.INSTANCE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
@@ -381,7 +381,7 @@ class TaskExecutorSubmissionTest {
             taskFinishedFuture.get();
 
             Collection<PartitionWithMetrics> partitionWithMetricsCollection =
-                    tmGateway.getPartitionWithMetrics(jobId).get();
+                    tmGateway.getAndRetainPartitionWithMetrics(jobId).get();
             assertThat(partitionWithMetricsCollection.size()).isOne();
             PartitionWithMetrics partitionWithMetrics =
                     partitionWithMetricsCollection.iterator().next();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -220,7 +220,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
     }
 
     @Override
-    public CompletableFuture<Collection<PartitionWithMetrics>> getPartitionWithMetrics(
+    public CompletableFuture<Collection<PartitionWithMetrics>> getAndRetainPartitionWithMetrics(
             JobID jobId) {
         return requestPartitionWithMetricsFunction.apply(jobId);
     }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-34661][runtime] TaskExecutor supports retain partitions after JM crashed.


## Brief change log

TaskExecutor supports retain partitions after JM crashed.


## Verifying this change


This change added tests in TaskExecutorPartitionLifecycleTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
