### PR TITLE
[FLINK-34971]Add the function of History Server cleaning job archives…

### DIFF
--- a/docs/layouts/shortcodes/generated/history_server_configuration.html
+++ b/docs/layouts/shortcodes/generated/history_server_configuration.html
@@ -33,6 +33,18 @@
             <td>The maximum number of jobs to retain in each archive directory defined by `historyserver.archive.fs.dir`. If set to `-1`(default), there is no limit to the number of archives. If set to `0` or less than `-1` HistoryServer will throw an <code class="highlighter-rouge">IllegalConfigurationException</code>. </td>
         </tr>
         <tr>
+            <td><h5>historyserver.cleanup.enable</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether HistoryServer should cleanup jobs that are present `historyserver.archive.fs.dir`.</td>
+        </tr>
+        <tr>
+            <td><h5>historyserver.cleanup.interval</h5></td>
+            <td style="word-wrap: break-word;">7 d</td>
+            <td>Duration</td>
+            <td>If `historyserver.cleanup.enable` is set to true, HistoryServer will cleanup jobs that are present `historyserver.archive.fs.dir` according to this config.</td>
+        </tr>
+        <tr>
             <td><h5>historyserver.log.jobmanager.url-pattern</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HistoryServerOptions.java
@@ -21,6 +21,8 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.description.Description;
 
+import java.time.Duration;
+
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.code;
 
@@ -58,6 +60,29 @@ public class HistoryServerOptions {
                             String.format(
                                     "Whether HistoryServer should cleanup jobs"
                                             + " that are no longer present `%s`.",
+                                    HISTORY_SERVER_ARCHIVE_DIRS.key()));
+
+    /** If this option is enabled then deleted job archives from HistoryServer regularly. */
+    public static final ConfigOption<Boolean> HISTORY_SERVER_CLEANUP_ENABLE =
+            key("historyserver.cleanup.enable")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            String.format(
+                                    "Whether HistoryServer should cleanup jobs"
+                                            + " that are present `%s`.",
+                                    HISTORY_SERVER_ARCHIVE_DIRS.key()));
+
+    /** HistoryServer will delete jobs archives regularly according to this config. */
+    public static final ConfigOption<Duration> HISTORY_SERVER_CLEANUP_INTERVAL =
+            key("historyserver.cleanup.interval")
+                    .durationType()
+                    .defaultValue(Duration.ofDays(7))
+                    .withDescription(
+                            String.format(
+                                    "If `%s` is set to true, HistoryServer will cleanup jobs"
+                                            + " that are present `%s` according to this config.",
+                                    HISTORY_SERVER_CLEANUP_ENABLE.key(),
                                     HISTORY_SERVER_ARCHIVE_DIRS.key()));
 
     /**

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServer.java
@@ -244,13 +244,19 @@ public class HistoryServer {
                     "Cannot set %s to 0 or less than -1",
                     HistoryServerOptions.HISTORY_SERVER_RETAINED_JOBS.key());
         }
+        boolean cleanupIntervalEnable =
+                config.get(HistoryServerOptions.HISTORY_SERVER_CLEANUP_ENABLE);
+        long cleanupIntervalMillis =
+                config.get(HistoryServerOptions.HISTORY_SERVER_CLEANUP_INTERVAL).toMillis();
         archiveFetcher =
                 new HistoryServerArchiveFetcher(
                         refreshDirs,
                         webDir,
                         jobArchiveEventListener,
                         cleanupExpiredArchives,
-                        maxHistorySize);
+                        maxHistorySize,
+                        cleanupIntervalEnable,
+                        cleanupIntervalMillis);
 
         this.shutdownHook =
                 ShutdownHookUtil.addShutdownHook(


### PR DESCRIPTION

Currently, flink does not provide the ability to regularly clean the archives of completed jobs. I think this ability is necessary.
When flink provides this ability, users can decide whether to use this ability. They also can define the time for regular cleaning.