### PR TITLE
[hotfix] Fix compile error in DataStreamV2SinkTransformation

### DIFF
--- a/flink-datastream/src/main/java/org/apache/flink/streaming/api/transformations/DataStreamV2SinkTransformation.java
+++ b/flink-datastream/src/main/java/org/apache/flink/streaming/api/transformations/DataStreamV2SinkTransformation.java
@@ -69,7 +69,7 @@ public class DataStreamV2SinkTransformation<InputT, OutputT>
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         final List<Transformation<?>> result = Lists.newArrayList();
         result.add(this);
         result.addAll(input.getTransitivePredecessors());

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/TestingTransformation.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/TestingTransformation.java
@@ -32,7 +32,7 @@ public class TestingTransformation<T> extends Transformation<T> {
     }
 
     @Override
-    public List<Transformation<?>> getTransitivePredecessors() {
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
         return Collections.emptyList();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*Fix the compile error in `DataStreamV2SinkTransformation`*


## Brief change log
- Fix the compile error in `DataStreamV2SinkTransformation`.


## Verifying this change

This is for fixing the compile error.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
