### PR TITLE
[FLINK-34025][runtime / web frontend] Add data skew metric endpoint and UI

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.html
@@ -41,6 +41,9 @@
         <xhtml:div class="node-label metric" title="Maximum busy percentage across all subtasks">
           Busy (max): {{ prettyPrint(busyPercentage) }}
         </xhtml:div>
+        <xhtml:div class="node-label metric" title="Data skew percentage across all subtasks">
+          Data Skew: {{ prettyPrint(dataSkewPercentage) }}
+        </xhtml:div>
         <xhtml:div class="node-label metric" *ngIf="lowWatermark">
           Low Watermark: {{ lowWatermark }}
         </xhtml:div>

--- a/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.ts
@@ -37,6 +37,7 @@ export class NodeComponent {
   lowWatermark: number | null | undefined;
   backPressuredPercentage: number | undefined = NaN;
   busyPercentage: number | undefined = NaN;
+  dataSkewPercentage: number | undefined = NaN;
   backgroundColor: string | undefined;
   borderColor: string | undefined;
   height = 0;
@@ -70,6 +71,7 @@ export class NodeComponent {
     if (this.isValid(value.busyPercentage)) {
       this.busyPercentage = value.busyPercentage;
     }
+    this.dataSkewPercentage = value.dataSkewPercentage;
     this.height = value.height || 0;
     this.id = value.id;
     if (description && description.length > 300) {
@@ -165,7 +167,7 @@ export class NodeComponent {
     if (value === undefined || isNaN(value)) {
       return 'N/A';
     } else {
-      return `${value}%`;
+      return `${Math.round(value)}%`;
     }
   }
 }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-detail.ts
@@ -136,6 +136,7 @@ export interface NodesItemCorrect extends NodesItem {
   lowWatermark?: number;
   backPressuredPercentage?: number;
   busyPercentage?: number;
+  dataSkewPercentage?: number;
 }
 
 export interface NodesItemLink {

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-metrics.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-metrics.ts
@@ -25,6 +25,18 @@ export interface MetricMap {
   [p: string]: number;
 }
 
+export interface AggregateValueMap {
+  min: number;
+  max: number;
+  avg: number;
+  sum: number;
+  skew: number;
+}
+
+export interface MetricMapWithAllAggregates {
+  [metricName: string]: AggregateValueMap;
+}
+
 export interface MetricMapWithTimestamp {
   timestamp: number;
   values: MetricMap;

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/dataskew/data-skew.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/dataskew/data-skew.component.html
@@ -1,0 +1,68 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<nz-card nzType="inner" nzTitle="What is Data Skew?">
+  <p>
+    Your Flink job has data skew when a subset of subtasks in any of the operators receives a
+    disproportionate number of records, potentially overloading a subset of task managers while the
+    rest remain idle, leading to inefficient processing and potentially backpressure and other
+    related problems.
+  </p>
+</nz-card>
+
+<nz-card nzType="inner" nzTitle="Data Skew" [nzLoading]="isLoading" [nzExtra]="extraTemplate">
+  <nz-table
+    class="no-border small"
+    [nzSize]="'small'"
+    [nzData]="listOfVerticesAndSkew"
+    [nzFrontPagination]="false"
+    [nzShowPagination]="false"
+  >
+    <tbody>
+      <tr>
+        <th>Vertex</th>
+        <th>Data Skew Percentage</th>
+      </tr>
+      <ng-container *ngFor="let vertexSkew of listOfVerticesAndSkew">
+        <tr>
+          <td>{{ vertexSkew.vertexName }}</td>
+          <td>{{ vertexSkew.skewPct }}%</td>
+        </tr>
+      </ng-container>
+    </tbody>
+  </nz-table>
+</nz-card>
+
+<nz-card nzType="inner" nzTitle="How is Data Skew Calculated?">
+  <p>
+    Data skew is calculated using the Coefficient of Variation (CV) statistic. The data skew
+    percentage shown here is calculated by using the
+    <i>numRecordsIn</i>
+    metric across the subtasks of your operators. The data skew percentage under the Overview tab
+    shows a live data skew percentage by using the
+    <i>numRecordsInPerSecond</i>
+    metric and therefore can be different from the skew percentage shown here.
+  </p>
+</nz-card>
+
+<ng-template #extraTemplate>
+  <button nz-button nzType="primary" class="refresh" nzSize="small" (click)="refresh()">
+    <i nz-icon nzType="sync"></i>
+    Refresh
+  </button>
+</ng-template>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/dataskew/data-skew.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/dataskew/data-skew.component.less
@@ -16,24 +16,18 @@
  * limitations under the License.
  */
 
-import { InjectionToken } from '@angular/core';
+:host {
+  ::ng-deep {
+    .nz-disable-td {
+      width: 100%;
+    }
 
-import { ModuleConfig } from '@flink-runtime-web/core/module-config';
+    .ant-table-cell {
+      white-space: pre-wrap;
+    }
+  }
+}
 
-export type JobModuleConfig = Pick<ModuleConfig, 'routerTabs'>;
-
-export const JOB_MODULE_DEFAULT_CONFIG: Required<JobModuleConfig> = {
-  routerTabs: [
-    { title: 'Overview', path: 'overview' },
-    { title: 'Exceptions', path: 'exceptions' },
-    { title: 'Data Skew', path: 'dataskew' },
-    { title: 'TimeLine', path: 'timeline' },
-    { title: 'Checkpoints', path: 'checkpoints' },
-    { title: 'Configuration', path: 'configuration' }
-  ]
-};
-
-export const JOB_MODULE_CONFIG = new InjectionToken<JobModuleConfig>('job-module-config', {
-  providedIn: 'root',
-  factory: () => JOB_MODULE_DEFAULT_CONFIG
-});
+nz-card {
+  margin: 24px;
+}

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/dataskew/data-skew.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/dataskew/data-skew.component.ts
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NgForOf } from '@angular/common';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, ChangeDetectorRef } from '@angular/core';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, takeUntil, map, mergeMap } from 'rxjs/operators';
+
+import { JobDetailCorrect } from '@flink-runtime-web/interfaces';
+import { MetricsService } from '@flink-runtime-web/services';
+import { NzButtonModule } from 'ng-zorro-antd/button';
+import { NzCardModule } from 'ng-zorro-antd/card';
+import { NzIconModule } from 'ng-zorro-antd/icon';
+import { NzTableModule } from 'ng-zorro-antd/table';
+
+import { JobLocalService } from '../job-local.service';
+
+@Component({
+  selector: 'flink-data-skew',
+  templateUrl: './data-skew.component.html',
+  styleUrls: ['./data-skew.component.less'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NzButtonModule, NzCardModule, NzTableModule, NgForOf, NzIconModule],
+  standalone: true
+})
+export class DataSkewComponent implements OnInit, OnDestroy {
+  public listOfVerticesAndSkew: Array<{ vertexName: string; skewPct: number }> = [];
+  public isLoading = true;
+  public jobDetail: JobDetailCorrect;
+
+  private destroy$ = new Subject<void>();
+  private refresh$ = new Subject<void>();
+
+  constructor(
+    private readonly metricsService: MetricsService,
+    private readonly jobLocalService: JobLocalService,
+    private readonly cdr: ChangeDetectorRef
+  ) {}
+
+  public ngOnInit(): void {
+    this.refresh$
+      .pipe(
+        map(() => {
+          return this.jobDetail;
+        }),
+        takeUntil(this.destroy$)
+      )
+      .pipe(map(jobDetail => jobDetail.vertices))
+      .pipe(
+        mergeMap(vertices => {
+          const result: Array<{ vertexName: string; skewPct: number }> = [];
+          vertices.forEach(v => {
+            this.metricsService
+              .loadAggregatedMetrics(this.jobDetail.jid, v.id, ['numRecordsIn'], 'skew')
+              .subscribe(metricMap => {
+                const skew = Number.isNaN(+metricMap['numRecordsIn']) ? 0 : Math.round(metricMap['numRecordsIn']);
+                result.push({ vertexName: v.name, skewPct: skew });
+                result.sort((a, b) => (a.skewPct > b.skewPct ? -1 : 1));
+                this.isLoading = false;
+                this.listOfVerticesAndSkew = result;
+                this.cdr.markForCheck();
+              });
+          });
+          return result;
+        })
+      )
+      .subscribe(_ => {}); // no-op subscriber to trigger the execution of the lazy processing
+
+    this.jobLocalService
+      .jobDetailChanges()
+      .pipe(
+        distinctUntilChanged((pre, next) => pre.jid === next.jid),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(data => {
+        this.jobDetail = data;
+        this.cdr.markForCheck();
+        this.refresh$.next();
+      });
+  }
+
+  public ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.refresh$.complete();
+  }
+
+  public refresh(): void {
+    this.refresh$.next();
+  }
+}

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/modules/completed-job/routes.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/modules/completed-job/routes.ts
@@ -102,6 +102,14 @@ export const COMPLETED_JOB_ROUES: Routes = [
         }
       },
       {
+        path: 'dataskew',
+        loadComponent: () =>
+          import('@flink-runtime-web/pages/job/dataskew/data-skew.component').then(m => m.DataSkewComponent),
+        data: {
+          path: 'dataskew'
+        }
+      },
+      {
         path: 'checkpoints',
         loadComponent: () =>
           import('@flink-runtime-web/pages/job/checkpoints/job-checkpoints.component').then(

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/modules/running-job/routes.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/modules/running-job/routes.ts
@@ -53,6 +53,14 @@ export const RUNNING_JOB_ROUTES: Routes = [
         }
       },
       {
+        path: 'dataskew',
+        loadComponent: () =>
+          import('@flink-runtime-web/pages/job/dataskew/data-skew.component').then(m => m.DataSkewComponent),
+        data: {
+          path: 'dataskew'
+        }
+      },
+      {
         path: 'checkpoints',
         loadComponent: () =>
           import('@flink-runtime-web/pages/job/checkpoints/job-checkpoints.component').then(

--- a/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
@@ -21,7 +21,13 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { MetricMap, JobMetric, Watermarks, MetricMapWithTimestamp } from '@flink-runtime-web/interfaces';
+import {
+  MetricMap,
+  MetricMapWithAllAggregates,
+  JobMetric,
+  Watermarks,
+  MetricMapWithTimestamp
+} from '@flink-runtime-web/interfaces';
 
 import { ConfigService } from './config.service';
 
@@ -71,43 +77,71 @@ export class MetricsService {
       );
   }
 
-  /** Get aggregated metric data from all subtasks of the given vertexId. */
+  /** Get aggregated metric data from all subtasks of the given vertexId. Example output:
+  { "numRecordsIn": { "min": 0.0, "max": 10.0, "sum": 15.0, "avg": 5.0, "skew": 66.0 } } */
+  public loadMetricsWithAllAggregates(
+    jobId: string,
+    vertexId: string,
+    listOfMetricName: string[]
+  ): Observable<MetricMapWithAllAggregates> {
+    const metricName = listOfMetricName.join(',');
+    return this.httpClient
+      .get<Array<{ id: string; min: number; max: number; avg: number; sum: number; skew: number }>>(
+        `${this.configService.BASE_URL}/jobs/${jobId}/vertices/${vertexId}/subtasks/metrics`,
+        { params: { get: metricName } }
+      )
+      .pipe(
+        map(arr => {
+          const result: MetricMapWithAllAggregates = {};
+          arr.forEach(item => {
+            result[item.id] = { min: NaN, max: NaN, avg: NaN, sum: NaN, skew: NaN };
+            result[item.id].min = +item.min;
+            result[item.id].max = +item.max;
+            result[item.id].avg = +item.avg;
+            result[item.id].sum = +item.sum;
+            result[item.id].skew = +item.skew;
+          });
+          return result;
+        })
+      );
+  }
+
+  /** Get metric data from all subtasks of the given vertexId, aggregated by a given aggregation type
+  Default aggregation type: max */
   public loadAggregatedMetrics(
     jobId: string,
     vertexId: string,
     listOfMetricName: string[],
     aggregate: string = 'max'
   ): Observable<MetricMap> {
-    const metricName = listOfMetricName.join(',');
-    return this.httpClient
-      .get<Array<{ id: string; min: number; max: number; avg: number; sum: number }>>(
-        `${this.configService.BASE_URL}/jobs/${jobId}/vertices/${vertexId}/subtasks/metrics`,
-        { params: { get: metricName } }
-      )
-      .pipe(
-        map(arr => {
-          const result: MetricMap = {};
-          arr.forEach(item => {
-            switch (aggregate) {
-              case 'min':
-                result[item.id] = +item.min;
-                break;
-              case 'max':
-                result[item.id] = +item.max;
-                break;
-              case 'avg':
-                result[item.id] = +item.avg;
-                break;
-              case 'sum':
-                result[item.id] = +item.sum;
-                break;
-              default:
-                throw new Error(`Unsupported aggregate: ${aggregate}`);
-            }
-          });
-          return result;
-        })
-      );
+    const result: MetricMap = {};
+    return this.loadMetricsWithAllAggregates(jobId, vertexId, listOfMetricName).pipe(
+      map((metricMapWithAllAggregates: MetricMapWithAllAggregates) => {
+        for (const metricName in metricMapWithAllAggregates) {
+          const value = metricMapWithAllAggregates[metricName];
+          switch (aggregate) {
+            case 'min':
+              result[metricName] = +value.min;
+              break;
+            case 'max':
+              result[metricName] = +value.max;
+              break;
+            case 'avg':
+              result[metricName] = +value.avg;
+              break;
+            case 'sum':
+              result[metricName] = +value.sum;
+              break;
+            case 'skew':
+              result[metricName] = +value.skew;
+              break;
+            default:
+              throw new Error(`Unsupported aggregate: ${aggregate}`);
+          }
+        }
+        return result;
+      })
+    );
   }
 
   public loadWatermarks(jobId: string, vertexId: string): Observable<Watermarks> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedMetric.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/AggregatedMetric.java
@@ -43,6 +43,8 @@ public class AggregatedMetric {
 
     private static final String FIELD_NAME_SUM = "sum";
 
+    private static final String FIELD_NAME_SKEW = "skew";
+
     @JsonProperty(value = FIELD_NAME_ID, required = true)
     private final String id;
 
@@ -62,23 +64,29 @@ public class AggregatedMetric {
     @JsonProperty(FIELD_NAME_SUM)
     private final Double sum;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(FIELD_NAME_SKEW)
+    private final Double skew;
+
     @JsonCreator
     public AggregatedMetric(
             final @JsonProperty(value = FIELD_NAME_ID, required = true) String id,
             final @Nullable @JsonProperty(FIELD_NAME_MIN) Double min,
             final @Nullable @JsonProperty(FIELD_NAME_MAX) Double max,
             final @Nullable @JsonProperty(FIELD_NAME_AVG) Double avg,
-            final @Nullable @JsonProperty(FIELD_NAME_SUM) Double sum) {
+            final @Nullable @JsonProperty(FIELD_NAME_SUM) Double sum,
+            final @Nullable @JsonProperty(FIELD_NAME_SKEW) Double skew) {
 
         this.id = requireNonNull(id, "id must not be null");
         this.min = min;
         this.max = max;
         this.avg = avg;
         this.sum = sum;
+        this.skew = skew;
     }
 
     public AggregatedMetric(final @JsonProperty(value = FIELD_NAME_ID, required = true) String id) {
-        this(id, null, null, null, null);
+        this(id, null, null, null, null, null);
     }
 
     @JsonIgnore
@@ -106,6 +114,11 @@ public class AggregatedMetric {
         return avg;
     }
 
+    @JsonIgnore
+    public Double getSkew() {
+        return skew;
+    }
+
     @Override
     public String toString() {
         return "AggregatedMetric{"
@@ -123,6 +136,9 @@ public class AggregatedMetric {
                 + '\''
                 + ", sum='"
                 + sum
+                + '\''
+                + ", skew='"
+                + skew
                 + '\''
                 + '}';
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsAggregationParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/MetricsAggregationParameter.java
@@ -59,6 +59,7 @@ public class MetricsAggregationParameter
         MIN,
         MAX,
         SUM,
-        AVG
+        AVG,
+        SKEW,
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/DoubleAccumulatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/DoubleAccumulatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.metrics;
+
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.within;
+
+public class DoubleAccumulatorTest {
+
+    @ParameterizedTest
+    @MethodSource("dataSkewTests")
+    public void testDataSkew(double n1, double n2, double n3, double expectedSkew) {
+        DoubleAccumulator.DoubleDataSkew dataSkew =
+                DoubleAccumulator.DoubleDataSkewFactory.get().get(n1);
+        dataSkew.add(n2);
+        dataSkew.add(n3);
+        assertThat(dataSkew.getValue()).isCloseTo(expectedSkew, within(0.5));
+    }
+
+    @Test
+    public void testDataSkewOnEmptyList() {
+        DoubleAccumulator.DoubleDataSkew dataSkew = new DoubleAccumulator.DoubleDataSkew();
+        assertThat(dataSkew.getValue()).isEqualTo(0.0);
+    }
+
+    @Test
+    public void testDataSkewOnSingleValueList() {
+        DoubleAccumulator.DoubleDataSkew dataSkew =
+                DoubleAccumulator.DoubleDataSkewFactory.get().get(123);
+        assertThat(dataSkew.getValue()).isEqualTo(0.0);
+    }
+
+    private static Stream<Arguments> dataSkewTests() {
+        // Data set, followed by the expected data skew percentage
+        return Stream.of(
+                // Avg: (23 + 3 + 10) / 3 = 12
+                // Avg Absolute Deviation = ( (23 - 12) + (12 - 3) + ( 12 - 10) ) / 3 = 7.33
+                // Skew Percentage = 7.33/12 * 100 -> 61%
+                Arguments.of(23.0, 3.0, 10.0, 61.0),
+                // Avg: (300 + 0 + 0) / 3 = 100
+                // Avg Absolute Deviation = ( (300 - 100) + (100 - 0) + (100 - 0) ) / 3 =  133
+                // Skew Percentage = 133/100 * 100 -> 133% should be capped at 100
+                Arguments.of(300.0, 0.0, 0.0, 100.0),
+                // Test against any possible division by zero errors
+                Arguments.of(0.0, 0.0, 0.0, 0.0),
+                // Test low skew,
+                Arguments.of(50.0, 51.0, 52.0, 1.0));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR implements the discussed and accepted FLIP [FLIP-418](https://cwiki.apache.org/confluence/display/FLINK/FLIP-418%3A+Show+data+skew+score+on+Flink+Dashboard): i) it shows a live data skew percentage on the vertices under "Overview" tab on the Flink Dashboard, ii) it also adds a new Data Skew tab that shows the accumulated data skew percentage for each vertex since the beginning of job. This will help users find inefficient/skewed operators/vertices faster. As it is, users have to click on each and every vertex, check how much data each subtask is processing and compare it to the other subtasks. This is cumbersome and indeed error-prone.

## Brief change log

- Add a new aggregation type (Data Skew) to `AbstractAggregatingMetricsHandler`. 
- Use the new aggregation type with the `numRecordsInPerSecond` metric to show a live skew percentage on Flink Job Graph UI.
- Add a new tab "Data Skew" which explains what data skew is and how it is calculated. Use the new aggregation type with the `numRecordsIn` metric to list the job vertices under the new Data Skew tab, sorted by the level of data skew.


## Verifying this change
 
- Added test that validates Data Skew calculation
- Added test that validates integration of Data Skew calculation and `AbstractAggregatingMetricsHandler`
- Manually verified the change. Screenshots below:
<img width="1720" alt="Screenshot 2024-04-01 at 15 29 27" src="https://github.com/apache/flink/assets/969071/fd85232b-5609-43f2-8220-4af9d67c38be">
<img width="1710" alt="Screenshot 2024-04-01 at 17 23 20" src="https://github.com/apache/flink/assets/969071/b39a24a8-d268-402a-81f0-d80868e85ff0">
<img width="1676" alt="Screenshot 2024-04-01 at 15 29 03" src="https://github.com/apache/flink/assets/969071/39fd0f56-0452-4a05-980c-d75c99156837">

When there are no incoming records to a vertex, data skew is shown as N/A on the Flink Job graph. The Job Graph shows a "live" version of data skew using, `numRecordsInPerSecond`, whereas the new data skew tab shows the data skew since the beginning of the job.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? JavaDocs
