### PR TITLE
[FLINK-34338][table] Add explanatory exception for wrong named params

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/WindowTableFunctionTest.scala
@@ -302,7 +302,7 @@ class WindowTableFunctionTest extends TableTestBase {
   }
 
   @Test
-  def testWindowTVFWithNamedParamsOrderChange(): Unit = {
+  def testWindowTVFWithNamedParamsOrderChange1(): Unit = {
     // the DATA param must be the first in FLIP-145
     // change the order about GAP and TIMECOL
     // TODO fix it in FLINK-34338
@@ -317,9 +317,25 @@ class WindowTableFunctionTest extends TableTestBase {
         |""".stripMargin
 
     assertThatThrownBy(() => util.verifyRelPlan(sql))
-      .hasMessage("fieldList must not be null, type = INTERVAL MINUTE")
-      .isInstanceOf[AssertionError]
-
+      .hasMessage("SQL validation failed. Illegal second argument to Window TVF: Expecting TIMECOL")
+      .isInstanceOf[ValidationException]
   }
 
+  @Test
+  def testWindowTVFWithNamedParamsOrderChange2(): Unit = {
+    val sql =
+      """
+        |SELECT *
+        |FROM TABLE(
+        |     SESSION(
+        |         GAP => INTERVAL '15' MINUTE,
+        |         DATA => TABLE MyTable,
+        |         TIMECOL => DESCRIPTOR(rowtime)))
+        |""".stripMargin
+
+    assertThatThrownBy(() => util.verifyRelPlan(sql))
+      .hasMessage(
+        "SQL validation failed. Illegal first argument to Window TVF: Note that the DATA param must be the first")
+      .isInstanceOf[ValidationException]
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

Exception message is not explanatory when named params are in wrong order. This PR adds proper exceptions. 



## Brief change log

  - Add checks and throw related exceptions
  - Add tests


## Verifying this change

via `WindowTableFunctionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
