### PR TITLE
[FLINK-34937][ci] Updates GitHub actions to use the properly pinned and most-recent version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@
 
 name: "Flink CI (beta)"
 
+# Apache policy: never use 'pull_request_target' as a trigger
 on:
   push:
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 name: "Build documentation"
+
+# Apache policy: never use 'pull_request_target' as a trigger
 on:
   schedule:
     - cron: '0 0 * * *' # Deploy every day

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           - release-1.18
           - release-1.17
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
       - name: Set branch environment variable

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           docker run --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink && ./.github/workflows/docs.sh"
       - name: Upload documentation
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@796cf0d5e4b535745ce49d7429f77cf39e25ef39 # v7.0.1
         with:
           switches: --archive --compress
           path: docs/target/
@@ -63,7 +63,7 @@ jobs:
           remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
       - name: Upload documentation alias
         if: env.flink_alias != ''
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@796cf0d5e4b535745ce49d7429f77cf39e25ef39 # v7.0.1
         with:
           switches: --archive --compress
           path: docs/target/

--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -25,8 +25,6 @@ on:
 jobs:
   Trigger:
     if: github.repository == 'apache/flink'
-    permissions:
-      actions: write
     strategy:
       matrix:
         branch:

--- a/.github/workflows/nightly-trigger.yml
+++ b/.github/workflows/nightly-trigger.yml
@@ -18,6 +18,7 @@
 
 name: "Nightly trigger (beta)"
 
+# Apache policy: never use 'pull_request_target' as a trigger
 on:
   schedule:
     - cron: '0 2 * * *'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,7 @@
 
 name: "Nightly (beta)"
 
+# Apache policy: never use 'pull_request_target' as a trigger
 on:
   workflow_dispatch:
 

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -17,6 +17,7 @@
 
 name: "Apache Flink Test Workflow Template"
 
+# Apache policy: never use 'pull_request_target' as a trigger
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/template.pre-compile-checks.yml
+++ b/.github/workflows/template.pre-compile-checks.yml
@@ -18,6 +18,7 @@
 
 name: "Pre-compile Checks"
 
+# Apache policy: never use 'pull_request_target' as a trigger
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## What is the purpose of the change

According to Apache Infra's [GitHub Action Policy|(https://infra.apache.org/github-actions-policy.html) we are allowed to use any action that is under `apache/`, `github/` and `actions` aside from the custom actions within the repository. Any other external action should be pinned and the corresponding code being reviewed to identify any malicious code.

## Brief change log

* Identified `burnett01/rsync-deployments` as the only external action that need to be pinned
* Reviewed code (see commit message)
* Pinned action
* Adds comment to remind contributors that `pull_request_target` is never meant to be used as a trigger to comply to Apache Infra
* Upgraded checkout action to `v4`
* Removes write permission from nightly trigger ([test run](https://github.com/XComp/flink/actions/runs/8466372207) to verify that the write permissions are not needed) 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable