### PR TITLE
[BP-1.19][FLINK-34955] Upgrade commons-compress to 1.26.0.

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -11,8 +11,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.ververica:frocksdbjni:6.20.3-ververica-2.0
 - commons-cli:commons-cli:1.5.0
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.11.0
-- org.apache.commons:commons-compress:1.24.0
+- commons-io:commons-io:2.15.1
+- org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-math3:3.6.1
 - org.apache.commons:commons-text:1.10.0

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -69,6 +69,13 @@ under the License.
 			<artifactId>kafka</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -16,9 +16,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.j2objc:j2objc-annotations:1.1
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.11.0
+- commons-io:commons-io:2.15.1
 - commons-logging:commons-logging:1.1.3
-- org.apache.commons:commons-compress:1.24.0
+- org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-text:1.10.0

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -21,10 +21,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.15
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.11.0
+- commons-io:commons-io:2.15.1
 - commons-logging:commons-logging:1.1.3
 - joda-time:joda-time:2.5
-- org.apache.commons:commons-compress:1.24.0
+- org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-text:1.10.0

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -30,13 +30,13 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.15
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.11.0
+- commons-io:commons-io:2.15.1
 - commons-logging:commons-logging:1.1.3
 - io.airlift:slice:0.38
 - io.airlift:units:1.3
 - joda-time:joda-time:2.5
 - org.alluxio:alluxio-shaded-client:2.7.3
-- org.apache.commons:commons-compress:1.24.0
+- org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-text:1.10.0

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -14,7 +14,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.confluent:common-utils:7.2.2
 - io.confluent:kafka-schema-registry-client:7.2.2
 - org.apache.avro:avro:1.11.3
-- org.apache.commons:commons-compress:1.24.0
+- org.apache.commons:commons-compress:1.26.0
+- org.apache.commons:commons-lang3:3.12.0
 - org.apache.kafka:kafka-clients:7.2.2-ccs
 - org.glassfish.jersey.core:jersey-common:2.30
 - org.xerial.snappy:snappy-java:1.1.10.4

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -10,6 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
 - com.google.guava:guava:30.1.1-jre
+- commons-io:commons-io:2.15.1
 - io.confluent:common-config:7.2.2
 - io.confluent:common-utils:7.2.2
 - io.confluent:kafka-schema-registry-client:7.2.2

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -10,4 +10,4 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
 - com.fasterxml.jackson.core:jackson-annotations:2.15.3
-- org.apache.commons:commons-compress:1.24.0
+- org.apache.commons:commons-compress:1.26.0

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -368,6 +368,18 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>${commons.io.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.calcite:calcite-linq4j:1.32.0
 - org.apache.calcite.avatica:avatica-core:1.22.0
 - commons-codec:commons-codec:1.15
-- commons-io:commons-io:2.11.0
+- commons-io:commons-io:2.15.1
 
 This project bundles the following dependencies under the MIT License. (http://www.opensource.org/licenses/mit-license.php)
 

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,7 @@ under the License.
 		<okhttp.version>3.14.9</okhttp.version>
 		<testcontainers.version>1.19.1</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>
+		<commons.io.version>2.15.1</commons.io.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>
 		<!--
@@ -685,7 +686,7 @@ under the License.
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.11.0</version>
+				<version>${commons.io.version}</version>
 			</dependency>
 
 			<!-- commons collections needs to be pinned to this critical security fix version -->
@@ -724,7 +725,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.24.0</version>
+				<version>1.26.0</version>
 				<exclusions>
 					<exclusion>
 						<!-- Causes unnecessary dependency convergence errors; see MENFORCER-437 -->


### PR DESCRIPTION
Backporting https://github.com/apache/flink/pull/24580 to 1.19.
cc @slfan1989