### PR TITLE
[FLINK-34988][build] Fix the reflection issue of ExecutionEnvironmentImpl for JDK17

### DIFF
--- a/flink-datastream/pom.xml
+++ b/flink-datastream/pom.xml
@@ -34,6 +34,16 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config><!--
+			we use reflection to register sink transformation translator,
+			it's a final map, we need to set this to pass tests in jdk17 or higher.
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
+
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImpl.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImpl.java
@@ -96,7 +96,7 @@ public class ExecutionEnvironmentImpl implements ExecutionEnvironment {
             DataStreamV2SinkTransformationTranslator.registerSinkTransformationTranslator();
         } catch (Exception e) {
             throw new RuntimeException(
-                    "Can not register process function transformation translator.");
+                    "Can not register process function transformation translator.", e);
         }
     }
 

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -37,6 +37,11 @@ under the License.
 		<test.parameterProgram.name>parameter-program</test.parameterProgram.name>
 		<test.ParameterProgramNoManifest.name>parameter-program-without-manifest</test.ParameterProgramNoManifest.name>
 		<test.ParameterProgramWithEagerSink.name>parameter-program-with-eager-sink</test.ParameterProgramWithEagerSink.name>
+		<surefire.module.config><!--
+			DataStream V2 use reflection to register sink transformation translator,
+			it's a final map, we need to set this to pass tests in jdk17 or higher.
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## What is the purpose of the change

*In JDK17, we cannot access a final field via reflection by default. Following #22794, I have added `--add-opens=java.base/java.util=ALL-UNNAMED` to the module's pom.xml which including tests touch the `ExecutionEnvironmentImpl`.*


## Brief change log
  - *added `--add-opens=java.base/java.util=ALL-UNNAMED` to the module's pom.xml which including tests touch the `ExecutionEnvironmentImpl`.*


## Verifying this change

Pull request CI is not run over JDK17, but I have tested all failed cases reported by FLINK-34988 in my local env(set JDK to 17).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
