### PR TITLE
[FLINK-33211][table] support flink table lineage

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
@@ -25,12 +25,18 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.lineage.DefaultLineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
 import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.Preconditions;
@@ -45,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -65,8 +72,11 @@ import java.util.Objects;
 @Deprecated
 @PublicEvolving
 public class FromElementsFunction<T>
-        implements SourceFunction<T>, CheckpointedFunction, OutputTypeConfigurable<T> {
-
+        implements SourceFunction<T>,
+                CheckpointedFunction,
+                OutputTypeConfigurable<T>,
+                LineageVertexProvider {
+    private static final String LINEAGE_NAMESPACE = "values://FromElementsFunction";
     private static final long serialVersionUID = 1L;
 
     /** The (de)serializer to be used for the data elements. */
@@ -304,5 +314,21 @@ public class FromElementsFunction<T>
                                 + viewedAs.getCanonicalName());
             }
         }
+    }
+
+    @Override
+    public LineageVertex getLineageVertex() {
+        return new SourceLineageVertex() {
+            @Override
+            public Boundedness boundedness() {
+                return Boundedness.BOUNDED;
+            }
+
+            @Override
+            public List<LineageDataset> datasets() {
+                return Arrays.asList(
+                        new DefaultLineageDataset("", LINEAGE_NAMESPACE, new HashMap<>()));
+            }
+        };
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.lineage.LineageGraph;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.OutputFormatOperatorFactory;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
@@ -123,6 +124,7 @@ public class StreamGraph implements Pipeline {
     private CheckpointStorage checkpointStorage;
     private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
     private InternalTimeServiceManager.Provider timerServiceProvider;
+    private LineageGraph lineageGraph;
     private JobType jobType = JobType.STREAMING;
     private Map<String, ResourceProfile> slotSharingGroupResources;
     private PipelineOptions.VertexDescriptionMode descriptionMode =
@@ -188,6 +190,14 @@ public class StreamGraph implements Pipeline {
 
     public void setJobName(String jobName) {
         this.jobName = jobName;
+    }
+
+    public LineageGraph getLineageGraph() {
+        return lineageGraph;
+    }
+
+    public void setLineageGraph(LineageGraph lineageGraph) {
+        this.lineageGraph = lineageGraph;
     }
 
     public void setStateBackend(StateBackend backend) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -46,6 +46,8 @@ import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.lineage.LineageGraph;
+import org.apache.flink.streaming.api.lineage.LineageGraphUtils;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionCheckpointStorage;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionInternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.sorted.state.BatchExecutionStateBackend;
@@ -281,10 +283,12 @@ public class StreamGraphGenerator {
         for (Transformation<?> transformation : transformations) {
             transform(transformation);
         }
-
         streamGraph.setSlotSharingGroupResource(slotSharingGroupResources);
 
         setFineGrainedGlobalStreamExchangeMode(streamGraph);
+
+        LineageGraph lineageGraph = LineageGraphUtils.convertToLineageGraph(transformations);
+        streamGraph.setLineageGraph(lineageGraph);
 
         for (StreamNode node : streamGraph.getStreamNodes()) {
             if (node.getInEdges().stream().anyMatch(this::shouldDisableUnalignedCheckpointing)) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageDataset.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageDataset.java
@@ -19,22 +19,36 @@
 
 package org.apache.flink.streaming.api.lineage;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 
-import java.util.List;
+import java.util.Map;
 
-/**
- * Job lineage graph that users can get sources, sinks and relationships from lineage and manage the
- * relationship between jobs and tables.
- */
-@PublicEvolving
-public interface LineageGraph {
-    /* Source lineage vertex list. */
-    List<SourceLineageVertex> sources();
+/** Default implementation for {@link LineageDataset}. */
+@Internal
+public class DefaultLineageDataset implements LineageDataset {
+    private String name;
+    private String namespace;
+    private Map<String, LineageDatasetFacet> facets;
 
-    /* Sink lineage vertex list. */
-    List<LineageVertex> sinks();
+    public DefaultLineageDataset(
+            String name, String namespace, Map<String, LineageDatasetFacet> facets) {
+        this.name = name;
+        this.namespace = namespace;
+        this.facets = facets;
+    }
 
-    /* lineage edges from sources to sinks. */
-    List<LineageEdge> relations();
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String namespace() {
+        return namespace;
+    }
+
+    @Override
+    public Map<String, LineageDatasetFacet> facets() {
+        return facets;
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageEdge.java
@@ -19,22 +19,28 @@
 
 package org.apache.flink.streaming.api.lineage;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 
-import java.util.List;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * Job lineage graph that users can get sources, sinks and relationships from lineage and manage the
- * relationship between jobs and tables.
- */
-@PublicEvolving
-public interface LineageGraph {
-    /* Source lineage vertex list. */
-    List<SourceLineageVertex> sources();
+/** Implementation of LineageEdge. */
+@Internal
+public class DefaultLineageEdge implements LineageEdge {
+    @JsonProperty private SourceLineageVertex sourceLineageVertex;
+    @JsonProperty private LineageVertex sinkVertex;
 
-    /* Sink lineage vertex list. */
-    List<LineageVertex> sinks();
+    public DefaultLineageEdge(SourceLineageVertex sourceLineageVertex, LineageVertex sinkVertex) {
+        this.sourceLineageVertex = sourceLineageVertex;
+        this.sinkVertex = sinkVertex;
+    }
 
-    /* lineage edges from sources to sinks. */
-    List<LineageEdge> relations();
+    @Override
+    public SourceLineageVertex source() {
+        return this.sourceLineageVertex;
+    }
+
+    @Override
+    public LineageVertex sink() {
+        return this.sinkVertex;
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageGraph.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.api.lineage;
 
 import org.apache.flink.annotation.Internal;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,9 +32,9 @@ import java.util.Set;
 /** Default implementation for {@link LineageGraph}. */
 @Internal
 public class DefaultLineageGraph implements LineageGraph {
-    private final List<LineageEdge> lineageEdges;
-    private final List<SourceLineageVertex> sources;
-    private final List<LineageVertex> sinks;
+    @JsonProperty private final List<LineageEdge> lineageEdges;
+    @JsonProperty private final List<SourceLineageVertex> sources;
+    @JsonProperty private final List<LineageVertex> sinks;
 
     private DefaultLineageGraph(List<LineageEdge> lineageEdges) {
         this.lineageEdges = lineageEdges;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageGraphUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageGraphUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
+import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
+import org.apache.flink.streaming.api.transformations.SinkTransformation;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/** Utils for building lineage graph from transformations. */
+@Internal
+public class LineageGraphUtils {
+
+    /** Convert transforms to LineageGraph. */
+    public static LineageGraph convertToLineageGraph(List<Transformation<?>> transformations) {
+        DefaultLineageGraph.LineageGraphBuilder builder = DefaultLineageGraph.builder();
+        for (Transformation<?> transformation : transformations) {
+            List<LineageEdge> edges = processSink(transformation);
+            for (LineageEdge lineageEdge : edges) {
+                builder.addLineageEdge(lineageEdge);
+            }
+        }
+        return builder.build();
+    }
+
+    private static List<LineageEdge> processSink(Transformation<?> transformation) {
+        List<LineageEdge> lineageEdges = new ArrayList<>();
+        LineageVertex sinkLineageVertex = null;
+        if (transformation instanceof SinkTransformation) {
+            sinkLineageVertex = ((SinkTransformation<?, ?>) transformation).getLineageVertex();
+        } else if (transformation instanceof LegacySinkTransformation) {
+            sinkLineageVertex = ((LegacySinkTransformation) transformation).getLineageVertex();
+        }
+
+        if (sinkLineageVertex != null) {
+            List<Transformation<?>> predecessors = transformation.getTransitivePredecessors();
+            for (Transformation<?> predecessor : predecessors) {
+                Optional<SourceLineageVertex> sourceOpt = processSource(predecessor);
+                if (sourceOpt.isPresent()) {
+                    lineageEdges.add(new DefaultLineageEdge(sourceOpt.get(), sinkLineageVertex));
+                }
+            }
+        }
+        return lineageEdges;
+    }
+
+    private static Optional<SourceLineageVertex> processSource(Transformation<?> transformation) {
+        if (transformation instanceof SourceTransformation) {
+            if (((SourceTransformation) transformation).getLineageVertex() != null) {
+                return Optional.of(
+                        (SourceLineageVertex)
+                                ((SourceTransformation) transformation).getLineageVertex());
+            }
+        } else if (transformation instanceof LegacySourceTransformation) {
+            if (((LegacySourceTransformation) transformation).getLineageVertex() != null) {
+                return Optional.of(
+                        (SourceLineageVertex)
+                                ((LegacySourceTransformation) transformation).getLineageVertex());
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
@@ -46,7 +46,7 @@ import java.util.List;
  * @param <T> The type of the elements in the input {@code LegacySinkTransformation}
  */
 @Internal
-public class LegacySinkTransformation<T> extends PhysicalTransformation<T> {
+public class LegacySinkTransformation<T> extends TransformationWithLineage<T> {
 
     private final Transformation<T> input;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
@@ -40,7 +40,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <T> The type of the elements that this source produces
  */
 @Internal
-public class LegacySourceTransformation<T> extends PhysicalTransformation<T>
+public class LegacySourceTransformation<T> extends TransformationWithLineage<T>
         implements WithBoundedness {
 
     private final StreamOperatorFactory<T> operatorFactory;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
@@ -43,7 +43,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @param <OutputT> The output type of the {@link Sink}
  */
 @Internal
-public class SinkTransformation<InputT, OutputT> extends PhysicalTransformation<OutputT> {
+public class SinkTransformation<InputT, OutputT> extends TransformationWithLineage<OutputT> {
 
     private final DataStream<InputT> inputStream;
     private final Sink<InputT> sink;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
@@ -37,7 +37,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** A {@link PhysicalTransformation} for {@link Source}. */
 @Internal
 public class SourceTransformation<OUT, SplitT extends SourceSplit, EnumChkT>
-        extends PhysicalTransformation<OUT> implements WithBoundedness {
+        extends TransformationWithLineage<OUT> implements WithBoundedness {
 
     private final Source<OUT, SplitT, EnumChkT> source;
     private final WatermarkStrategy<OUT> watermarkStrategy;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TransformationWithLineage.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TransformationWithLineage.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+
+/**
+ * A {@link Transformation} that contains lineage information.
+ *
+ * @param <T> The type of the elements that result from this {@code Transformation}
+ * @see Transformation
+ */
+@Internal
+public abstract class TransformationWithLineage<T> extends PhysicalTransformation<T> {
+    private LineageVertex lineageVertex;
+
+    /**
+     * Creates a new {@code Transformation} with the given name, output type and parallelism.
+     *
+     * @param name The name of the {@code Transformation}, this will be shown in Visualizations and
+     *     the Log
+     * @param outputType The output type of this {@code Transformation}
+     * @param parallelism The parallelism of this {@code Transformation}
+     */
+    TransformationWithLineage(String name, TypeInformation<T> outputType, int parallelism) {
+        super(name, outputType, parallelism);
+    }
+
+    /**
+     * Creates a new {@code Transformation} with the given name, output type and parallelism.
+     *
+     * @param name The name of the {@code Transformation}, this will be shown in Visualizations and
+     *     the Log
+     * @param outputType The output type of this {@code Transformation}
+     * @param parallelism The parallelism of this {@code Transformation}
+     * @param parallelismConfigured If true, the parallelism of the transformation is explicitly set
+     *     and should be respected. Otherwise the parallelism can be changed at runtime.
+     */
+    TransformationWithLineage(
+            String name,
+            TypeInformation<T> outputType,
+            int parallelism,
+            boolean parallelismConfigured) {
+        super(name, outputType, parallelism, parallelismConfigured);
+    }
+
+    /** Returns the lineage vertex of this {@code Transformation}. */
+    public LineageVertex getLineageVertex() {
+        return lineageVertex;
+    }
+
+    /** Change the lineage vertex of this {@code Transformation}. */
+    public void setLineageVertex(LineageVertex lineageVertex) {
+        this.lineageVertex = lineageVertex;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SinkTransformationTranslator.java
@@ -59,7 +59,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A {@link org.apache.flink.streaming.api.graph.TransformationTranslator} for the {@link
- * org.apache.flink.streaming.api.transformations.SinkTransformation}.
+ * SinkTransformation}.
  */
 @Internal
 public class SinkTransformationTranslator<Input, Output>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ModifyType.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ModifyType.java
@@ -14,27 +14,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.flink.streaming.api.lineage;
+package org.apache.flink.table.operations;
 
 import org.apache.flink.annotation.PublicEvolving;
 
-import java.util.List;
-
-/**
- * Job lineage graph that users can get sources, sinks and relationships from lineage and manage the
- * relationship between jobs and tables.
- */
+/** The type of sink modification. */
 @PublicEvolving
-public interface LineageGraph {
-    /* Source lineage vertex list. */
-    List<SourceLineageVertex> sources();
+public enum ModifyType {
+    INSERT,
 
-    /* Sink lineage vertex list. */
-    List<LineageVertex> sinks();
+    UPDATE,
 
-    /* lineage edges from sources to sinks. */
-    List<LineageEdge> relations();
+    DELETE
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/SinkModifyOperation.java
@@ -163,14 +163,4 @@ public class SinkModifyOperation implements ModifyOperation {
                 Collections.singletonList(child),
                 Operation::asSummaryString);
     }
-
-    /** The type of sink modification. */
-    @Internal
-    public enum ModifyType {
-        INSERT,
-
-        UPDATE,
-
-        DELETE
-    }
 }

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -235,7 +235,14 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
-  </dependencies>
+
+		<dependency>
+			<groupId>net.javacrumbs.json-unit</groupId>
+			<artifactId>json-unit-assertj</artifactId>
+			<version>2.23.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 	<build>
 		<plugins>

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDataset.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDataset.java
@@ -14,27 +14,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.flink.streaming.api.lineage;
+package org.apache.flink.table.planner.lineage;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.listener.CatalogContext;
 
-import java.util.List;
+/** Basic table lineage dataset which has catalog context and table in it. */
+public interface TableLineageDataset extends LineageDataset {
 
-/**
- * Job lineage graph that users can get sources, sinks and relationships from lineage and manage the
- * relationship between jobs and tables.
- */
-@PublicEvolving
-public interface LineageGraph {
-    /* Source lineage vertex list. */
-    List<SourceLineageVertex> sources();
+    /* The catalog context of the table lineage vertex. */
+    CatalogContext catalogContext();
 
-    /* Sink lineage vertex list. */
-    List<LineageVertex> sinks();
+    /* The table of the lineage vertex. */
+    CatalogBaseTable table();
 
-    /* lineage edges from sources to sinks. */
-    List<LineageEdge> relations();
+    /* Database name and table name for the table lineage vertex. */
+    ObjectPath objectPath();
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDatasetImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageDatasetImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.lineage;
+
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ContextResolvedTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.listener.CatalogContext;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/** Implementation for TableLineageDataSet. */
+public class TableLineageDatasetImpl implements TableLineageDataset {
+    @JsonProperty private String name;
+    @JsonProperty private String namespace;
+    private CatalogContext catalogContext;
+    private CatalogBaseTable catalogBaseTable;
+    @JsonProperty private ObjectPath objectPath;
+    @JsonProperty private Map<String, LineageDatasetFacet> facets;
+
+    public TableLineageDatasetImpl(
+            ContextResolvedTable contextResolvedTable, Optional<LineageDataset> lineageDatasetOpt) {
+        this.name = contextResolvedTable.getIdentifier().asSummaryString();
+        this.namespace =
+                lineageDatasetOpt.map(lineageDataset -> lineageDataset.namespace()).orElse("");
+        this.catalogContext =
+                CatalogContext.createContext(
+                        contextResolvedTable.getCatalog().isPresent()
+                                ? ((AbstractCatalog) contextResolvedTable.getCatalog().get())
+                                        .getName()
+                                : "",
+                        contextResolvedTable.getCatalog().orElse(null));
+        this.catalogBaseTable = contextResolvedTable.getTable();
+        this.objectPath =
+                contextResolvedTable.isAnonymous()
+                        ? null
+                        : contextResolvedTable.getIdentifier().toObjectPath();
+        this.facets = new HashMap<>();
+        if (lineageDatasetOpt.isPresent()) {
+            this.facets.putAll(lineageDatasetOpt.get().facets());
+        }
+    }
+
+    public void addLineageDatasetFacet(LineageDatasetFacet facet) {
+        facets.put(facet.name(), facet);
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public String namespace() {
+        return namespace;
+    }
+
+    @Override
+    public Map<String, LineageDatasetFacet> facets() {
+        return facets;
+    }
+
+    @Override
+    public CatalogContext catalogContext() {
+        return catalogContext;
+    }
+
+    @Override
+    public CatalogBaseTable table() {
+        return catalogBaseTable;
+    }
+
+    @Override
+    public ObjectPath objectPath() {
+        return objectPath;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableLineageUtils.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.lineage;
+
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ContextResolvedTable;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.operations.ModifyType;
+import org.apache.flink.types.RowKind;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/** Util class for building table lineage graph. */
+public class TableLineageUtils {
+
+    /** Extract optional lineage info from output format, sink, or sink function. */
+    public static Optional<LineageVertex> extractLineageDataset(@Nullable Object object) {
+        if (object != null && object instanceof LineageVertexProvider) {
+            return Optional.of(((LineageVertexProvider) object).getLineageVertex());
+        }
+
+        return Optional.empty();
+    }
+
+    public static LineageDataset createTableLineageDataset(
+            ContextResolvedTable contextResolvedTable, Optional<LineageVertex> lineageDataset) {
+        String name = contextResolvedTable.getIdentifier().asSummaryString();
+        TableLineageDatasetImpl tableLineageDataset =
+                new TableLineageDatasetImpl(
+                        contextResolvedTable, findLineageDataset(name, lineageDataset));
+
+        return tableLineageDataset;
+    }
+
+    public static ModifyType convert(ChangelogMode inputChangelogMode) {
+        if (inputChangelogMode.containsOnly(RowKind.INSERT)) {
+            return ModifyType.INSERT;
+        } else if (inputChangelogMode.containsOnly(RowKind.DELETE)) {
+            return ModifyType.DELETE;
+        } else {
+            return ModifyType.UPDATE;
+        }
+    }
+
+    private static Optional<LineageDataset> findLineageDataset(
+            String name, Optional<LineageVertex> lineageVertexOpt) {
+        if (lineageVertexOpt.isPresent()) {
+            LineageVertex lineageVertex = lineageVertexOpt.get();
+            if (lineageVertex.datasets().size() == 1) {
+                return Optional.of(lineageVertex.datasets().get(0));
+            }
+
+            for (LineageDataset dataset : lineageVertex.datasets()) {
+                if (dataset.name().equals(name)) {
+                    return Optional.of(dataset);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static Map<String, String> extractOptions(CatalogBaseTable catalogBaseTable) {
+        try {
+            return catalogBaseTable.getOptions();
+        } catch (Exception e) {
+            return new HashMap<>();
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableSinkLineageVertex.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableSinkLineageVertex.java
@@ -14,27 +14,21 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.flink.streaming.api.lineage;
+package org.apache.flink.table.planner.lineage;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.table.operations.ModifyType;
 
-import java.util.List;
-
-/**
- * Job lineage graph that users can get sources, sinks and relationships from lineage and manage the
- * relationship between jobs and tables.
- */
+/** Sink lineage vertex for table. */
 @PublicEvolving
-public interface LineageGraph {
-    /* Source lineage vertex list. */
-    List<SourceLineageVertex> sources();
+public interface TableSinkLineageVertex extends LineageVertex {
 
-    /* Sink lineage vertex list. */
-    List<LineageVertex> sinks();
-
-    /* lineage edges from sources to sinks. */
-    List<LineageEdge> relations();
+    /**
+     * Modify type, INSERT/UPDATE/DELETE statement, listener can identify different sink by the type
+     * to determine whether the sink should be added to the lineage.
+     */
+    ModifyType modifyType();
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableSinkLineageVertexImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableSinkLineageVertexImpl.java
@@ -14,27 +14,34 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.flink.streaming.api.lineage;
+package org.apache.flink.table.planner.lineage;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.table.operations.ModifyType;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
-/**
- * Job lineage graph that users can get sources, sinks and relationships from lineage and manage the
- * relationship between jobs and tables.
- */
-@PublicEvolving
-public interface LineageGraph {
-    /* Source lineage vertex list. */
-    List<SourceLineageVertex> sources();
+/** Implementation of TableSinkLineageVertex. */
+public class TableSinkLineageVertexImpl implements TableSinkLineageVertex {
+    @JsonProperty private List<LineageDataset> datasets;
+    @JsonProperty private ModifyType modifyType;
 
-    /* Sink lineage vertex list. */
-    List<LineageVertex> sinks();
+    public TableSinkLineageVertexImpl(List<LineageDataset> datasets, ModifyType modifyType) {
+        this.datasets = datasets;
+        this.modifyType = modifyType;
+    }
 
-    /* lineage edges from sources to sinks. */
-    List<LineageEdge> relations();
+    @Override
+    public List<LineageDataset> datasets() {
+        return datasets;
+    }
+
+    @Override
+    public ModifyType modifyType() {
+        return modifyType;
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableSourceLineageVertex.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableSourceLineageVertex.java
@@ -14,27 +14,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.flink.streaming.api.lineage;
+package org.apache.flink.table.planner.lineage;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
 
-import java.util.List;
-
-/**
- * Job lineage graph that users can get sources, sinks and relationships from lineage and manage the
- * relationship between jobs and tables.
- */
+/** Source lineage vertex for table. */
 @PublicEvolving
-public interface LineageGraph {
-    /* Source lineage vertex list. */
-    List<SourceLineageVertex> sources();
-
-    /* Sink lineage vertex list. */
-    List<LineageVertex> sinks();
-
-    /* lineage edges from sources to sinks. */
-    List<LineageEdge> relations();
-}
+public interface TableSourceLineageVertex extends SourceLineageVertex {}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableSourceLineageVertexImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/lineage/TableSourceLineageVertexImpl.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.lineage;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/** Implementation of TableSourceLineageVertex. */
+public class TableSourceLineageVertexImpl implements TableSourceLineageVertex {
+    @JsonProperty private List<LineageDataset> datasets;
+    @JsonProperty private Boundedness boundedness;
+
+    public TableSourceLineageVertexImpl(List<LineageDataset> datasets, Boundedness boundedness) {
+        this.datasets = datasets;
+        this.boundedness = boundedness;
+    }
+
+    @Override
+    public List<LineageDataset> datasets() {
+        return this.datasets;
+    }
+
+    @Override
+    public Boundedness boundedness() {
+        return boundedness;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -121,6 +121,7 @@ import org.apache.flink.table.operations.EndStatementSetOperation;
 import org.apache.flink.table.operations.ExplainOperation;
 import org.apache.flink.table.operations.LoadModuleOperation;
 import org.apache.flink.table.operations.ModifyOperation;
+import org.apache.flink.table.operations.ModifyType;
 import org.apache.flink.table.operations.NopOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
@@ -1322,7 +1323,7 @@ public class SqlNodeToOperationConversion {
                 contextResolvedTable,
                 queryOperation,
                 null, // targetColumns
-                SinkModifyOperation.ModifyType.DELETE);
+                ModifyType.DELETE);
     }
 
     private Operation convertUpdate(SqlUpdate sqlUpdate) {
@@ -1351,10 +1352,7 @@ public class SqlNodeToOperationConversion {
                 getTargetColumnIndices(contextResolvedTable, sqlUpdate.getTargetColumnList());
 
         return new SinkModifyOperation(
-                contextResolvedTable,
-                queryOperation,
-                columnIndices,
-                SinkModifyOperation.ModifyType.UPDATE);
+                contextResolvedTable, queryOperation, columnIndices, ModifyType.UPDATE);
     }
 
     private int[][] getTargetColumnIndices(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -29,10 +29,13 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.transformations.LegacySourceTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.SourceTransformationWrapper;
+import org.apache.flink.streaming.api.transformations.TransformationWithLineage;
 import org.apache.flink.streaming.runtime.partitioner.KeyGroupStreamPartitioner;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -47,6 +50,9 @@ import org.apache.flink.table.connector.source.SourceProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.connectors.TransformationScanProvider;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.lineage.TableLineageUtils;
+import org.apache.flink.table.planner.lineage.TableSourceLineageVertex;
+import org.apache.flink.table.planner.lineage.TableSourceLineageVertexImpl;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
@@ -67,6 +73,7 @@ import org.apache.flink.types.RowKind;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -121,9 +128,11 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
                 tableSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
         final int sourceParallelism = deriveSourceParallelism(provider);
         final boolean sourceParallelismConfigured = isParallelismConfigured(provider);
+        Optional<LineageVertex> lineageVertex = Optional.empty();
         if (provider instanceof SourceFunctionProvider) {
             final SourceFunctionProvider sourceFunctionProvider = (SourceFunctionProvider) provider;
             final SourceFunction<RowData> function = sourceFunctionProvider.createSourceFunction();
+            lineageVertex = TableLineageUtils.extractLineageDataset(function);
             sourceTransform =
                     createSourceFunctionTransformation(
                             env,
@@ -133,6 +142,20 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
                             outputTypeInfo,
                             sourceParallelism,
                             sourceParallelismConfigured);
+
+            LineageDataset tableLineageDataset =
+                    TableLineageUtils.createTableLineageDataset(
+                            tableSourceSpec.getContextResolvedTable(), lineageVertex);
+
+            TableSourceLineageVertex sourceLineageVertex =
+                    new TableSourceLineageVertexImpl(
+                            Arrays.asList(tableLineageDataset),
+                            provider.isBounded()
+                                    ? Boundedness.BOUNDED
+                                    : Boundedness.CONTINUOUS_UNBOUNDED);
+
+            ((TransformationWithLineage<RowData>) sourceTransform)
+                    .setLineageVertex(sourceLineageVertex);
             if (function instanceof ParallelSourceFunction && sourceParallelismConfigured) {
                 meta.fill(sourceTransform);
                 return new SourceTransformationWrapper<>(sourceTransform);
@@ -142,12 +165,14 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         } else if (provider instanceof InputFormatProvider) {
             final InputFormat<RowData, ?> inputFormat =
                     ((InputFormatProvider) provider).createInputFormat();
+            lineageVertex = TableLineageUtils.extractLineageDataset(inputFormat);
             sourceTransform =
                     createInputFormatTransformation(
                             env, inputFormat, outputTypeInfo, meta.getName());
             meta.fill(sourceTransform);
         } else if (provider instanceof SourceProvider) {
             final Source<RowData, ?, ?> source = ((SourceProvider) provider).createSource();
+            lineageVertex = TableLineageUtils.extractLineageDataset(source);
             // TODO: Push down watermark strategy to source scan
             sourceTransform =
                     env.fromSource(
@@ -175,17 +200,35 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
                     provider.getClass().getSimpleName() + " is unsupported now.");
         }
 
-        if (sourceParallelismConfigured) {
-            return applySourceTransformationWrapper(
-                    sourceTransform,
-                    planner.getFlinkContext().getClassLoader(),
-                    outputTypeInfo,
-                    config,
-                    tableSource.getChangelogMode(),
-                    sourceParallelism);
-        } else {
-            return sourceTransform;
+        LineageDataset tableLineageDataset =
+                TableLineageUtils.createTableLineageDataset(
+                        tableSourceSpec.getContextResolvedTable(), lineageVertex);
+
+        TableSourceLineageVertex sourceLineageVertex =
+                new TableSourceLineageVertexImpl(
+                        Arrays.asList(tableLineageDataset),
+                        provider.isBounded()
+                                ? Boundedness.BOUNDED
+                                : Boundedness.CONTINUOUS_UNBOUNDED);
+
+        if (sourceTransform instanceof TransformationWithLineage) {
+            ((TransformationWithLineage<RowData>) sourceTransform)
+                    .setLineageVertex(sourceLineageVertex);
         }
+
+        if (sourceParallelismConfigured) {
+            Transformation<RowData> sourceTransformationWrapper =
+                    applySourceTransformationWrapper(
+                            sourceTransform,
+                            planner.getFlinkContext().getClassLoader(),
+                            outputTypeInfo,
+                            config,
+                            tableSource.getChangelogMode(),
+                            sourceParallelism);
+            return sourceTransformationWrapper;
+        }
+
+        return sourceTransform;
     }
 
     private boolean isParallelismConfigured(ScanTableSource.ScanRuntimeProvider runtimeProvider) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/source/ValuesSource.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/source/ValuesSource.java
@@ -32,14 +32,22 @@ import org.apache.flink.connector.source.split.ValuesSourceSplit;
 import org.apache.flink.connector.source.split.ValuesSourceSplitSerializer;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Preconditions;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -52,7 +60,9 @@ import java.util.stream.IntStream;
  * must be 1. RowData is not serializable and the parallelism of table source may not be 1, so we
  * introduce a new source for testing in table module.
  */
-public class ValuesSource implements Source<RowData, ValuesSourceSplit, NoOpEnumState> {
+public class ValuesSource
+        implements Source<RowData, ValuesSourceSplit, NoOpEnumState>, LineageVertexProvider {
+    private static final String LINEAGE_NAMESPACE = "values://ValuesSource";
     private final TypeSerializer<RowData> serializer;
 
     private final List<byte[]> serializedElements;
@@ -125,5 +135,37 @@ public class ValuesSource implements Source<RowData, ValuesSourceSplit, NoOpEnum
     @Override
     public SimpleVersionedSerializer<NoOpEnumState> getEnumeratorCheckpointSerializer() {
         return new NoOpEnumStateSerializer();
+    }
+
+    @Override
+    public LineageVertex getLineageVertex() {
+        return new SourceLineageVertex() {
+            @Override
+            public Boundedness boundedness() {
+                return boundedness;
+            }
+
+            @Override
+            public List<LineageDataset> datasets() {
+                LineageDataset dataset =
+                        new LineageDataset() {
+                            @Override
+                            public String name() {
+                                return "";
+                            }
+
+                            @Override
+                            public String namespace() {
+                                return LINEAGE_NAMESPACE;
+                            }
+
+                            @Override
+                            public Map<String, LineageDatasetFacet> facets() {
+                                return new HashMap<>();
+                            }
+                        };
+                return Arrays.asList(dataset);
+            }
+        };
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/TableLineageGraphTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/TableLineageGraphTest.java
@@ -14,27 +14,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.flink.streaming.api.lineage;
+package org.apache.flink.table.planner.plan.batch.sql;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.planner.plan.common.TableLineageGraphTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
 
-import java.util.List;
+/** Lineage Graph tests for varies queries in batch. */
+public class TableLineageGraphTest extends TableLineageGraphTestBase {
 
-/**
- * Job lineage graph that users can get sources, sinks and relationships from lineage and manage the
- * relationship between jobs and tables.
- */
-@PublicEvolving
-public interface LineageGraph {
-    /* Source lineage vertex list. */
-    List<SourceLineageVertex> sources();
+    @Override
+    protected TableTestUtil getTableTestUtil() {
+        return batchTestUtil(TableConfig.getDefault());
+    }
 
-    /* Sink lineage vertex list. */
-    List<LineageVertex> sinks();
-
-    /* lineage edges from sources to sinks. */
-    List<LineageEdge> relations();
+    @Override
+    protected boolean isBatchMode() {
+        return true;
+    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/common/TableLineageGraphTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/common/TableLineageGraphTestBase.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.common;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
+import org.apache.flink.streaming.api.lineage.LineageGraph;
+import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializationFeature;
+
+import net.javacrumbs.jsonunit.core.Option;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
+/** Lineage Graph tests for varies queries. */
+public abstract class TableLineageGraphTestBase extends TableTestBase {
+    private static final String RESOURCE_PATH = "src/test/resources/lineage-graph/";
+    private final ObjectMapper mapper = new ObjectMapper();
+    private TableTestUtil util;
+
+    protected abstract boolean isBatchMode();
+
+    protected abstract TableTestUtil getTableTestUtil();
+
+    private final String query =
+            "SELECT\n"
+                    + "  AVG(a) AS avg_a,\n"
+                    + "  COUNT(*) AS cnt,\n"
+                    + "  count(b) AS cnt_b,\n"
+                    + "  min(b) AS min_b,\n"
+                    + "  MAX(c) FILTER (WHERE a > 1) AS max_c\n"
+                    + "FROM FirstTable";
+
+    private final String lookupJoin = "";
+
+    private final String union =
+            "("
+                    + query
+                    + ") UNION \n"
+                    + "(SELECT\n"
+                    + "  AVG(a) AS avg_a,\n"
+                    + "  COUNT(*) AS cnt,\n"
+                    + "  count(b) AS cnt_b,\n"
+                    + "  min(b) AS min_b,\n"
+                    + "  MAX(c) FILTER (WHERE a > 1) AS max_c\n"
+                    + "FROM SecondTable)";
+
+    @BeforeEach
+    void setup() {
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        util = getTableTestUtil();
+
+        util.getTableEnv()
+                .executeSql(
+                        "CREATE TABLE FirstTable (\n"
+                                + "  a BIGINT,\n"
+                                + "  b INT NOT NULL,\n"
+                                + "  c VARCHAR,\n"
+                                + "  d BIGINT\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'bounded' = '"
+                                + isBatchMode()
+                                + "')");
+
+        util.getTableEnv()
+                .executeSql(
+                        "CREATE TABLE SecondTable (\n"
+                                + "  a BIGINT,\n"
+                                + "  b INT NOT NULL,\n"
+                                + "  c VARCHAR,\n"
+                                + "  d BIGINT\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'bounded' = '"
+                                + isBatchMode()
+                                + "')");
+
+        util.getTableEnv()
+                .executeSql(
+                        "CREATE TABLE SinkTable (\n"
+                                + "  avg_a DOUBLE,\n"
+                                + "  cnt BIGINT,\n"
+                                + "  cnt_b BIGINT,\n"
+                                + "  min_b BIGINT,\n"
+                                + "  max_c VARCHAR\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'sink-insert-only' = 'false')");
+    }
+
+    @Test
+    void testInsertWithSelect() throws Exception {
+        List<Transformation<?>> transformations =
+                util.generateTransformations(String.format("INSERT INTO SinkTable\n%s", query));
+        LineageGraph lineageGraph = generateLineageGraph(transformations);
+        verify(lineageGraph, isBatchMode() ? "query-batch.json" : "query-stream.json");
+    }
+
+    @Test
+    void testInsertWithUnion() throws Exception {
+        List<Transformation<?>> transformations =
+                util.generateTransformations(String.format("INSERT INTO SinkTable\n%s", union));
+        LineageGraph lineageGraph = generateLineageGraph(transformations);
+        verify(lineageGraph, isBatchMode() ? "union-batch.json" : "union-stream.json");
+    }
+
+    private LineageGraph generateLineageGraph(List<Transformation<?>> transformations) {
+        StreamGraphGenerator streamGraphGenerator =
+                new StreamGraphGenerator(
+                        transformations, new ExecutionConfig(), new CheckpointConfig());
+        StreamGraph graph = streamGraphGenerator.generate();
+        LineageGraph lineageGraph = graph.getLineageGraph();
+        return lineageGraph;
+    }
+
+    private void verify(LineageGraph lineageGraph, String jsonPath) throws Exception {
+        String json = mapper.writeValueAsString(lineageGraph);
+        String expected = new String(Files.readAllBytes(Paths.get(RESOURCE_PATH + jsonPath)));
+        assertThatJson(json).when(Option.IGNORING_ARRAY_ORDER).isEqualTo(expected);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/TableLineageGraphTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/TableLineageGraphTest.java
@@ -14,27 +14,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
-package org.apache.flink.streaming.api.lineage;
+package org.apache.flink.table.planner.plan.stream.sql;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.planner.plan.common.TableLineageGraphTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
 
-import java.util.List;
+/** Lineage Graph tests for varies queries in stream. */
+public class TableLineageGraphTest extends TableLineageGraphTestBase {
 
-/**
- * Job lineage graph that users can get sources, sinks and relationships from lineage and manage the
- * relationship between jobs and tables.
- */
-@PublicEvolving
-public interface LineageGraph {
-    /* Source lineage vertex list. */
-    List<SourceLineageVertex> sources();
+    @Override
+    protected TableTestUtil getTableTestUtil() {
+        return streamTestUtil(TableConfig.getDefault());
+    }
 
-    /* Sink lineage vertex list. */
-    List<LineageVertex> sinks();
-
-    /* lineage edges from sources to sinks. */
-    List<LineageEdge> relations();
+    @Override
+    protected boolean isBatchMode() {
+        return false;
+    }
 }

--- a/flink-table/flink-table-planner/src/test/resources/lineage-graph/query-batch.json
+++ b/flink-table/flink-table-planner/src/test/resources/lineage-graph/query-batch.json
@@ -1,0 +1,70 @@
+{
+  "lineageEdges": [
+    {
+      "sourceLineageVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.FirstTable",
+            "namespace": "values://FromElementsFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "FirstTable",
+              "fullName": "default_database.FirstTable"
+            },
+            "facets": {}
+          }
+        ],
+        "boundedness": "BOUNDED"
+      },
+      "sinkVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.SinkTable",
+            "namespace": "values://RetractingSinkFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "SinkTable",
+              "fullName": "default_database.SinkTable"
+            },
+            "facets": {}
+          }
+        ],
+        "modifyType": "INSERT"
+      }
+    }
+  ],
+  "sources": [
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.FirstTable",
+          "namespace": "values://FromElementsFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "FirstTable",
+            "fullName": "default_database.FirstTable"
+          },
+          "facets": {}
+        }
+      ],
+      "boundedness": "BOUNDED"
+    }
+  ],
+  "sinks": [
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.SinkTable",
+          "namespace": "values://RetractingSinkFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "SinkTable",
+            "fullName": "default_database.SinkTable"
+          },
+          "facets": {}
+        }
+      ],
+      "modifyType": "INSERT"
+    }
+  ]
+}

--- a/flink-table/flink-table-planner/src/test/resources/lineage-graph/query-stream.json
+++ b/flink-table/flink-table-planner/src/test/resources/lineage-graph/query-stream.json
@@ -1,0 +1,70 @@
+{
+  "lineageEdges": [
+    {
+      "sourceLineageVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.FirstTable",
+            "namespace": "values://FromElementsFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "FirstTable",
+              "fullName": "default_database.FirstTable"
+            },
+            "facets": {}
+          }
+        ],
+        "boundedness": "CONTINUOUS_UNBOUNDED"
+      },
+      "sinkVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.SinkTable",
+            "namespace": "values://RetractingSinkFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "SinkTable",
+              "fullName": "default_database.SinkTable"
+            },
+            "facets": {}
+          }
+        ],
+        "modifyType": "UPDATE"
+      }
+    }
+  ],
+  "sources": [
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.FirstTable",
+          "namespace": "values://FromElementsFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "FirstTable",
+            "fullName": "default_database.FirstTable"
+          },
+          "facets": {}
+        }
+      ],
+      "boundedness": "CONTINUOUS_UNBOUNDED"
+    }
+  ],
+  "sinks": [
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.SinkTable",
+          "namespace": "values://RetractingSinkFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "SinkTable",
+            "fullName": "default_database.SinkTable"
+          },
+          "facets": {}
+        }
+      ],
+      "modifyType": "UPDATE"
+    }
+  ]
+}

--- a/flink-table/flink-table-planner/src/test/resources/lineage-graph/union-batch.json
+++ b/flink-table/flink-table-planner/src/test/resources/lineage-graph/union-batch.json
@@ -1,0 +1,117 @@
+{
+  "lineageEdges": [
+    {
+      "sourceLineageVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.FirstTable",
+            "namespace": "values://FromElementsFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "FirstTable",
+              "fullName": "default_database.FirstTable"
+            },
+            "facets": {}
+          }
+        ],
+        "boundedness": "BOUNDED"
+      },
+      "sinkVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.SinkTable",
+            "namespace": "values://RetractingSinkFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "SinkTable",
+              "fullName": "default_database.SinkTable"
+            },
+            "facets": {}
+          }
+        ],
+        "modifyType": "INSERT"
+      }
+    },
+    {
+      "sourceLineageVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.SecondTable",
+            "namespace": "values://FromElementsFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "SecondTable",
+              "fullName": "default_database.SecondTable"
+            },
+            "facets": {}
+          }
+        ],
+        "boundedness": "BOUNDED"
+      },
+      "sinkVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.SinkTable",
+            "namespace": "values://RetractingSinkFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "SinkTable",
+              "fullName": "default_database.SinkTable"
+            },
+            "facets": {}
+          }
+        ],
+        "modifyType": "INSERT"
+      }
+    }
+  ],
+  "sources": [
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.FirstTable",
+          "namespace": "values://FromElementsFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "FirstTable",
+            "fullName": "default_database.FirstTable"
+          },
+          "facets": {}
+        }
+      ],
+      "boundedness": "BOUNDED"
+    },
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.SecondTable",
+          "namespace": "values://FromElementsFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "SecondTable",
+            "fullName": "default_database.SecondTable"
+          },
+          "facets": {}
+        }
+      ],
+      "boundedness": "BOUNDED"
+    }
+  ],
+  "sinks": [
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.SinkTable",
+          "namespace": "values://RetractingSinkFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "SinkTable",
+            "fullName": "default_database.SinkTable"
+          },
+          "facets": {}
+        }
+      ],
+      "modifyType": "INSERT"
+    }
+  ]
+}

--- a/flink-table/flink-table-planner/src/test/resources/lineage-graph/union-stream.json
+++ b/flink-table/flink-table-planner/src/test/resources/lineage-graph/union-stream.json
@@ -1,0 +1,117 @@
+{
+  "lineageEdges": [
+    {
+      "sourceLineageVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.FirstTable",
+            "namespace": "values://FromElementsFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "FirstTable",
+              "fullName": "default_database.FirstTable"
+            },
+            "facets": {}
+          }
+        ],
+        "boundedness": "CONTINUOUS_UNBOUNDED"
+      },
+      "sinkVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.SinkTable",
+            "namespace": "values://RetractingSinkFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "SinkTable",
+              "fullName": "default_database.SinkTable"
+            },
+            "facets": {}
+          }
+        ],
+        "modifyType": "UPDATE"
+      }
+    },
+    {
+      "sourceLineageVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.SecondTable",
+            "namespace": "values://FromElementsFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "SecondTable",
+              "fullName": "default_database.SecondTable"
+            },
+            "facets": {}
+          }
+        ],
+        "boundedness": "CONTINUOUS_UNBOUNDED"
+      },
+      "sinkVertex": {
+        "datasets": [
+          {
+            "name": "default_catalog.default_database.SinkTable",
+            "namespace": "values://RetractingSinkFunction",
+            "objectPath": {
+              "databaseName": "default_database",
+              "objectName": "SinkTable",
+              "fullName": "default_database.SinkTable"
+            },
+            "facets": {}
+          }
+        ],
+        "modifyType": "UPDATE"
+      }
+    }
+  ],
+  "sources": [
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.FirstTable",
+          "namespace": "values://FromElementsFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "FirstTable",
+            "fullName": "default_database.FirstTable"
+          },
+          "facets": {}
+        }
+      ],
+      "boundedness": "CONTINUOUS_UNBOUNDED"
+    },
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.SecondTable",
+          "namespace": "values://FromElementsFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "SecondTable",
+            "fullName": "default_database.SecondTable"
+          },
+          "facets": {}
+        }
+      ],
+      "boundedness": "CONTINUOUS_UNBOUNDED"
+    }
+  ],
+  "sinks": [
+    {
+      "datasets": [
+        {
+          "name": "default_catalog.default_database.SinkTable",
+          "namespace": "values://RetractingSinkFunction",
+          "objectPath": {
+            "databaseName": "default_database",
+            "objectName": "SinkTable",
+            "fullName": "default_database.SinkTable"
+          },
+          "facets": {}
+        }
+      ],
+      "modifyType": "UPDATE"
+    }
+  ]
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -19,6 +19,7 @@ package org.apache.flink.table.planner.utils
 
 import org.apache.flink.FlinkVersion
 import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
+import org.apache.flink.api.dag.Transformation
 import org.apache.flink.api.java.typeutils.{PojoTypeInfo, RowTypeInfo, TupleTypeInfo}
 import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
 import org.apache.flink.configuration.BatchExecutionOptions
@@ -27,6 +28,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode
 import org.apache.flink.streaming.api.{environment, TimeCharacteristic}
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => ScalaStreamExecEnv}
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.java.{StreamTableEnvironment => JavaStreamTableEnv}
@@ -944,6 +946,21 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
       expectedPlans,
       () => assertEqualsOrExpand("sql", insert),
       withQueryBlockAlias = false)
+  }
+
+  /**
+   * Generate the stream graph from the INSERT statement.
+   *
+   * @param insert
+   *   the INSERT statement to check
+   */
+  def generateTransformations(insert: String): util.List[Transformation[_]] = {
+    val stmtSet = getTableEnv.createStatementSet()
+    stmtSet.addInsertSql(insert)
+
+    val testStmtSet = stmtSet.asInstanceOf[StatementSetImpl[_]]
+    val operations = testStmtSet.getOperations;
+    getPlanner.translate(operations)
   }
 
   /**

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/values/ValuesInputFormat.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/values/ValuesInputFormat.java
@@ -20,8 +20,14 @@ package org.apache.flink.table.runtime.operators.values;
 
 import org.apache.flink.api.common.io.GenericInputFormat;
 import org.apache.flink.api.common.io.NonParallelInput;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.core.io.GenericInputSplit;
+import org.apache.flink.streaming.api.lineage.DefaultLineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedInput;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
@@ -30,11 +36,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 
 /** Generated ValuesInputFormat. */
 public class ValuesInputFormat extends GenericInputFormat<RowData>
-        implements NonParallelInput, ResultTypeQueryable<RowData> {
-
+        implements NonParallelInput, ResultTypeQueryable<RowData>, LineageVertexProvider {
+    private static final String LINEAGE_NAMESPACE = "values://ValuesInputFormat";
     private static final Logger LOG = LoggerFactory.getLogger(ValuesInputFormat.class);
     private static final long serialVersionUID = 1L;
 
@@ -74,5 +83,21 @@ public class ValuesInputFormat extends GenericInputFormat<RowData>
     @Override
     public InternalTypeInfo<RowData> getProducedType() {
         return returnType;
+    }
+
+    @Override
+    public LineageVertex getLineageVertex() {
+        return new SourceLineageVertex() {
+            @Override
+            public Boundedness boundedness() {
+                return Boundedness.BOUNDED;
+            }
+
+            @Override
+            public List<LineageDataset> datasets() {
+                return Arrays.asList(
+                        new DefaultLineageDataset("", LINEAGE_NAMESPACE, new HashMap<>()));
+            }
+        };
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1679,6 +1679,7 @@ under the License.
 						<exclude>flink-table/flink-table-planner/src/test/resources/**/*.out</exclude>
 						<exclude>flink-table/flink-table-planner/src/test/resources/json/*.json</exclude>
 						<exclude>flink-table/flink-table-planner/src/test/resources/jsonplan/*.json</exclude>
+						<exclude>flink-table/flink-table-planner/src/test/resources/lineage-graph/*.json</exclude>
 						<exclude>flink-table/flink-table-planner/src/test/resources/restore-tests/**</exclude>
 						<exclude>flink-yarn/src/test/resources/krb5.keytab</exclude>
 						<exclude>flink-end-to-end-tests/test-scripts/test-data/**</exclude>


### PR DESCRIPTION
## What is the purpose of the change
1. Add Table Lineage Vertex into transformation in planner. The final LineageGraph is generated from transformation and put into StreamGraph. The lineage graph will be published to Lineage Listener in follow up PR.
2. Deprecated table source and sink are not considered as no enough info can be used for name and namespace for lineage dataset.

## Brief change log
  - add table lineage interface and default implementations
  - create lineage vertex and add them to transformation in the phase of physical plan to transformation conversion. 

## Verifying this change
1. Add TableLineageGraphTest for both stream and batch.
2. Added LineageGraph verification in TransformationsTest for legacy sources.
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
