### PR TITLE
[FLINK-34657] add lineage provider API

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageVertexProvider.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageVertexProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Create lineage vertex for source and sink in DataStream. If the source and sink connectors in
+ * datastream job implement this interface, flink will get lineage vertex and create all-to-all
+ * lineages between sources and sinks by default.
+ */
+@PublicEvolving
+public interface LineageVertexProvider {
+    LineageVertex getLineageVertex();
+}


### PR DESCRIPTION
## What is the purpose of the change

Add lineage provider interface for flink connector to expose lineage info.


## Brief change log

  - Add LineageVertexProvider interface

## Verifying this change

This change is a trivial new interface, no test.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
