### PR TITLE
[backport][hotfix][table] Fix typo in maven shade configuration

### DIFF
--- a/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
@@ -111,7 +111,7 @@
 									<include>org.apache.flink:flink-table-common</include>
 									<include>org.apache.flink:flink-annotations</include>
 									<include>org.apache.flink:flink-core</include>
-									<incldue>org.apache.flink:flink-runtime</incldue>
+									<include>org.apache.flink:flink-runtime</include>
 									<include>org.apache.flink:flink-clients</include>
 									<include>org.apache.flink:flink-table-api-java</include>
 									<include>org.apache.flink:flink-json</include>


### PR DESCRIPTION
Backport to 1.18