### PR TITLE
[FLINK-35021] AggregateQueryOperations produces wrong asSerializableString representation

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/AggregateQueryOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/AggregateQueryOperation.java
@@ -76,15 +76,26 @@ public class AggregateQueryOperation implements QueryOperation {
 
     @Override
     public String asSerializableString() {
+        final String groupingExprs = getGroupingExprs();
         return String.format(
                 "SELECT %s FROM (%s\n)\nGROUP BY %s",
                 Stream.concat(groupingExpressions.stream(), aggregateExpressions.stream())
                         .map(ResolvedExpression::asSerializableString)
                         .collect(Collectors.joining(", ")),
                 OperationUtils.indent(child.asSerializableString()),
-                groupingExpressions.stream()
-                        .map(ResolvedExpression::asSerializableString)
-                        .collect(Collectors.joining(", ")));
+                groupingExprs);
+    }
+
+    private String getGroupingExprs() {
+        if (groupingExpressions.isEmpty()) {
+            return "1";
+        } else {
+            final String groupingExprs =
+                    groupingExpressions.stream()
+                            .map(ResolvedExpression::asSerializableString)
+                            .collect(Collectors.joining(", "));
+            return groupingExprs;
+        }
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlExecutionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlExecutionTest.java
@@ -60,6 +60,7 @@ public class QueryOperationSqlExecutionTest implements TableTestProgramRunner {
                 QueryOperationTestPrograms.VALUES_QUERY_OPERATION,
                 QueryOperationTestPrograms.FILTER_QUERY_OPERATION,
                 QueryOperationTestPrograms.AGGREGATE_QUERY_OPERATION,
+                QueryOperationTestPrograms.AGGREGATE_NO_GROUP_BY_QUERY_OPERATION,
                 QueryOperationTestPrograms.DISTINCT_QUERY_OPERATION,
                 QueryOperationTestPrograms.JOIN_QUERY_OPERATION,
                 QueryOperationTestPrograms.ORDER_BY_QUERY_OPERATION,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlSerializationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlSerializationTest.java
@@ -53,6 +53,7 @@ public class QueryOperationSqlSerializationTest implements TableTestProgramRunne
                 QueryOperationTestPrograms.VALUES_QUERY_OPERATION,
                 QueryOperationTestPrograms.FILTER_QUERY_OPERATION,
                 QueryOperationTestPrograms.AGGREGATE_QUERY_OPERATION,
+                QueryOperationTestPrograms.AGGREGATE_NO_GROUP_BY_QUERY_OPERATION,
                 QueryOperationTestPrograms.DISTINCT_QUERY_OPERATION,
                 QueryOperationTestPrograms.JOIN_QUERY_OPERATION,
                 QueryOperationTestPrograms.ORDER_BY_QUERY_OPERATION,
@@ -114,7 +115,7 @@ public class QueryOperationSqlSerializationTest implements TableTestProgramRunne
                 (StreamGraph)
                         env.generatePipelineFromQueryOperation(queryOperation, transformations);
 
-        assertThat(sqlStep.sql).isEqualTo(streamGraph.getJobName());
+        assertThat(streamGraph.getJobName()).isEqualTo(sqlStep.sql);
     }
 
     private static TableEnvironment setupEnv(TableTestProgram program) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
@@ -147,6 +147,33 @@ public class QueryOperationTestPrograms {
                                     + ")")
                     .build();
 
+    static final TableTestProgram AGGREGATE_NO_GROUP_BY_QUERY_OPERATION =
+            TableTestProgram.of(
+                            "aggregate-query-no-group-by-operation", "verifies sql serialization")
+                    .setupTableSource(
+                            SourceTestStep.newBuilder("s")
+                                    .addSchema("a bigint", "b string")
+                                    .producedValues(
+                                            Row.of(10L, "apple"),
+                                            Row.of(20L, "apple"),
+                                            Row.of(5L, "pear"),
+                                            Row.of(15L, "pear"))
+                                    .build())
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink")
+                                    .addSchema("b bigint")
+                                    .consumedValues(Row.of(50L))
+                                    .build())
+                    .runTableApi(t -> t.from("s").select($("a").sum()), "sink")
+                    .runSql(
+                            "SELECT `EXPR$0` FROM (\n"
+                                    + "    SELECT (SUM(`a`)) AS `EXPR$0` FROM (\n"
+                                    + "        SELECT `a`, `b` FROM `default_catalog`.`default_database`.`s`\n"
+                                    + "    )\n"
+                                    + "    GROUP BY 1\n"
+                                    + ")")
+                    .build();
+
     static final TableTestProgram WINDOW_AGGREGATE_QUERY_OPERATION =
             TableTestProgram.of("window-aggregate-query-operation", "verifies sql serialization")
                     .setupTableSource(


### PR DESCRIPTION


## What is the purpose of the change

Fixes the bug that `AggregateQueryOperation` produces a wrong SQL if there were no explicit groupings provided

## Verifying this change

Added tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
