### PR TITLE
[hotfix] Correct the option key for sortPartition's java doc

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/PartitionWindowedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/PartitionWindowedStream.java
@@ -72,10 +72,9 @@ public interface PartitionWindowedStream<T> {
      * records must be {@link Tuple}.
      *
      * <p>This operator will use managed memory for the sort.For {@link
-     * NonKeyedPartitionWindowedStream}, the managed memory size can be set by
-     * "execution.sort.partition.memory" in {@link ExecutionOptions}. For {@link
-     * KeyedPartitionWindowedStream}, the managed memory size can be set by
-     * "execution.sort.keyed.partition.memory" in {@link ExecutionOptions}.
+     * NonKeyedPartitionWindowedStream}, the managed memory size can be set by {@link
+     * ExecutionOptions#SORT_PARTITION_MEMORY}. For {@link KeyedPartitionWindowedStream}, the
+     * managed memory size can be set by {@link ExecutionOptions#SORT_KEYED_PARTITION_MEMORY}.
      *
      * @param field The field 1-based index on which records is sorted.
      * @param order The order in which records is sorted.
@@ -99,10 +98,9 @@ public interface PartitionWindowedStream<T> {
      * </ul>
      *
      * <p>This operator will use managed memory for the sort.For {@link
-     * NonKeyedPartitionWindowedStream}, the managed memory size can be set by
-     * "execution.sort.partition.memory" in {@link ExecutionOptions}. For {@link
-     * KeyedPartitionWindowedStream}, the managed memory size can be set by
-     * "execution.sort.keyed.partition.memory" in {@link ExecutionOptions}.
+     * NonKeyedPartitionWindowedStream}, the managed memory size can be set by {@link
+     * ExecutionOptions#SORT_PARTITION_MEMORY}. For {@link KeyedPartitionWindowedStream}, the
+     * managed memory size can be set by {@link ExecutionOptions#SORT_KEYED_PARTITION_MEMORY}.
      *
      * @param field The field expression referring to the field on which records is sorted.
      * @param order The order in which records is sorted.
@@ -114,10 +112,9 @@ public interface PartitionWindowedStream<T> {
      * Sorts the records according to a {@link KeySelector} in the specified order.
      *
      * <p>This operator will use managed memory for the sort.For {@link
-     * NonKeyedPartitionWindowedStream}, the managed memory size can be set by
-     * "execution.sort.partition.memory" in {@link ExecutionOptions}. For {@link
-     * KeyedPartitionWindowedStream}, the managed memory size can be set by
-     * "execution.sort.keyed.partition.memory" in {@link ExecutionOptions}.
+     * NonKeyedPartitionWindowedStream}, the managed memory size can be set by {@link
+     * ExecutionOptions#SORT_PARTITION_MEMORY}. For {@link KeyedPartitionWindowedStream}, the
+     * managed memory size can be set by {@link ExecutionOptions#SORT_KEYED_PARTITION_MEMORY}.
      *
      * @param keySelector The key selector to extract key from the records for sorting.
      * @param order The order in which records is sorted.


### PR DESCRIPTION
## What is the purpose of the change

*Correct the option key for sortPartition's java doc*


## Brief change log

  - *Correct the option key for sortPartition's java doc.*
  - *Document the field start from 1 for sortPartition*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
