### PR TITLE
[FLINK-34915][table] Complete `DESCRIBE CATALOG` syntax

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/describe.md
+++ b/docs/content.zh/docs/dev/table/sql/describe.md
@@ -243,9 +243,9 @@ describe catalog cat2;
 +-----------+-------------------+
 | info name |        info value |
 +-----------+-------------------+
-|      Name |              cat2 |
-|      Type | generic_in_memory |
-|   Comment |                   |
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
 +-----------+-------------------+
 3 rows in set
 
@@ -253,33 +253,35 @@ desc catalog cat2;
 +-----------+-------------------+
 | info name |        info value |
 +-----------+-------------------+
-|      Name |              cat2 |
-|      Type | generic_in_memory |
-|   Comment |                   |
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
 +-----------+-------------------+
 3 rows in set
 ```
 展示完整的元数据描述。
 ```sql
 describe catalog extended cat2;
-+------------+---------------------------------------------------------+
-|  info name |                                              info value |
-+------------+---------------------------------------------------------+
-|       Name |                                                    cat2 |
-|       Type |                                       generic_in_memory |
-|    Comment |                                                         |
-| Properties | ('default-database','db'), ('type','generic_in_memory') |
-+------------+---------------------------------------------------------+
-4 rows in set
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
+|             option:type | generic_in_memory |
++-------------------------+-------------------+
+5 rows in set
 
 desc catalog extended cat2;
-+------------+---------------------------------------------------------+
-|  info name |                                              info value |
-+------------+---------------------------------------------------------+
-|       Name |                                                    cat2 |
-|       Type |                                       generic_in_memory |
-|    Comment |                                                         |
-| Properties | ('default-database','db'), ('type','generic_in_memory') |
-+------------+---------------------------------------------------------+
-4 rows in set
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
+|             option:type | generic_in_memory |
++-------------------------+-------------------+
+5 rows in set
 ```

--- a/docs/content.zh/docs/dev/table/sql/describe.md
+++ b/docs/content.zh/docs/dev/table/sql/describe.md
@@ -24,9 +24,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
+<a name="describe-statements"></a>
+
 # DESCRIBE 语句
 
 DESCRIBE 语句用于描述表或视图的 schema 或 catalog 的元数据。
+
+<a name="run-a-describe-statement"></a>
 
 ## 执行 DESCRIBE 语句
 
@@ -181,33 +185,11 @@ Flink SQL> DESC CATALOG EXTENDED cat2;
 {{< /tab >}}
 {{< /tabs >}}
 
-{{< top >}}
-
-## DESCRIBE
-
-```sql
-{ DESCRIBE | DESC } [EXTENDED] [catalog_name.][db_name.]table_name
-```
-
-描述一个现有表或视图的 schema。
-
-假设 `Orders` 表是按如下方式创建的：
-```sql
-CREATE TABLE Orders (
-    `user` BIGINT NOT NULl comment 'this is primary key',
-    product VARCHAR(32),
-    amount INT,
-    ts TIMESTAMP(3) comment 'notice: watermark',
-    ptime AS PROCTIME() comment 'this is a computed column',
-    PRIMARY KEY(`user`) NOT ENFORCED,
-    WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS
-) with (
-    'connector' = 'datagen'
-);
-```
-展示 schema。
-```sql
-describe Orders;
+上述示例的结果是：
+{{< tabs "c20da697-b9fc-434b-b7e5-3b51510eee5b" >}}
+{{< tab "Java" >}}
+```text
+# DESCRIBE TABLE Orders
 +---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 |    name |                        type |  null |       key |        extras |                  watermark |                   comment |
 +---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
@@ -218,68 +200,150 @@ describe Orders;
 |   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
 +---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 5 rows in set
-```
 
-## DESCRIBE CATALOG
+# DESCRIBE CATALOG cat2
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
++-----------+-------------------+
+3 rows in set
 
+# DESCRIBE CATALOG EXTENDED cat2
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
++-------------------------+-------------------+
+4 rows in set
 ```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```text
+# DESCRIBE TABLE Orders
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+5 rows in set
+
+# DESCRIBE CATALOG cat2
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
++-----------+-------------------+
+3 rows in set
+
+# DESCRIBE CATALOG EXTENDED cat2
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
++-------------------------+-------------------+
+4 rows in set
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```text
+# DESCRIBE TABLE Orders
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+5 rows in set
+
+# DESCRIBE CATALOG cat2
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
++-----------+-------------------+
+3 rows in set
+
+# DESCRIBE CATALOG EXTENDED cat2
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
++-------------------------+-------------------+
+4 rows in set
+```
+{{< /tab >}}
+{{< tab "SQL CLI" >}}
+```text
+# DESCRIBE TABLE Orders
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+5 rows in set
+
+# DESCRIBE CATALOG cat2
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
++-----------+-------------------+
+3 rows in set
+
+# DESCRIBE CATALOG EXTENDED cat2
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
++-------------------------+-------------------+
+4 rows in set
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+{{< top >}}
+
+<a name="syntax"></a>
+
+## 语法
+
+- DESCRIBE TABLE
+```sql
+{ DESCRIBE | DESC } [catalog_name.][db_name.]table_name
+```
+- DESCRIBE CATALOG
+```sql
 { DESCRIBE | DESC } CATALOG [EXTENDED] catalog_name
-```
-
-描述一个现有 catalog 的元数据。
-
-元数据信息包括 catalog 的名称、类型和注释。如果指定了可选的 EXTENDED 选项，则还会输出 catalog 属性。
-
-假设 `cat2` 是按如下方式创建的：
-```sql
-create catalog cat2 WITH (
-    'type'='generic_in_memory',
-    'default-database'='db'
-);
-```
-展示元数据描述。
-```sql
-describe catalog cat2;
-+-----------+-------------------+
-| info name |        info value |
-+-----------+-------------------+
-|      name |              cat2 |
-|      type | generic_in_memory |
-|   comment |                   |
-+-----------+-------------------+
-3 rows in set
-
-desc catalog cat2;
-+-----------+-------------------+
-| info name |        info value |
-+-----------+-------------------+
-|      name |              cat2 |
-|      type | generic_in_memory |
-|   comment |                   |
-+-----------+-------------------+
-3 rows in set
-```
-展示完整的元数据描述。
-```sql
-describe catalog extended cat2;
-+-------------------------+-------------------+
-|               info name |        info value |
-+-------------------------+-------------------+
-|                    name |              cat2 |
-|                    type | generic_in_memory |
-|                 comment |                   |
-| option:default-database |                db |
-+-------------------------+-------------------+
-4 rows in set
-
-desc catalog extended cat2;
-+-------------------------+-------------------+
-|               info name |        info value |
-+-------------------------+-------------------+
-|                    name |              cat2 |
-|                    type | generic_in_memory |
-|                 comment |                   |
-| option:default-database |                db |
-+-------------------------+-------------------+
-4 rows in set
 ```

--- a/docs/content.zh/docs/dev/table/sql/describe.md
+++ b/docs/content.zh/docs/dev/table/sql/describe.md
@@ -240,46 +240,46 @@ create catalog cat2 WITH (
 展示元数据描述。
 ```sql
 describe catalog cat2;
-+--------------------------+---------------------------+
-| catalog_description_item | catalog_description_value |
-+--------------------------+---------------------------+
-|                     Name |                      cat2 |
-|                     Type |         generic_in_memory |
-|                  Comment |                           |
-+--------------------------+---------------------------+
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      Name |              cat2 |
+|      Type | generic_in_memory |
+|   Comment |                   |
++-----------+-------------------+
 3 rows in set
 
 desc catalog cat2;
-+--------------------------+---------------------------+
-| catalog_description_item | catalog_description_value |
-+--------------------------+---------------------------+
-|                     Name |                      cat2 |
-|                     Type |         generic_in_memory |
-|                  Comment |                           |
-+--------------------------+---------------------------+
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      Name |              cat2 |
+|      Type | generic_in_memory |
+|   Comment |                   |
++-----------+-------------------+
 3 rows in set
 ```
 展示完整的元数据描述。
 ```sql
 describe catalog extended cat2;
-+--------------------------+---------------------------------------------------------+
-| catalog_description_item |                               catalog_description_value |
-+--------------------------+---------------------------------------------------------+
-|                     Name |                                                    cat2 |
-|                     Type |                                       generic_in_memory |
-|                  Comment |                                                         |
-|               Properties | ('default-database','db'), ('type','generic_in_memory') |
-+--------------------------+---------------------------------------------------------+
++------------+---------------------------------------------------------+
+|  info name |                                              info value |
++------------+---------------------------------------------------------+
+|       Name |                                                    cat2 |
+|       Type |                                       generic_in_memory |
+|    Comment |                                                         |
+| Properties | ('default-database','db'), ('type','generic_in_memory') |
++------------+---------------------------------------------------------+
 4 rows in set
 
 desc catalog extended cat2;
-+--------------------------+---------------------------------------------------------+
-| catalog_description_item |                               catalog_description_value |
-+--------------------------+---------------------------------------------------------+
-|                     Name |                                                    cat2 |
-|                     Type |                                       generic_in_memory |
-|                  Comment |                                                         |
-|               Properties | ('default-database','db'), ('type','generic_in_memory') |
-+--------------------------+---------------------------------------------------------+
++------------+---------------------------------------------------------+
+|  info name |                                              info value |
++------------+---------------------------------------------------------+
+|       Name |                                                    cat2 |
+|       Type |                                       generic_in_memory |
+|    Comment |                                                         |
+| Properties | ('default-database','db'), ('type','generic_in_memory') |
++------------+---------------------------------------------------------+
 4 rows in set
 ```

--- a/docs/content.zh/docs/dev/table/sql/describe.md
+++ b/docs/content.zh/docs/dev/table/sql/describe.md
@@ -269,9 +269,8 @@ describe catalog extended cat2;
 |                    type | generic_in_memory |
 |                 comment |                   |
 | option:default-database |                db |
-|             option:type | generic_in_memory |
 +-------------------------+-------------------+
-5 rows in set
+4 rows in set
 
 desc catalog extended cat2;
 +-------------------------+-------------------+
@@ -281,7 +280,6 @@ desc catalog extended cat2;
 |                    type | generic_in_memory |
 |                 comment |                   |
 | option:default-database |                db |
-|             option:type | generic_in_memory |
 +-------------------------+-------------------+
-5 rows in set
+4 rows in set
 ```

--- a/docs/content.zh/docs/dev/table/sql/describe.md
+++ b/docs/content.zh/docs/dev/table/sql/describe.md
@@ -24,13 +24,9 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<a name="describe-statements"></a>
-
 # DESCRIBE 语句
 
-DESCRIBE 语句用于描述表或视图的 schema。
-
-<a name="run-a-describe-statement"></a>
+DESCRIBE 语句用于描述表或视图的 schema 或 catalog 的元数据。
 
 ## 执行 DESCRIBE 语句
 
@@ -81,6 +77,15 @@ tableEnv.executeSql("DESCRIBE Orders").print();
 
 // 打印 schema
 tableEnv.executeSql("DESC Orders").print();
+
+// 注册名为 “cat2” 的 catalog
+tableEnv.executeSql("CREATE CATALOG cat2 WITH ('type'='generic_in_memory', 'default-database'='db')");
+
+// 打印元数据
+tableEnv.executeSql("DESCRIBE CATALOG cat2").print();
+
+// 打印完整的元数据
+tableEnv.executeSql("DESC CATALOG EXTENDED cat2").print();
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
@@ -104,6 +109,15 @@ tableEnv.executeSql("DESCRIBE Orders").print()
 
 // 打印 schema
 tableEnv.executeSql("DESC Orders").print()
+
+// 注册名为 “cat2” 的 catalog
+tableEnv.executeSql("CREATE CATALOG cat2 WITH ('type'='generic_in_memory', 'default-database'='db')")
+
+// 打印元数据
+tableEnv.executeSql("DESCRIBE CATALOG cat2").print()
+
+// 打印完整的元数据
+tableEnv.executeSql("DESC CATALOG EXTENDED cat2").print()
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -127,6 +141,15 @@ table_env.execute_sql("DESCRIBE Orders").print()
 
 # 打印 schema
 table_env.execute_sql("DESC Orders").print()
+
+# 注册名为 “cat2” 的 catalog
+table_env.execute_sql("CREATE CATALOG cat2 WITH ('type'='generic_in_memory', 'default-database'='db')")
+
+# 打印元数据
+table_env.execute_sql("DESCRIBE CATALOG cat2").print()
+
+# 打印完整的元数据
+table_env.execute_sql("DESC CATALOG EXTENDED cat2").print()
 ```
 {{< /tab >}}
 {{< tab "SQL CLI" >}}
@@ -147,82 +170,116 @@ Flink SQL> CREATE TABLE Orders (
 Flink SQL> DESCRIBE Orders;
 
 Flink SQL> DESC Orders;
-```
-{{< /tab >}}
-{{< /tabs >}}
 
-上述示例的结果是：
-{{< tabs "c20da697-b9fc-434b-b7e5-3b51510eee5b" >}}
-{{< tab "Java" >}}
-```text
+Flink SQL> CREATE CATALOG cat2 WITH ('type'='generic_in_memory', 'default-database'='db');
+[INFO] Execute statement succeeded.
 
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
-| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
-|  amount |                         INT |  TRUE |           |               |                            |                           |
-|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
-|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-5 rows in set
+Flink SQL> DESCRIBE CATALOG cat2;
 
-```
-{{< /tab >}}
-{{< tab "Scala" >}}
-```text
-
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
-| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
-|  amount |                         INT |  TRUE |           |               |                            |                           |
-|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
-|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-5 rows in set
-
-```
-{{< /tab >}}
-{{< tab "Python" >}}
-```text
-
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
-| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
-|  amount |                         INT |  TRUE |           |               |                            |                           |
-|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
-|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-5 rows in set
-
-```
-{{< /tab >}}
-{{< tab "SQL CLI" >}}
-```text
-
-root
- |-- user: BIGINT NOT NULL COMMENT 'this is primary key'
- |-- product: VARCHAR(32)
- |-- amount: INT
- |-- ts: TIMESTAMP(3) *ROWTIME* COMMENT 'notice: watermark'
- |-- ptime: TIMESTAMP(3) NOT NULL *PROCTIME* AS PROCTIME() COMMENT 'this is a computed column'
- |-- WATERMARK FOR ts AS `ts` - INTERVAL '1' SECOND
- |-- CONSTRAINT PK_3599338 PRIMARY KEY (user)
-
+Flink SQL> DESC CATALOG EXTENDED cat2;
 ```
 {{< /tab >}}
 {{< /tabs >}}
 
 {{< top >}}
 
-<a name="syntax"></a>
-
-## 语法
+## DESCRIBE
 
 ```sql
-{ DESCRIBE | DESC } [catalog_name.][db_name.]table_name
+{ DESCRIBE | DESC } [EXTENDED] [catalog_name.][db_name.]table_name
+```
+
+描述一个现有表或视图的 schema。
+
+假设 `Orders` 表是按如下方式创建的：
+```sql
+CREATE TABLE Orders (
+    `user` BIGINT NOT NULl comment 'this is primary key',
+    product VARCHAR(32),
+    amount INT,
+    ts TIMESTAMP(3) comment 'notice: watermark',
+    ptime AS PROCTIME() comment 'this is a computed column',
+    PRIMARY KEY(`user`) NOT ENFORCED,
+    WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS
+) with (
+    'connector' = 'datagen'
+);
+```
+展示 schema。
+```sql
+describe Orders;
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+5 rows in set
+```
+
+## DESCRIBE CATALOG
+
+```
+{ DESCRIBE | DESC } CATALOG [EXTENDED] catalog_name
+```
+
+描述一个现有 catalog 的元数据。
+
+元数据信息包括 catalog 的名称、类型和注释。如果指定了可选的 EXTENDED 选项，则还会输出 catalog 属性。
+
+假设 `cat2` 是按如下方式创建的：
+```sql
+create catalog cat2 WITH (
+    'type'='generic_in_memory',
+    'default-database'='db'
+);
+```
+展示元数据描述。
+```sql
+describe catalog cat2;
++--------------------------+---------------------------+
+| catalog_description_item | catalog_description_value |
++--------------------------+---------------------------+
+|                     Name |                      cat2 |
+|                     Type |         generic_in_memory |
+|                  Comment |                           |
++--------------------------+---------------------------+
+3 rows in set
+
+desc catalog cat2;
++--------------------------+---------------------------+
+| catalog_description_item | catalog_description_value |
++--------------------------+---------------------------+
+|                     Name |                      cat2 |
+|                     Type |         generic_in_memory |
+|                  Comment |                           |
++--------------------------+---------------------------+
+3 rows in set
+```
+展示完整的元数据描述。
+```sql
+describe catalog extended cat2;
++--------------------------+---------------------------------------------------------+
+| catalog_description_item |                               catalog_description_value |
++--------------------------+---------------------------------------------------------+
+|                     Name |                                                    cat2 |
+|                     Type |                                       generic_in_memory |
+|                  Comment |                                                         |
+|               Properties | ('default-database','db'), ('type','generic_in_memory') |
++--------------------------+---------------------------------------------------------+
+4 rows in set
+
+desc catalog extended cat2;
++--------------------------+---------------------------------------------------------+
+| catalog_description_item |                               catalog_description_value |
++--------------------------+---------------------------------------------------------+
+|                     Name |                                                    cat2 |
+|                     Type |                                       generic_in_memory |
+|                  Comment |                                                         |
+|               Properties | ('default-database','db'), ('type','generic_in_memory') |
++--------------------------+---------------------------------------------------------+
+4 rows in set
 ```

--- a/docs/content/docs/dev/table/sql/describe.md
+++ b/docs/content/docs/dev/table/sql/describe.md
@@ -26,7 +26,7 @@ under the License.
 
 # DESCRIBE Statements
 
-DESCRIBE statements are used to describe the schema of a table or a view.
+DESCRIBE statements are used to describe the schema of a table or a view, or the metadata of a catalog.
 
 
 ## Run a DESCRIBE statement
@@ -80,6 +80,15 @@ tableEnv.executeSql("DESCRIBE Orders").print();
 
 // print the schema
 tableEnv.executeSql("DESC Orders").print();
+
+// register a catalog named "cat2"
+tableEnv.executeSql("CREATE CATALOG cat2 WITH ('type'='generic_in_memory', 'default-database'='db')");
+
+// print the metadata
+tableEnv.executeSql("DESCRIBE CATALOG cat2").print();
+
+// print the complete metadata
+tableEnv.executeSql("DESC CATALOG EXTENDED cat2").print();
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
@@ -103,6 +112,15 @@ tableEnv.executeSql("DESCRIBE Orders").print()
 
 // print the schema
 tableEnv.executeSql("DESC Orders").print()
+
+// register a catalog named "cat2"
+tableEnv.executeSql("CREATE CATALOG cat2 WITH ('type'='generic_in_memory', 'default-database'='db')")
+
+// print the metadata
+tableEnv.executeSql("DESCRIBE CATALOG cat2").print()
+
+// print the complete metadata
+tableEnv.executeSql("DESC CATALOG EXTENDED cat2").print()
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -126,6 +144,15 @@ table_env.execute_sql("DESCRIBE Orders").print()
 
 # print the schema
 table_env.execute_sql("DESC Orders").print()
+
+# register a catalog named "cat2"
+table_env.execute_sql("CREATE CATALOG cat2 WITH ('type'='generic_in_memory', 'default-database'='db')")
+
+# print the metadata
+table_env.execute_sql("DESCRIBE CATALOG cat2").print()
+
+# print the complete metadata
+table_env.execute_sql("DESC CATALOG EXTENDED cat2").print()
 ```
 {{< /tab >}}
 {{< tab "SQL CLI" >}}
@@ -146,81 +173,116 @@ Flink SQL> CREATE TABLE Orders (
 Flink SQL> DESCRIBE Orders;
 
 Flink SQL> DESC Orders;
+
+Flink SQL> CREATE CATALOG cat2 WITH ('type'='generic_in_memory', 'default-database'='db');
+[INFO] Execute statement succeeded.
+
+Flink SQL> DESCRIBE CATALOG cat2;
+
+Flink SQL> DESC CATALOG EXTENDED cat2;
 ```
 {{< /tab >}}
 {{< /tabs >}}
-
-The result of the above example is:
-{{< tabs "c20da697-b9fc-434b-b7e5-3b51510eee5b" >}}
-{{< tab "Java" >}}
-```text
-
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
-| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
-|  amount |                         INT |  TRUE |           |               |                            |                           |
-|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
-|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-5 rows in set
-
-```
-{{< /tab >}}
-{{< tab "Scala" >}}
-```text
-
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
-| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
-|  amount |                         INT |  TRUE |           |               |                            |                           |
-|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
-|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-5 rows in set
-
-```
-{{< /tab >}}
-{{< tab "Python" >}}
-```text
-
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
-| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
-|  amount |                         INT |  TRUE |           |               |                            |                           |
-|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
-|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
-5 rows in set
-
-```
-{{< /tab >}}
-{{< tab "SQL CLI" >}}
-```text
-
-root
- |-- user: BIGINT NOT NULL COMMENT 'this is primary key'
- |-- product: VARCHAR(32)
- |-- amount: INT
- |-- ts: TIMESTAMP(3) *ROWTIME* COMMENT 'notice: watermark'
- |-- ptime: TIMESTAMP(3) NOT NULL *PROCTIME* AS PROCTIME() COMMENT 'this is a computed column'
- |-- WATERMARK FOR ts AS `ts` - INTERVAL '1' SECOND
- |-- CONSTRAINT PK_3599338 PRIMARY KEY (user)
-
-```
-{{< /tab >}}
-{{< /tabs >}}
-
 
 {{< top >}}
 
-## Syntax
+## DESCRIBE
 
 ```sql
-{ DESCRIBE | DESC } [catalog_name.][db_name.]table_name
+{ DESCRIBE | DESC } [EXTENDED] [catalog_name.][db_name.]table_name
+```
+
+Describe the metadata of an existing table or view.
+
+Assumes that the table `Orders` is created as follows:
+```sql
+CREATE TABLE Orders (
+    `user` BIGINT NOT NULl comment 'this is primary key',
+    product VARCHAR(32),
+    amount INT,
+    ts TIMESTAMP(3) comment 'notice: watermark',
+    ptime AS PROCTIME() comment 'this is a computed column',
+    PRIMARY KEY(`user`) NOT ENFORCED,
+    WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS
+) with (
+    'connector' = 'datagen'
+);
+```
+Shows the schema.
+```sql
+describe Orders;
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+5 rows in set
+```
+
+## DESCRIBE CATALOG
+
+```
+{ DESCRIBE | DESC } CATALOG [EXTENDED] catalog_name
+```
+
+Describe the metadata of an existing catalog.
+
+The metadata information includes the catalog’s name, type, and comment. If the optional EXTENDED option is specified, catalog properties are also returned.
+
+Assumes that the catalog `cat2` is created as follows:
+```sql
+create catalog cat2 WITH (
+    'type'='generic_in_memory',
+    'default-database'='db'
+);
+```
+Shows the metadata description.
+```sql
+describe catalog cat2;
++--------------------------+---------------------------+
+| catalog_description_item | catalog_description_value |
++--------------------------+---------------------------+
+|                     Name |                      cat2 |
+|                     Type |         generic_in_memory |
+|                  Comment |                           |
++--------------------------+---------------------------+
+3 rows in set
+
+desc catalog cat2;
++--------------------------+---------------------------+
+| catalog_description_item | catalog_description_value |
++--------------------------+---------------------------+
+|                     Name |                      cat2 |
+|                     Type |         generic_in_memory |
+|                  Comment |                           |
++--------------------------+---------------------------+
+3 rows in set
+```
+Shows the complete metadata description.
+```sql
+describe catalog extended cat2;
++--------------------------+---------------------------------------------------------+
+| catalog_description_item |                               catalog_description_value |
++--------------------------+---------------------------------------------------------+
+|                     Name |                                                    cat2 |
+|                     Type |                                       generic_in_memory |
+|                  Comment |                                                         |
+|               Properties | ('default-database','db'), ('type','generic_in_memory') |
++--------------------------+---------------------------------------------------------+
+4 rows in set
+
+desc catalog extended cat2;
++--------------------------+---------------------------------------------------------+
+| catalog_description_item |                               catalog_description_value |
++--------------------------+---------------------------------------------------------+
+|                     Name |                                                    cat2 |
+|                     Type |                                       generic_in_memory |
+|                  Comment |                                                         |
+|               Properties | ('default-database','db'), ('type','generic_in_memory') |
++--------------------------+---------------------------------------------------------+
+4 rows in set
 ```

--- a/docs/content/docs/dev/table/sql/describe.md
+++ b/docs/content/docs/dev/table/sql/describe.md
@@ -184,33 +184,11 @@ Flink SQL> DESC CATALOG EXTENDED cat2;
 {{< /tab >}}
 {{< /tabs >}}
 
-{{< top >}}
-
-## DESCRIBE
-
-```sql
-{ DESCRIBE | DESC } [EXTENDED] [catalog_name.][db_name.]table_name
-```
-
-Describe the metadata of an existing table or view.
-
-Assumes that the table `Orders` is created as follows:
-```sql
-CREATE TABLE Orders (
-    `user` BIGINT NOT NULl comment 'this is primary key',
-    product VARCHAR(32),
-    amount INT,
-    ts TIMESTAMP(3) comment 'notice: watermark',
-    ptime AS PROCTIME() comment 'this is a computed column',
-    PRIMARY KEY(`user`) NOT ENFORCED,
-    WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS
-) with (
-    'connector' = 'datagen'
-);
-```
-Shows the schema.
-```sql
-describe Orders;
+The result of the above example is:
+{{< tabs "c20da697-b9fc-434b-b7e5-3b51510eee5b" >}}
+{{< tab "Java" >}}
+```text
+# DESCRIBE TABLE Orders
 +---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 |    name |                        type |  null |       key |        extras |                  watermark |                   comment |
 +---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
@@ -221,68 +199,150 @@ describe Orders;
 |   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
 +---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 5 rows in set
-```
 
-## DESCRIBE CATALOG
+# DESCRIBE CATALOG cat2
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
++-----------+-------------------+
+3 rows in set
+
+# DESCRIBE CATALOG EXTENDED cat2
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
++-------------------------+-------------------+
+4 rows in set
+```
+{{< /tab >}}
+{{< tab "Scala" >}}
+```text
+# DESCRIBE TABLE Orders
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+5 rows in set
+
+# DESCRIBE CATALOG cat2
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
++-----------+-------------------+
+3 rows in set
+
+# DESCRIBE CATALOG EXTENDED cat2
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
++-------------------------+-------------------+
+4 rows in set
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```text
+# DESCRIBE TABLE Orders
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+5 rows in set
+
+# DESCRIBE CATALOG cat2
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
++-----------+-------------------+
+3 rows in set
+
+# DESCRIBE CATALOG EXTENDED cat2
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
++-------------------------+-------------------+
+4 rows in set
+```
+{{< /tab >}}
+{{< tab "SQL CLI" >}}
+```text
+# DESCRIBE TABLE Orders
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+5 rows in set
+
+# DESCRIBE CATALOG cat2
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
++-----------+-------------------+
+3 rows in set
+
+# DESCRIBE CATALOG EXTENDED cat2
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
++-------------------------+-------------------+
+4 rows in set
 
 ```
+{{< /tab >}}
+{{< /tabs >}}
+
+
+{{< top >}}
+
+## Syntax
+
+- DESCRIBE TABLE
+```sql
+{ DESCRIBE | DESC } [catalog_name.][db_name.]table_name
+```
+- DESCRIBE CATALOG
+```sql
 { DESCRIBE | DESC } CATALOG [EXTENDED] catalog_name
-```
-
-Describe the metadata of an existing catalog.
-
-The metadata information includes the catalog’s name, type, and comment. If the optional EXTENDED option is specified, catalog properties are also returned.
-
-Assumes that the catalog `cat2` is created as follows:
-```sql
-create catalog cat2 WITH (
-    'type'='generic_in_memory',
-    'default-database'='db'
-);
-```
-Shows the metadata description.
-```sql
-describe catalog cat2;
-+-----------+-------------------+
-| info name |        info value |
-+-----------+-------------------+
-|      name |              cat2 |
-|      type | generic_in_memory |
-|   comment |                   |
-+-----------+-------------------+
-3 rows in set
-
-desc catalog cat2;
-+-----------+-------------------+
-| info name |        info value |
-+-----------+-------------------+
-|      name |              cat2 |
-|      type | generic_in_memory |
-|   comment |                   |
-+-----------+-------------------+
-3 rows in set
-```
-Shows the complete metadata description.
-```sql
-describe catalog extended cat2;
-+-------------------------+-------------------+
-|               info name |        info value |
-+-------------------------+-------------------+
-|                    name |              cat2 |
-|                    type | generic_in_memory |
-|                 comment |                   |
-| option:default-database |                db |
-+-------------------------+-------------------+
-4 rows in set
-
-desc catalog extended cat2;
-+-------------------------+-------------------+
-|               info name |        info value |
-+-------------------------+-------------------+
-|                    name |              cat2 |
-|                    type | generic_in_memory |
-|                 comment |                   |
-| option:default-database |                db |
-+-------------------------+-------------------+
-4 rows in set
 ```

--- a/docs/content/docs/dev/table/sql/describe.md
+++ b/docs/content/docs/dev/table/sql/describe.md
@@ -246,9 +246,9 @@ describe catalog cat2;
 +-----------+-------------------+
 | info name |        info value |
 +-----------+-------------------+
-|      Name |              cat2 |
-|      Type | generic_in_memory |
-|   Comment |                   |
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
 +-----------+-------------------+
 3 rows in set
 
@@ -256,33 +256,35 @@ desc catalog cat2;
 +-----------+-------------------+
 | info name |        info value |
 +-----------+-------------------+
-|      Name |              cat2 |
-|      Type | generic_in_memory |
-|   Comment |                   |
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
 +-----------+-------------------+
 3 rows in set
 ```
 Shows the complete metadata description.
 ```sql
 describe catalog extended cat2;
-+------------+---------------------------------------------------------+
-|  info name |                                              info value |
-+------------+---------------------------------------------------------+
-|       Name |                                                    cat2 |
-|       Type |                                       generic_in_memory |
-|    Comment |                                                         |
-| Properties | ('default-database','db'), ('type','generic_in_memory') |
-+------------+---------------------------------------------------------+
-4 rows in set
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
+|             option:type | generic_in_memory |
++-------------------------+-------------------+
+5 rows in set
 
 desc catalog extended cat2;
-+------------+---------------------------------------------------------+
-|  info name |                                              info value |
-+------------+---------------------------------------------------------+
-|       Name |                                                    cat2 |
-|       Type |                                       generic_in_memory |
-|    Comment |                                                         |
-| Properties | ('default-database','db'), ('type','generic_in_memory') |
-+------------+---------------------------------------------------------+
-4 rows in set
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
+|             option:type | generic_in_memory |
++-------------------------+-------------------+
+5 rows in set
 ```

--- a/docs/content/docs/dev/table/sql/describe.md
+++ b/docs/content/docs/dev/table/sql/describe.md
@@ -272,9 +272,8 @@ describe catalog extended cat2;
 |                    type | generic_in_memory |
 |                 comment |                   |
 | option:default-database |                db |
-|             option:type | generic_in_memory |
 +-------------------------+-------------------+
-5 rows in set
+4 rows in set
 
 desc catalog extended cat2;
 +-------------------------+-------------------+
@@ -284,7 +283,6 @@ desc catalog extended cat2;
 |                    type | generic_in_memory |
 |                 comment |                   |
 | option:default-database |                db |
-|             option:type | generic_in_memory |
 +-------------------------+-------------------+
-5 rows in set
+4 rows in set
 ```

--- a/docs/content/docs/dev/table/sql/describe.md
+++ b/docs/content/docs/dev/table/sql/describe.md
@@ -243,46 +243,46 @@ create catalog cat2 WITH (
 Shows the metadata description.
 ```sql
 describe catalog cat2;
-+--------------------------+---------------------------+
-| catalog_description_item | catalog_description_value |
-+--------------------------+---------------------------+
-|                     Name |                      cat2 |
-|                     Type |         generic_in_memory |
-|                  Comment |                           |
-+--------------------------+---------------------------+
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      Name |              cat2 |
+|      Type | generic_in_memory |
+|   Comment |                   |
++-----------+-------------------+
 3 rows in set
 
 desc catalog cat2;
-+--------------------------+---------------------------+
-| catalog_description_item | catalog_description_value |
-+--------------------------+---------------------------+
-|                     Name |                      cat2 |
-|                     Type |         generic_in_memory |
-|                  Comment |                           |
-+--------------------------+---------------------------+
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      Name |              cat2 |
+|      Type | generic_in_memory |
+|   Comment |                   |
++-----------+-------------------+
 3 rows in set
 ```
 Shows the complete metadata description.
 ```sql
 describe catalog extended cat2;
-+--------------------------+---------------------------------------------------------+
-| catalog_description_item |                               catalog_description_value |
-+--------------------------+---------------------------------------------------------+
-|                     Name |                                                    cat2 |
-|                     Type |                                       generic_in_memory |
-|                  Comment |                                                         |
-|               Properties | ('default-database','db'), ('type','generic_in_memory') |
-+--------------------------+---------------------------------------------------------+
++------------+---------------------------------------------------------+
+|  info name |                                              info value |
++------------+---------------------------------------------------------+
+|       Name |                                                    cat2 |
+|       Type |                                       generic_in_memory |
+|    Comment |                                                         |
+| Properties | ('default-database','db'), ('type','generic_in_memory') |
++------------+---------------------------------------------------------+
 4 rows in set
 
 desc catalog extended cat2;
-+--------------------------+---------------------------------------------------------+
-| catalog_description_item |                               catalog_description_value |
-+--------------------------+---------------------------------------------------------+
-|                     Name |                                                    cat2 |
-|                     Type |                                       generic_in_memory |
-|                  Comment |                                                         |
-|               Properties | ('default-database','db'), ('type','generic_in_memory') |
-+--------------------------+---------------------------------------------------------+
++------------+---------------------------------------------------------+
+|  info name |                                              info value |
++------------+---------------------------------------------------------+
+|       Name |                                                    cat2 |
+|       Type |                                       generic_in_memory |
+|    Comment |                                                         |
+| Properties | ('default-database','db'), ('type','generic_in_memory') |
++------------+---------------------------------------------------------+
 4 rows in set
 ```

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -707,3 +707,49 @@ show create catalog cat2;
 +---------------------------------------------------------------------------------------------+
 1 row in set
 !ok
+
+describe catalog cat2;
++--------------------------+---------------------------+
+| catalog_description_item | catalog_description_value |
++--------------------------+---------------------------+
+|                     Name |                      cat2 |
+|                     Type |         generic_in_memory |
+|                  Comment |                           |
++--------------------------+---------------------------+
+3 rows in set
+!ok
+
+describe catalog extended cat2;
++--------------------------+---------------------------------------------------------+
+| catalog_description_item |                               catalog_description_value |
++--------------------------+---------------------------------------------------------+
+|                     Name |                                                    cat2 |
+|                     Type |                                       generic_in_memory |
+|                  Comment |                                                         |
+|               Properties | ('default-database','db'), ('type','generic_in_memory') |
++--------------------------+---------------------------------------------------------+
+4 rows in set
+!ok
+
+desc catalog cat2;
++--------------------------+---------------------------+
+| catalog_description_item | catalog_description_value |
++--------------------------+---------------------------+
+|                     Name |                      cat2 |
+|                     Type |         generic_in_memory |
+|                  Comment |                           |
++--------------------------+---------------------------+
+3 rows in set
+!ok
+
+desc catalog extended cat2;
++--------------------------+---------------------------------------------------------+
+| catalog_description_item |                               catalog_description_value |
++--------------------------+---------------------------------------------------------+
+|                     Name |                                                    cat2 |
+|                     Type |                                       generic_in_memory |
+|                  Comment |                                                         |
+|               Properties | ('default-database','db'), ('type','generic_in_memory') |
++--------------------------+---------------------------------------------------------+
+4 rows in set
+!ok

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -709,47 +709,47 @@ show create catalog cat2;
 !ok
 
 describe catalog cat2;
-+--------------------------+---------------------------+
-| catalog_description_item | catalog_description_value |
-+--------------------------+---------------------------+
-|                     Name |                      cat2 |
-|                     Type |         generic_in_memory |
-|                  Comment |                           |
-+--------------------------+---------------------------+
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      Name |              cat2 |
+|      Type | generic_in_memory |
+|   Comment |                   |
++-----------+-------------------+
 3 rows in set
 !ok
 
 describe catalog extended cat2;
-+--------------------------+---------------------------------------------------------+
-| catalog_description_item |                               catalog_description_value |
-+--------------------------+---------------------------------------------------------+
-|                     Name |                                                    cat2 |
-|                     Type |                                       generic_in_memory |
-|                  Comment |                                                         |
-|               Properties | ('default-database','db'), ('type','generic_in_memory') |
-+--------------------------+---------------------------------------------------------+
++------------+---------------------------------------------------------+
+|  info name |                                              info value |
++------------+---------------------------------------------------------+
+|       Name |                                                    cat2 |
+|       Type |                                       generic_in_memory |
+|    Comment |                                                         |
+| Properties | ('default-database','db'), ('type','generic_in_memory') |
++------------+---------------------------------------------------------+
 4 rows in set
 !ok
 
 desc catalog cat2;
-+--------------------------+---------------------------+
-| catalog_description_item | catalog_description_value |
-+--------------------------+---------------------------+
-|                     Name |                      cat2 |
-|                     Type |         generic_in_memory |
-|                  Comment |                           |
-+--------------------------+---------------------------+
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      Name |              cat2 |
+|      Type | generic_in_memory |
+|   Comment |                   |
++-----------+-------------------+
 3 rows in set
 !ok
 
 desc catalog extended cat2;
-+--------------------------+---------------------------------------------------------+
-| catalog_description_item |                               catalog_description_value |
-+--------------------------+---------------------------------------------------------+
-|                     Name |                                                    cat2 |
-|                     Type |                                       generic_in_memory |
-|                  Comment |                                                         |
-|               Properties | ('default-database','db'), ('type','generic_in_memory') |
-+--------------------------+---------------------------------------------------------+
++------------+---------------------------------------------------------+
+|  info name |                                              info value |
++------------+---------------------------------------------------------+
+|       Name |                                                    cat2 |
+|       Type |                                       generic_in_memory |
+|    Comment |                                                         |
+| Properties | ('default-database','db'), ('type','generic_in_memory') |
++------------+---------------------------------------------------------+
 4 rows in set
 !ok

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -712,44 +712,46 @@ describe catalog cat2;
 +-----------+-------------------+
 | info name |        info value |
 +-----------+-------------------+
-|      Name |              cat2 |
-|      Type | generic_in_memory |
-|   Comment |                   |
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
 +-----------+-------------------+
 3 rows in set
 !ok
 
 describe catalog extended cat2;
-+------------+---------------------------------------------------------+
-|  info name |                                              info value |
-+------------+---------------------------------------------------------+
-|       Name |                                                    cat2 |
-|       Type |                                       generic_in_memory |
-|    Comment |                                                         |
-| Properties | ('default-database','db'), ('type','generic_in_memory') |
-+------------+---------------------------------------------------------+
-4 rows in set
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
+|             option:type | generic_in_memory |
++-------------------------+-------------------+
+5 rows in set
 !ok
 
 desc catalog cat2;
 +-----------+-------------------+
 | info name |        info value |
 +-----------+-------------------+
-|      Name |              cat2 |
-|      Type | generic_in_memory |
-|   Comment |                   |
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
 +-----------+-------------------+
 3 rows in set
 !ok
 
 desc catalog extended cat2;
-+------------+---------------------------------------------------------+
-|  info name |                                              info value |
-+------------+---------------------------------------------------------+
-|       Name |                                                    cat2 |
-|       Type |                                       generic_in_memory |
-|    Comment |                                                         |
-| Properties | ('default-database','db'), ('type','generic_in_memory') |
-+------------+---------------------------------------------------------+
-4 rows in set
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
+|             option:type | generic_in_memory |
++-------------------------+-------------------+
+5 rows in set
 !ok

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -727,9 +727,8 @@ describe catalog extended cat2;
 |                    type | generic_in_memory |
 |                 comment |                   |
 | option:default-database |                db |
-|             option:type | generic_in_memory |
 +-------------------------+-------------------+
-5 rows in set
+4 rows in set
 !ok
 
 desc catalog cat2;
@@ -751,7 +750,6 @@ desc catalog extended cat2;
 |                    type | generic_in_memory |
 |                 comment |                   |
 | option:default-database |                db |
-|             option:type | generic_in_memory |
 +-------------------------+-------------------+
-5 rows in set
+4 rows in set
 !ok

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
@@ -838,3 +838,53 @@ CREATE CATALOG `cat2` WITH (
   'type' = 'generic_in_memory'
 )
 !ok
+
+describe catalog cat2;
+!output
++--------------------------+---------------------------+
+| catalog_description_item | catalog_description_value |
++--------------------------+---------------------------+
+|                     Name |                      cat2 |
+|                     Type |         generic_in_memory |
+|                  Comment |                           |
++--------------------------+---------------------------+
+3 rows in set
+!ok
+
+describe catalog extended cat2;
+!output
++--------------------------+---------------------------------------------------------+
+| catalog_description_item |                               catalog_description_value |
++--------------------------+---------------------------------------------------------+
+|                     Name |                                                    cat2 |
+|                     Type |                                       generic_in_memory |
+|                  Comment |                                                         |
+|               Properties | ('default-database','db'), ('type','generic_in_memory') |
++--------------------------+---------------------------------------------------------+
+4 rows in set
+!ok
+
+desc catalog cat2;
+!output
++--------------------------+---------------------------+
+| catalog_description_item | catalog_description_value |
++--------------------------+---------------------------+
+|                     Name |                      cat2 |
+|                     Type |         generic_in_memory |
+|                  Comment |                           |
++--------------------------+---------------------------+
+3 rows in set
+!ok
+
+desc catalog extended cat2;
+!output
++--------------------------+---------------------------------------------------------+
+| catalog_description_item |                               catalog_description_value |
++--------------------------+---------------------------------------------------------+
+|                     Name |                                                    cat2 |
+|                     Type |                                       generic_in_memory |
+|                  Comment |                                                         |
+|               Properties | ('default-database','db'), ('type','generic_in_memory') |
++--------------------------+---------------------------------------------------------+
+4 rows in set
+!ok

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
@@ -841,50 +841,50 @@ CREATE CATALOG `cat2` WITH (
 
 describe catalog cat2;
 !output
-+--------------------------+---------------------------+
-| catalog_description_item | catalog_description_value |
-+--------------------------+---------------------------+
-|                     Name |                      cat2 |
-|                     Type |         generic_in_memory |
-|                  Comment |                           |
-+--------------------------+---------------------------+
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      Name |              cat2 |
+|      Type | generic_in_memory |
+|   Comment |                   |
++-----------+-------------------+
 3 rows in set
 !ok
 
 describe catalog extended cat2;
 !output
-+--------------------------+---------------------------------------------------------+
-| catalog_description_item |                               catalog_description_value |
-+--------------------------+---------------------------------------------------------+
-|                     Name |                                                    cat2 |
-|                     Type |                                       generic_in_memory |
-|                  Comment |                                                         |
-|               Properties | ('default-database','db'), ('type','generic_in_memory') |
-+--------------------------+---------------------------------------------------------+
++------------+---------------------------------------------------------+
+|  info name |                                              info value |
++------------+---------------------------------------------------------+
+|       Name |                                                    cat2 |
+|       Type |                                       generic_in_memory |
+|    Comment |                                                         |
+| Properties | ('default-database','db'), ('type','generic_in_memory') |
++------------+---------------------------------------------------------+
 4 rows in set
 !ok
 
 desc catalog cat2;
 !output
-+--------------------------+---------------------------+
-| catalog_description_item | catalog_description_value |
-+--------------------------+---------------------------+
-|                     Name |                      cat2 |
-|                     Type |         generic_in_memory |
-|                  Comment |                           |
-+--------------------------+---------------------------+
++-----------+-------------------+
+| info name |        info value |
++-----------+-------------------+
+|      Name |              cat2 |
+|      Type | generic_in_memory |
+|   Comment |                   |
++-----------+-------------------+
 3 rows in set
 !ok
 
 desc catalog extended cat2;
 !output
-+--------------------------+---------------------------------------------------------+
-| catalog_description_item |                               catalog_description_value |
-+--------------------------+---------------------------------------------------------+
-|                     Name |                                                    cat2 |
-|                     Type |                                       generic_in_memory |
-|                  Comment |                                                         |
-|               Properties | ('default-database','db'), ('type','generic_in_memory') |
-+--------------------------+---------------------------------------------------------+
++------------+---------------------------------------------------------+
+|  info name |                                              info value |
++------------+---------------------------------------------------------+
+|       Name |                                                    cat2 |
+|       Type |                                       generic_in_memory |
+|    Comment |                                                         |
+| Properties | ('default-database','db'), ('type','generic_in_memory') |
++------------+---------------------------------------------------------+
 4 rows in set
 !ok

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
@@ -860,9 +860,8 @@ describe catalog extended cat2;
 |                    type | generic_in_memory |
 |                 comment |                   |
 | option:default-database |                db |
-|             option:type | generic_in_memory |
 +-------------------------+-------------------+
-5 rows in set
+4 rows in set
 !ok
 
 desc catalog cat2;
@@ -886,7 +885,6 @@ desc catalog extended cat2;
 |                    type | generic_in_memory |
 |                 comment |                   |
 | option:default-database |                db |
-|             option:type | generic_in_memory |
 +-------------------------+-------------------+
-5 rows in set
+4 rows in set
 !ok

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
@@ -844,24 +844,25 @@ describe catalog cat2;
 +-----------+-------------------+
 | info name |        info value |
 +-----------+-------------------+
-|      Name |              cat2 |
-|      Type | generic_in_memory |
-|   Comment |                   |
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
 +-----------+-------------------+
 3 rows in set
 !ok
 
 describe catalog extended cat2;
 !output
-+------------+---------------------------------------------------------+
-|  info name |                                              info value |
-+------------+---------------------------------------------------------+
-|       Name |                                                    cat2 |
-|       Type |                                       generic_in_memory |
-|    Comment |                                                         |
-| Properties | ('default-database','db'), ('type','generic_in_memory') |
-+------------+---------------------------------------------------------+
-4 rows in set
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
+|             option:type | generic_in_memory |
++-------------------------+-------------------+
+5 rows in set
 !ok
 
 desc catalog cat2;
@@ -869,22 +870,23 @@ desc catalog cat2;
 +-----------+-------------------+
 | info name |        info value |
 +-----------+-------------------+
-|      Name |              cat2 |
-|      Type | generic_in_memory |
-|   Comment |                   |
+|      name |              cat2 |
+|      type | generic_in_memory |
+|   comment |                   |
 +-----------+-------------------+
 3 rows in set
 !ok
 
 desc catalog extended cat2;
 !output
-+------------+---------------------------------------------------------+
-|  info name |                                              info value |
-+------------+---------------------------------------------------------+
-|       Name |                                                    cat2 |
-|       Type |                                       generic_in_memory |
-|    Comment |                                                         |
-| Properties | ('default-database','db'), ('type','generic_in_memory') |
-+------------+---------------------------------------------------------+
-4 rows in set
++-------------------------+-------------------+
+|               info name |        info value |
++-------------------------+-------------------+
+|                    name |              cat2 |
+|                    type | generic_in_memory |
+|                 comment |                   |
+| option:default-database |                db |
+|             option:type | generic_in_memory |
++-------------------------+-------------------+
+5 rows in set
 !ok

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -73,16 +73,22 @@ SqlCall SqlShowCurrentCatalogOrDatabase() :
     )
 }
 
+/**
+* Parse a "DESCRIBE CATALOG" metadata query command.
+* { DESCRIBE | DESC } CATALOG [EXTENDED] catalog_name;
+*/
 SqlDescribeCatalog SqlDescribeCatalog() :
 {
     SqlIdentifier catalogName;
     SqlParserPos pos;
+    boolean isExtended = false;
 }
 {
     ( <DESCRIBE> | <DESC> ) <CATALOG> { pos = getPos();}
+    [ <EXTENDED> { isExtended = true;} ]
     catalogName = SimpleIdentifier()
     {
-        return new SqlDescribeCatalog(pos, catalogName);
+        return new SqlDescribeCatalog(pos, catalogName, isExtended);
     }
 
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlDescribeCatalog.java
@@ -34,12 +34,14 @@ import java.util.List;
 public class SqlDescribeCatalog extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
-            new SqlSpecialOperator("DESCRIBE CATALOG", SqlKind.OTHER);
+            new SqlSpecialOperator("DESCRIBE CATALOG", SqlKind.OTHER_DDL);
     private final SqlIdentifier catalogName;
+    private final boolean isExtended;
 
-    public SqlDescribeCatalog(SqlParserPos pos, SqlIdentifier catalogName) {
+    public SqlDescribeCatalog(SqlParserPos pos, SqlIdentifier catalogName, boolean isExtended) {
         super(pos);
         this.catalogName = catalogName;
+        this.isExtended = isExtended;
     }
 
     @Override
@@ -56,9 +58,16 @@ public class SqlDescribeCatalog extends SqlCall {
         return catalogName.getSimple();
     }
 
+    public boolean isExtended() {
+        return isExtended;
+    }
+
     @Override
     public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
         writer.keyword("DESCRIBE CATALOG");
+        if (isExtended) {
+            writer.keyword("EXTENDED");
+        }
         catalogName.unparse(writer, leftPrec, rightPrec);
     }
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -59,8 +59,10 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     @Test
     void testDescribeCatalog() {
         sql("describe catalog a").ok("DESCRIBE CATALOG `A`");
+        sql("describe catalog extended a").ok("DESCRIBE CATALOG EXTENDED `A`");
 
         sql("desc catalog a").ok("DESCRIBE CATALOG `A`");
+        sql("desc catalog extended a").ok("DESCRIBE CATALOG EXTENDED `A`");
     }
 
     @Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.internal.TableResultUtils.buildTableResult;
 
@@ -92,23 +93,19 @@ public class DescribeCatalogOperation implements Operation, ExecutableOperation 
         }
 
         return buildTableResult(
-                Arrays.asList("catalog_description_item", "catalog_description_value")
-                        .toArray(new String[0]),
+                Arrays.asList("info name", "info value").toArray(new String[0]),
                 Arrays.asList(DataTypes.STRING(), DataTypes.STRING()).toArray(new DataType[0]),
                 rows.stream().map(List::toArray).toArray(Object[][]::new));
     }
 
     private String convertPropertiesToString(Map<String, String> map) {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (Map.Entry<String, String> entry : map.entrySet()) {
-            stringBuilder.append(
-                    String.format(
-                            "('%s','%s'), ",
-                            EncodingUtils.escapeSingleQuotes(entry.getKey()),
-                            EncodingUtils.escapeSingleQuotes(entry.getValue())));
-        }
-        // remove the last unnecessary comma and space
-        stringBuilder.delete(stringBuilder.length() - 2, stringBuilder.length());
-        return stringBuilder.toString();
+        return map.entrySet().stream()
+                .map(
+                        entry ->
+                                String.format(
+                                        "('%s','%s')",
+                                        EncodingUtils.escapeSingleQuotes(entry.getKey()),
+                                        EncodingUtils.escapeSingleQuotes(entry.getValue())))
+                .collect(Collectors.joining(", "));
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
@@ -25,7 +25,6 @@ import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogDescriptor;
 import org.apache.flink.table.catalog.CommonCatalogOptions;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.utils.EncodingUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,7 +32,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.internal.TableResultUtils.buildTableResult;
 
@@ -81,31 +79,20 @@ public class DescribeCatalogOperation implements Operation, ExecutableOperation 
         List<List<Object>> rows =
                 new ArrayList<>(
                         Arrays.asList(
-                                Arrays.asList("Name", catalogName),
+                                Arrays.asList("name", catalogName),
                                 Arrays.asList(
-                                        "Type",
+                                        "type",
                                         properties.getOrDefault(
                                                 CommonCatalogOptions.CATALOG_TYPE.key(), "")),
-                                Arrays.asList("Comment", "") // TODO: retain for future needs
+                                Arrays.asList("comment", "") // TODO: retain for future needs
                                 ));
         if (isExtended) {
-            rows.add(Arrays.asList("Properties", convertPropertiesToString(properties)));
+            properties.forEach((key, value) -> rows.add(Arrays.asList("option:" + key, value)));
         }
 
         return buildTableResult(
                 Arrays.asList("info name", "info value").toArray(new String[0]),
                 Arrays.asList(DataTypes.STRING(), DataTypes.STRING()).toArray(new DataType[0]),
                 rows.stream().map(List::toArray).toArray(Object[][]::new));
-    }
-
-    private String convertPropertiesToString(Map<String, String> map) {
-        return map.entrySet().stream()
-                .map(
-                        entry ->
-                                String.format(
-                                        "('%s','%s')",
-                                        EncodingUtils.escapeSingleQuotes(entry.getKey()),
-                                        EncodingUtils.escapeSingleQuotes(entry.getValue())))
-                .collect(Collectors.joining(", "));
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
@@ -84,15 +84,25 @@ public class DescribeCatalogOperation implements Operation, ExecutableOperation 
                                         "type",
                                         properties.getOrDefault(
                                                 CommonCatalogOptions.CATALOG_TYPE.key(), "")),
-                                Arrays.asList("comment", "") // TODO: retain for future needs
-                                ));
+                                // TODO: Show the catalog comment until FLINK-34918 is resolved
+                                Arrays.asList("comment", "")));
         if (isExtended) {
-            properties.forEach((key, value) -> rows.add(Arrays.asList("option:" + key, value)));
+            properties.entrySet().stream()
+                    .filter(
+                            entry ->
+                                    !CommonCatalogOptions.CATALOG_TYPE.key().equals(entry.getKey()))
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(
+                            entry ->
+                                    rows.add(
+                                            Arrays.asList(
+                                                    String.format("option:%s", entry.getKey()),
+                                                    entry.getValue())));
         }
 
         return buildTableResult(
-                Arrays.asList("info name", "info value").toArray(new String[0]),
-                Arrays.asList(DataTypes.STRING(), DataTypes.STRING()).toArray(new DataType[0]),
+                new String[] {"info name", "info value"},
+                new DataType[] {DataTypes.STRING(), DataTypes.STRING()},
                 rows.stream().map(List::toArray).toArray(Object[][]::new));
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DescribeCatalogOperation.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.CatalogDescriptor;
+import org.apache.flink.table.catalog.CommonCatalogOptions;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.utils.EncodingUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.api.internal.TableResultUtils.buildTableResult;
+
+/** Operation to describe a DESCRIBE CATALOG catalog_name statement. */
+@Internal
+public class DescribeCatalogOperation implements Operation, ExecutableOperation {
+
+    private final String catalogName;
+    private final boolean isExtended;
+
+    public DescribeCatalogOperation(String catalogName, boolean isExtended) {
+        this.catalogName = catalogName;
+        this.isExtended = isExtended;
+    }
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public boolean isExtended() {
+        return isExtended;
+    }
+
+    @Override
+    public String asSummaryString() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("identifier", catalogName);
+        params.put("isExtended", isExtended);
+        return OperationUtils.formatWithChildren(
+                "DESCRIBE CATALOG", params, Collections.emptyList(), Operation::asSummaryString);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        CatalogDescriptor catalogDescriptor =
+                ctx.getCatalogManager()
+                        .getCatalogDescriptor(catalogName)
+                        .orElseThrow(
+                                () ->
+                                        new ValidationException(
+                                                String.format(
+                                                        "Cannot obtain metadata information from Catalog %s.",
+                                                        catalogName)));
+        Map<String, String> properties = catalogDescriptor.getConfiguration().toMap();
+        List<List<Object>> rows =
+                new ArrayList<>(
+                        Arrays.asList(
+                                Arrays.asList("Name", catalogName),
+                                Arrays.asList(
+                                        "Type",
+                                        properties.getOrDefault(
+                                                CommonCatalogOptions.CATALOG_TYPE.key(), "")),
+                                Arrays.asList("Comment", "") // TODO: retain for future needs
+                                ));
+        if (isExtended) {
+            rows.add(Arrays.asList("Properties", convertPropertiesToString(properties)));
+        }
+
+        return buildTableResult(
+                Arrays.asList("catalog_description_item", "catalog_description_value")
+                        .toArray(new String[0]),
+                Arrays.asList(DataTypes.STRING(), DataTypes.STRING()).toArray(new DataType[0]),
+                rows.stream().map(List::toArray).toArray(Object[][]::new));
+    }
+
+    private String convertPropertiesToString(Map<String, String> map) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            stringBuilder.append(
+                    String.format(
+                            "('%s','%s'), ",
+                            EncodingUtils.escapeSingleQuotes(entry.getKey()),
+                            EncodingUtils.escapeSingleQuotes(entry.getValue())));
+        }
+        // remove the last unnecessary comma and space
+        stringBuilder.delete(stringBuilder.length() - 2, stringBuilder.length());
+        return stringBuilder.toString();
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlDescribeCatalogConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlDescribeCatalogConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.dql.SqlDescribeCatalog;
+import org.apache.flink.table.operations.DescribeCatalogOperation;
+import org.apache.flink.table.operations.Operation;
+
+/** A converter for {@link SqlDescribeCatalog}. */
+public class SqlDescribeCatalogConverter implements SqlNodeConverter<SqlDescribeCatalog> {
+
+    @Override
+    public Operation convertSqlNode(SqlDescribeCatalog sqlDescribeCatalog, ConvertContext context) {
+        return new DescribeCatalogOperation(
+                sqlDescribeCatalog.getCatalogName(), sqlDescribeCatalog.isExtended());
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -54,6 +54,7 @@ public class SqlNodeConverters {
         register(new SqlProcedureCallConverter());
         register(new SqlShowDatabasesConverter());
         register(new SqlShowCreateCatalogConverter());
+        register(new SqlDescribeCatalogConverter());
     }
 
     /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.table.api.SqlParserException;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.operations.DescribeCatalogOperation;
 import org.apache.flink.table.operations.LoadModuleOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ShowCreateCatalogOperation;
@@ -69,6 +70,41 @@ public class SqlOtherOperationConverterTest extends SqlNodeToOperationConversion
         assertThat(operation).isInstanceOf(UseCatalogOperation.class);
         assertThat(((UseCatalogOperation) operation).getCatalogName()).isEqualTo("cat1");
         assertThat(operation.asSummaryString()).isEqualTo("USE CATALOG cat1");
+    }
+
+    @Test
+    void testDescribeCatalog() {
+        final String sql1 = "DESCRIBE CATALOG cat1";
+        Operation operation = parse(sql1);
+        assertThat(operation).isInstanceOf(DescribeCatalogOperation.class);
+        assertThat(((DescribeCatalogOperation) operation).getCatalogName()).isEqualTo("cat1");
+        assertThat(((DescribeCatalogOperation) operation).isExtended()).isEqualTo(false);
+        assertThat(operation.asSummaryString())
+                .isEqualTo("DESCRIBE CATALOG: (identifier: [cat1], isExtended: [false])");
+
+        final String sql2 = "DESCRIBE CATALOG EXTENDED cat1";
+        Operation operation2 = parse(sql2);
+        assertThat(operation2).isInstanceOf(DescribeCatalogOperation.class);
+        assertThat(((DescribeCatalogOperation) operation2).getCatalogName()).isEqualTo("cat1");
+        assertThat(((DescribeCatalogOperation) operation2).isExtended()).isEqualTo(true);
+        assertThat(operation2.asSummaryString())
+                .isEqualTo("DESCRIBE CATALOG: (identifier: [cat1], isExtended: [true])");
+
+        final String sql3 = "DESC CATALOG cat1";
+        Operation operation3 = parse(sql3);
+        assertThat(operation3).isInstanceOf(DescribeCatalogOperation.class);
+        assertThat(((DescribeCatalogOperation) operation3).getCatalogName()).isEqualTo("cat1");
+        assertThat(((DescribeCatalogOperation) operation3).isExtended()).isEqualTo(false);
+        assertThat(operation3.asSummaryString())
+                .isEqualTo("DESCRIBE CATALOG: (identifier: [cat1], isExtended: [false])");
+
+        final String sql4 = "DESC CATALOG EXTENDED cat1";
+        Operation operation4 = parse(sql4);
+        assertThat(operation4).isInstanceOf(DescribeCatalogOperation.class);
+        assertThat(((DescribeCatalogOperation) operation4).getCatalogName()).isEqualTo("cat1");
+        assertThat(((DescribeCatalogOperation) operation4).isExtended()).isEqualTo(true);
+        assertThat(operation4.asSummaryString())
+                .isEqualTo("DESCRIBE CATALOG: (identifier: [cat1], isExtended: [true])");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Describe the metadata of an existing catalog. The metadata information includes the catalog’s name, type, and comment. If the optional EXTENDED option is specified, catalog properties are also returned.

## Brief change log

* { DESCRIBE | DESC } CATALOG [EXTENDED] catalog_name

## Verifying this change

This change added tests and can be verified as follows:

flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? yes