### PR TITLE
[FLINK-35060][Test/Connector] Provide compatibility of old CheckpointMode for connector testing framework

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/CheckpointingMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/CheckpointingMode.java
@@ -90,4 +90,16 @@ public enum CheckpointingMode {
                 throw new IllegalArgumentException("Unsupported semantic: " + semantic);
         }
     }
+
+    public static org.apache.flink.streaming.api.CheckpointingMode convertFromCheckpointingMode(
+            org.apache.flink.core.execution.CheckpointingMode semantic) {
+        switch (semantic) {
+            case EXACTLY_ONCE:
+                return org.apache.flink.streaming.api.CheckpointingMode.EXACTLY_ONCE;
+            case AT_LEAST_ONCE:
+                return org.apache.flink.streaming.api.CheckpointingMode.AT_LEAST_ONCE;
+            default:
+                throw new IllegalArgumentException("Unsupported semantic: " + semantic);
+        }
+    }
 }

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/external/sink/TestingSinkSettings.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/external/sink/TestingSinkSettings.java
@@ -20,6 +20,8 @@ package org.apache.flink.connector.testframe.external.sink;
 
 import org.apache.flink.core.execution.CheckpointingMode;
 
+import static org.apache.flink.streaming.api.CheckpointingMode.convertFromCheckpointingMode;
+import static org.apache.flink.streaming.api.CheckpointingMode.convertToCheckpointingMode;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Settings for configuring the sink under testing. */
@@ -34,9 +36,14 @@ public class TestingSinkSettings {
         this.checkpointingMode = checkpointingMode;
     }
 
-    /** Checkpointing mode required for the sink. */
-    public CheckpointingMode getCheckpointingMode() {
-        return checkpointingMode;
+    /**
+     * Checkpointing mode required for the sink. This method is required for downstream projects
+     * e.g. Flink connectors extending this test for the case when there should be supported Flink
+     * versions below 1.20. Could be removed together with dropping support for Flink 1.19.
+     */
+    @Deprecated
+    public org.apache.flink.streaming.api.CheckpointingMode getCheckpointingMode() {
+        return convertFromCheckpointingMode(checkpointingMode);
     }
 
     /** Builder class for {@link TestingSinkSettings}. */
@@ -45,6 +52,18 @@ public class TestingSinkSettings {
 
         public Builder setCheckpointingMode(CheckpointingMode checkpointingMode) {
             this.checkpointingMode = checkpointingMode;
+            return this;
+        }
+
+        /**
+         * This method is required for downstream projects e.g. Flink connectors extending this test
+         * for the case when there should be supported Flink versions below 1.20. Could be removed
+         * together with dropping support for Flink 1.19.
+         */
+        @Deprecated
+        public Builder setCheckpointingMode(
+                org.apache.flink.streaming.api.CheckpointingMode checkpointingMode) {
+            this.checkpointingMode = convertToCheckpointingMode(checkpointingMode);
             return this;
         }
 

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/external/source/TestingSourceSettings.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/external/source/TestingSourceSettings.java
@@ -21,6 +21,8 @@ package org.apache.flink.connector.testframe.external.source;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.core.execution.CheckpointingMode;
 
+import static org.apache.flink.streaming.api.CheckpointingMode.convertFromCheckpointingMode;
+import static org.apache.flink.streaming.api.CheckpointingMode.convertToCheckpointingMode;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Settings for configuring the source under testing. */
@@ -37,9 +39,14 @@ public class TestingSourceSettings {
         return boundedness;
     }
 
-    /** Checkpointing mode required for the source. */
-    public CheckpointingMode getCheckpointingMode() {
-        return checkpointingMode;
+    /**
+     * Checkpointing mode required for the source. This method is required for downstream projects
+     * e.g. Flink connectors extending this test for the case when there should be supported Flink
+     * versions below 1.20. Could be removed together with dropping support for Flink 1.19.
+     */
+    @Deprecated
+    public org.apache.flink.streaming.api.CheckpointingMode getCheckpointingMode() {
+        return convertFromCheckpointingMode(checkpointingMode);
     }
 
     private TestingSourceSettings(Boundedness boundedness, CheckpointingMode checkpointingMode) {
@@ -59,6 +66,18 @@ public class TestingSourceSettings {
 
         public Builder setCheckpointingMode(CheckpointingMode checkpointingMode) {
             this.checkpointingMode = checkpointingMode;
+            return this;
+        }
+
+        /**
+         * This method is required for downstream projects e.g. Flink connectors extending this test
+         * for the case when there should be supported Flink versions below 1.20. Could be removed
+         * together with dropping support for Flink 1.19.
+         */
+        @Deprecated
+        public Builder setCheckpointingMode(
+                org.apache.flink.streaming.api.CheckpointingMode checkpointingMode) {
+            this.checkpointingMode = convertToCheckpointingMode(checkpointingMode);
             return this;
         }
 

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/junit/annotations/TestSemantics.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/junit/annotations/TestSemantics.java
@@ -27,7 +27,8 @@ import java.lang.annotation.Target;
 
 /**
  * Marks the field in test class defining supported semantic: {@link
- * org.apache.flink.core.execution.CheckpointingMode}.
+ * org.apache.flink.core.execution.CheckpointingMode} and {@link
+ * org.apache.flink.streaming.api.CheckpointingMode} (deprecated).
  *
  * <p>Only one field can be annotated in test class.
  */

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/junit/extensions/ConnectorTestingExtension.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/junit/extensions/ConnectorTestingExtension.java
@@ -36,6 +36,7 @@ import org.junit.platform.commons.support.AnnotationSupport;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -97,11 +98,32 @@ public class ConnectorTestingExtension implements BeforeAllCallback, AfterAllCal
         }
 
         // Store supported semantic
-        final List<CheckpointingMode[]> semantics =
+        List<CheckpointingMode[]> semantics =
                 AnnotationSupport.findAnnotatedFieldValues(
                         context.getRequiredTestInstance(),
                         TestSemantics.class,
                         CheckpointingMode[].class);
+        // Fallback part start.
+        // This is for compatibility of org.apache.flink.streaming.api.CheckpointingMode, which can
+        // be removed if we drop the support of 1.19 and old CheckpointingMode.
+        final List<org.apache.flink.streaming.api.CheckpointingMode[]> fallbackSemantics =
+                AnnotationSupport.findAnnotatedFieldValues(
+                        context.getRequiredTestInstance(),
+                        TestSemantics.class,
+                        org.apache.flink.streaming.api.CheckpointingMode[].class);
+        if (!fallbackSemantics.isEmpty()) {
+            semantics = new ArrayList<>(semantics);
+        }
+        for (org.apache.flink.streaming.api.CheckpointingMode[] oldModes : fallbackSemantics) {
+            semantics.add(
+                    Arrays.stream(oldModes)
+                            .sequential()
+                            .map(
+                                    org.apache.flink.streaming.api.CheckpointingMode
+                                            ::convertToCheckpointingMode)
+                            .toArray(CheckpointingMode[]::new));
+        }
+        // Fallback part ends.
         checkExactlyOneAnnotatedField(semantics, TestSemantics.class);
         context.getStore(TEST_RESOURCE_NAMESPACE)
                 .put(SUPPORTED_SEMANTIC_STORE_KEY, semantics.get(0));

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/UnorderedCollectIteratorAssert.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/UnorderedCollectIteratorAssert.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
 import static org.apache.flink.shaded.guava31.com.google.common.base.Predicates.not;
+import static org.apache.flink.streaming.api.CheckpointingMode.convertToCheckpointingMode;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -56,6 +57,18 @@ public class UnorderedCollectIteratorAssert<T>
     public UnorderedCollectIteratorAssert<T> withNumRecordsLimit(int limit) {
         this.limit = limit;
         return this;
+    }
+
+    /**
+     * This method is required for downstream projects e.g. Flink connectors extending this test for
+     * the case when there should be supported Flink versions below 1.20. Could be removed together
+     * with dropping support for Flink 1.19.
+     */
+    @Deprecated
+    public void matchesRecordsFromSource(
+            List<List<T>> recordsBySplitsFromSource,
+            org.apache.flink.streaming.api.CheckpointingMode semantic) {
+        matchesRecordsFromSource(recordsBySplitsFromSource, convertToCheckpointingMode(semantic));
     }
 
     public void matchesRecordsFromSource(


### PR DESCRIPTION
## What is the purpose of the change

After FLINK-34516, the `org.apache.flink.streaming.api.CheckpointingMode` has been moved to `org.apache.flink.core.execution.CheckpointingMode`. It introduced a breaking change to connector testing framework as well as to externalized connector repos by mistake. This PR fix this by providing methods with old signatures.

## Brief change log

- Provide methods with old signatures in `TestingSinkSettings` and `TestingSourceSettings`
- Support old `CheckpointingMode` in annotation `TestSemantics`, add fallback logic in `ConnectorTestingExtension`.

## Verifying this change

This change can be verified manually in downstream projects, such as the kafka connector.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
