### PR TITLE
[FLINK-35037][table-planner]Optimize uniqueKeys and upsertKeys inference of windows with ROW_NUMBER.

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniqueness.scala
@@ -439,6 +439,18 @@ class FlinkRelMdColumnUniqueness private extends MetadataHandler[BuiltInMetadata
       mq: RelMetadataQuery,
       columns: ImmutableBitSet,
       ignoreNulls: Boolean): JBoolean = {
+    var (groups, aggStartPos) = FlinkRelMdUniqueKeys.INSTANCE.getGroupsAndStartPos(overAgg)
+    for (group <- groups) {
+      FlinkRelMdUniqueKeys.INSTANCE.getUniqueKeysOfWindowGroup(group, aggStartPos) match {
+        case Some(upsertKeys) =>
+          val isColumnsBelongsToRowNumber = upsertKeys.exists(columns.contains)
+          if (isColumnsBelongsToRowNumber) {
+            return true
+          }
+        case _ =>
+      }
+      aggStartPos = aggStartPos + group.aggCalls.length
+    }
     val input = overAgg.getInput
     val inputFieldLength = input.getRowType.getFieldCount
     val columnsBelongsToInput = ImmutableBitSet.of(columns.filter(_ < inputFieldLength).toList)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
@@ -455,11 +455,56 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
     getUniqueKeysOfOverAgg(rel, mq, ignoreNulls)
   }
 
+  def getUniqueKeysOfWindowGroup(
+      group: Window.Group,
+      startPos: Int): Option[JSet[ImmutableBitSet]] = {
+    val retSet = new JHashSet[ImmutableBitSet]
+    val aggCalls = group.aggCalls
+    for ((aggCall, offset) <- aggCalls.zipWithIndex) {
+      // If it's a ROW_NUMBER window, then the unique keys are partition by key and row number.
+      if (aggCall.getOperator.equals(SqlStdOperatorTable.ROW_NUMBER)) {
+        val rowNumberColumnIndex = startPos + offset
+        retSet.add(group.keys.union(ImmutableBitSet.of(rowNumberColumnIndex)))
+      }
+    }
+    if (retSet.isEmpty) {
+      None
+    } else {
+      Some(retSet)
+    }
+  }
+
+  def getGroupsAndStartPos(window: SingleRel): Tuple2[JList[Window.Group], Int] = {
+    val groups: JList[Window.Group] = window match {
+      case window: Window => window.groups
+      case streamOverAggregate: StreamPhysicalOverAggregate =>
+        streamOverAggregate.logicWindow.groups
+      case batchOverAggregate: BatchPhysicalOverAggregate => batchOverAggregate.windowGroups
+      case _ => throw new IllegalArgumentException("Illegal window type.")
+    }
+    val aggCounts = groups.map(_.aggCalls.length).sum
+    val aggStartIndex = window.getRowType.getFieldCount - aggCounts
+    (groups, aggStartIndex)
+  }
+
   private def getUniqueKeysOfOverAgg(
       window: SingleRel,
       mq: RelMetadataQuery,
       ignoreNulls: Boolean): JSet[ImmutableBitSet] = {
-    mq.getUniqueKeys(window.getInput, ignoreNulls)
+    val retSet = new JHashSet[ImmutableBitSet]
+    var (groups, aggStartPos) = getGroupsAndStartPos(window)
+    for (group <- groups) {
+      getUniqueKeysOfWindowGroup(group, aggStartPos) match {
+        case Some(uniqueKeys) => retSet.addAll(uniqueKeys)
+        case _ =>
+      }
+      aggStartPos = aggStartPos + group.aggCalls.length
+    }
+    val inputKeys = mq.getUniqueKeys(window.getInput, ignoreNulls)
+    if (inputKeys != null && inputKeys.nonEmpty) {
+      retSet.addAll(inputKeys)
+    }
+    retSet
   }
 
   def getUniqueKeys(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalOverAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalOverAggregate.scala
@@ -38,7 +38,7 @@ class BatchPhysicalOverAggregate(
     inputRel: RelNode,
     outputRowType: RelDataType,
     inputRowType: RelDataType,
-    windowGroups: Seq[Window.Group],
+    val windowGroups: Seq[Window.Group],
     logicWindow: Window)
   extends BatchPhysicalOverAggregateBase(
     cluster,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdColumnUniquenessTest.scala
@@ -485,6 +485,7 @@ class FlinkRelMdColumnUniquenessTest extends FlinkRelMdHandlerTestBase {
         assertTrue(mq.areColumnsUnique(agg, ImmutableBitSet.of(0, 5)))
         assertTrue(mq.areColumnsUnique(agg, ImmutableBitSet.of(0, 10)))
         assertNull(mq.areColumnsUnique(agg, ImmutableBitSet.of(5, 10)))
+        assertTrue(mq.areColumnsUnique(agg, ImmutableBitSet.of(4, 5)))
     }
     assertTrue(mq.areColumnsUnique(streamOverAgg, ImmutableBitSet.of(0)))
     assertFalse(mq.areColumnsUnique(streamOverAgg, ImmutableBitSet.of(1)))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -176,7 +176,7 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
       rank => assertEquals(uniqueKeys(Array(0)), mq.getUniqueKeys(rank).toSet)
     }
 
-    Array(logicalRowNumber, flinkLogicalRowNumber, streamRowNumber)
+    Array(logicalWindow, logicalRowNumber, flinkLogicalRowNumber, streamRowNumber)
       .foreach {
         rank => assertEquals(uniqueKeys(Array(0), Array(7)), mq.getUniqueKeys(rank).toSet)
       }
@@ -283,7 +283,7 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   @Test
   def testGetUniqueKeysOnOverAgg(): Unit = {
     Array(flinkLogicalOverAgg, batchOverAgg).foreach {
-      agg => assertEquals(uniqueKeys(Array(0)), mq.getUniqueKeys(agg).toSet)
+      agg => assertEquals(uniqueKeys(Array(0), Array(4, 5)), mq.getUniqueKeys(agg).toSet)
     }
 
     assertEquals(uniqueKeys(Array(0)), mq.getUniqueKeys(streamOverAgg).toSet)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUpsertKeysTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUpsertKeysTest.scala
@@ -188,7 +188,7 @@ class FlinkRelMdUpsertKeysTest extends FlinkRelMdHandlerTestBase {
       rank => assertEquals(toBitSet(Array(0)), mq.getUpsertKeys(rank).toSet)
     }
 
-    Array(logicalRowNumber, flinkLogicalRowNumber, streamRowNumber)
+    Array(logicalWindow, logicalRowNumber, flinkLogicalRowNumber, streamRowNumber)
       .foreach(rank => assertEquals(toBitSet(Array(0), Array(7)), mq.getUpsertKeys(rank).toSet))
   }
 


### PR DESCRIPTION
## What is the purpose of the change

The PR aims to add valid uniqueKeys and uniqueKeys candidates for windows with ROW_NUMBER.  The candidates are pairs of partition by keys and field of ROW_NUMBER for each window group.


## Brief change log

  - *Add `getUniqueKeysOfWindowGroup` function to resolve uniqueKeys candidates for window group who contains ROW_NUMBER.*
  - *Change uniqueKeys/UpsertKeys/ColumnUniqueness inference logic for relNodes of `Window`, `BatchPhysicalOverAggregate` and `StreamPhysicalOverAggregate types`.*
  - *Test the logic in corresponding tests, like `FlinkRelMdColumnUniquenessTest`*
  - *Fix wrong initialization of window groups in `FlinkRelMdHandlerTestBase`.*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests in `FlinkRelMdColumnUniquenessTest`, `FlinkRelMdUniqueKeysTest` and `FlinkRelMdUpsertKeysTest` to check if partition by keys and field of ROW_NUMBER are candidates.  *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
