### PR TITLE
[FLINK-35023][tests] Use surefire.module.config in yarn-test

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNApplicationITCase.java
@@ -40,6 +40,7 @@ import java.io.FileNotFoundException;
 import java.time.Duration;
 import java.util.Collections;
 
+import static org.apache.flink.configuration.CoreOptions.FLINK_JVM_OPTIONS;
 import static org.apache.flink.yarn.configuration.YarnConfigOptions.CLASSPATH_INCLUDE_USER_JAR;
 import static org.apache.flink.yarn.util.TestUtils.getTestJarPath;
 
@@ -135,6 +136,9 @@ class YARNApplicationITCase extends YarnTestBase {
         configuration.set(DeploymentOptions.TARGET, YarnDeploymentTarget.APPLICATION.getName());
         configuration.set(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion);
         configuration.set(PipelineOptions.JARS, Collections.singletonList(userJar.toString()));
+
+        // Apply the JVM arguments that were set for unit tests to any Flink JVMs
+        configuration.set(FLINK_JVM_OPTIONS, System.getProperty("surefire.module.config"));
 
         return configuration;
     }


### PR DESCRIPTION
## What is the purpose of the change

For JDK 17+, some configuration is necessary to use the Datastream V2 (FLINK-34548 and FLIP-409).  This was added to `surefire.module.config` for most of the necessary tests.  The `flink-yarn-tests` spawn new processes (notably JobManager) which should take into account the same configuration as other surefire tests.

## Brief change log

* Copy the `surefire.module.config` property into the `env.java.opts.all` Flink configuration when running a new test cluster.

## Verifying this change

This change fixes an existing test: `YARNApplicationITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
