### PR TITLE
[FLINK-35065][metrics] Add numFiredTimers and numFiredTimersPerSecond

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1632,7 +1632,7 @@ Note that the metrics are only available via reporters.
       <td>Histogram</td>
     </tr>
     <tr>
-      <th rowspan="25"><strong>Task</strong></th>
+      <th rowspan="27"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
       <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{< ref "docs/ops/metrics" >}}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
@@ -1690,6 +1690,16 @@ Note that the metrics are only available via reporters.
     <tr>
       <td>numBuffersOutPerSecond</td>
       <td>The number of network buffers this task emits per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>numFiredTimers</td>
+      <td>The total number of timers this task has fired.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numFiredTimersPerSecond</td>
+      <td>The number of timers this task fires per second.</td>
       <td>Meter</td>
     </tr>
     <tr>

--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1632,7 +1632,7 @@ Note that the metrics are only available via reporters.
       <td>Histogram</td>
     </tr>
     <tr>
-      <th rowspan="24"><strong>Task</strong></th>
+      <th rowspan="25"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
       <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{< ref "docs/ops/metrics" >}}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1622,7 +1622,7 @@ Note that the metrics are only available via reporters.
       <td>Histogram</td>
     </tr>
     <tr>
-      <th rowspan="25"><strong>Task</strong></th>
+      <th rowspan="27"><strong>Task</strong></th>
       <td>numBytesInLocal</td>
       <td><span class="label label-danger">Attention:</span> deprecated, use <a href="{{< ref "docs/ops/metrics" >}}#default-shuffle-service">Default shuffle service metrics</a>.</td>
       <td>Counter</td>
@@ -1680,6 +1680,16 @@ Note that the metrics are only available via reporters.
     <tr>
       <td>numBuffersOutPerSecond</td>
       <td>The number of network buffers this task emits per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
+      <td>numFiredTimers</td>
+      <td>The total number of timers this task has fired.</td>
+      <td>Counter</td>
+    </tr>
+    <tr>
+      <td>numFiredTimersPerSecond</td>
+      <td>The number of timers this task fires per second.</td>
       <td>Meter</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -44,6 +44,9 @@ public class MetricNames {
     public static final String IO_CURRENT_INPUT_WATERMARK_PATERN = "currentInput%dWatermark";
     public static final String IO_CURRENT_OUTPUT_WATERMARK = "currentOutputWatermark";
 
+    public static final String NUM_FIRED_TIMERS = "numFiredTimers";
+    public static final String NUM_FIRED_TIMERS_RATE = "numFiredTimers" + SUFFIX_RATE;
+
     public static final String NUM_RUNNING_JOBS = "numRunningJobs";
     public static final String TASK_SLOTS_AVAILABLE = "taskSlotsAvailable";
     public static final String TASK_SLOTS_TOTAL = "taskSlotsTotal";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -55,6 +55,8 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     private final SumCounter numRecordsIn;
     private final SumCounter numRecordsOut;
     private final Counter numBuffersOut;
+    private final Counter numFiredTimers;
+    private final MeterView numFiredTimersRate;
     private final Counter numMailsProcessed;
 
     private final Meter numBytesInRate;
@@ -140,6 +142,10 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         this.accumulatedIdleTime =
                 gauge(MetricNames.ACC_TASK_IDLE_TIME, idleTimePerSecond::getAccumulatedCount);
 
+        this.numFiredTimers = counter(MetricNames.NUM_FIRED_TIMERS, new SimpleCounter());
+        this.numFiredTimersRate =
+                meter(MetricNames.NUM_FIRED_TIMERS_RATE, new MeterView(numFiredTimers));
+
         this.numMailsProcessed = new SimpleCounter();
         this.mailboxThroughput =
                 meter(MetricNames.MAILBOX_THROUGHPUT, new MeterView(numMailsProcessed));
@@ -205,6 +211,10 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
     public Counter getNumBuffersOutCounter() {
         return numBuffersOut;
+    }
+
+    public Counter getNumFiredTimers() {
+        return numFiredTimers;
     }
 
     public Counter getNumMailsProcessedCounter() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
@@ -73,6 +74,7 @@ public interface InternalTimeServiceManager<K> {
     @FunctionalInterface
     interface Provider extends Serializable {
         <K> InternalTimeServiceManager<K> create(
+                TaskIOMetricGroup taskIOMetricGroup,
                 CheckpointableKeyedStateBackend<K> keyedStatedBackend,
                 ClassLoader userClassloader,
                 KeyContext keyContext,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -228,6 +228,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 
                 timeServiceManager =
                         timeServiceManagerProvider.create(
+                                environment.getMetricGroup().getIOMetricGroup(),
                                 keyedStatedBackend,
                                 environment.getUserCodeClassLoader().asClassLoader(),
                                 keyContext,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators.sorted.state;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateBackend;
@@ -85,6 +86,7 @@ public class BatchExecutionInternalTimeServiceManager<K>
     }
 
     public static <K> InternalTimeServiceManager<K> create(
+            TaskIOMetricGroup taskIOMetricGroup,
             CheckpointableKeyedStateBackend<K> keyedStatedBackend,
             ClassLoader userClassloader,
             KeyContext keyContext, // the operator

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.SubTaskInitializationMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
@@ -194,6 +195,7 @@ class StateInitializationContextImplTest {
                         new InternalTimeServiceManager.Provider() {
                             @Override
                             public <K> InternalTimeServiceManager<K> create(
+                                    TaskIOMetricGroup taskIOMetricGroup,
                                     CheckpointableKeyedStateBackend<K> keyedStatedBackend,
                                     ClassLoader userClassloader,
                                     KeyContext keyContext,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.checkpoint.metadata.CheckpointTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
@@ -343,6 +344,7 @@ class StreamTaskStateInitializerImplTest {
                     new InternalTimeServiceManager.Provider() {
                         @Override
                         public <K> InternalTimeServiceManager<K> create(
+                                TaskIOMetricGroup taskIOMetricGroup,
                                 CheckpointableKeyedStateBackend<K> keyedStatedBackend,
                                 ClassLoader userClassloader,
                                 KeyContext keyContext,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
@@ -87,6 +88,8 @@ class BatchExecutionInternalTimeServiceTest {
         assertThatThrownBy(
                         () ->
                                 BatchExecutionInternalTimeServiceManager.create(
+                                        UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
+                                                .getIOMetricGroup(),
                                         stateBackend,
                                         this.getClass().getClassLoader(),
                                         new DummyKeyContext(),
@@ -141,6 +144,8 @@ class BatchExecutionInternalTimeServiceTest {
                         KEY_SERIALIZER, new KeyGroupRange(0, 1), new ExecutionConfig());
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
+                        UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
+                                .getIOMetricGroup(),
                         keyedStatedBackend,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
@@ -177,6 +182,8 @@ class BatchExecutionInternalTimeServiceTest {
                         KEY_SERIALIZER, new KeyGroupRange(0, 1), new ExecutionConfig());
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
+                        UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
+                                .getIOMetricGroup(),
                         keyedStatedBackend,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
@@ -206,6 +213,8 @@ class BatchExecutionInternalTimeServiceTest {
                         KEY_SERIALIZER, new KeyGroupRange(0, 1), new ExecutionConfig());
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
+                        UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
+                                .getIOMetricGroup(),
                         keyedStatedBackend,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
@@ -253,6 +262,8 @@ class BatchExecutionInternalTimeServiceTest {
         TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
+                        UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
+                                .getIOMetricGroup(),
                         keyedStatedBackend,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
@@ -288,6 +299,8 @@ class BatchExecutionInternalTimeServiceTest {
         TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
+                        UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
+                                .getIOMetricGroup(),
                         keyedStatedBackend,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
@@ -328,6 +341,8 @@ class BatchExecutionInternalTimeServiceTest {
         TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
+                        UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
+                                .getIOMetricGroup(),
                         keyedStatedBackend,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.checkpoint.SubTaskInitializationMetricsBuilder;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
@@ -149,6 +150,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
             new InternalTimeServiceManager.Provider() {
                 @Override
                 public <K> InternalTimeServiceManager<K> create(
+                        TaskIOMetricGroup taskIOMetricGroup,
                         CheckpointableKeyedStateBackend<K> keyedStatedBackend,
                         ClassLoader userClassloader,
                         KeyContext keyContext,
@@ -158,6 +160,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
                         throws Exception {
                     InternalTimeServiceManagerImpl<K> typedTimeServiceManager =
                             InternalTimeServiceManagerImpl.create(
+                                    taskIOMetricGroup,
                                     keyedStatedBackend,
                                     userClassloader,
                                     keyContext,

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
@@ -236,6 +237,7 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
                 new InternalTimeServiceManager.Provider() {
                     @Override
                     public <K> InternalTimeServiceManager<K> create(
+                            TaskIOMetricGroup taskIOMetricGroup,
                             CheckpointableKeyedStateBackend<K> keyedStatedBackend,
                             ClassLoader userClassloader,
                             KeyContext keyContext,


### PR DESCRIPTION
## Brief change log

This PR adds numFiredTimers and numFiredTimersPerSecond metrics

## Verifying this change

-

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **n**o / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
