### PR TITLE
[FLINK-35069][API/DataStream]ContinuousProcessingTimeTrigger avoids registering timers at the end of the window

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
@@ -71,6 +71,10 @@ public class ContinuousProcessingTimeTrigger<W extends Window> extends Trigger<O
     @Override
     public TriggerResult onProcessingTime(long time, W window, TriggerContext ctx)
             throws Exception {
+        if (time == window.maxTimestamp()) {
+            return TriggerResult.FIRE;
+        }
+
         ReducingState<Long> fireTimestampState = ctx.getPartitionedState(stateDesc);
 
         if (fireTimestampState.get().equals(time)) {


### PR DESCRIPTION

## What is the purpose of the change

This pull request avoids registering times in a loop at the end of the window for ContinuousProcessingTimeTrigger 

## Brief change log

  - Don't register timer when "time == window.maxTimestamp()" in ContinuousProcessingTimeTrigger#onProcessingTime.

## Verifying this change

This change added a new unit test ContinuousProcessingTimeTriggerTest#testEventTimeWindowFiring.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
