### PR TITLE
[FLINK-34250][docs] add new option for avro format docs

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/avro.md
+++ b/docs/content.zh/docs/connectors/table/formats/avro.md
@@ -86,6 +86,15 @@ Format 参数
       <td>String</td>
       <td>仅用于 <a href="{{< ref "docs/connectors/table/filesystem" >}}">filesystem</a>，avro 压缩编解码器。默认 snappy 压缩。目前支持：null, deflate、snappy、bzip2、xz。</td>
     </tr>
+    <tr>
+      <td><h5>timestamp_mapping.legacy</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">true</td>
+      <td>Boolean</td>
+      <td>使用 avro 中时间戳的旧映射。 在 1.19 之前，Flink 的默认行为错误地将 SQL TIMESTAMP 和 TIMESTAMP_LTZ 类型映射到 AVRO TIMESTAMP。<br>
+      正确的行为是 Flink SQL TIMESTAMP 映射 Avro LOCAL TIMESTAMP 和 Flink SQL TIMESTAMP_LTZ 映射 Avro TIMESTAMP，您可以通过禁用此旧映射来获得正确的映射。<br>
+      出于兼容性考虑，默认使用旧行为。</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/table/formats/avro.md
+++ b/docs/content/docs/connectors/table/formats/avro.md
@@ -98,6 +98,16 @@ Format Options
       <td>String</td>
       <td>For <a href="{{< ref "docs/connectors/table/filesystem" >}}">Filesystem</a> only, the compression codec for avro. Snappy compression as default. The valid enumerations are: null, deflate, snappy, bzip2, xz.</td>
     </tr>
+    <tr>
+      <td><h5>timestamp_mapping.legacy</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;">true</td>
+      <td>Boolean</td>
+      <td>Use the legacy mapping of timestamp in avro. Before 1.19, The default behavior of Flink wrongly mapped both SQL TIMESTAMP and TIMESTAMP_LTZ type to AVRO TIMESTAMP. <br>
+      The correct behavior is Flink SQL TIMESTAMP maps Avro LOCAL TIMESTAMP and Flink SQL TIMESTAMP_LTZ maps Avro TIMESTAMP, you can obtain the correct mapping by disable using this legacy mapping. <br>
+      Use legacy behavior by default for compatibility consideration. </td>
+    </tr>
     </tbody>
 </table>
 


### PR DESCRIPTION
## What is the purpose of the change

Add the missing new Avro option in corresponding doc.


## Brief change log
  - Add new option in avro.md


## Verifying this change

This change is a trivial doc change without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
