### PR TITLE
[FLINK-35040] Revert `commons-io` to 2.11.0

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.ververica:frocksdbjni:6.20.3-ververica-2.0
 - commons-cli:commons-cli:1.5.0
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.15.1
+- commons-io:commons-io:2.11.0
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-math3:3.6.1

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.j2objc:j2objc-annotations:1.1
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.15.1
+- commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-configuration2:2.1.1

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -21,7 +21,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.15
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.15.1
+- commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - joda-time:joda-time:2.5
 - org.apache.commons:commons-compress:1.26.0

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -30,7 +30,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-beanutils:commons-beanutils:1.9.4
 - commons-codec:commons-codec:1.15
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.15.1
+- commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - io.airlift:slice:0.38
 - io.airlift:units:1.3

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3
 - com.google.guava:guava:32.0.1-jre
-- commons-io:commons-io:2.15.1
+- commons-io:commons-io:2.11.0
 - io.confluent:common-utils:7.5.3
 - io.confluent:kafka-schema-registry-client:7.5.3
 - org.apache.avro:avro:1.11.3

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -12,7 +12,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.calcite:calcite-linq4j:1.32.0
 - org.apache.calcite.avatica:avatica-core:1.22.0
 - commons-codec:commons-codec:1.15
-- commons-io:commons-io:2.15.1
+- commons-io:commons-io:2.11.0
 
 This project bundles the following dependencies under the MIT License. (http://www.opensource.org/licenses/mit-license.php)
 

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@ under the License.
 		<okhttp.version>3.14.9</okhttp.version>
 		<testcontainers.version>1.19.1</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>
-		<commons.io.version>2.15.1</commons.io.version>
+		<commons.io.version>2.11.0</commons.io.version>
 		<japicmp.skip>false</japicmp.skip>
 		<flink.convergence.phase>validate</flink.convergence.phase>
 		<!--


### PR DESCRIPTION
## What is the purpose of the change

The performance of serializerHeavyString regresses since April 3, and had not yet recovered on April 8th.

After running a series of benchmarks, I found [FLINK-34955](https://issues.apache.org/jira/browse/FLINK-34955) causes the performance regression. 

FLINK-34955 wants to fix CVE issues of `common-compress`, but it upgrades the `commons-io` together. I try to revert `commons-io` to 2.11.0, and the performance is recovered.


## Brief change log

- [FLINK-35040] Revert `commons-io` to 2.11.0
  - Revert part of `[FLINK-34955] Upgrade commons-compress to 1.26.0. (#24580)`

