### PR TITLE
[FLINK-32084][checkpoint] Migrate current file merging of channel state snapshot into the unify file merging framework

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestExecutorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestExecutorFactory.java
@@ -19,9 +19,12 @@ package org.apache.flink.runtime.checkpoint.channel;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
+import org.apache.flink.util.function.SupplierWithException;
 
 import javax.annotation.concurrent.GuardedBy;
+
+import java.io.IOException;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -42,10 +45,15 @@ public class ChannelStateWriteRequestExecutorFactory {
     public ChannelStateWriteRequestExecutor getOrCreateExecutor(
             JobVertexID jobVertexID,
             int subtaskIndex,
-            CheckpointStorage checkpointStorage,
+            SupplierWithException<CheckpointStorageWorkerView, ? extends IOException>
+                    checkpointStorageWorkerViewSupplier,
             int maxSubtasksPerChannelStateFile) {
         return getOrCreateExecutor(
-                jobVertexID, subtaskIndex, checkpointStorage, maxSubtasksPerChannelStateFile, true);
+                jobVertexID,
+                subtaskIndex,
+                checkpointStorageWorkerViewSupplier,
+                maxSubtasksPerChannelStateFile,
+                true);
     }
 
     /**
@@ -55,15 +63,19 @@ public class ChannelStateWriteRequestExecutorFactory {
     ChannelStateWriteRequestExecutor getOrCreateExecutor(
             JobVertexID jobVertexID,
             int subtaskIndex,
-            CheckpointStorage checkpointStorage,
+            SupplierWithException<CheckpointStorageWorkerView, ? extends IOException>
+                    checkpointStorageWorkerViewSupplier,
             int maxSubtasksPerChannelStateFile,
             boolean startExecutor) {
         synchronized (lock) {
             if (executor == null) {
+                ChannelStateWriteRequestDispatcher dispatcher =
+                        new ChannelStateWriteRequestDispatcherImpl(
+                                checkpointStorageWorkerViewSupplier,
+                                new ChannelStateSerializerImpl());
                 executor =
                         new ChannelStateWriteRequestExecutorImpl(
-                                new ChannelStateWriteRequestDispatcherImpl(
-                                        checkpointStorage, jobID, new ChannelStateSerializerImpl()),
+                                dispatcher,
                                 maxSubtasksPerChannelStateFile,
                                 executor -> {
                                     assert Thread.holdsLock(lock);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImpl.java
@@ -23,9 +23,10 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.state.CheckpointStateOutputStream;
-import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.SupplierWithException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,14 +88,15 @@ public class ChannelStateWriterImpl implements ChannelStateWriter {
             JobVertexID jobVertexID,
             String taskName,
             int subtaskIndex,
-            CheckpointStorage checkpointStorage,
+            SupplierWithException<CheckpointStorageWorkerView, ? extends IOException>
+                    checkpointStorageWorkerViewSupplier,
             ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory,
             int maxSubtasksPerChannelStateFile) {
         this(
                 jobVertexID,
                 taskName,
                 subtaskIndex,
-                checkpointStorage,
+                checkpointStorageWorkerViewSupplier,
                 DEFAULT_MAX_CHECKPOINTS,
                 channelStateExecutorFactory,
                 maxSubtasksPerChannelStateFile);
@@ -113,7 +115,8 @@ public class ChannelStateWriterImpl implements ChannelStateWriter {
             JobVertexID jobVertexID,
             String taskName,
             int subtaskIndex,
-            CheckpointStorage checkpointStorage,
+            SupplierWithException<CheckpointStorageWorkerView, ? extends IOException>
+                    checkpointStorageWorkerViewSupplier,
             int maxCheckpoints,
             ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory,
             int maxSubtasksPerChannelStateFile) {
@@ -125,7 +128,7 @@ public class ChannelStateWriterImpl implements ChannelStateWriter {
                 channelStateExecutorFactory.getOrCreateExecutor(
                         jobVertexID,
                         subtaskIndex,
-                        checkpointStorage,
+                        checkpointStorageWorkerViewSupplier,
                         maxSubtasksPerChannelStateFile),
                 maxCheckpoints);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorageAccess.java
@@ -232,7 +232,6 @@ public class FsCheckpointStorageAccess extends AbstractFsCheckpointStorageAccess
             FileMergingSnapshotManager mergingSnapshotManager, Environment environment)
             throws IOException {
         return new FsMergingCheckpointStorageAccess(
-                fileSystem,
                 checkpointsDirectory,
                 getDefaultSavepointDirectory(),
                 environment.getJobID(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageAccess.java
@@ -41,7 +41,6 @@ public class FsMergingCheckpointStorageAccess extends FsCheckpointStorageAccess 
     private final FileMergingSnapshotManager.SubtaskKey subtaskKey;
 
     public FsMergingCheckpointStorageAccess(
-            FileSystem fs,
             Path checkpointBaseDirectory,
             @Nullable Path defaultSavepointDirectory,
             JobID jobId,
@@ -51,7 +50,10 @@ public class FsMergingCheckpointStorageAccess extends FsCheckpointStorageAccess 
             Environment environment)
             throws IOException {
         super(
-                fs,
+                // Multiple subtask/threads would share one output stream,
+                // SafetyNetWrapperFileSystem cannot be used to prevent different threads from
+                // interfering with each other when exiting.
+                FileSystem.getUnguardedFileSystem(checkpointBaseDirectory.toUri()),
                 checkpointBaseDirectory,
                 defaultSavepointDirectory,
                 false,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImplTest.java
@@ -76,8 +76,7 @@ class ChannelStateWriteRequestDispatcherImplTest {
             Function<NetworkBuffer[], ChannelStateWriteRequest> requestBuilder) throws Exception {
         ChannelStateWriteRequestDispatcher dispatcher =
                 new ChannelStateWriteRequestDispatcherImpl(
-                        new JobManagerCheckpointStorage(),
-                        JOB_ID,
+                        () -> new JobManagerCheckpointStorage().createCheckpointStorage(JOB_ID),
                         new ChannelStateSerializerImpl());
         ChannelStateWriteResult result = new ChannelStateWriteResult();
         dispatcher.dispatch(ChannelStateWriteRequest.registerSubtask(JOB_VERTEX_ID, SUBTASK_INDEX));
@@ -113,8 +112,7 @@ class ChannelStateWriteRequestDispatcherImplTest {
             throws Exception {
         ChannelStateWriteRequestDispatcher processor =
                 new ChannelStateWriteRequestDispatcherImpl(
-                        new JobManagerCheckpointStorage(),
-                        JOB_ID,
+                        () -> new JobManagerCheckpointStorage().createCheckpointStorage(JOB_ID),
                         new ChannelStateSerializerImpl());
         ChannelStateWriteResult result = new ChannelStateWriteResult();
         processor.dispatch(ChannelStateWriteRequest.registerSubtask(JOB_VERTEX_ID, SUBTASK_INDEX));
@@ -157,8 +155,7 @@ class ChannelStateWriteRequestDispatcherImplTest {
             throws Exception {
         ChannelStateWriteRequestDispatcher processor =
                 new ChannelStateWriteRequestDispatcherImpl(
-                        new JobManagerCheckpointStorage(),
-                        JOB_ID,
+                        () -> new JobManagerCheckpointStorage().createCheckpointStorage(JOB_ID),
                         new ChannelStateSerializerImpl());
         processor.dispatch(ChannelStateWriteRequest.registerSubtask(JOB_VERTEX_ID, SUBTASK_INDEX));
         JobVertexID newJobVertex = JOB_VERTEX_ID;
@@ -194,8 +191,7 @@ class ChannelStateWriteRequestDispatcherImplTest {
     private void testAbortCheckpointAndCheckAllException(int numberOfSubtask) throws Exception {
         ChannelStateWriteRequestDispatcher processor =
                 new ChannelStateWriteRequestDispatcherImpl(
-                        new JobManagerCheckpointStorage(),
-                        JOB_ID,
+                        () -> new JobManagerCheckpointStorage().createCheckpointStorage(JOB_ID),
                         new ChannelStateSerializerImpl());
         List<ChannelStateWriteResult> results = new ArrayList<>(numberOfSubtask);
         for (int i = 0; i < numberOfSubtask; i++) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherTest.java
@@ -169,8 +169,7 @@ public class ChannelStateWriteRequestDispatcherTest {
     void doRun() {
         ChannelStateWriteRequestDispatcher processor =
                 new ChannelStateWriteRequestDispatcherImpl(
-                        new JobManagerCheckpointStorage(),
-                        JOB_ID,
+                        () -> new JobManagerCheckpointStorage().createCheckpointStorage(JOB_ID),
                         new ChannelStateSerializerImpl());
         try {
             processor.dispatch(register());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestExecutorImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestExecutorImplTest.java
@@ -175,8 +175,7 @@ class ChannelStateWriteRequestExecutorImplTest {
         long checkpointId = 1L;
         ChannelStateWriteRequestDispatcher processor =
                 new ChannelStateWriteRequestDispatcherImpl(
-                        new JobManagerCheckpointStorage(),
-                        JOB_ID,
+                        () -> new JobManagerCheckpointStorage().createCheckpointStorage(JOB_ID),
                         new ChannelStateSerializerImpl());
         Object registerLock = new Object();
         ChannelStateWriteRequestExecutorImpl worker =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -48,6 +48,7 @@ import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
@@ -64,6 +65,7 @@ import java.util.Map;
 import java.util.concurrent.Future;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** The {@link DummyEnvironment} is used for test purpose. */
 public class DummyEnvironment implements Environment {
@@ -81,6 +83,8 @@ public class DummyEnvironment implements Environment {
     private final Configuration taskConfiguration = new Configuration();
     private final ChannelStateWriteRequestExecutorFactory channelStateExecutorFactory =
             new ChannelStateWriteRequestExecutorFactory(jobInfo.getJobId());
+
+    private CheckpointStorageAccess checkpointStorageAccess;
 
     public DummyEnvironment() {
         this("Test Job", 1, 0, 1);
@@ -290,5 +294,15 @@ public class DummyEnvironment implements Environment {
     @Override
     public JobInfo getJobInfo() {
         return jobInfo;
+    }
+
+    @Override
+    public void setCheckpointStorageAccess(CheckpointStorageAccess checkpointStorageAccess) {
+        this.checkpointStorageAccess = checkpointStorageAccess;
+    }
+
+    @Override
+    public CheckpointStorageAccess getCheckpointStorageAccess() {
+        return checkNotNull(checkpointStorageAccess);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChannelPersistenceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ChannelPersistenceITCase.java
@@ -81,6 +81,8 @@ class ChannelPersistenceITCase {
     private static final JobVertexID JOB_VERTEX_ID = new JobVertexID();
     private static final int SUBTASK_INDEX = 0;
 
+    private static final CheckpointStorage CHECKPOINT_STORAGE = new JobManagerCheckpointStorage();
+
     @Test
     void testUpstreamBlocksAfterRecoveringState() throws Exception {
         upstreamBlocksAfterRecoveringState(ResultPartitionType.PIPELINED);
@@ -264,7 +266,7 @@ class ChannelPersistenceITCase {
                         JOB_VERTEX_ID,
                         "test",
                         SUBTASK_INDEX,
-                        new JobManagerCheckpointStorage(maxStateSize),
+                        () -> CHECKPOINT_STORAGE.createCheckpointStorage(JOB_ID),
                         new ChannelStateWriteRequestExecutorFactory(JOB_ID),
                         5)) {
             writer.start(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -327,6 +327,15 @@ public class ExecutionCheckpointingOptions {
                     .defaultValue(false)
                     .withDescription("Flag to enable approximate local recovery.");
 
+    // TODO: deprecated
+    // Currently, both two file merging mechanism can work simultaneously:
+    //  1. If UNALIGNED_MAX_SUBTASKS_PER_CHANNEL_STATE_FILE=1 and
+    // state.checkpoints.file-merging.enabled: true, only the unified file merging mechanism takes
+    // effect.
+    //  2. if UNALIGNED_MAX_SUBTASKS_PER_CHANNEL_STATE_FILE>1 and
+    // state.checkpoints.file-merging.enabled: false, only the current mechanism takes effect.
+    //  3. if UNALIGNED_MAX_SUBTASKS_PER_CHANNEL_STATE_FILE>1 and
+    // state.checkpoints.file-merging.enabled: true, both two mechanism take effect.
     public static final ConfigOption<Integer> UNALIGNED_MAX_SUBTASKS_PER_CHANNEL_STATE_FILE =
             key("execution.checkpointing.unaligned.max-subtasks-per-channel-state-file")
                     .intType()

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -72,6 +72,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLoader;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
+import org.apache.flink.runtime.state.filesystem.FsMergingCheckpointStorageAccess;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskmanager.AsyncExceptionHandler;
 import org.apache.flink.runtime.taskmanager.AsynchronousException;
@@ -148,6 +149,7 @@ import static org.apache.flink.runtime.metrics.MetricNames.GATE_RESTORE_DURATION
 import static org.apache.flink.runtime.metrics.MetricNames.INITIALIZE_STATE_DURATION;
 import static org.apache.flink.runtime.metrics.MetricNames.MAILBOX_START_DURATION;
 import static org.apache.flink.runtime.metrics.MetricNames.READ_OUTPUT_DATA_DURATION;
+import static org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinatorImpl.openChannelStateWriter;
 import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.flink.util.concurrent.FutureUtils.assertNoException;
@@ -483,27 +485,54 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
             }
 
             this.systemTimerService = createTimerService("System Time Trigger for " + getName());
+            final CheckpointStorageAccess finalCheckpointStorageAccess = checkpointStorageAccess;
 
+            ChannelStateWriter channelStateWriter =
+                    configuration.isUnalignedCheckpointsEnabled()
+                            ? openChannelStateWriter(
+                                    getName(),
+                                    // Note: don't pass checkpointStorageAccess directly to channel
+                                    // state writer.
+                                    // The fileSystem of checkpointStorageAccess may be an instance
+                                    // of SafetyNetWrapperFileSystem, which close all held streams
+                                    // when thread exits. Chanel state writers are invoked in other
+                                    // threads instead of task thread, therefore channel state
+                                    // writer cannot share file streams directly, otherwise
+                                    // conflicts will occur on job exit.
+                                    () -> {
+                                        if (finalCheckpointStorageAccess
+                                                instanceof FsMergingCheckpointStorageAccess) {
+                                            // FsMergingCheckpointStorageAccess using unguarded
+                                            // fileSystem, which can be shared.
+                                            return finalCheckpointStorageAccess;
+                                        } else {
+                                            // Other checkpoint storage access should be lazily
+                                            // initialized to avoid sharing.
+                                            return checkpointStorage.createCheckpointStorage(
+                                                    getEnvironment().getJobID());
+                                        }
+                                    },
+                                    environment,
+                                    configuration.getMaxSubtasksPerChannelStateFile())
+                            : ChannelStateWriter.NO_OP;
             this.subtaskCheckpointCoordinator =
                     new SubtaskCheckpointCoordinatorImpl(
-                            checkpointStorage,
                             checkpointStorageAccess,
                             getName(),
                             actionExecutor,
                             getAsyncOperationsThreadPool(),
                             environment,
                             this,
-                            configuration.isUnalignedCheckpointsEnabled(),
+                            this::prepareInputSnapshot,
+                            configuration.getMaxConcurrentCheckpoints(),
+                            channelStateWriter,
                             configuration
                                     .getConfiguration()
                                     .get(
                                             ExecutionCheckpointingOptions
                                                     .ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH),
-                            this::prepareInputSnapshot,
-                            configuration.getMaxConcurrentCheckpoints(),
                             BarrierAlignmentUtil.createRegisterTimerCallback(
-                                    mainMailboxExecutor, systemTimerService),
-                            configuration.getMaxSubtasksPerChannelStateFile());
+                                    mainMailboxExecutor, systemTimerService));
             resourceCloser.registerCloseable(subtaskCheckpointCoordinator::close);
 
             // Register to stop all timers and threads. Should be closed first.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
@@ -138,6 +139,8 @@ public class StreamMockEnvironment implements Environment {
             UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
 
     private CheckpointResponder checkpointResponder = NoOpCheckpointResponder.INSTANCE;
+
+    private CheckpointStorageAccess checkpointStorageAccess;
 
     public StreamMockEnvironment(
             Configuration jobConfig,
@@ -437,5 +440,13 @@ public class StreamMockEnvironment implements Environment {
     @Override
     public JobInfo getJobInfo() {
         return jobInfo;
+    }
+
+    public void setCheckpointStorageAccess(CheckpointStorageAccess checkpointStorageAccess) {
+        this.checkpointStorageAccess = checkpointStorageAccess;
+    }
+
+    public CheckpointStorageAccess getCheckpointStorageAccess() {
+        return checkpointStorageAccess;
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.TestTaskStateManagerBuilder;
+import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
@@ -252,6 +253,9 @@ public class StreamTaskMailboxTestHarnessBuilder<OUT> {
         Queue<Object> outputList = new ArrayDeque<>();
         streamMockEnvironment.addOutput(outputList, outputStreamRecordSerializer);
         streamMockEnvironment.setTaskMetricGroup(taskMetricGroup);
+        streamMockEnvironment.setCheckpointStorageAccess(
+                new JobManagerCheckpointStorage()
+                        .createCheckpointStorage(streamMockEnvironment.getJobID()));
 
         for (ResultPartitionWriter writer : additionalOutputs) {
             streamMockEnvironment.addOutput(writer);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Migrate current file merging of channel state snapshot into the unify file merging framework.
This PR only focuses on the snapshot/writing part.


## Brief change log
- Introduce `UnifyMergingChannelStateWriteRequestDispatcher` which construct a ` ChannelStateCheckpointWriter` that uses unified file merging mechanism to write channel state.
- Update `ChannelStateWriteRequestExecutorFactory#getOrCreateExecutor` , different ways to merge small files can be chosen here.

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).


This change is already covered by existing tests, such as *(please describe tests)*.
- `ChannelStateWriteRequestDispatcherTest`
- `ChannelStateWriteRequestExecutorFactoryTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (checkpointing)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
