### PR TITLE
[FLINK-35025][Runtime/State] Abstract stream operators for async state processing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/ContextStateFutureImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/ContextStateFutureImpl.java
@@ -37,9 +37,9 @@ import org.apache.flink.core.state.StateFutureImpl;
  */
 public class ContextStateFutureImpl<T> extends StateFutureImpl<T> {
 
-    private final RecordContext<?, ?> recordContext;
+    private final RecordContext<?> recordContext;
 
-    ContextStateFutureImpl(CallbackRunner callbackRunner, RecordContext<?, ?> recordContext) {
+    ContextStateFutureImpl(CallbackRunner callbackRunner, RecordContext<?> recordContext) {
         super(callbackRunner);
         this.recordContext = recordContext;
         // When state request submitted, ref count +1, as described in FLIP-425:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/KeyAccountingUnit.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/KeyAccountingUnit.java
@@ -28,13 +28,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * which is used to preserve the ordering of independent chained {@link
  * org.apache.flink.api.common.state.v2.StateFuture}.
  *
- * @param <R> the type of record
  * @param <K> the type of key
  */
-public class KeyAccountingUnit<R, K> {
+public class KeyAccountingUnit<K> {
 
     /** The in-flight records that are being processed, their keys are different from each other. */
-    private final Map<K, R> noConflictInFlightRecords;
+    private final Map<K, Object> noConflictInFlightRecords;
 
     public KeyAccountingUnit(int initCapacity) {
         this.noConflictInFlightRecords = new ConcurrentHashMap<>(initCapacity);
@@ -46,12 +45,12 @@ public class KeyAccountingUnit<R, K> {
      *
      * @return true if no one is occupying this key, and this record succeeds to take it.
      */
-    public boolean occupy(R record, K key) {
+    public boolean occupy(Object record, K key) {
         return noConflictInFlightRecords.putIfAbsent(key, record) == null;
     }
 
     /** Release a key, which is invoked when a {@link RecordContext} is released. */
-    public void release(R record, K key) {
+    public void release(Object record, K key) {
         if (noConflictInFlightRecords.remove(key) != record) {
             throw new IllegalStateException(
                     String.format(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/RecordContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/RecordContext.java
@@ -27,14 +27,12 @@ import java.util.function.Consumer;
  *
  * <p>Reference counting mechanism, please refer to {@link ContextStateFutureImpl}.
  *
- * @param <R> The type of the record that extends {@code
- *     org.apache.flink.streaming.runtime.streamrecord.StreamElement}.
  * @param <K> The type of the key inside the record.
  */
-public class RecordContext<R, K> extends ReferenceCounted {
+public class RecordContext<K> extends ReferenceCounted {
 
     /** The record to be processed. */
-    private final R record;
+    private final Object record;
 
     /** The key inside the record. */
     private final K key;
@@ -47,9 +45,9 @@ public class RecordContext<R, K> extends ReferenceCounted {
      * #referenceCountReachedZero()}, which may be called once the ref count reaches zero in any
      * thread.
      */
-    private final Consumer<RecordContext<R, K>> disposer;
+    private final Consumer<RecordContext<K>> disposer;
 
-    RecordContext(R record, K key, Consumer<RecordContext<R, K>> disposer) {
+    RecordContext(Object record, K key, Consumer<RecordContext<K>> disposer) {
         super(0);
         this.record = record;
         this.key = key;
@@ -57,7 +55,7 @@ public class RecordContext<R, K> extends ReferenceCounted {
         this.disposer = disposer;
     }
 
-    public R getRecord() {
+    public Object getRecord() {
         return record;
     }
 
@@ -96,7 +94,7 @@ public class RecordContext<R, K> extends ReferenceCounted {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        RecordContext<?, ?> that = (RecordContext<?, ?>) o;
+        RecordContext<?> that = (RecordContext<?>) o;
         if (!Objects.equals(record, that.record)) {
             return false;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateFutureFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateFutureFactory.java
@@ -25,19 +25,18 @@ import org.apache.flink.core.state.InternalStateFuture;
  * An internal factory for {@link InternalStateFuture} that build future with necessary context
  * switch and wired with mailbox executor.
  */
-public class StateFutureFactory<R, K> {
+public class StateFutureFactory<K> {
 
-    private final AsyncExecutionController<R, K> asyncExecutionController;
+    private final AsyncExecutionController<K> asyncExecutionController;
     private final MailboxExecutor mailboxExecutor;
 
     StateFutureFactory(
-            AsyncExecutionController<R, K> asyncExecutionController,
-            MailboxExecutor mailboxExecutor) {
+            AsyncExecutionController<K> asyncExecutionController, MailboxExecutor mailboxExecutor) {
         this.asyncExecutionController = asyncExecutionController;
         this.mailboxExecutor = mailboxExecutor;
     }
 
-    public <OUT> InternalStateFuture<OUT> create(RecordContext<R, K> context) {
+    public <OUT> InternalStateFuture<OUT> create(RecordContext<K> context) {
         return new ContextStateFutureImpl<>(
                 (runnable) ->
                         mailboxExecutor.submit(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequest.java
@@ -49,14 +49,14 @@ public class StateRequest<K, IN, OUT> implements Serializable {
     private final InternalStateFuture<OUT> stateFuture;
 
     /** The record context of this request. */
-    private final RecordContext<?, K> context;
+    private final RecordContext<K> context;
 
     StateRequest(
             @Nullable State state,
             StateRequestType type,
             @Nullable IN payload,
             InternalStateFuture<OUT> stateFuture,
-            RecordContext<?, K> context) {
+            RecordContext<K> context) {
         this.state = state;
         this.type = type;
         this.payload = payload;
@@ -82,7 +82,7 @@ public class StateRequest<K, IN, OUT> implements Serializable {
         return stateFuture;
     }
 
-    RecordContext<?, K> getRecordContext() {
+    RecordContext<K> getRecordContext() {
         return context;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestBuffer.java
@@ -60,7 +60,11 @@ public class StateRequestBuffer<K> {
     }
 
     void enqueueToActive(StateRequest<K, ?, ?> request) {
-        activeQueue.add(request);
+        if (request.getRequestType() == StateRequestType.SYNC_POINT) {
+            request.getFuture().complete(null);
+        } else {
+            activeQueue.add(request);
+        }
     }
 
     void enqueueToBlocking(StateRequest<K, ?, ?> request) {
@@ -83,7 +87,7 @@ public class StateRequestBuffer<K> {
         }
 
         StateRequest<K, ?, ?> stateRequest = blockingQueue.get(key).removeFirst();
-        activeQueue.add(stateRequest);
+        enqueueToActive(stateRequest);
         if (blockingQueue.get(key).isEmpty()) {
             blockingQueue.remove(key);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -300,6 +300,50 @@ class AsyncExecutionControllerTest {
         }
     }
 
+    @Test
+    public void testSyncPoint() {
+        AtomicInteger counter = new AtomicInteger(0);
+
+        // Test the sync point processing without a key occupied.
+        RecordContext<String> recordContext = aec.buildContext("record", "key");
+        aec.setCurrentContext(recordContext);
+        recordContext.retain();
+        aec.syncPointRequestWithCallback(counter::incrementAndGet);
+        assertThat(counter.get()).isEqualTo(1);
+        assertThat(recordContext.getReferenceCount()).isEqualTo(1);
+        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(0);
+        assertThat(aec.stateRequestsBuffer.blockingQueueSize()).isEqualTo(0);
+        assertThat(aec.keyAccountingUnit.occupiedCount()).isEqualTo(1);
+        recordContext.release();
+        assertThat(aec.keyAccountingUnit.occupiedCount()).isEqualTo(0);
+
+        counter.set(0);
+        // Test the sync point processing with a key occupied.
+        RecordContext<String> recordContext1 = aec.buildContext("record1", "occupied");
+        aec.setCurrentContext(recordContext1);
+        userCode.run();
+
+        RecordContext<String> recordContext2 = aec.buildContext("record2", "occupied");
+        aec.setCurrentContext(recordContext2);
+        aec.syncPointRequestWithCallback(counter::incrementAndGet);
+        recordContext2.retain();
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(recordContext2.getReferenceCount()).isGreaterThan(1);
+        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(1);
+        assertThat(aec.stateRequestsBuffer.blockingQueueSize()).isEqualTo(1);
+        aec.triggerIfNeeded(true);
+        assertThat(counter.get()).isEqualTo(0);
+        assertThat(recordContext2.getReferenceCount()).isGreaterThan(1);
+        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(1);
+        assertThat(aec.stateRequestsBuffer.blockingQueueSize()).isEqualTo(1);
+        aec.triggerIfNeeded(true);
+        assertThat(counter.get()).isEqualTo(1);
+        assertThat(recordContext2.getReferenceCount()).isEqualTo(1);
+        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(0);
+        assertThat(aec.stateRequestsBuffer.blockingQueueSize()).isEqualTo(0);
+        recordContext2.release();
+    }
+
     private StateExecutor createStateExecutor() {
         TestAsyncStateBackend testAsyncStateBackend = new TestAsyncStateBackend();
         assertThat(testAsyncStateBackend.supportsAsyncKeyedStateBackend()).isTrue();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -74,7 +74,7 @@ class AsyncExecutionControllerTest {
         String key1 = "key1";
         // Simulate the wrapping in {@link RecordProcessorUtils#getRecordProcessor()}, wrapping the
         // record and key with RecordContext.
-        RecordContext<String, String> recordContext1 = aec.buildContext(record1, key1);
+        RecordContext<String> recordContext1 = aec.buildContext(record1, key1);
         aec.setCurrentContext(recordContext1);
         // execute user code
         userCode.run();
@@ -99,14 +99,14 @@ class AsyncExecutionControllerTest {
         // ============================ element 2 & 3 ============================
         String record2 = "key1-r2";
         String key2 = "key1";
-        RecordContext<String, String> recordContext2 = aec.buildContext(record2, key2);
+        RecordContext<String> recordContext2 = aec.buildContext(record2, key2);
         aec.setCurrentContext(recordContext2);
         // execute user code
         userCode.run();
 
         String record3 = "key1-r3";
         String key3 = "key1";
-        RecordContext<String, String> recordContext3 = aec.buildContext(record3, key3);
+        RecordContext<String> recordContext3 = aec.buildContext(record3, key3);
         aec.setCurrentContext(recordContext3);
         // execute user code
         userCode.run();
@@ -151,7 +151,7 @@ class AsyncExecutionControllerTest {
         // ============================ element4 ============================
         String record4 = "key3-r3";
         String key4 = "key3";
-        RecordContext<String, String> recordContext4 = aec.buildContext(record4, key4);
+        RecordContext<String> recordContext4 = aec.buildContext(record4, key4);
         aec.setCurrentContext(recordContext4);
         // execute user code
         userCode.run();
@@ -182,21 +182,21 @@ class AsyncExecutionControllerTest {
 
         String record1 = "key1-r1";
         String key1 = "key1";
-        RecordContext<String, String> recordContext1 = aec.buildContext(record1, key1);
+        RecordContext<String> recordContext1 = aec.buildContext(record1, key1);
         aec.setCurrentContext(recordContext1);
         // execute user code
         userCode.run();
 
         String record2 = "key2-r1";
         String key2 = "key2";
-        RecordContext<String, String> recordContext2 = aec.buildContext(record2, key2);
+        RecordContext<String> recordContext2 = aec.buildContext(record2, key2);
         aec.setCurrentContext(recordContext2);
         // execute user code
         userCode.run();
 
         String record3 = "key1-r2";
         String key3 = "key1";
-        RecordContext<String, String> recordContext3 = aec.buildContext(record3, key3);
+        RecordContext<String> recordContext3 = aec.buildContext(record3, key3);
         aec.setCurrentContext(recordContext3);
         // execute user code
         userCode.run();
@@ -266,7 +266,7 @@ class AsyncExecutionControllerTest {
                 String record =
                         String.format("key%d-r%d", round * batchSize + i, round * batchSize + i);
                 String key = String.format("key%d", round * batchSize + i);
-                RecordContext<String, String> recordContext = aec.buildContext(record, key);
+                RecordContext<String> recordContext = aec.buildContext(record, key);
                 aec.setCurrentContext(recordContext);
                 userCode.run();
             }
@@ -279,7 +279,7 @@ class AsyncExecutionControllerTest {
         for (int i = 0; i < maxInFlight; i++) {
             String record = String.format("sameKey-r%d", i, i);
             String key = "sameKey";
-            RecordContext<String, String> recordContext = aec.buildContext(record, key);
+            RecordContext<String> recordContext = aec.buildContext(record, key);
             aec.setCurrentContext(recordContext);
             userCode.run();
         }
@@ -291,7 +291,7 @@ class AsyncExecutionControllerTest {
         for (int i = maxInFlight; i < 10 * maxInFlight; i++) {
             String record = String.format("sameKey-r%d", i, i);
             String key = "sameKey";
-            RecordContext<String, String> recordContext = aec.buildContext(record, key);
+            RecordContext<String> recordContext = aec.buildContext(record, key);
             aec.setCurrentContext(recordContext);
             userCode.run();
             assertThat(aec.inFlightRecordNum.get()).isEqualTo(maxInFlight + 1);
@@ -326,12 +326,12 @@ class AsyncExecutionControllerTest {
 
     static class TestValueState implements ValueState<Integer> {
 
-        private final AsyncExecutionController<String, String> asyncExecutionController;
+        private final AsyncExecutionController<String> asyncExecutionController;
 
         private final TestUnderlyingState underlyingState;
 
         public TestValueState(
-                AsyncExecutionController<String, String> aec, TestUnderlyingState underlyingState) {
+                AsyncExecutionController<String> aec, TestUnderlyingState underlyingState) {
             this.asyncExecutionController = aec;
             this.underlyingState = underlyingState;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/ContextStateFutureImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/ContextStateFutureImplTest.java
@@ -34,7 +34,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testThenApply() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String, String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
 
         // validate
         ContextStateFutureImpl<Void> future =
@@ -58,7 +58,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testThenAccept() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String, String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
 
         // validate
         ContextStateFutureImpl<Void> future =
@@ -82,7 +82,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testThenCompose() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String, String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
 
         // validate
         ContextStateFutureImpl<Void> future =
@@ -106,7 +106,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testThenCombine() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String, String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
 
         // validate
         ContextStateFutureImpl<Void> future1 =
@@ -156,7 +156,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testComplex() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String, String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
 
         for (int i = 0; i < 32; i++) { // 2^5 for completion status combination
             // Each bit of 'i' represents the complete status when the user code executes.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/KeyAccountingUnitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/KeyAccountingUnitTest.java
@@ -28,7 +28,7 @@ class KeyAccountingUnitTest {
 
     @Test
     void testBasic() {
-        KeyAccountingUnit<String, Integer> keyAccountingUnit = new KeyAccountingUnit<>(10);
+        KeyAccountingUnit<Integer> keyAccountingUnit = new KeyAccountingUnit<>(10);
         assertThat(keyAccountingUnit.occupy("record1", 1)).isTrue();
         assertThat(keyAccountingUnit.occupy("record1", 1)).isFalse();
         assertThat(keyAccountingUnit.occupy("record2", 2)).isTrue();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -128,7 +128,7 @@ public abstract class AbstractStreamOperator<OUT>
      *
      * <p>This is for elements from the first input.
      */
-    private transient KeySelector<?, ?> stateKeySelector1;
+    protected transient KeySelector<?, ?> stateKeySelector1;
 
     /**
      * {@code KeySelector} for extracting a key from an element being processed. This is used to
@@ -136,7 +136,7 @@ public abstract class AbstractStreamOperator<OUT>
      *
      * <p>This is for elements from the second input.
      */
-    private transient KeySelector<?, ?> stateKeySelector2;
+    protected transient KeySelector<?, ?> stateKeySelector2;
 
     private transient StreamOperatorStateHandler stateHandler;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -190,7 +190,7 @@ public abstract class AbstractStreamOperatorV2<OUT>
     }
 
     @Override
-    public final void initializeState(StreamTaskStateInitializer streamTaskStateManager)
+    public void initializeState(StreamTaskStateInitializer streamTaskStateManager)
             throws Exception {
         final TypeSerializer<?> keySerializer =
                 config.getStateKeySerializer(getUserCodeClassloader());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordProcessorUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/RecordProcessorUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.operators.KeyContextHandler;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.AsyncStateProcessing;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -54,6 +55,9 @@ public class RecordProcessorUtils {
 
         if (canOmitSetKeyContext) {
             return input::processElement;
+        } else if (input instanceof AsyncStateProcessing
+                && ((AsyncStateProcessing) input).isAsyncStateProcessingEnabled()) {
+            return ((AsyncStateProcessing) input).getRecordProcessor(1);
         } else {
             return record -> {
                 input.setKeyContextElement(record);
@@ -82,6 +86,9 @@ public class RecordProcessorUtils {
 
         if (canOmitSetKeyContext) {
             return operator::processElement1;
+        } else if (operator instanceof AsyncStateProcessing
+                && ((AsyncStateProcessing) operator).isAsyncStateProcessingEnabled()) {
+            return ((AsyncStateProcessing) operator).getRecordProcessor(1);
         } else {
             return record -> {
                 operator.setKeyContextElement1(record);
@@ -110,6 +117,9 @@ public class RecordProcessorUtils {
 
         if (canOmitSetKeyContext) {
             return operator::processElement2;
+        } else if (operator instanceof AsyncStateProcessing
+                && ((AsyncStateProcessing) operator).isAsyncStateProcessingEnabled()) {
+            return ((AsyncStateProcessing) operator).getRecordProcessor(2);
         } else {
             return record -> {
                 operator.setKeyContextElement2(record);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperator.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.asyncprocessing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
+import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+/**
+ * This operator is an abstract class that give the {@link AbstractStreamOperator} the ability to
+ * perform {@link AsyncStateProcessing}. The aim is to make any subclass of {@link
+ * AbstractStreamOperator} could manipulate async state with only a change of base class.
+ */
+@Internal
+@SuppressWarnings("rawtypes")
+public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStreamOperator<OUT>
+        implements AsyncStateProcessingOperator {
+
+    private AsyncExecutionController asyncExecutionController;
+
+    private RecordContext currentProcessingContext;
+
+    /** Initialize necessary state components for {@link AbstractStreamOperator}. */
+    @Override
+    public void setup(
+            StreamTask<?, ?> containingTask,
+            StreamConfig config,
+            Output<StreamRecord<OUT>> output) {
+        super.setup(containingTask, config, output);
+        // TODO: properly read config and setup
+        final MailboxExecutor mailboxExecutor =
+                containingTask.getEnvironment().getMainMailboxExecutor();
+        this.asyncExecutionController = new AsyncExecutionController(mailboxExecutor, null);
+    }
+
+    @Override
+    public boolean isAsyncStateProcessingEnabled() {
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final <T> void setAsyncKeyedContextElement(
+            StreamRecord<T> record, KeySelector<T, ?> keySelector) throws Exception {
+        currentProcessingContext =
+                asyncExecutionController.buildContext(
+                        record.getValue(), keySelector.getKey(record.getValue()));
+        // The processElement will be treated as a callback for dummy request. So reference
+        // counting should be maintained.
+        // When state request submitted, ref count +1, as described in FLIP-425:
+        // To cover the statements without a callback, in addition to the reference count marked
+        // in Fig.5, each state request itself is also protected by a paired reference count.
+        currentProcessingContext.retain();
+        asyncExecutionController.setCurrentContext(currentProcessingContext);
+    }
+
+    @Override
+    public final void postProcessElement() {
+        // The processElement will be treated as a callback for dummy request. So reference
+        // counting should be maintained.
+        // When a state request completes, ref count -1, as described in FLIP-425:
+        // To cover the statements without a callback, in addition to the reference count marked
+        // in Fig.5, each state request itself is also protected by a paired reference count.
+        currentProcessingContext.release();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final <T> ThrowingConsumer<StreamRecord<T>, Exception> getRecordProcessor(int inputId) {
+        // Ideally, only TwoStreamInputOperator/OneInputStreamOperator(Input) will invoke here.
+        // Only those operators have the definition of processElement(1/2).
+        if (this instanceof TwoInputStreamOperator) {
+            switch (inputId) {
+                case 1:
+                    return record -> {
+                        setAsyncKeyedContextElement(record, (KeySelector<T, ?>) stateKeySelector1);
+                        ((TwoInputStreamOperator) this).processElement1(record);
+                        postProcessElement();
+                    };
+                case 2:
+                    return record -> {
+                        setAsyncKeyedContextElement(record, (KeySelector<T, ?>) stateKeySelector2);
+                        ((TwoInputStreamOperator) this).processElement2(record);
+                        postProcessElement();
+                    };
+                default:
+                    break;
+            }
+        } else if (this instanceof Input && inputId == 1) {
+            return record -> {
+                setAsyncKeyedContextElement(record, (KeySelector<T, ?>) stateKeySelector1);
+                ((Input) this).processElement(record);
+                postProcessElement();
+            };
+        }
+        throw new IllegalArgumentException(
+                String.format(
+                        "Unsupported operator type %s with input id %d",
+                        getClass().getName(), inputId));
+    }
+
+    @VisibleForTesting
+    AsyncExecutionController<?> getAsyncExecutionController() {
+        return asyncExecutionController;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.asyncprocessing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
+import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+/**
+ * This operator is an abstract class that give the {@link AbstractStreamOperatorV2} the ability to
+ * perform {@link AsyncStateProcessing}. The aim is to make any subclass of {@link
+ * AbstractStreamOperatorV2} could manipulate async state with only a change of base class.
+ */
+@Internal
+@SuppressWarnings("rawtypes")
+public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractStreamOperatorV2<OUT>
+        implements AsyncStateProcessingOperator {
+
+    private final MailboxExecutor mailboxExecutor;
+
+    private AsyncExecutionController asyncExecutionController;
+
+    private RecordContext currentProcessingContext;
+
+    public AbstractAsyncStateStreamOperatorV2(
+            StreamOperatorParameters<OUT> parameters, int numberOfInputs) {
+        super(parameters, numberOfInputs);
+        this.mailboxExecutor =
+                parameters.getContainingTask().getEnvironment().getMainMailboxExecutor();
+    }
+
+    /** Initialize necessary state components for {@link AbstractStreamOperatorV2}. */
+    @Override
+    public final void initializeState(StreamTaskStateInitializer streamTaskStateManager)
+            throws Exception {
+        super.initializeState(streamTaskStateManager);
+        // TODO: Read config and properly set.
+        this.asyncExecutionController = new AsyncExecutionController(mailboxExecutor, null);
+    }
+
+    @Override
+    public boolean isAsyncStateProcessingEnabled() {
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final <T> void setAsyncKeyedContextElement(
+            StreamRecord<T> record, KeySelector<T, ?> keySelector) throws Exception {
+        currentProcessingContext =
+                asyncExecutionController.buildContext(
+                        record.getValue(), keySelector.getKey(record.getValue()));
+        // The processElement will be treated as a callback for dummy request. So reference
+        // counting should be maintained.
+        // When state request submitted, ref count +1, as described in FLIP-425:
+        // To cover the statements without a callback, in addition to the reference count marked
+        // in Fig.5, each state request itself is also protected by a paired reference count.
+        currentProcessingContext.retain();
+        asyncExecutionController.setCurrentContext(currentProcessingContext);
+    }
+
+    @Override
+    public final void postProcessElement() {
+        // The processElement will be treated as a callback for dummy request. So reference
+        // counting should be maintained.
+        // When a state request completes, ref count -1, as described in FLIP-425:
+        // To cover the statements without a callback, in addition to the reference count marked
+        // in Fig.5, each state request itself is also protected by a paired reference count.
+        currentProcessingContext.release();
+    }
+
+    @Override
+    public final <T> ThrowingConsumer<StreamRecord<T>, Exception> getRecordProcessor(int inputId) {
+        // The real logic should be in First/SecondInputOfTwoInput#getRecordProcessor.
+        throw new UnsupportedOperationException(
+                "Never getRecordProcessor from AbstractAsyncStateStreamOperatorV2,"
+                        + " since this part is handled by the Input.");
+    }
+
+    @VisibleForTesting
+    AsyncExecutionController<?> getAsyncExecutionController() {
+        return asyncExecutionController;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessing.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessing.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.asyncprocessing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+/** This class defines the basic interfaces to process a state in operator/input layer. */
+@Internal
+public interface AsyncStateProcessing {
+
+    /**
+     * Get if the async state processing is enabled for this input/operator.
+     *
+     * @return ture if async state processing is enabled.
+     */
+    boolean isAsyncStateProcessingEnabled();
+
+    /**
+     * Get the record processor that could process record from input, which is the only entry for
+     * async processing.
+     *
+     * @param inputId the input identifier, start from 1. Borrow the design from {@code
+     *     org.apache.flink.streaming.api.operators.AbstractInput#inputId}. This is only relevant if
+     *     there is multiple inputs for the instance.
+     */
+    <T> ThrowingConsumer<StreamRecord<T>, Exception> getRecordProcessor(int inputId);
+
+    /**
+     * Static method helper to make a record processor with given infos.
+     *
+     * @param asyncOperator the operator that can process state asynchronously.
+     * @param keySelector the key selector.
+     * @param processor the record processing logic.
+     * @return the built record processor that can returned by {@link #getRecordProcessor(int)}.
+     */
+    static <T> ThrowingConsumer<StreamRecord<T>, Exception> makeRecordProcessor(
+            AsyncStateProcessingOperator asyncOperator,
+            KeySelector<T, ?> keySelector,
+            ThrowingConsumer<StreamRecord<T>, Exception> processor) {
+        return (record) -> {
+            asyncOperator.setAsyncKeyedContextElement(record, keySelector);
+            processor.accept(record);
+            asyncOperator.postProcessElement();
+        };
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessingOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessingOperator.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.operators.asyncprocessing;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.function.ThrowingRunnable;
 
 /**
  * A more detailed interface based on {@link AsyncStateProcessing}, which gives the essential
@@ -28,6 +29,9 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
  */
 @Internal
 public interface AsyncStateProcessingOperator extends AsyncStateProcessing {
+
+    /** Get the {@link ElementOrder} of this operator. */
+    ElementOrder getElementOrder();
 
     /**
      * Set key context for async state processing.
@@ -41,4 +45,12 @@ public interface AsyncStateProcessingOperator extends AsyncStateProcessing {
 
     /** A callback that will be triggered after an element finishes {@code processElement}. */
     void postProcessElement();
+
+    /**
+     * Check the order of same-key record, and then process the record. Mainly used when the {@link
+     * #getElementOrder()} returns {@link ElementOrder#RECORD_ORDER}.
+     *
+     * @param processing the record processing logic.
+     */
+    void preserveRecordOrderAndProcess(ThrowingRunnable<Exception> processing);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessingOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessingOperator.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.asyncprocessing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * A more detailed interface based on {@link AsyncStateProcessing}, which gives the essential
+ * methods for an operator to perform async state processing.
+ */
+@Internal
+public interface AsyncStateProcessingOperator extends AsyncStateProcessing {
+
+    /**
+     * Set key context for async state processing.
+     *
+     * @param record the record.
+     * @param keySelector the key selector to select a key from record.
+     * @param <T> the type of the record.
+     */
+    <T> void setAsyncKeyedContextElement(StreamRecord<T> record, KeySelector<T, ?> keySelector)
+            throws Exception;
+
+    /** A callback that will be triggered after an element finishes {@code processElement}. */
+    void postProcessElement();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/ElementOrder.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/ElementOrder.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.asyncprocessing;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * This enum defines the element order of being processed. Only the elements with the same key
+ * should be considered here. We should keep this internal and away from API module for now, until
+ * we could see the concrete need for {@link #FIRST_STATE_ORDER} from average users.
+ */
+@Internal
+public enum ElementOrder {
+    /**
+     * Treat the record processing as a whole, meaning that any {@code processElement} call for the
+     * elements with same key should follow the order of record arrival AND no parallel run is
+     * allowed.
+     */
+    RECORD_ORDER,
+
+    /**
+     * The {@code processElement} call will be invoked on record arrival, but may be blocked at the
+     * first state accessing if there is a preceding same-key record under processing.
+     */
+    FIRST_STATE_ORDER,
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.asyncprocessing;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Basic tests for {@link AbstractAsyncStateStreamOperator}. */
+public class AbstractAsyncStateStreamOperatorTest {
+
+    protected KeyedOneInputStreamOperatorTestHarness<Integer, Tuple2<Integer, String>, String>
+            createTestHarness(int maxParalelism, int numSubtasks, int subtaskIndex)
+                    throws Exception {
+        TestOperator testOperator = new TestOperator();
+        return new KeyedOneInputStreamOperatorTestHarness<>(
+                testOperator,
+                new TestKeySelector(),
+                BasicTypeInfo.INT_TYPE_INFO,
+                maxParalelism,
+                numSubtasks,
+                subtaskIndex);
+    }
+
+    @Test
+    public void testCreateAsyncExecutionController() throws Exception {
+        try (KeyedOneInputStreamOperatorTestHarness<Integer, Tuple2<Integer, String>, String>
+                testHarness = createTestHarness(128, 1, 0)) {
+            testHarness.open();
+            assertThat(testHarness.getOperator())
+                    .isInstanceOf(AbstractAsyncStateStreamOperator.class);
+            assertThat(
+                            ((AbstractAsyncStateStreamOperator) testHarness.getOperator())
+                                    .getAsyncExecutionController())
+                    .isNotNull();
+        }
+    }
+
+    /** A simple testing operator. */
+    private static class TestOperator extends AbstractAsyncStateStreamOperator<String>
+            implements OneInputStreamOperator<Tuple2<Integer, String>, String>,
+                    Triggerable<Integer, VoidNamespace> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void open() throws Exception {
+            super.open();
+        }
+
+        @Override
+        public void processElement(StreamRecord<Tuple2<Integer, String>> element)
+                throws Exception {}
+
+        @Override
+        public void onEventTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {}
+
+        @Override
+        public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer)
+                throws Exception {}
+    }
+
+    /** {@link KeySelector} for tests. */
+    static class TestKeySelector implements KeySelector<Tuple2<Integer, String>, Integer> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Integer getKey(Tuple2<Integer, String> value) {
+            return value.f0;
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2Test.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2Test.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.asyncprocessing;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.streaming.api.operators.AbstractInput;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Basic tests for {@link AbstractAsyncStateStreamOperatorV2}. */
+public class AbstractAsyncStateStreamOperatorV2Test {
+
+    protected KeyedOneInputStreamOperatorV2TestHarness<Integer, Tuple2<Integer, String>, String>
+            createTestHarness(int maxParalelism, int numSubtasks, int subtaskIndex)
+                    throws Exception {
+        return new KeyedOneInputStreamOperatorV2TestHarness<>(
+                new TestOperatorFactory(),
+                new AbstractAsyncStateStreamOperatorTest.TestKeySelector(),
+                BasicTypeInfo.INT_TYPE_INFO,
+                maxParalelism,
+                numSubtasks,
+                subtaskIndex);
+    }
+
+    @Test
+    public void testCreateAsyncExecutionController() throws Exception {
+        try (KeyedOneInputStreamOperatorV2TestHarness<Integer, Tuple2<Integer, String>, String>
+                testHarness = createTestHarness(128, 1, 0)) {
+            testHarness.open();
+            assertThat(testHarness.getBaseOperator())
+                    .isInstanceOf(AbstractAsyncStateStreamOperatorV2.class);
+            assertThat(
+                            ((AbstractAsyncStateStreamOperatorV2) testHarness.getBaseOperator())
+                                    .getAsyncExecutionController())
+                    .isNotNull();
+        }
+    }
+
+    private static class KeyedOneInputStreamOperatorV2TestHarness<K, IN, OUT>
+            extends KeyedOneInputStreamOperatorTestHarness<K, IN, OUT> {
+        public KeyedOneInputStreamOperatorV2TestHarness(
+                StreamOperatorFactory<OUT> operatorFactory,
+                final KeySelector<IN, K> keySelector,
+                TypeInformation<K> keyType,
+                int maxParallelism,
+                int numSubtasks,
+                int subtaskIndex)
+                throws Exception {
+            super(operatorFactory, keySelector, keyType, maxParallelism, numSubtasks, subtaskIndex);
+        }
+
+        public StreamOperator<OUT> getBaseOperator() {
+            return operator;
+        }
+    }
+
+    private static class TestOperatorFactory extends AbstractStreamOperatorFactory<String> {
+        @Override
+        public <T extends StreamOperator<String>> T createStreamOperator(
+                StreamOperatorParameters<String> parameters) {
+            return (T) new SingleInputTestOperator(parameters);
+        }
+
+        @Override
+        public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+            return SingleInputTestOperator.class;
+        }
+    }
+
+    /**
+     * Testing operator that can respond to commands by either setting/deleting state, emitting
+     * state or setting timers.
+     */
+    private static class SingleInputTestOperator extends AbstractAsyncStateStreamOperatorV2<String>
+            implements MultipleInputStreamOperator<String>, Triggerable<Integer, VoidNamespace> {
+
+        private static final long serialVersionUID = 1L;
+
+        public SingleInputTestOperator(StreamOperatorParameters<String> parameters) {
+            super(parameters, 1);
+        }
+
+        @Override
+        public void open() throws Exception {
+            super.open();
+        }
+
+        @Override
+        public List<Input> getInputs() {
+            return Collections.singletonList(
+                    new AbstractInput<Tuple2<Integer, String>, String>(this, 1) {
+                        @Override
+                        public void processElement(StreamRecord<Tuple2<Integer, String>> element)
+                                throws Exception {}
+                    });
+        }
+
+        @Override
+        public void onEventTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {}
+
+        @Override
+        public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer)
+                throws Exception {}
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/OneInput.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/OneInput.java
@@ -18,16 +18,19 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput.input;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.AsyncStateProcessing;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.function.ThrowingConsumer;
 
 /** {@link Input} for {@link OneInputStreamOperator}. */
-public class OneInput extends InputBase {
+public class OneInput extends InputBase implements AsyncStateProcessing {
 
     private final OneInputStreamOperator<RowData, RowData> operator;
 
@@ -53,5 +56,18 @@ public class OneInput extends InputBase {
     @Override
     public void processWatermarkStatus(WatermarkStatus watermarkStatus) throws Exception {
         operator.processWatermarkStatus(watermarkStatus);
+    }
+
+    @Internal
+    @Override
+    public final boolean isAsyncStateProcessingEnabled() {
+        return (operator instanceof AsyncStateProcessing)
+                && ((AsyncStateProcessing) operator).isAsyncStateProcessingEnabled();
+    }
+
+    @Internal
+    @Override
+    public final <T> ThrowingConsumer<StreamRecord<T>, Exception> getRecordProcessor(int inputId) {
+        return ((AsyncStateProcessing) operator).getRecordProcessor(1);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/SecondInputOfTwoInput.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/input/SecondInputOfTwoInput.java
@@ -18,16 +18,19 @@
 
 package org.apache.flink.table.runtime.operators.multipleinput.input;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.AsyncStateProcessing;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.function.ThrowingConsumer;
 
 /** {@link Input} for the second input of {@link TwoInputStreamOperator}. */
-public class SecondInputOfTwoInput extends InputBase {
+public class SecondInputOfTwoInput extends InputBase implements AsyncStateProcessing {
 
     private final TwoInputStreamOperator<RowData, RowData, RowData> operator;
 
@@ -53,5 +56,18 @@ public class SecondInputOfTwoInput extends InputBase {
     @Override
     public void processWatermarkStatus(WatermarkStatus watermarkStatus) throws Exception {
         operator.processWatermarkStatus2(watermarkStatus);
+    }
+
+    @Internal
+    @Override
+    public final boolean isAsyncStateProcessingEnabled() {
+        return (operator instanceof AsyncStateProcessing)
+                && ((AsyncStateProcessing) operator).isAsyncStateProcessingEnabled();
+    }
+
+    @Internal
+    @Override
+    public final <T> ThrowingConsumer<StreamRecord<T>, Exception> getRecordProcessor(int inputId) {
+        return ((AsyncStateProcessing) operator).getRecordProcessor(2);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

 As part of the async execution model of disaggregated state management, this PR gives the basic definition of `StreamingOperator` integrated with async execution.

The philosophy behind this PR is **we are trying NOT to invade the previous code path**. The most strict thing is that **it MUST NOT affect any _hot path_ without this feature**.

By the way, the type parameter of record around `AsyncExecutionController` is erased, since the stream operator does not have the knowledge of record type, and the `AEC` does not need it.

## Brief change log

 - Erase the type parameter of record around `AsyncExecutionController` 
 - Define the `AbstractAsyncStateStreamOperator` and `AbstractAsyncStateStreamOperatorV2` corresponding to the `AbstracStreamOperator` and `AbstracStreamOperatorV2` respectively.
 - Wire the record processing logic with new introduced abstract stream operators in `RecordProcessorUtils`.
 

## Verifying this change

This change around `AEC` is already covered by existing tests. Basic UTs for new operators are added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
