### PR TITLE
[FLINK-35098][orc] Fix incorrect results in thanEquals filters

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
@@ -90,7 +90,7 @@ public class OrcFilters {
                                             convertBinary(
                                                     call,
                                                     OrcFilters::convertGreaterThanEquals,
-                                                    OrcFilters::convertLessThan))
+                                                    OrcFilters::convertLessThanEquals))
                             .put(
                                     BuiltInFunctionDefinitions.LESS_THAN,
                                     call ->
@@ -104,7 +104,7 @@ public class OrcFilters {
                                             convertBinary(
                                                     call,
                                                     OrcFilters::convertLessThanEquals,
-                                                    OrcFilters::convertGreaterThan))
+                                                    OrcFilters::convertGreaterThanEquals))
                             .build();
 
     private static boolean isRef(Expression expression) {

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
@@ -357,4 +357,18 @@ public class OrcFileSystemITCase extends BatchFileSystemITCaseBase {
                 "select a from orcLimitTable limit 5",
                 Arrays.asList(Row.of(1), Row.of(1), Row.of(1), Row.of(1), Row.of(1)));
     }
+
+    @TestTemplate
+    void testThanEquals() throws ExecutionException, InterruptedException {
+        super.tableEnv()
+                .executeSql(
+                        "insert into orcLimitTable values ('a', 9, 9), ('b', 10, 10), ('c', 11, 11)")
+                .await();
+
+        check("select y from orcLimitTable where y <= 10", Arrays.asList(Row.of(9), Row.of(10)));
+        check("select y from orcLimitTable where 10 >= y", Arrays.asList(Row.of(9), Row.of(10)));
+
+        check("select y from orcLimitTable where y >= 10", Arrays.asList(Row.of(10), Row.of(11)));
+        check("select y from orcLimitTable where 10 <= y", Arrays.asList(Row.of(10), Row.of(11)));
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix incorrect results in thanEquals filters

## Brief change log

  - Fix the reverse function for Orc GREATER_THAN_OR_EQUAL
  - Fix the reverse function for Orc LESS_THAN_OR_EQUAL


## Verifying this change

Via tests in `org.apache.flink.orc.OrcFileSystemITCase::testThanEquals`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
