### PR TITLE
[FLINK-35098][ORC] Fix incorrect results with literal first expressions

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
@@ -83,28 +83,28 @@ public class OrcFilters {
                                             convertBinary(
                                                     call,
                                                     OrcFilters::convertGreaterThan,
-                                                    OrcFilters::convertLessThanEquals))
+                                                    OrcFilters::convertLessThan))
                             .put(
                                     BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL,
                                     call ->
                                             convertBinary(
                                                     call,
                                                     OrcFilters::convertGreaterThanEquals,
-                                                    OrcFilters::convertLessThan))
+                                                    OrcFilters::convertLessThanEquals))
                             .put(
                                     BuiltInFunctionDefinitions.LESS_THAN,
                                     call ->
                                             convertBinary(
                                                     call,
                                                     OrcFilters::convertLessThan,
-                                                    OrcFilters::convertGreaterThanEquals))
+                                                    OrcFilters::convertGreaterThan))
                             .put(
                                     BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL,
                                     call ->
                                             convertBinary(
                                                     call,
                                                     OrcFilters::convertLessThanEquals,
-                                                    OrcFilters::convertGreaterThan))
+                                                    OrcFilters::convertGreaterThanEquals))
                             .build();
 
     private static boolean isRef(Expression expression) {

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
@@ -86,4 +86,28 @@ class OrcFileSystemFilterTest {
         OrcFilters.Predicate predicate8 = new OrcFilters.And(predicate4, predicate6);
         assertThat(predicate7).hasToString(predicate8.toString());
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testApplyPredicateReverse() {
+        List<ResolvedExpression> args = new ArrayList<>();
+
+        // equal
+        FieldReferenceExpression fieldReferenceExpression =
+                new FieldReferenceExpression("long1", DataTypes.BIGINT(), 0, 0);
+        ValueLiteralExpression valueLiteralExpression = new ValueLiteralExpression(10);
+        args.add(valueLiteralExpression);
+        args.add(fieldReferenceExpression);
+
+        // greater than
+        CallExpression greaterExpression =
+                CallExpression.permanent(
+                        BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL,
+                        args,
+                        DataTypes.BOOLEAN());
+        OrcFilters.Predicate predicate1 = OrcFilters.toOrcPredicate(greaterExpression);
+        OrcFilters.Predicate predicate2 =
+                new OrcFilters.LessThanEquals("long1", PredicateLeaf.Type.LONG, 10);
+        assertThat(predicate1).hasToString(predicate2.toString());
+    }
 }

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
@@ -39,7 +39,7 @@ class OrcFileSystemFilterTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testApplyPredicate() {
+    void testApplyPredicate() {
         List<ResolvedExpression> args = new ArrayList<>();
 
         // equal
@@ -86,7 +86,7 @@ class OrcFileSystemFilterTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testApplyPredicateReverse() {
+    void testApplyPredicateReverse() {
         List<ResolvedExpression> args = new ArrayList<>();
 
         FieldReferenceExpression fieldReferenceExpression =

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
@@ -215,6 +215,8 @@ public class OrcFileSystemITCase extends BatchFileSystemITCaseBase {
                 .await();
         check("select y from orcLimitTable where 10 >= y", Collections.singletonList(Row.of(10)));
         check("select y from orcLimitTable where 11 <= y", Collections.singletonList(Row.of(11)));
+        check("select y from orcLimitTable where 11 > y", Collections.singletonList(Row.of(10)));
+        check("select y from orcLimitTable where 10 < y", Collections.singletonList(Row.of(11)));
     }
 
     @TestTemplate

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
@@ -209,6 +209,15 @@ public class OrcFileSystemITCase extends BatchFileSystemITCaseBase {
     }
 
     @TestTemplate
+    void testOrcFilterPushDownLiteralFirst() throws ExecutionException, InterruptedException {
+        super.tableEnv().executeSql("insert into orcLimitTable values('a', 10, 10)").await();
+
+        List<Row> expected = Collections.singletonList(Row.of(10));
+        check("select y from orcLimitTable where y <= 10", expected);
+        check("select y from orcLimitTable where 10 >= y", expected);
+    }
+
+    @TestTemplate
     void testNestedTypes() throws Exception {
         String path = initNestedTypesFile(initNestedTypesData());
         super.tableEnv()

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
@@ -210,11 +210,11 @@ public class OrcFileSystemITCase extends BatchFileSystemITCaseBase {
 
     @TestTemplate
     void testOrcFilterPushDownLiteralFirst() throws ExecutionException, InterruptedException {
-        super.tableEnv().executeSql("insert into orcLimitTable values('a', 10, 10)").await();
-
-        List<Row> expected = Collections.singletonList(Row.of(10));
-        check("select y from orcLimitTable where y <= 10", expected);
-        check("select y from orcLimitTable where 10 >= y", expected);
+        super.tableEnv()
+                .executeSql("insert into orcLimitTable values('a', 10, 10), ('b', 11, 11)")
+                .await();
+        check("select y from orcLimitTable where 10 >= y", Collections.singletonList(Row.of(10)));
+        check("select y from orcLimitTable where 11 <= y", Collections.singletonList(Row.of(11)));
     }
 
     @TestTemplate


### PR DESCRIPTION
## What is the purpose of the change

Fixes an issue with SQL queries containing expressions like **10 >= y** when using Filesystem connector and ORC format.

## Brief change log

  - In OrcFilters fixed filters push down of GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL functions 

## Verifying this change

Added tests:
  - `OrcFileSystemITCase::testOrcFilterPushDownLiteralFirst` verifies a query result.
  - `OrcFileSystemFilterTest::testApplyPredicateReverse` verifies expression conversions to ORC filter predicates.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
