### PR TITLE
[FLINK-35097][table] Fix 'raw' format deserialization

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/formats/raw/RawFormatDeserializationSchema.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/formats/raw/RawFormatDeserializationSchema.java
@@ -59,8 +59,6 @@ public class RawFormatDeserializationSchema implements DeserializationSchema<Row
 
     private final DataLengthValidator validator;
 
-    private transient GenericRowData reuse;
-
     public RawFormatDeserializationSchema(
             LogicalType deserializedType,
             TypeInformation<RowData> producedTypeInfo,
@@ -76,7 +74,6 @@ public class RawFormatDeserializationSchema implements DeserializationSchema<Row
 
     @Override
     public void open(InitializationContext context) throws Exception {
-        reuse = new GenericRowData(1);
         converter.open();
     }
 
@@ -89,8 +86,10 @@ public class RawFormatDeserializationSchema implements DeserializationSchema<Row
             validator.validate(message);
             field = converter.convert(message);
         }
-        reuse.setField(0, field);
-        return reuse;
+
+        GenericRowData rowData = new GenericRowData(1);
+        rowData.setField(0, field);
+        return rowData;
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/formats/raw/RawFormatSerDeSchemaTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/formats/raw/RawFormatSerDeSchemaTest.java
@@ -68,107 +68,79 @@ public class RawFormatSerDeSchemaTest {
     @Parameterized.Parameters(name = "{index}: {0}")
     public static List<TestSpec> testData() {
         return Arrays.asList(
-                TestSpec.type(TINYINT())
-                        .values(new Byte[] {Byte.MAX_VALUE})
-                        .binary(new byte[][] {{Byte.MAX_VALUE}}),
+                TestSpec.type(TINYINT()).values(Byte.MAX_VALUE).binary(new byte[] {Byte.MAX_VALUE}),
+                TestSpec.type(SMALLINT()).values(Short.MAX_VALUE).binary(hexStringToByte("7fff")),
                 TestSpec.type(SMALLINT())
-                        .values(new Short[] {Short.MAX_VALUE})
-                        .binary(new byte[][] {hexStringToByte("7fff")}),
-                TestSpec.type(SMALLINT())
-                        .values(new Short[] {Short.MAX_VALUE})
+                        .values(Short.MAX_VALUE)
                         .withLittleEndian()
-                        .binary(new byte[][] {hexStringToByte("ff7f")}),
+                        .binary(hexStringToByte("ff7f")),
+                TestSpec.type(INT()).values(Integer.MAX_VALUE).binary(hexStringToByte("7fffffff")),
                 TestSpec.type(INT())
-                        .values(new Integer[] {Integer.MAX_VALUE})
-                        .binary(new byte[][] {hexStringToByte("7fffffff")}),
-                TestSpec.type(INT())
-                        .values(new Integer[] {Integer.MAX_VALUE})
+                        .values(Integer.MAX_VALUE)
                         .withLittleEndian()
-                        .binary(new byte[][] {hexStringToByte("ffffff7f")}),
+                        .binary(hexStringToByte("ffffff7f")),
                 TestSpec.type(BIGINT())
-                        .values(new Long[] {Long.MAX_VALUE})
-                        .binary(new byte[][] {hexStringToByte("7fffffffffffffff")}),
+                        .values(Long.MAX_VALUE)
+                        .binary(hexStringToByte("7fffffffffffffff")),
                 TestSpec.type(BIGINT())
-                        .values(new Long[] {Long.MAX_VALUE})
+                        .values(Long.MAX_VALUE)
                         .withLittleEndian()
-                        .binary(new byte[][] {hexStringToByte("ffffffffffffff7f")}),
+                        .binary(hexStringToByte("ffffffffffffff7f")),
+                TestSpec.type(FLOAT()).values(Float.MAX_VALUE).binary(hexStringToByte("7f7fffff")),
                 TestSpec.type(FLOAT())
-                        .values(new Float[] {Float.MAX_VALUE})
-                        .binary(new byte[][] {hexStringToByte("7f7fffff")}),
-                TestSpec.type(FLOAT())
-                        .values(new Float[] {Float.MAX_VALUE})
+                        .values(Float.MAX_VALUE)
                         .withLittleEndian()
-                        .binary(new byte[][] {hexStringToByte("ffff7f7f")}),
+                        .binary(hexStringToByte("ffff7f7f")),
                 TestSpec.type(DOUBLE())
-                        .values(new Double[] {Double.MAX_VALUE})
-                        .binary(new byte[][] {hexStringToByte("7fefffffffffffff")}),
+                        .values(Double.MAX_VALUE)
+                        .binary(hexStringToByte("7fefffffffffffff")),
                 TestSpec.type(DOUBLE())
-                        .values(new Double[] {Double.MAX_VALUE})
+                        .values(Double.MAX_VALUE)
                         .withLittleEndian()
-                        .binary(new byte[][] {hexStringToByte("ffffffffffffef7f")}),
-                TestSpec.type(BOOLEAN())
-                        .values(new Boolean[] {true})
-                        .binary(new byte[][] {new byte[] {1}}),
-                TestSpec.type(BOOLEAN())
-                        .values(new Boolean[] {false})
-                        .binary(new byte[][] {new byte[] {0}}),
+                        .binary(hexStringToByte("ffffffffffffef7f")),
+                TestSpec.type(BOOLEAN()).values(true).binary(new byte[] {1}),
+                TestSpec.type(BOOLEAN()).values(false).binary(new byte[] {0}),
+                TestSpec.type(STRING()).values("Hello World").binary("Hello World".getBytes()),
                 TestSpec.type(STRING())
-                        .values(new String[] {"Hello World"})
-                        .binary(new byte[][] {"Hello World".getBytes()}),
+                        .values("你好世界，Hello World")
+                        .binary("你好世界，Hello World".getBytes()),
                 TestSpec.type(STRING())
-                        .values(new String[] {"你好世界，Hello World"})
-                        .binary(new byte[][] {"你好世界，Hello World".getBytes()}),
-                TestSpec.type(STRING())
-                        .values(new String[] {"Flink Awesome!"})
+                        .values("Flink Awesome!")
                         .withCharset("UTF-16")
-                        .binary(new byte[][] {"Flink Awesome!".getBytes(StandardCharsets.UTF_16)}),
+                        .binary("Flink Awesome!".getBytes(StandardCharsets.UTF_16)),
                 TestSpec.type(STRING())
-                        .values(new String[] {"Flink 帅哭!"})
+                        .values("Flink 帅哭!")
                         .withCharset("UTF-16")
-                        .binary(new byte[][] {"Flink 帅哭!".getBytes(StandardCharsets.UTF_16)}),
+                        .binary("Flink 帅哭!".getBytes(StandardCharsets.UTF_16)),
+                TestSpec.type(STRING()).values("").binary("".getBytes()),
+                TestSpec.type(VARCHAR(5)).values("HELLO").binary("HELLO".getBytes()),
                 TestSpec.type(STRING())
-                        .values(new String[] {""})
-                        .binary(new byte[][] {"".getBytes()}),
-                TestSpec.type(VARCHAR(5))
-                        .values(new String[] {"HELLO"})
-                        .binary(new byte[][] {"HELLO".getBytes()}),
-                TestSpec.type(STRING())
-                        .values(new String[] {"line 1", "line 2", "line 3"})
-                        .binary(
-                                new byte[][] {
-                                    "line 1".getBytes(), "line 2".getBytes(), "line 3".getBytes()
-                                }),
+                        .values("line 1", "line 2", "line 3")
+                        .binary("line 1".getBytes(), "line 2".getBytes(), "line 3".getBytes()),
                 TestSpec.type(BYTES())
-                        .values(new byte[][] {{1, 3, 5, 7, 9}})
-                        .binary(new byte[][] {{1, 3, 5, 7, 9}}),
-                TestSpec.type(BYTES()).values(new byte[][] {}).binary(new byte[][] {{}}),
-                TestSpec.type(BINARY(3))
-                        .values(new byte[][] {{1, 3, 5}})
-                        .binary(new byte[][] {{1, 3, 5}}),
+                        .values(new byte[] {1, 3, 5, 7, 9})
+                        .binary(new byte[] {1, 3, 5, 7, 9}),
+                TestSpec.type(BYTES()).values(new byte[] {}).binary(new byte[] {}),
+                TestSpec.type(BINARY(3)).values(new byte[] {1, 3, 5}).binary(new byte[] {1, 3, 5}),
                 TestSpec.type(RAW(LocalDateTime.class, new LocalDateTimeSerializer()))
-                        .values(
-                                new LocalDateTime[] {
-                                    LocalDateTime.parse("2020-11-11T18:08:01.123")
-                                })
+                        .values(LocalDateTime.parse("2020-11-11T18:08:01.123"))
                         .binary(
-                                new byte[][] {
-                                    serializeLocalDateTime(
-                                            LocalDateTime.parse("2020-11-11T18:08:01.123"))
-                                }),
+                                serializeLocalDateTime(
+                                        LocalDateTime.parse("2020-11-11T18:08:01.123"))),
 
                 // test nulls
-                TestSpec.type(TINYINT()).values(new Byte[] {null}).binary(new byte[][] {null}),
-                TestSpec.type(SMALLINT()).values(new Short[] {null}).binary(new byte[][] {null}),
-                TestSpec.type(INT()).values(new Integer[] {null}).binary(new byte[][] {null}),
-                TestSpec.type(BIGINT()).values(new Long[] {null}).binary(new byte[][] {null}),
-                TestSpec.type(FLOAT()).values(new Float[] {null}).binary(new byte[][] {null}),
-                TestSpec.type(DOUBLE()).values(new Double[] {null}).binary(new byte[][] {null}),
-                TestSpec.type(BOOLEAN()).values(new Boolean[] {null}).binary(new byte[][] {null}),
-                TestSpec.type(STRING()).values(new String[] {null}).binary(new byte[][] {null}),
-                TestSpec.type(BYTES()).values(new byte[][] {null}).binary(new byte[][] {null}),
+                TestSpec.type(TINYINT()).values((Object) null).binary((byte[]) null),
+                TestSpec.type(SMALLINT()).values((Object) null).binary((byte[]) null),
+                TestSpec.type(INT()).values((Object) null).binary((byte[]) null),
+                TestSpec.type(BIGINT()).values((Object) null).binary((byte[]) null),
+                TestSpec.type(FLOAT()).values((Object) null).binary((byte[]) null),
+                TestSpec.type(DOUBLE()).values((Object) null).binary((byte[]) null),
+                TestSpec.type(BOOLEAN()).values((Object) null).binary((byte[]) null),
+                TestSpec.type(STRING()).values((Object) null).binary((byte[]) null),
+                TestSpec.type(BYTES()).values((Object) null).binary((byte[]) null),
                 TestSpec.type(RAW(LocalDateTime.class, new LocalDateTimeSerializer()))
-                        .values(new LocalDateTime[] {null})
-                        .binary(new byte[][] {null}));
+                        .values((Object) null)
+                        .binary((byte[]) null));
     }
 
     @Parameterized.Parameter public TestSpec testSpec;
@@ -247,12 +219,12 @@ public class RawFormatSerDeSchemaTest {
             return new TestSpec(fieldType);
         }
 
-        public TestSpec values(Object[] values) {
+        public TestSpec values(Object... values) {
             this.values = values;
             return this;
         }
 
-        public TestSpec binary(byte[][] bytes) {
+        public TestSpec binary(byte[]... bytes) {
             this.binary = bytes;
             return this;
         }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/formats/raw/RawFormatSerDeSchemaTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/formats/raw/RawFormatSerDeSchemaTest.java
@@ -39,6 +39,7 @@ import org.junit.runners.Parameterized;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -67,76 +68,107 @@ public class RawFormatSerDeSchemaTest {
     @Parameterized.Parameters(name = "{index}: {0}")
     public static List<TestSpec> testData() {
         return Arrays.asList(
-                TestSpec.type(TINYINT()).value(Byte.MAX_VALUE).binary(new byte[] {Byte.MAX_VALUE}),
-                TestSpec.type(SMALLINT()).value(Short.MAX_VALUE).binary(hexStringToByte("7fff")),
+                TestSpec.type(TINYINT())
+                        .values(new Byte[] {Byte.MAX_VALUE})
+                        .binary(new byte[][] {{Byte.MAX_VALUE}}),
                 TestSpec.type(SMALLINT())
-                        .value(Short.MAX_VALUE)
+                        .values(new Short[] {Short.MAX_VALUE})
+                        .binary(new byte[][] {hexStringToByte("7fff")}),
+                TestSpec.type(SMALLINT())
+                        .values(new Short[] {Short.MAX_VALUE})
                         .withLittleEndian()
-                        .binary(hexStringToByte("ff7f")),
-                TestSpec.type(INT()).value(Integer.MAX_VALUE).binary(hexStringToByte("7fffffff")),
+                        .binary(new byte[][] {hexStringToByte("ff7f")}),
                 TestSpec.type(INT())
-                        .value(Integer.MAX_VALUE)
+                        .values(new Integer[] {Integer.MAX_VALUE})
+                        .binary(new byte[][] {hexStringToByte("7fffffff")}),
+                TestSpec.type(INT())
+                        .values(new Integer[] {Integer.MAX_VALUE})
                         .withLittleEndian()
-                        .binary(hexStringToByte("ffffff7f")),
+                        .binary(new byte[][] {hexStringToByte("ffffff7f")}),
                 TestSpec.type(BIGINT())
-                        .value(Long.MAX_VALUE)
-                        .binary(hexStringToByte("7fffffffffffffff")),
+                        .values(new Long[] {Long.MAX_VALUE})
+                        .binary(new byte[][] {hexStringToByte("7fffffffffffffff")}),
                 TestSpec.type(BIGINT())
-                        .value(Long.MAX_VALUE)
+                        .values(new Long[] {Long.MAX_VALUE})
                         .withLittleEndian()
-                        .binary(hexStringToByte("ffffffffffffff7f")),
-                TestSpec.type(FLOAT()).value(Float.MAX_VALUE).binary(hexStringToByte("7f7fffff")),
+                        .binary(new byte[][] {hexStringToByte("ffffffffffffff7f")}),
                 TestSpec.type(FLOAT())
-                        .value(Float.MAX_VALUE)
+                        .values(new Float[] {Float.MAX_VALUE})
+                        .binary(new byte[][] {hexStringToByte("7f7fffff")}),
+                TestSpec.type(FLOAT())
+                        .values(new Float[] {Float.MAX_VALUE})
                         .withLittleEndian()
-                        .binary(hexStringToByte("ffff7f7f")),
+                        .binary(new byte[][] {hexStringToByte("ffff7f7f")}),
                 TestSpec.type(DOUBLE())
-                        .value(Double.MAX_VALUE)
-                        .binary(hexStringToByte("7fefffffffffffff")),
+                        .values(new Double[] {Double.MAX_VALUE})
+                        .binary(new byte[][] {hexStringToByte("7fefffffffffffff")}),
                 TestSpec.type(DOUBLE())
-                        .value(Double.MAX_VALUE)
+                        .values(new Double[] {Double.MAX_VALUE})
                         .withLittleEndian()
-                        .binary(hexStringToByte("ffffffffffffef7f")),
-                TestSpec.type(BOOLEAN()).value(true).binary(new byte[] {1}),
-                TestSpec.type(BOOLEAN()).value(false).binary(new byte[] {0}),
-                TestSpec.type(STRING()).value("Hello World").binary("Hello World".getBytes()),
+                        .binary(new byte[][] {hexStringToByte("ffffffffffffef7f")}),
+                TestSpec.type(BOOLEAN())
+                        .values(new Boolean[] {true})
+                        .binary(new byte[][] {new byte[] {1}}),
+                TestSpec.type(BOOLEAN())
+                        .values(new Boolean[] {false})
+                        .binary(new byte[][] {new byte[] {0}}),
                 TestSpec.type(STRING())
-                        .value("你好世界，Hello World")
-                        .binary("你好世界，Hello World".getBytes()),
+                        .values(new String[] {"Hello World"})
+                        .binary(new byte[][] {"Hello World".getBytes()}),
                 TestSpec.type(STRING())
-                        .value("Flink Awesome!")
+                        .values(new String[] {"你好世界，Hello World"})
+                        .binary(new byte[][] {"你好世界，Hello World".getBytes()}),
+                TestSpec.type(STRING())
+                        .values(new String[] {"Flink Awesome!"})
                         .withCharset("UTF-16")
-                        .binary("Flink Awesome!".getBytes(StandardCharsets.UTF_16)),
+                        .binary(new byte[][] {"Flink Awesome!".getBytes(StandardCharsets.UTF_16)}),
                 TestSpec.type(STRING())
-                        .value("Flink 帅哭!")
+                        .values(new String[] {"Flink 帅哭!"})
                         .withCharset("UTF-16")
-                        .binary("Flink 帅哭!".getBytes(StandardCharsets.UTF_16)),
-                TestSpec.type(STRING()).value("").binary("".getBytes()),
-                TestSpec.type(VARCHAR(5)).value("HELLO").binary("HELLO".getBytes()),
-                TestSpec.type(BYTES())
-                        .value(new byte[] {1, 3, 5, 7, 9})
-                        .binary(new byte[] {1, 3, 5, 7, 9}),
-                TestSpec.type(BYTES()).value(new byte[] {}).binary(new byte[] {}),
-                TestSpec.type(BINARY(3)).value(new byte[] {1, 3, 5}).binary(new byte[] {1, 3, 5}),
-                TestSpec.type(RAW(LocalDateTime.class, new LocalDateTimeSerializer()))
-                        .value(LocalDateTime.parse("2020-11-11T18:08:01.123"))
+                        .binary(new byte[][] {"Flink 帅哭!".getBytes(StandardCharsets.UTF_16)}),
+                TestSpec.type(STRING())
+                        .values(new String[] {""})
+                        .binary(new byte[][] {"".getBytes()}),
+                TestSpec.type(VARCHAR(5))
+                        .values(new String[] {"HELLO"})
+                        .binary(new byte[][] {"HELLO".getBytes()}),
+                TestSpec.type(STRING())
+                        .values(new String[] {"line 1", "line 2", "line 3"})
                         .binary(
-                                serializeLocalDateTime(
-                                        LocalDateTime.parse("2020-11-11T18:08:01.123"))),
+                                new byte[][] {
+                                    "line 1".getBytes(), "line 2".getBytes(), "line 3".getBytes()
+                                }),
+                TestSpec.type(BYTES())
+                        .values(new byte[][] {{1, 3, 5, 7, 9}})
+                        .binary(new byte[][] {{1, 3, 5, 7, 9}}),
+                TestSpec.type(BYTES()).values(new byte[][] {}).binary(new byte[][] {{}}),
+                TestSpec.type(BINARY(3))
+                        .values(new byte[][] {{1, 3, 5}})
+                        .binary(new byte[][] {{1, 3, 5}}),
+                TestSpec.type(RAW(LocalDateTime.class, new LocalDateTimeSerializer()))
+                        .values(
+                                new LocalDateTime[] {
+                                    LocalDateTime.parse("2020-11-11T18:08:01.123")
+                                })
+                        .binary(
+                                new byte[][] {
+                                    serializeLocalDateTime(
+                                            LocalDateTime.parse("2020-11-11T18:08:01.123"))
+                                }),
 
                 // test nulls
-                TestSpec.type(TINYINT()).value(null).binary(null),
-                TestSpec.type(SMALLINT()).value(null).binary(null),
-                TestSpec.type(INT()).value(null).binary(null),
-                TestSpec.type(BIGINT()).value(null).binary(null),
-                TestSpec.type(FLOAT()).value(null).binary(null),
-                TestSpec.type(DOUBLE()).value(null).binary(null),
-                TestSpec.type(BOOLEAN()).value(null).binary(null),
-                TestSpec.type(STRING()).value(null).binary(null),
-                TestSpec.type(BYTES()).value(null).binary(null),
+                TestSpec.type(TINYINT()).values(new Byte[] {null}).binary(new byte[][] {null}),
+                TestSpec.type(SMALLINT()).values(new Short[] {null}).binary(new byte[][] {null}),
+                TestSpec.type(INT()).values(new Integer[] {null}).binary(new byte[][] {null}),
+                TestSpec.type(BIGINT()).values(new Long[] {null}).binary(new byte[][] {null}),
+                TestSpec.type(FLOAT()).values(new Float[] {null}).binary(new byte[][] {null}),
+                TestSpec.type(DOUBLE()).values(new Double[] {null}).binary(new byte[][] {null}),
+                TestSpec.type(BOOLEAN()).values(new Boolean[] {null}).binary(new byte[][] {null}),
+                TestSpec.type(STRING()).values(new String[] {null}).binary(new byte[][] {null}),
+                TestSpec.type(BYTES()).values(new byte[][] {null}).binary(new byte[][] {null}),
                 TestSpec.type(RAW(LocalDateTime.class, new LocalDateTimeSerializer()))
-                        .value(null)
-                        .binary(null));
+                        .values(new LocalDateTime[] {null})
+                        .binary(new byte[][] {null}));
     }
 
     @Parameterized.Parameter public TestSpec testSpec;
@@ -155,17 +187,35 @@ public class RawFormatSerDeSchemaTest {
         deserializationSchema.open(mock(DeserializationSchema.InitializationContext.class));
         serializationSchema.open(mock(SerializationSchema.InitializationContext.class));
 
-        Row row = Row.of(testSpec.value);
         DataStructureConverter<Object, Object> converter =
                 DataStructureConverters.getConverter(ROW(FIELD("single", testSpec.type)));
-        RowData originalRowData = (RowData) converter.toInternal(row);
 
-        byte[] serializedBytes = serializationSchema.serialize(originalRowData);
-        assertThat(serializedBytes).isEqualTo(testSpec.binary);
+        byte[][] serializedBytesArr = new byte[testSpec.values.length][];
+        RowData[] deserializedRowDataArr = new RowData[testSpec.values.length];
 
-        RowData deserializeRowData = deserializationSchema.deserialize(serializedBytes);
-        Row actual = (Row) converter.toExternal(deserializeRowData);
-        assertThat(actual).isEqualTo(row);
+        // The following loops are partitioned to ensure the serialized/deserialized
+        // values are not copied by reference. (see FLINK-35097)
+
+        // Process serialization
+        for (int i = 0; i < testSpec.values.length; i++) {
+            Row row = Row.of(testSpec.values[i]);
+            RowData originalRowData = (RowData) converter.toInternal(row);
+            serializedBytesArr[i] = serializationSchema.serialize(originalRowData);
+        }
+
+        // Test serialization and process deserialization
+        for (int i = 0; i < testSpec.values.length; i++) {
+            assertThat(serializedBytesArr[i]).isEqualTo(testSpec.binary[i]);
+
+            deserializedRowDataArr[i] = deserializationSchema.deserialize(serializedBytesArr[i]);
+        }
+
+        // Test deserialization
+        for (int i = 0; i < testSpec.values.length; i++) {
+            Row row = Row.of(testSpec.values[i]);
+            Row actual = (Row) converter.toExternal(deserializedRowDataArr[i]);
+            assertThat(actual).isEqualTo(row);
+        }
     }
 
     private static byte[] serializeLocalDateTime(LocalDateTime localDateTime) {
@@ -183,9 +233,9 @@ public class RawFormatSerDeSchemaTest {
 
     private static class TestSpec {
 
-        private Object value;
-        private byte[] binary;
-        private DataType type;
+        private Object[] values;
+        private byte[][] binary;
+        private final DataType type;
         private String charsetName = "UTF-8";
         private boolean isBigEndian = true;
 
@@ -197,12 +247,12 @@ public class RawFormatSerDeSchemaTest {
             return new TestSpec(fieldType);
         }
 
-        public TestSpec value(Object value) {
-            this.value = value;
+        public TestSpec values(Object[] values) {
+            this.values = values;
             return this;
         }
 
-        public TestSpec binary(byte[] bytes) {
+        public TestSpec binary(byte[][] bytes) {
             this.binary = bytes;
             return this;
         }
@@ -219,12 +269,16 @@ public class RawFormatSerDeSchemaTest {
 
         @Override
         public String toString() {
-            String hex = binary == null ? "null" : "0x" + StringUtils.byteToHexString(binary);
+            ArrayList<String> hexes = new ArrayList<>();
+            for (byte[] b : binary) {
+                hexes.add(b == null ? "" : "0x" + StringUtils.byteToHexString(b));
+            }
+
             return "TestSpec{"
-                    + "value="
-                    + value
+                    + "values="
+                    + Arrays.toString(values)
                     + ", binary="
-                    + hex
+                    + hexes
                     + ", type="
                     + type
                     + ", charsetName='"


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fixes broken deserialization of the `raw` format.

## Brief change log

The existing `reuse` attribute is returned by the `deserialize()` method in `RawFormatDeserializationSchema`. The attribute is successively modified during deserialization but since it's returned by reference in the method, all the returned deserializations refer to a single value. This change removes the attributes and instead constructs the returned value in the `deserialize()` method inside the method itself, thus avoiding overwrites.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

**Existing Behavior**
1. Create a test file with the content:
```
line 1
line 2
line3
```
2. Run
```SQL
CREATE TABLE MyRawTable (
`doc` string,
) WITH (
'path' = 'file:///path/to/data',
'format' = 'raw',
'connector' = 'filesystem'
);
```
3. Check inserted values
```SQL
SELECT * FROM MyRawTable;
```
```
doc
-----
line 3
line 3
line 3
```

**After the Change**
```SQL
SELECT * FROM MyRawTable;
```
```
doc
-----
line 1
line 2
line 3
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
