### PR TITLE
[FLINK-35125][state] Implement ValueState for ForStStateBackend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalSyncState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalSyncState.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+
+/**
+ * Internal state interface for the stateBackend layer, where state requests are executed
+ * synchronously. Unlike the user-facing state interface, {@code InternalSyncState}'s interfaces
+ * provide the key directly in the method signature, so there is no need to pass the keyContext
+ * information for these interfaces.
+ *
+ * @param <K> Type of the key in the state.
+ */
+@Internal
+public interface InternalSyncState<K> {
+
+    /**
+     * Removes the value mapped under the given key.
+     *
+     * @param key The key to be deleted.
+     * @throws IOException Thrown when the performed I/O operation fails.
+     */
+    void clear(K key) throws IOException;
+
+    /**
+     * Indicates whether MultiGet API is supported.
+     *
+     * @return True if supported, false if not.
+     */
+    default boolean isSupportMultiGet() {
+        return false;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalSyncValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalSyncValueState.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * {@link InternalSyncState} interface for partitioned value state.
+ *
+ * <p>In addition to providing an ordinary single record access interface, the {@code
+ * InternalSyncValueState} also provides batch access interfaces for performance optimization.
+ *
+ * @param <K> The type of key the state is associated to
+ * @param <V> The type of the value in the state.
+ */
+@Internal
+public interface InternalSyncValueState<K, V> extends InternalSyncState<K> {
+
+    /**
+     * Put the <key, value> pair into the state.
+     *
+     * @param key The key of the kv pair
+     * @param value The new value of the kv pair.
+     * @throws IOException Thrown when the performed I/O operation fails.
+     */
+    void put(K key, V value) throws IOException;
+
+    /**
+     * Returns the value corresponding to the given key.
+     *
+     * @param key The key to lookup.
+     * @return The value associated with the given key, or null, if no value is found for the key.
+     * @throws IOException Thrown when the performed I/O operation fails.
+     */
+    V get(K key) throws IOException;
+
+    /**
+     * Write a batch of key-value pairs into state.
+     *
+     * @param batch The key-value data to be written.
+     * @throws IOException Thrown when the performed I/O operation fails.
+     */
+    void writeBatch(List<Tuple2<K, V>> batch) throws IOException;
+
+    /**
+     * Get the values corresponding to a batch of keys from the state. This interface should work
+     * with {@link InternalSyncState#isSupportMultiGet()}, which indicates whether the state
+     * supports the multiGet API.
+     *
+     * @param keys A batch of keys to be queried
+     * @return The corresponding values.
+     * @throws IOException Thrown when the performed I/O operation fails.
+     */
+    List<V> multiGet(List<K> keys) throws IOException;
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/state/AbstractForStState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/state/AbstractForStState.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
+import org.apache.flink.runtime.state.v2.InternalSyncState;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteOptions;
+
+import java.io.IOException;
+
+/**
+ * Base class for {@link InternalSyncState} implementations that store state in a ForSt database.
+ *
+ * @param <K> Type of the key in the state.
+ * @param <V> Type of the value in the state.
+ */
+public class AbstractForStState<K, V> implements InternalSyncState<K> {
+
+    protected final RocksDB db;
+
+    protected final ColumnFamilyHandle columnFamily;
+
+    private final int maxParallelism;
+
+    protected final WriteOptions writeOptions;
+
+    protected final TypeSerializer<K> keySerializer;
+
+    protected final TypeSerializer<V> valueSerializer;
+
+    private final ThreadLocal<SerializedCompositeKeyBuilder<K>> serializedKeyBuilder;
+
+    private final ThreadLocal<DataInputDeserializer> valueDataInputView;
+
+    private final ThreadLocal<DataOutputSerializer> valueDataOutputView;
+
+    protected AbstractForStState(
+            RocksDB forstDB,
+            WriteOptions writeOptions,
+            ColumnFamilyHandle columnFamily,
+            TypeSerializer<K> keySerializer,
+            TypeSerializer<V> valueSerializer,
+            int maxParallelism) {
+        this.db = forstDB;
+        this.writeOptions = writeOptions;
+        this.columnFamily = columnFamily;
+        this.keySerializer = keySerializer;
+        this.valueSerializer = valueSerializer;
+        this.serializedKeyBuilder =
+                ThreadLocal.withInitial(
+                        () ->
+                                new SerializedCompositeKeyBuilder<>(
+                                        keySerializer,
+                                        CompositeKeySerializationUtils
+                                                .computeRequiredBytesInKeyGroupPrefix(
+                                                        maxParallelism),
+                                        32));
+        this.valueDataInputView = ThreadLocal.withInitial(DataInputDeserializer::new);
+        this.valueDataOutputView = ThreadLocal.withInitial(() -> new DataOutputSerializer(128));
+        this.maxParallelism = maxParallelism;
+    }
+
+    @Override
+    public void clear(K key) throws IOException {
+        try {
+            db.delete(columnFamily, writeOptions, serializeCurrentKeyAndKeyGroup(key));
+        } catch (RocksDBException e) {
+            throw new IOException("Error while removing entry from ForStDB", e);
+        }
+    }
+
+    protected byte[] serializeCurrentKeyAndKeyGroup(K key) throws IOException {
+        SerializedCompositeKeyBuilder<K> keyBuilder = serializedKeyBuilder.get();
+        keyBuilder.setKeyAndKeyGroup(
+                key, KeyGroupRangeAssignment.assignToKeyGroup(key, maxParallelism));
+        return keyBuilder.build();
+    }
+
+    protected byte[] serializeValue(V value) throws IOException {
+        DataOutputSerializer outputView = valueDataOutputView.get();
+        outputView.clear();
+        valueSerializer.serialize(value, outputView);
+        return outputView.getCopyOfBuffer();
+    }
+
+    protected V deserializeValue(byte[] valueBytes) throws IOException {
+        DataInputDeserializer deserializeView = valueDataInputView.get();
+        deserializeView.setBuffer(valueBytes);
+        return valueSerializer.deserialize(deserializeView);
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/state/ForStValueState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/state/ForStValueState.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.v2.InternalSyncValueState;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * {@link InternalSyncValueState} implementation that stores state in ForStDB.
+ *
+ * @param <K> The type of the key.
+ * @param <V> The type of the value.
+ */
+public class ForStValueState<K, V> extends AbstractForStState<K, V>
+        implements InternalSyncValueState<K, V> {
+
+    private static final int PER_RECORD_ESTIMATE_BYTES = 100;
+
+    public ForStValueState(
+            RocksDB forstDB,
+            WriteOptions writeOptions,
+            ColumnFamilyHandle columnFamily,
+            TypeSerializer<K> keySerializer,
+            TypeSerializer<V> valueSerializer,
+            int maxParallelism) {
+        super(forstDB, writeOptions, columnFamily, keySerializer, valueSerializer, maxParallelism);
+    }
+
+    @Override
+    public void put(K key, V value) throws IOException {
+        try {
+            db.put(
+                    columnFamily,
+                    writeOptions,
+                    serializeCurrentKeyAndKeyGroup(key),
+                    serializeValue(value));
+        } catch (RocksDBException e) {
+            throw new IOException("Error while adding data to ForStDB", e);
+        }
+    }
+
+    @Override
+    public V get(K key) throws IOException {
+        try {
+            byte[] valueBytes = db.get(columnFamily, serializeCurrentKeyAndKeyGroup(key));
+            if (valueBytes == null) {
+                return null;
+            }
+            return deserializeValue(valueBytes);
+        } catch (RocksDBException e) {
+            throw new IOException("Error while retrieving data from ForStDB.", e);
+        }
+    }
+
+    @Override
+    public void writeBatch(List<Tuple2<K, V>> batch) throws IOException {
+        try (WriteBatch writeBatch = new WriteBatch(batch.size() * PER_RECORD_ESTIMATE_BYTES)) {
+            for (Tuple2<K, V> keyValue : batch) {
+                writeBatch.put(
+                        columnFamily,
+                        serializeCurrentKeyAndKeyGroup(keyValue.f0),
+                        serializeValue(keyValue.f1));
+            }
+            db.write(writeOptions, writeBatch);
+        } catch (RocksDBException e) {
+            throw new IOException("Error while adding data to ForStDB", e);
+        }
+    }
+
+    @Override
+    public List<V> multiGet(List<K> keys) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/state/ForStStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/state/ForStStateTestBase.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.state;
+
+import org.apache.flink.configuration.ConfigConstants;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.RocksDB;
+
+/** The base class for ForSt State tests. */
+public class ForStStateTestBase {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    protected RocksDB db;
+
+    @Before
+    public void setUp() throws Exception {
+        db = RocksDB.open(folder.newFolder().getAbsolutePath());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (db != null) {
+            db.close();
+        }
+    }
+
+    protected ColumnFamilyHandle createColumnFamilyHandle(String columnFamilyName)
+            throws Exception {
+        byte[] nameBytes = columnFamilyName.getBytes(ConfigConstants.DEFAULT_CHARSET);
+        ColumnFamilyDescriptor columnFamilyDescriptor =
+                new ColumnFamilyDescriptor(nameBytes, new ColumnFamilyOptions());
+        return db.createColumnFamily(columnFamilyDescriptor);
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/state/ForStValueStateTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/state/ForStValueStateTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.state;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.WriteOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit test for {@link ForStValueState}. */
+public class ForStValueStateTest extends ForStStateTestBase {
+
+    private TypeSerializer<Integer> keySerializer;
+
+    private TypeSerializer<String> valueSerializer;
+
+    private int maxParallelism;
+
+    @Before
+    public void prepare() throws Exception {
+        super.setUp();
+        this.keySerializer = IntSerializer.INSTANCE;
+        this.valueSerializer = StringSerializer.INSTANCE;
+        this.maxParallelism = 128;
+    }
+
+    @Test
+    public void testPutGetAndClear() throws Exception {
+        ColumnFamilyHandle valueStateHandle = createColumnFamilyHandle("valueState");
+        ForStValueState<Integer, String> valueState =
+                new ForStValueState<>(
+                        db,
+                        new WriteOptions(),
+                        valueStateHandle,
+                        keySerializer,
+                        valueSerializer,
+                        maxParallelism);
+
+        valueState.put(1, "test-1");
+        assertThat(valueState.get(1)).isEqualTo("test-1");
+        valueState.put(2, "test-2");
+        assertThat(valueState.get(2)).isEqualTo("test-2");
+        valueState.put(1, "test-3");
+        assertThat(valueState.get(1)).isEqualTo("test-3");
+
+        valueState.clear(1);
+        assertThat(valueState.get(1)).isNull();
+        valueState.clear(2);
+        assertThat(valueState.get(2)).isNull();
+    }
+
+    @Test
+    public void testWriteBatch() throws Exception {
+        ColumnFamilyHandle valueStateHandle = createColumnFamilyHandle("write-batch");
+        ForStValueState<Integer, String> valueState =
+                new ForStValueState<>(
+                        db,
+                        new WriteOptions(),
+                        valueStateHandle,
+                        keySerializer,
+                        valueSerializer,
+                        maxParallelism);
+
+        List<Tuple2<Integer, String>> keyValueData = new ArrayList<>();
+        keyValueData.add(Tuple2.of(1, "test-1"));
+        keyValueData.add(Tuple2.of(2, "test-2"));
+        keyValueData.add(Tuple2.of(3, "test-3"));
+        keyValueData.add(Tuple2.of(3, "test-4"));
+
+        valueState.writeBatch(keyValueData);
+
+        assertThat(valueState.get(1)).isEqualTo("test-1");
+        assertThat(valueState.get(2)).isEqualTo("test-2");
+        assertThat(valueState.get(3)).isEqualTo("test-4");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements the ValueState for ForStStateBackend.

## Brief change log

  -  Define the InternalSyncState interfaces in flink-runtime layer
  -  Implement ForStValueState


## Verifying this change

This change added tests and can be verified by ForStValueStateTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
