### PR TITLE
[FLINK-35156][Runtime] Make operators of DataStream V2 integrate with async state processing framework

### DIFF
--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/ProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/ProcessOperator.java
@@ -23,15 +23,15 @@ import org.apache.flink.datastream.impl.common.OutputCollector;
 import org.apache.flink.datastream.impl.common.TimestampCollector;
 import org.apache.flink.datastream.impl.context.DefaultNonPartitionedContext;
 import org.apache.flink.datastream.impl.context.DefaultRuntimeContext;
-import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.AbstractAsyncStateUdfStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /** Operator for {@link OneInputStreamProcessFunction}. */
 public class ProcessOperator<IN, OUT>
-        extends AbstractUdfStreamOperator<OUT, OneInputStreamProcessFunction<IN, OUT>>
+        extends AbstractAsyncStateUdfStreamOperator<OUT, OneInputStreamProcessFunction<IN, OUT>>
         implements OneInputStreamOperator<IN, OUT>, BoundedOneInput {
 
     protected transient DefaultRuntimeContext context;

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperator.java
@@ -23,17 +23,17 @@ import org.apache.flink.datastream.impl.common.OutputCollector;
 import org.apache.flink.datastream.impl.common.TimestampCollector;
 import org.apache.flink.datastream.impl.context.DefaultNonPartitionedContext;
 import org.apache.flink.datastream.impl.context.DefaultRuntimeContext;
-import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.AbstractAsyncStateUdfStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** Operator for {@link TwoInputBroadcastStreamProcessFunction}. */
 public class TwoInputBroadcastProcessOperator<IN1, IN2, OUT>
-        extends AbstractUdfStreamOperator<
+        extends AbstractAsyncStateUdfStreamOperator<
                 OUT, TwoInputBroadcastStreamProcessFunction<IN1, IN2, OUT>>
         implements TwoInputStreamOperator<IN1, IN2, OUT>, BoundedMultiInput {
 

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperator.java
@@ -23,17 +23,17 @@ import org.apache.flink.datastream.impl.common.OutputCollector;
 import org.apache.flink.datastream.impl.common.TimestampCollector;
 import org.apache.flink.datastream.impl.context.DefaultNonPartitionedContext;
 import org.apache.flink.datastream.impl.context.DefaultRuntimeContext;
-import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.AbstractAsyncStateUdfStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** Operator for {@link TwoInputNonBroadcastStreamProcessFunction}. */
 public class TwoInputNonBroadcastProcessOperator<IN1, IN2, OUT>
-        extends AbstractUdfStreamOperator<
+        extends AbstractAsyncStateUdfStreamOperator<
                 OUT, TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT>>
         implements TwoInputStreamOperator<IN1, IN2, OUT>, BoundedMultiInput {
 

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperator.java
@@ -24,11 +24,11 @@ import org.apache.flink.datastream.impl.common.OutputCollector;
 import org.apache.flink.datastream.impl.common.TimestampCollector;
 import org.apache.flink.datastream.impl.context.DefaultRuntimeContext;
 import org.apache.flink.datastream.impl.context.DefaultTwoOutputNonPartitionedContext;
-import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.AbstractAsyncStateUdfStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.OutputTag;
 
@@ -38,7 +38,7 @@ import org.apache.flink.util.OutputTag;
  * <p>We support the second output via flink side-output mechanism.
  */
 public class TwoOutputProcessOperator<IN, OUT_MAIN, OUT_SIDE>
-        extends AbstractUdfStreamOperator<
+        extends AbstractAsyncStateUdfStreamOperator<
                 OUT_MAIN, TwoOutputStreamProcessFunction<IN, OUT_MAIN, OUT_SIDE>>
         implements OneInputStreamOperator<IN, OUT_MAIN>, BoundedOneInput {
     protected transient TimestampCollector<OUT_MAIN> mainCollector;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateUdfStreamOperator.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.asyncprocessing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.DefaultOpenContext;
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.util.FunctionUtils;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractUdfStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
+import org.apache.flink.streaming.api.operators.UserFunctionProvider;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.util.functions.StreamingFunctionUtils;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This is used as the base class for operators that have a user-defined function. This class
+ * handles the opening and closing of the user-defined functions, as part of the operator life
+ * cycle. This class is nearly identical with {@link AbstractUdfStreamOperator}, but extending from
+ * {@link AbstractAsyncStateStreamOperator} to integrate with asynchronous state access. Another
+ * difference is this class is internal.
+ *
+ * @param <OUT> The output type of the operator
+ * @param <F> The type of the user function
+ */
+@Internal
+public abstract class AbstractAsyncStateUdfStreamOperator<OUT, F extends Function>
+        extends AbstractAsyncStateStreamOperator<OUT>
+        implements OutputTypeConfigurable<OUT>, UserFunctionProvider<F> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The user function. */
+    protected final F userFunction;
+
+    public AbstractAsyncStateUdfStreamOperator(F userFunction) {
+        this.userFunction = requireNonNull(userFunction);
+        checkUdfCheckpointingPreconditions();
+    }
+
+    /**
+     * Gets the user function executed in this operator.
+     *
+     * @return The user function of this operator.
+     */
+    public F getUserFunction() {
+        return userFunction;
+    }
+
+    // ------------------------------------------------------------------------
+    //  operator life cycle
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void setup(
+            StreamTask<?, ?> containingTask,
+            StreamConfig config,
+            Output<StreamRecord<OUT>> output) {
+        super.setup(containingTask, config, output);
+        FunctionUtils.setFunctionRuntimeContext(userFunction, getRuntimeContext());
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        super.snapshotState(context);
+        StreamingFunctionUtils.snapshotFunctionState(
+                context, getOperatorStateBackend(), userFunction);
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+        StreamingFunctionUtils.restoreFunctionState(context, userFunction);
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        FunctionUtils.openFunction(userFunction, DefaultOpenContext.INSTANCE);
+    }
+
+    @Override
+    public void finish() throws Exception {
+        super.finish();
+        if (userFunction instanceof SinkFunction) {
+            ((SinkFunction<?>) userFunction).finish();
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        FunctionUtils.closeFunction(userFunction);
+    }
+
+    // ------------------------------------------------------------------------
+    //  checkpointing and recovery
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        super.notifyCheckpointComplete(checkpointId);
+
+        if (userFunction instanceof CheckpointListener) {
+            ((CheckpointListener) userFunction).notifyCheckpointComplete(checkpointId);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        super.notifyCheckpointAborted(checkpointId);
+
+        if (userFunction instanceof CheckpointListener) {
+            ((CheckpointListener) userFunction).notifyCheckpointAborted(checkpointId);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    //  Output type configuration
+    // ------------------------------------------------------------------------
+
+    @Override
+    public void setOutputType(TypeInformation<OUT> outTypeInfo, ExecutionConfig executionConfig) {
+        StreamingFunctionUtils.setOutputType(userFunction, outTypeInfo, executionConfig);
+    }
+
+    // ------------------------------------------------------------------------
+    //  Utilities
+    // ------------------------------------------------------------------------
+
+    private void checkUdfCheckpointingPreconditions() {
+        if (userFunction instanceof CheckpointedFunction
+                && userFunction instanceof ListCheckpointed) {
+
+            throw new IllegalStateException(
+                    "User functions are not allowed to implement "
+                            + "CheckpointedFunction AND ListCheckpointed.");
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This is a simple PR that wire the new introduced operators of DataStream V2 with the `AbstractAsyncStateStreamOperator`.

## Brief change log

 - Introduce `AbstractAsyncStateUdfStreamOperator` that is nearly identical with `AbstractUdfStreamOperator`, but extends from `AbstractAsyncStateStreamOperator`
 - Replace base class of `ProcessOperator` (v2) from `AbstractUdfStreamOperator` to `AbstractAsyncStateUdfStreamOperator`.

## Verifying this change

This change is a trivial rework without any test coverage. More will be added when the whole state processing works.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
