### PR TITLE
[FLINK-35155] Introduce TableRuntimeException

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableRuntimeException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableRuntimeException.java
@@ -16,28 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.data.utils;
+package org.apache.flink.table.api;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.TableRuntimeException;
-
-import javax.annotation.Nullable;
+import org.apache.flink.annotation.PublicEvolving;
 
 /**
- * Interface to model a function that performs the casting of a value from one type to another.
+ * Exception for errors occurring in the runtime.
  *
- * @param <IN> Input internal type
- * @param <OUT> Output internal type
+ * <p>This exception indicates the exception was thrown intentionally, e.g. during evaluation of
+ * {@code SINGLE_VALUE} function. Most likely a user error.
  */
-@Internal
-@FunctionalInterface
-public interface CastExecutor<IN, OUT> {
-    /**
-     * Cast the input value. The output is null only and only if the input is null. The method
-     * throws an exception if something goes wrong when casting.
-     *
-     * @param value Input value.
-     */
-    @Nullable
-    OUT cast(@Nullable IN value) throws TableRuntimeException;
+@PublicEvolving
+public class TableRuntimeException extends RuntimeException {
+
+    public TableRuntimeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TableRuntimeException(String message) {
+        super(message);
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCodeGeneratorCastRule.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.functions.casting;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableRuntimeException;
 import org.apache.flink.table.data.utils.CastExecutor;
 import org.apache.flink.table.planner.codegen.CodeGenUtils;
 import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
@@ -112,7 +112,7 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
         // the cast method
         final String functionSignature =
                 "@Override public Object cast(Object _myInputObj) throws "
-                        + className(TableException.class);
+                        + className(TableRuntimeException.class);
 
         // Write the function body
         final CastRuleUtils.CodeWriter bodyWriter = new CastRuleUtils.CodeWriter();
@@ -127,7 +127,7 @@ abstract class AbstractCodeGeneratorCastRule<IN, OUT> extends AbstractCastRule<I
                     (exceptionTerm, catchWriter) ->
                             catchWriter.throwStmt(
                                     constructorCall(
-                                            TableException.class,
+                                            TableRuntimeException.class,
                                             strLiteral(
                                                     "Error when casting "
                                                             + inputLogicalType

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -773,7 +773,7 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
              |${operands.map(_.code).mkString("\n")}
              |${nullValue.code}
              |org.apache.flink.util.ExceptionUtils.rethrow(
-             |  new RuntimeException(${operands.head.resultTerm}.toString()));
+             |  new org.apache.flink.table.api.TableRuntimeException(${operands.head.resultTerm}.toString()));
              |""".stripMargin
         GeneratedExpression(nullValue.resultTerm, nullValue.nullTerm, code, resultType)
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInFunctionTestBase.java
@@ -216,6 +216,15 @@ abstract class BuiltInFunctionTestBase {
             return this;
         }
 
+        TestSetSpec testTableApiRuntimeError(
+                Expression expression,
+                Class<? extends Throwable> exceptionError,
+                String errorMessage) {
+            testItems.add(
+                    new TableApiErrorTestItem(expression, exceptionError, errorMessage, false));
+            return this;
+        }
+
         TestSetSpec testSqlResult(String expression, Object result, AbstractDataType<?> dataType) {
             return testSqlResult(expression, singletonList(result), singletonList(dataType));
         }
@@ -245,6 +254,12 @@ abstract class BuiltInFunctionTestBase {
         TestSetSpec testSqlRuntimeError(
                 String expression, Class<? extends Throwable> exceptionError) {
             testItems.add(new SqlErrorTestItem(expression, exceptionError, null, false));
+            return this;
+        }
+
+        TestSetSpec testSqlRuntimeError(
+                String expression, Class<? extends Throwable> exceptionError, String errorMessage) {
+            testItems.add(new SqlErrorTestItem(expression, exceptionError, errorMessage, false));
             return this;
         }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.JsonExistsOnError;
 import org.apache.flink.table.api.JsonOnNull;
 import org.apache.flink.table.api.JsonType;
 import org.apache.flink.table.api.JsonValueOnEmptyOrError;
+import org.apache.flink.table.api.TableRuntimeException;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
@@ -162,9 +163,11 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         BOOLEAN())
                 .testSqlRuntimeError(
                         "JSON_EXISTS(f0, 'strict $.invalid' ERROR ON ERROR)",
+                        TableRuntimeException.class,
                         "No results for path: $['invalid']")
                 .testTableApiRuntimeError(
                         $("f0").jsonExists("strict $.invalid", JsonExistsOnError.ERROR),
+                        TableRuntimeException.class,
                         "No results for path: $['invalid']");
     }
 
@@ -400,9 +403,11 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 STRING())
                         .testSqlRuntimeError(
                                 "JSON_QUERY(f0, 'lax $.err4' ERROR ON EMPTY)",
+                                TableRuntimeException.class,
                                 "Empty result of JSON_QUERY function is not allowed")
                         .testTableApiRuntimeError(
                                 $("f0").jsonQuery("lax $.err5", WITHOUT_ARRAY, ERROR, NULL),
+                                TableRuntimeException.class,
                                 "Empty result of JSON_QUERY function is not allowed")
 
                         // Error Behavior
@@ -426,9 +431,11 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 STRING())
                         .testSqlRuntimeError(
                                 "JSON_QUERY(f0, 'strict $.err9' ERROR ON ERROR)",
+                                TableRuntimeException.class,
                                 "No results for path")
                         .testTableApiRuntimeError(
                                 $("f0").jsonQuery("strict $.err10", WITHOUT_ARRAY, NULL, ERROR),
+                                TableRuntimeException.class,
                                 "No results for path"));
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscAggFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscAggFunctionITCase.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.api.TableRuntimeException;
+import org.apache.flink.types.Row;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.types.RowKind.INSERT;
+
+/** Tests for built-in ARRAY_AGG aggregation functions. */
+class MiscAggFunctionITCase extends BuiltInAggregateFunctionTestBase {
+
+    @Override
+    Stream<TestSpec> getTestCaseSpecs() {
+        return Stream.of(
+                TestSpec.forExpression("SINGLE_VALUE")
+                        .withSource(
+                                ROW(STRING(), INT()),
+                                Arrays.asList(
+                                        Row.ofKind(INSERT, "A", 1),
+                                        Row.ofKind(INSERT, "A", 2),
+                                        Row.ofKind(INSERT, "B", 2)))
+                        .testSqlRuntimeError(
+                                source ->
+                                        "SELECT f0, SINGLE_VALUE(f1) FROM "
+                                                + source
+                                                + " GROUP BY f0",
+                                ROW(STRING(), INT()),
+                                TableRuntimeException.class,
+                                "SingleValueAggFunction received more than one element."));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/casting/CastRulesTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.typeutils.base.LocalDateSerializer;
 import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableRuntimeException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericArrayData;
@@ -170,13 +170,13 @@ class CastRulesTest {
         return Stream.of(
                 CastTestSpecBuilder.testCastTo(TINYINT())
                         .fromCase(TINYINT(), null, null)
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
-                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
+                        .fail(STRING(), fromString("Apache"), TableRuntimeException.class)
                         .fromCase(STRING(), fromString("1.234"), (byte) 1)
                         .fromCase(STRING(), fromString("123"), (byte) 123)
                         .fromCase(STRING(), fromString(" 123 "), (byte) 123)
-                        .fail(STRING(), fromString("-130"), TableException.class)
+                        .fail(STRING(), fromString("-130"), TableRuntimeException.class)
                         .fromCase(
                                 DECIMAL(4, 3),
                                 fromBigDecimal(new BigDecimal("9.87"), 4, 3),
@@ -205,13 +205,13 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), false, (byte) 0),
                 CastTestSpecBuilder.testCastTo(SMALLINT())
                         .fromCase(SMALLINT(), null, null)
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
-                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
+                        .fail(STRING(), fromString("Apache"), TableRuntimeException.class)
                         .fromCase(STRING(), fromString("1.234"), (short) 1)
                         .fromCase(STRING(), fromString("123"), (short) 123)
                         .fromCase(STRING(), fromString(" 123 "), (short) 123)
-                        .fail(STRING(), fromString("-32769"), TableException.class)
+                        .fail(STRING(), fromString("-32769"), TableRuntimeException.class)
                         .fromCase(
                                 DECIMAL(4, 3),
                                 fromBigDecimal(new BigDecimal("9.87"), 4, 3),
@@ -250,13 +250,13 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), true, (short) 1)
                         .fromCase(BOOLEAN(), false, (short) 0),
                 CastTestSpecBuilder.testCastTo(INT())
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
-                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
+                        .fail(STRING(), fromString("Apache"), TableRuntimeException.class)
                         .fromCase(STRING(), fromString("1.234"), 1)
                         .fromCase(STRING(), fromString("123"), 123)
                         .fromCase(STRING(), fromString(" 123 "), 123)
-                        .fail(STRING(), fromString("-3276913443134"), TableException.class)
+                        .fail(STRING(), fromString("-3276913443134"), TableRuntimeException.class)
                         .fromCase(DECIMAL(4, 3), fromBigDecimal(new BigDecimal("9.87"), 4, 3), 9)
                         // https://issues.apache.org/jira/browse/FLINK-24420 - Check out of range
                         // instead of overflow
@@ -297,9 +297,9 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), false, 0),
                 CastTestSpecBuilder.testCastTo(BIGINT())
                         .fromCase(BIGINT(), null, null)
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
-                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
+                        .fail(STRING(), fromString("Apache"), TableRuntimeException.class)
                         .fromCase(STRING(), fromString("1.234"), 1L)
                         .fromCase(STRING(), fromString("123"), 123L)
                         .fromCase(STRING(), fromString(" 123 "), 123L)
@@ -339,9 +339,9 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), false, 0L),
                 CastTestSpecBuilder.testCastTo(FLOAT())
                         .fromCase(FLOAT(), null, null)
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
-                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
+                        .fail(STRING(), fromString("Apache"), TableRuntimeException.class)
                         .fromCase(STRING(), fromString("1.234"), 1.234f)
                         .fromCase(STRING(), fromString("123"), 123.0f)
                         .fromCase(STRING(), fromString(" 123 "), 123.0f)
@@ -386,9 +386,9 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), false, 0.0f),
                 CastTestSpecBuilder.testCastTo(DOUBLE())
                         .fromCase(DOUBLE(), null, null)
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
-                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
+                        .fail(STRING(), fromString("Apache"), TableRuntimeException.class)
                         .fromCase(STRING(), fromString("1.234"), 1.234d)
                         .fromCase(STRING(), fromString("123"), 123.0d)
                         .fromCase(STRING(), fromString(" 123 "), 123.0d)
@@ -436,8 +436,8 @@ class CastRulesTest {
                         .fromCase(BOOLEAN(), true, 1.0d)
                         .fromCase(BOOLEAN(), false, 0.0d),
                 CastTestSpecBuilder.testCastTo(DATE())
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
                         .fromCase(
                                 STRING(),
                                 fromString("123"),
@@ -450,7 +450,7 @@ class CastRulesTest {
                                 STRING(),
                                 fromString("2021-09-27 12:34:56.123456789"),
                                 DateTimeUtils.toInternal(LocalDate.of(2021, 9, 27)))
-                        .fail(STRING(), fromString("2021/09/27"), TableException.class)
+                        .fail(STRING(), fromString("2021/09/27"), TableRuntimeException.class)
                         .fromCase(
                                 TIMESTAMP(9),
                                 TIMESTAMP,
@@ -460,8 +460,8 @@ class CastRulesTest {
                                 TIMESTAMP_LTZ,
                                 DateTimeUtils.toInternal(LocalDate.of(2022, 1, 4))),
                 CastTestSpecBuilder.testCastTo(TIME())
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
                         .fromCase(
                                 STRING(),
                                 fromString("23"),
@@ -470,8 +470,11 @@ class CastRulesTest {
                                 STRING(),
                                 fromString("23:45"),
                                 DateTimeUtils.toInternal(LocalTime.of(23, 45, 0)))
-                        .fail(STRING(), fromString("2021-09-27"), TableException.class)
-                        .fail(STRING(), fromString("2021-09-27 12:34:56"), TableException.class)
+                        .fail(STRING(), fromString("2021-09-27"), TableRuntimeException.class)
+                        .fail(
+                                STRING(),
+                                fromString("2021-09-27 12:34:56"),
+                                TableRuntimeException.class)
                         // https://issues.apache.org/jira/browse/FLINK-17224 Currently, fractional
                         // seconds are lost
                         .fromCase(
@@ -481,7 +484,7 @@ class CastRulesTest {
                         .fail(
                                 STRING(),
                                 fromString("2021-09-27 12:34:56.123456789"),
-                                TableException.class)
+                                TableRuntimeException.class)
                         .fromCase(
                                 TIMESTAMP(6),
                                 TIMESTAMP,
@@ -491,14 +494,14 @@ class CastRulesTest {
                                 TIMESTAMP_LTZ,
                                 DateTimeUtils.toInternal(LocalTime.of(11, 34, 56, 123_000_000))),
                 CastTestSpecBuilder.testCastTo(TIMESTAMP(9))
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
-                        .fail(STRING(), fromString("123"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
+                        .fail(STRING(), fromString("123"), TableRuntimeException.class)
                         .fromCase(
                                 STRING(),
                                 fromString("2021-09-27"),
                                 timestampDataFromLocalDateTime(2021, 9, 27, 0, 0, 0, 0))
-                        .fail(STRING(), fromString("2021/09/27"), TableException.class)
+                        .fail(STRING(), fromString("2021/09/27"), TableRuntimeException.class)
                         .fromCase(
                                 STRING(),
                                 fromString("2021-09-27 12:34:56.123"),
@@ -578,9 +581,9 @@ class CastRulesTest {
                                 fromString("2021-09-27 12:34:56.12345"),
                                 timestampDataFromLocalDateTime(2021, 9, 27, 12, 34, 56, 123400000)),
                 CastTestSpecBuilder.testCastTo(TIMESTAMP_LTZ(9))
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
-                        .fail(STRING(), fromString("123"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
+                        .fail(STRING(), fromString("123"), TableRuntimeException.class)
                         .fromCase(
                                 STRING(),
                                 CET_CONTEXT,
@@ -1127,12 +1130,12 @@ class CastRulesTest {
                                 EMPTY_UTF8),
                 CastTestSpecBuilder.testCastTo(BOOLEAN())
                         .fromCase(BOOLEAN(), null, null)
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
                         .fromCase(CHAR(4), fromString("true"), true)
                         .fromCase(VARCHAR(5), fromString("FalsE"), false)
-                        .fail(STRING(), fromString("Apache Flink"), TableException.class)
+                        .fail(STRING(), fromString("Apache Flink"), TableRuntimeException.class)
                         .fromCase(STRING(), fromString("TRUE"), true)
-                        .fail(STRING(), fromString(""), TableException.class)
+                        .fail(STRING(), fromString(""), TableRuntimeException.class)
                         // Should fail when https://issues.apache.org/jira/browse/FLINK-24576 is
                         // fixed
                         .fromCase(
@@ -1253,9 +1256,9 @@ class CastRulesTest {
                                 fromString("Apache"),
                                 new byte[] {65, 112, 97, 99, 104, 101}),
                 CastTestSpecBuilder.testCastTo(DECIMAL(5, 3))
-                        .fail(CHAR(3), fromString("foo"), TableException.class)
-                        .fail(VARCHAR(5), fromString("Flink"), TableException.class)
-                        .fail(STRING(), fromString("Apache"), TableException.class)
+                        .fail(CHAR(3), fromString("foo"), TableRuntimeException.class)
+                        .fail(VARCHAR(5), fromString("Flink"), TableRuntimeException.class)
+                        .fail(STRING(), fromString("Apache"), TableRuntimeException.class)
                         .fromCase(
                                 STRING(),
                                 fromString("1.234"),

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -23,8 +23,7 @@ import org.apache.flink.table.api.JsonExistsOnError;
 import org.apache.flink.table.api.JsonQueryOnEmptyOrError;
 import org.apache.flink.table.api.JsonQueryWrapper;
 import org.apache.flink.table.api.JsonValueOnEmptyOrError;
-import org.apache.flink.table.api.TableException;
-import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.table.api.TableRuntimeException;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
@@ -103,7 +102,8 @@ public class SqlJsonUtils {
             final Object convertedNode = MAPPER.treeToValue(node, Object.class);
             return MAPPER.writeValueAsString(convertedNode);
         } catch (JsonProcessingException e) {
-            throw new TableException("JSON object could not be serialized: " + node.asText(), e);
+            throw new TableRuntimeException(
+                    "JSON object could not be serialized: " + node.asText(), e);
         }
     }
 
@@ -389,82 +389,82 @@ public class SqlJsonUtils {
         }
     }
 
-    private static RuntimeException toUnchecked(Exception e) {
-        if (e instanceof RuntimeException) {
-            return (RuntimeException) e;
+    private static TableRuntimeException toUnchecked(Exception e) {
+        if (e instanceof TableRuntimeException) {
+            return (TableRuntimeException) e;
         }
-        return new RuntimeException(e);
+        return new TableRuntimeException(e.getMessage(), e);
     }
 
     private static RuntimeException illegalJsonPathModeInPathSpec(
             String pathMode, String pathSpec) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Illegal jsonpath mode ''%s'' in jsonpath spec: ''%s''",
                         pathMode, pathSpec));
     }
 
     private static RuntimeException illegalJsonPathMode(String pathMode) {
-        return new FlinkRuntimeException(String.format("Illegal jsonpath mode ''%s''", pathMode));
+        return new TableRuntimeException(String.format("Illegal jsonpath mode ''%s''", pathMode));
     }
 
     private static RuntimeException illegalJsonPathSpec(String pathSpec) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Illegal jsonpath spec ''%s'', format of the spec should be: ''<lax|strict> $'{'expr'}'''",
                         pathSpec));
     }
 
     private static RuntimeException strictPathModeRequiresNonEmptyValue() {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 "Strict jsonpath mode requires a non empty returned value, but is null");
     }
 
     private static RuntimeException illegalErrorBehaviorInJsonExistsFunc(String errorBehavior) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Illegal error behavior ''{0}'' specified in JSON_EXISTS function",
                         errorBehavior));
     }
 
     private static RuntimeException emptyResultOfJsonValueFuncNotAllowed() {
-        return new FlinkRuntimeException("Empty result of JSON_VALUE function is not allowed");
+        return new TableRuntimeException("Empty result of JSON_VALUE function is not allowed");
     }
 
     private static RuntimeException illegalEmptyBehaviorInJsonValueFunc(String emptyBehavior) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Illegal empty behavior ''{0}'' specified in JSON_VALUE function",
                         emptyBehavior));
     }
 
     private static RuntimeException illegalErrorBehaviorInJsonValueFunc(String errorBehavior) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Illegal error behavior ''%s'' specified in JSON_VALUE function",
                         errorBehavior));
     }
 
     private static RuntimeException scalarValueRequiredInStrictModeOfJsonValueFunc(String value) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Strict jsonpath mode requires scalar value, and the actual value is: ''%s''",
                         value));
     }
 
     private static RuntimeException illegalWrapperBehaviorInJsonQueryFunc(String wrapperBehavior) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Illegal wrapper behavior ''%s'' specified in JSON_QUERY function",
                         wrapperBehavior));
     }
 
     private static RuntimeException emptyResultOfJsonQueryFuncNotAllowed() {
-        return new FlinkRuntimeException("Empty result of JSON_QUERY function is not allowed");
+        return new TableRuntimeException("Empty result of JSON_QUERY function is not allowed");
     }
 
     private static RuntimeException illegalEmptyBehaviorInJsonQueryFunc(String emptyBehavior) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Illegal empty behavior ''%s'' specified in JSON_VALUE function",
                         emptyBehavior));
@@ -472,14 +472,14 @@ public class SqlJsonUtils {
 
     private static RuntimeException arrayOrObjectValueRequiredInStrictModeOfJsonQueryFunc(
             String value) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Strict jsonpath mode requires array or object value, and the actual value is: ''%s''",
                         value));
     }
 
     private static RuntimeException illegalErrorBehaviorInJsonQueryFunc(String errorBehavior) {
-        return new FlinkRuntimeException(
+        return new TableRuntimeException(
                 String.format(
                         "Illegal error behavior ''%s'' specified in JSON_VALUE function",
                         errorBehavior));


### PR DESCRIPTION
## What is the purpose of the change

Introduce `TableRuntimeException` to better classify intentional exceptions thrown from SQL runtime.


## Verifying this change

Added tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
