### PR TITLE
[FLINK-35159] Transition ExecutionGraph to RUNNING after slot assignment

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1209,7 +1209,6 @@ public class AdaptiveScheduler
                 executionGraphWithVertexParallelism.getExecutionGraph();
 
         executionGraph.start(componentMainThreadExecutor);
-        executionGraph.transitionToRunning();
 
         executionGraph.setInternalTaskFailuresListener(
                 new UpdateSchedulerNgOnInternalFailuresListener(this));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -123,7 +123,6 @@ public class CreatingExecutionGraph extends StateWithoutExecutionGraph {
                         operatorCoordinatorHandlerFactory.create(executionGraph, context);
                 operatorCoordinatorHandler.initializeOperatorCoordinators(
                         context.getMainThreadExecutor());
-                operatorCoordinatorHandler.startAllOperatorCoordinators();
                 final String updatedPlan =
                         JsonPlanGenerator.generatePlan(
                                 executionGraph.getJobID(),
@@ -137,6 +136,10 @@ public class CreatingExecutionGraph extends StateWithoutExecutionGraph {
                                                 .iterator(),
                                 executionGraphWithVertexParallelism.getVertexParallelism());
                 executionGraph.setJsonPlan(updatedPlan);
+
+                executionGraph.transitionToRunning();
+                operatorCoordinatorHandler.startAllOperatorCoordinators();
+
                 context.goToExecuting(
                         result.getExecutionGraph(),
                         executionGraphHandler,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -54,8 +54,6 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraphTest;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.executiongraph.ExecutionGraph;
-import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.executiongraph.failover.FixedDelayRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.failover.NoRestartBackoffTimeStrategy;
@@ -64,7 +62,6 @@ import org.apache.flink.runtime.executiongraph.metrics.DownTimeGauge;
 import org.apache.flink.runtime.executiongraph.metrics.UpTimeGauge;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
@@ -75,7 +72,6 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
-import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultAllocatedSlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool;
@@ -149,7 +145,6 @@ import java.util.stream.Collectors;
 import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createNoOpVertex;
-import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.setVertexResource;
 import static org.apache.flink.runtime.jobgraph.JobGraphTestUtils.streamingJobGraph;
 import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.createSlotOffersForResourceRequirements;
 import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.offerSlots;
@@ -1781,56 +1776,6 @@ public class AdaptiveSchedulerTest {
                                 "some directory", false, SavepointFormatType.CANONICAL))
                 .eventuallyFailsWith(ExecutionException.class)
                 .withCauseInstanceOf(CheckpointException.class);
-    }
-
-    @Test
-    void testSavepointFailsWhenBlockingEdgeExists() throws Exception {
-        JobVertex jobVertex = createNoOpVertex(PARALLELISM);
-        jobVertex.getOrCreateResultDataSet(
-                new IntermediateDataSetID(), ResultPartitionType.BLOCKING);
-
-        final ExecutionGraph executionGraph =
-                ExecutionGraphTestUtils.createExecutionGraph(
-                        EXECUTOR_RESOURCE.getExecutor(), jobVertex);
-
-        executionGraph
-                .getAllExecutionVertices()
-                .forEach(
-                        task ->
-                                setVertexResource(
-                                        task,
-                                        new TestingLogicalSlotBuilder()
-                                                .createTestingLogicalSlot()));
-        executionGraph.transitionToRunning();
-        executionGraph
-                .getAllExecutionVertices()
-                .forEach(
-                        task ->
-                                task.getCurrentExecutionAttempt()
-                                        .transitionState(ExecutionState.RUNNING));
-
-        final AdaptiveScheduler scheduler =
-                new AdaptiveSchedulerBuilder(
-                                streamingJobGraph(jobVertex),
-                                mainThreadExecutor,
-                                EXECUTOR_RESOURCE.getExecutor())
-                        .build();
-
-        scheduler.goToExecuting(executionGraph, null, null, Collections.emptyList());
-
-        assertThatFuture(
-                        scheduler.stopWithSavepoint(
-                                "some directory", false, SavepointFormatType.CANONICAL))
-                .eventuallyFailsWith(ExecutionException.class)
-                .withCauseInstanceOf(CheckpointException.class)
-                .withMessageContaining(CheckpointFailureReason.BLOCKING_OUTPUT_EXIST.message());
-
-        assertThatFuture(
-                        scheduler.triggerSavepoint(
-                                "some directory", false, SavepointFormatType.CANONICAL))
-                .eventuallyFailsWith(ExecutionException.class)
-                .withCauseInstanceOf(CheckpointException.class)
-                .withMessageContaining(CheckpointFailureReason.BLOCKING_OUTPUT_EXIST.message());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
@@ -93,8 +93,12 @@ class CreatingExecutionGraphTest {
                 ignored -> CreatingExecutionGraph.AssignmentResult.notPossible());
         context.setExpectWaitingForResources();
 
-        executionGraphWithVertexParallelismFuture.complete(
-                getGraph(new StateTrackingMockExecutionGraph()));
+        final StateTrackingMockExecutionGraph executionGraph =
+                new StateTrackingMockExecutionGraph();
+
+        executionGraphWithVertexParallelismFuture.complete(getGraph(executionGraph));
+
+        assertThat(executionGraph.getState()).isEqualTo(JobStatus.INITIALIZING);
     }
 
     @Test


### PR DESCRIPTION
Transitioning the ExecutionGraph to running implicitly starts periodic checkpoint triggering. This should only occur after the all initialization steps have occurred.
The existing code could leak the CheckpointCoordinator if '#handleExecutionGraphCreation' fails to 'tryToAssignSlots'; this eventually leads to a checkpoint being triggered for old ExecutionGraph for which the operator holders were not initialized yet, which causes an exception that crashes the JM.

~~We now force this to happen in the `Executing` constructor, at which point all the initialization steps must already be complete, and we can be sure that the EG gets transitioned into a terminal state when an error occurs (implicitly disabling checkpointing again).~~

We now do this only after slots have been assigned, right before the transition into Executing. At that point we either transition into executing (where we can be sure we'll transition into a terminal state eventually) or fail hard if an error occurs.