### PR TITLE
[FLINK-35162][state] Implement WriteBatchOperation and general MultiGetOperation for ForSt

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  *
  * @param <K> the type of the key
  */
-public class AsyncExecutionController<K> {
+public class AsyncExecutionController<K> implements StateRequestHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(AsyncExecutionController.class);
 
@@ -176,7 +176,7 @@ public class AsyncExecutionController<K> {
     }
 
     /**
-     * Submit a {@link StateRequest} to this AEC and trigger if needed.
+     * Submit a {@link StateRequest} to this AsyncExecutionController and trigger it if needed.
      *
      * @param state the state to request. Could be {@code null} if the type is {@link
      *     StateRequestType#SYNC_POINT}.
@@ -184,6 +184,7 @@ public class AsyncExecutionController<K> {
      * @param payload the payload input for this request.
      * @return the state future.
      */
+    @Override
     public <IN, OUT> InternalStateFuture<OUT> handleRequest(
             @Nullable State state, StateRequestType type, @Nullable IN payload) {
         // Step 1: build state future & assign context.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/ContextKey.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/ContextKey.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing;
+
+import org.apache.flink.util.function.FunctionWithException;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * The composite key which contains some context information, such as keyGroup, etc.
+ *
+ * @param <K> The type of the raw key.
+ */
+@ThreadSafe
+public class ContextKey<K> {
+
+    private final K rawKey;
+
+    private final int keyGroup;
+
+    /**
+     * A record in user layer may access the state multiple times. The {@code serializedKey} can be
+     * used to cache the serialized key bytes after its first serialization, so that subsequent
+     * state accesses with the same key can avoid being serialized repeatedly.
+     */
+    private @Nullable volatile byte[] serializedKey = null;
+
+    public ContextKey(K rawKey, int keyGroup) {
+        this.rawKey = rawKey;
+        this.keyGroup = keyGroup;
+        this.serializedKey = null;
+    }
+
+    public ContextKey(K rawKey, int keyGroup, byte[] serializedKey) {
+        this.rawKey = rawKey;
+        this.keyGroup = keyGroup;
+        this.serializedKey = serializedKey;
+    }
+
+    public K getRawKey() {
+        return rawKey;
+    }
+
+    public int getKeyGroup() {
+        return keyGroup;
+    }
+
+    /**
+     * Get the serialized key. If the cached serialized key is null, the provided serialization
+     * function will be called, and the serialization result will be cached by ContextKey.
+     *
+     * @param serializeKeyFunc the provided serialization function for this contextKey.
+     * @return the serialized bytes.
+     */
+    public byte[] getOrCreateSerializedKey(
+            FunctionWithException<ContextKey<K>, byte[], IOException> serializeKeyFunc)
+            throws IOException {
+        if (serializedKey != null) {
+            return serializedKey;
+        }
+        synchronized (this) {
+            if (serializedKey == null) {
+                this.serializedKey = serializeKeyFunc.apply(this);
+            }
+        }
+        return serializedKey;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rawKey, keyGroup);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ContextKey<?> that = (ContextKey<?>) o;
+        if (!Objects.equals(rawKey, that.rawKey)) {
+            return false;
+        }
+        return Objects.equals(keyGroup, that.keyGroup);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.v2.State;
+import org.apache.flink.core.state.InternalStateFuture;
+
+import javax.annotation.Nullable;
+
+/** The handler which can process {@link StateRequest}. */
+@Internal
+public interface StateRequestHandler {
+
+    /**
+     * Submit a {@link StateRequest} to this StateRequestHandler.
+     *
+     * @param state the state to request. Could be {@code null} if the type is {@link
+     *     StateRequestType#SYNC_POINT}.
+     * @param type the type of this request.
+     * @param payload the payload input for this request.
+     * @return the state future.
+     */
+    <IN, OUT> InternalStateFuture<OUT> handleRequest(
+            @Nullable State state, StateRequestType type, @Nullable IN payload);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalKeyedState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalKeyedState.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
+import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 
 /**
@@ -38,7 +39,7 @@ import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 @Internal
 public abstract class InternalKeyedState<K, V> implements State {
 
-    private final AsyncExecutionController<K> asyncExecutionController;
+    private final StateRequestHandler stateRequestHandler;
 
     private final StateDescriptor<V> stateDescriptor;
 
@@ -46,9 +47,8 @@ public abstract class InternalKeyedState<K, V> implements State {
      * Creates a new InternalKeyedState with the given asyncExecutionController and stateDescriptor.
      */
     public InternalKeyedState(
-            AsyncExecutionController<K> asyncExecutionController,
-            StateDescriptor<V> stateDescriptor) {
-        this.asyncExecutionController = asyncExecutionController;
+            StateRequestHandler stateRequestHandler, StateDescriptor<V> stateDescriptor) {
+        this.stateRequestHandler = stateRequestHandler;
         this.stateDescriptor = stateDescriptor;
     }
 
@@ -61,7 +61,7 @@ public abstract class InternalKeyedState<K, V> implements State {
      */
     protected final <IN, OUT> StateFuture<OUT> handleRequest(
             StateRequestType stateRequestType, IN payload) {
-        return asyncExecutionController.handleRequest(this, stateRequestType, payload);
+        return stateRequestHandler.handleRequest(this, stateRequestType, payload);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalValueState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalValueState.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.v2;
 import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
+import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 
 /**
@@ -32,9 +33,8 @@ import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 public class InternalValueState<K, V> extends InternalKeyedState<K, V> implements ValueState<V> {
 
     public InternalValueState(
-            AsyncExecutionController<K> asyncExecutionController,
-            ValueStateDescriptor<V> valueStateDescriptor) {
-        super(asyncExecutionController, valueStateDescriptor);
+            StateRequestHandler stateRequestHandler, ValueStateDescriptor<V> valueStateDescriptor) {
+        super(stateRequestHandler, valueStateDescriptor);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -63,7 +63,7 @@ class AsyncExecutionControllerTest {
 
     @BeforeEach
     void setup() {
-        aec = new AsyncExecutionController<>(new SyncMailboxExecutor(), createStateExecutor());
+        aec = new AsyncExecutionController<>(new SyncMailboxExecutor(), createStateExecutor(), 128);
         underlyingState = new TestUnderlyingState();
         valueState = new TestValueState(aec, underlyingState);
         output = new AtomicInteger();
@@ -241,7 +241,11 @@ class AsyncExecutionControllerTest {
         final int maxInFlight = 10;
         aec =
                 new AsyncExecutionController<>(
-                        new SyncMailboxExecutor(), new TestStateExecutor(), batchSize, maxInFlight);
+                        new SyncMailboxExecutor(),
+                        new TestStateExecutor(),
+                        batchSize,
+                        maxInFlight,
+                        128);
         valueState = new TestValueState(aec, underlyingState);
 
         AtomicInteger output = new AtomicInteger();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/ContextStateFutureImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/ContextStateFutureImplTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.asyncprocessing;
 
 import org.apache.flink.core.state.StateFutureUtils;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testThenApply() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = buildRecordContext("a", "b");
 
         // validate
         ContextStateFutureImpl<Void> future =
@@ -58,7 +59,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testThenAccept() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = buildRecordContext("a", "b");
 
         // validate
         ContextStateFutureImpl<Void> future =
@@ -82,7 +83,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testThenCompose() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = buildRecordContext("a", "b");
 
         // validate
         ContextStateFutureImpl<Void> future =
@@ -106,7 +107,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testThenCombine() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = buildRecordContext("a", "b");
 
         // validate
         ContextStateFutureImpl<Void> future1 =
@@ -156,7 +157,7 @@ public class ContextStateFutureImplTest {
     @Test
     public void testComplex() {
         SingleStepRunner runner = new SingleStepRunner();
-        RecordContext<String> recordContext = new RecordContext<>("a", "b", (e) -> {});
+        RecordContext<String> recordContext = buildRecordContext("a", "b");
 
         for (int i = 0; i < 32; i++) { // 2^5 for completion status combination
             // Each bit of 'i' represents the complete status when the user code executes.
@@ -219,6 +220,11 @@ public class ContextStateFutureImplTest {
                         .isEqualTo(0);
             }
         }
+    }
+
+    private <K> RecordContext<K> buildRecordContext(Object record, K key) {
+        int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(key, 128);
+        return new RecordContext<>(record, key, (e) -> {}, keyGroup);
     }
 
     /** A runner that performs single-step debugging. */

--- a/flink-state-backends/flink-statebackend-forst/pom.xml
+++ b/flink-state-backends/flink-statebackend-forst/pom.xml
@@ -60,12 +60,11 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
-<!--		TODO: Enable forst dependency when it's available in the maven central repository -->
-<!--		<dependency>-->
-<!--			<groupId>com.ververica</groupId>-->
-<!--			<artifactId>forstjni</artifactId>-->
-<!--			<version>0.1.0-beta</version>-->
-<!--		</dependency>-->
+		<dependency>
+			<groupId>com.ververica</groupId>
+			<artifactId>forstjni</artifactId>
+			<version>0.1.0-beta</version>
+		</dependency>
 
 		<!-- test dependencies -->
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBOperation.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Data access operation to ForStDB. This interface is used to encapsulate the DB access operations
+ * formed after grouping state access. For more information about “Grouping state access”, please
+ * refer to FLIP-426.
+ *
+ * @param <OUT> The type of output for DB access.
+ */
+@Internal
+public interface ForStDBOperation<OUT> {
+
+    /**
+     * Process the ForStDB access requests.
+     *
+     * @return Processing result.
+     */
+    CompletableFuture<OUT> process();
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperation.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.rocksdb.RocksDB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * The general-purpose multiGet operation implementation for ForStDB, which simulates multiGet by
+ * calling the Get API multiple times with multiple threads.
+ *
+ * @param <K> The type of key in get access request.
+ * @param <V> The type of value in get access request.
+ */
+public class ForStGeneralMultiGetOperation<K, V> implements ForStDBOperation<List<V>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForStGeneralMultiGetOperation.class);
+
+    private final RocksDB db;
+
+    private final List<GetRequest<K, V>> batchRequest;
+
+    private final Executor executor;
+
+    ForStGeneralMultiGetOperation(
+            RocksDB db, List<GetRequest<K, V>> batchRequest, Executor executor) {
+        this.db = db;
+        this.batchRequest = batchRequest;
+        this.executor = executor;
+    }
+
+    @Override
+    public CompletableFuture<List<V>> process() {
+
+        CompletableFuture<List<V>> future = new CompletableFuture<>();
+        @SuppressWarnings("unchecked")
+        V[] result = (V[]) new Object[batchRequest.size()];
+        Arrays.fill(result, null);
+
+        AtomicInteger counter = new AtomicInteger(batchRequest.size());
+        for (int i = 0; i < batchRequest.size(); i++) {
+            GetRequest<K, V> request = batchRequest.get(i);
+            final int index = i;
+            executor.execute(
+                    () -> {
+                        try {
+                            ForStInnerTable<K, V> table = request.table;
+                            byte[] key = table.serializeKey(request.key);
+                            byte[] value = db.get(table.getColumnFamilyHandle(), key);
+                            if (value != null) {
+                                result[index] = table.deserializeValue(value);
+                            }
+                        } catch (Exception e) {
+                            LOG.warn(
+                                    "Error when process general multiGet operation for forStDB", e);
+                            future.completeExceptionally(e);
+                        } finally {
+                            if (counter.decrementAndGet() == 0
+                                    && !future.isCompletedExceptionally()) {
+                                future.complete(Arrays.asList(result));
+                            }
+                        }
+                    });
+        }
+        return future;
+    }
+
+    /** The Get access request for ForStDB. */
+    static class GetRequest<K, V> {
+        final K key;
+        final ForStInnerTable<K, V> table;
+
+        private GetRequest(K key, ForStInnerTable<K, V> table) {
+            this.key = key;
+            this.table = table;
+        }
+
+        static <K, V> GetRequest<K, V> of(K key, ForStInnerTable<K, V> table) {
+            return new GetRequest<>(key, table);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStInnerTable.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStInnerTable.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.rocksdb.ColumnFamilyHandle;
+
+import java.io.IOException;
+
+/**
+ * The concept of an abstracted table oriented towards ForStDB, and each ForStInnerTable can be
+ * mapped to a ForSt internal State.
+ *
+ * <p>The mapping between ForStInnerTable and ForStDB's columnFamily can be one-to-one or
+ * many-to-one.
+ *
+ * @param <K> The key type of the table.
+ * @param <V> The value type of the table.
+ */
+public interface ForStInnerTable<K, V> {
+
+    /** Get the columnFamily handle corresponding to table. */
+    ColumnFamilyHandle getColumnFamilyHandle();
+
+    /**
+     * Serialize the given key to bytes.
+     *
+     * @param key the key to be serialized.
+     * @return the key bytes
+     * @throws IOException Thrown if the serialization encountered an I/O related error.
+     */
+    byte[] serializeKey(K key) throws IOException;
+
+    /**
+     * Serialize the given value to the outputView.
+     *
+     * @param value the value to be serialized.
+     * @return the value bytes
+     * @throws IOException Thrown if the serialization encountered an I/O related error.
+     */
+    byte[] serializeValue(V value) throws IOException;
+
+    /**
+     * Deserialize the given bytes value to POJO value.
+     *
+     * @param value the value bytes to be deserialized.
+     * @return the deserialized POJO value
+     * @throws IOException Thrown if the deserialization encountered an I/O related error.
+     */
+    V deserializeValue(byte[] value) throws IOException;
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStValueState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStValueState.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.api.common.state.v2.ValueState;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.runtime.asyncprocessing.ContextKey;
+import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
+import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
+import org.apache.flink.runtime.state.v2.InternalValueState;
+import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
+
+import org.rocksdb.ColumnFamilyHandle;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+/**
+ * The {@link InternalValueState} implement for ForStDB.
+ *
+ * @param <K> The type of the key.
+ * @param <V> The type of the value.
+ */
+public class ForStValueState<K, V> extends InternalValueState<K, V>
+        implements ValueState<V>, ForStInnerTable<ContextKey<K>, V> {
+
+    /** The column family which this internal value state belongs to. */
+    private final ColumnFamilyHandle columnFamilyHandle;
+
+    /** The serialized key builder which should be thread-safe. */
+    private final ThreadLocal<SerializedCompositeKeyBuilder<K>> serializedKeyBuilder;
+
+    /** The data outputStream used for value serializer, which should be thread-safe. */
+    private final ThreadLocal<DataOutputSerializer> valueSerializerView;
+
+    /** The data inputStream used for value deserializer, which should be thread-safe. */
+    private final ThreadLocal<DataInputDeserializer> valueDeserializerView;
+
+    public ForStValueState(
+            StateRequestHandler stateRequestHandler,
+            ColumnFamilyHandle columnFamily,
+            ValueStateDescriptor<V> valueStateDescriptor,
+            Supplier<SerializedCompositeKeyBuilder<K>> serializedKeyBuilderInitializer,
+            Supplier<DataOutputSerializer> valueSerializerViewInitializer,
+            Supplier<DataInputDeserializer> valueDeserializerViewInitializer) {
+        super(stateRequestHandler, valueStateDescriptor);
+        this.columnFamilyHandle = columnFamily;
+        this.serializedKeyBuilder = ThreadLocal.withInitial(serializedKeyBuilderInitializer);
+        this.valueSerializerView = ThreadLocal.withInitial(valueSerializerViewInitializer);
+        this.valueDeserializerView = ThreadLocal.withInitial(valueDeserializerViewInitializer);
+    }
+
+    @Override
+    public ColumnFamilyHandle getColumnFamilyHandle() {
+        return columnFamilyHandle;
+    }
+
+    @Override
+    public byte[] serializeKey(ContextKey<K> contextKey) throws IOException {
+        return contextKey.getOrCreateSerializedKey(
+                ctxKey -> {
+                    SerializedCompositeKeyBuilder<K> builder = serializedKeyBuilder.get();
+                    builder.setKeyAndKeyGroup(ctxKey.getRawKey(), ctxKey.getKeyGroup());
+                    return builder.build();
+                });
+    }
+
+    @Override
+    public byte[] serializeValue(V value) throws IOException {
+        DataOutputSerializer outputView = valueSerializerView.get();
+        outputView.clear();
+        getValueSerializer().serialize(value, outputView);
+        return outputView.getCopyOfBuffer();
+    }
+
+    @Override
+    public V deserializeValue(byte[] valueBytes) throws IOException {
+        DataInputDeserializer inputView = valueDeserializerView.get();
+        inputView.setBuffer(valueBytes);
+        return getValueSerializer().deserialize(inputView);
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStValueState.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStValueState.java
@@ -21,7 +21,6 @@ package org.apache.flink.state.forst;
 import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
-import org.apache.flink.runtime.asyncprocessing.ContextKey;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
 import org.apache.flink.runtime.state.v2.InternalValueState;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStWriteBatchOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStWriteBatchOperation.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+
+/**
+ * The writeBatch operation implementation for ForStDB.
+ *
+ * @param <K> The type of key in put access request.
+ * @param <V> The type of value in put access request.
+ */
+public class ForStWriteBatchOperation<K, V> implements ForStDBOperation<Void> {
+
+    private static final int PER_RECORD_ESTIMATE_BYTES = 100;
+
+    private final RocksDB db;
+
+    private final List<PutRequest<K, V>> batchRequest;
+
+    private final WriteOptions writeOptions;
+
+    private final Executor executor;
+
+    ForStWriteBatchOperation(
+            RocksDB db,
+            List<PutRequest<K, V>> batchRequest,
+            WriteOptions writeOptions,
+            Executor executor) {
+        this.db = db;
+        this.batchRequest = batchRequest;
+        this.writeOptions = writeOptions;
+        this.executor = executor;
+    }
+
+    @Override
+    public CompletableFuture<Void> process() {
+        return CompletableFuture.runAsync(
+                () -> {
+                    try (WriteBatch writeBatch =
+                            new WriteBatch(batchRequest.size() * PER_RECORD_ESTIMATE_BYTES)) {
+                        for (PutRequest<K, V> request : batchRequest) {
+                            ForStInnerTable<K, V> table = request.table;
+                            if (request.value == null) {
+                                // put(key, null) == delete(key)
+                                writeBatch.delete(
+                                        table.getColumnFamilyHandle(),
+                                        table.serializeKey(request.key));
+                            } else {
+                                writeBatch.put(
+                                        table.getColumnFamilyHandle(),
+                                        table.serializeKey(request.key),
+                                        table.serializeValue(request.value));
+                            }
+                        }
+                        db.write(writeOptions, writeBatch);
+                    } catch (Exception e) {
+                        throw new CompletionException("Error while adding data to ForStDB", e);
+                    }
+                },
+                executor);
+    }
+
+    /** The Put access request for ForStDB. */
+    static class PutRequest<K, V> {
+        final K key;
+        @Nullable final V value;
+        final ForStInnerTable<K, V> table;
+
+        private PutRequest(K key, V value, ForStInnerTable<K, V> table) {
+            this.key = key;
+            this.value = value;
+            this.table = table;
+        }
+
+        /**
+         * If the value of the PutRequest is null, then the request will signify the deletion of the
+         * data associated with that key.
+         */
+        static <K, V> PutRequest<K, V> of(K key, @Nullable V value, ForStInnerTable<K, V> table) {
+            return new PutRequest<>(key, value, table);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
@@ -25,7 +25,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.core.state.InternalStateFuture;
-import org.apache.flink.runtime.asyncprocessing.ContextKey;
+import org.apache.flink.runtime.asyncprocessing.RecordContext;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
@@ -81,7 +81,9 @@ public class ForStDBOperationTestBase {
     }
 
     protected ContextKey<Integer> buildContextKey(int i) {
-        return new ContextKey<>(i, KeyGroupRangeAssignment.assignToKeyGroup(i, 128));
+        int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(i, 128);
+        RecordContext<Integer> recordContext = new RecordContext<>(i, i, t -> {}, keyGroup);
+        return new ContextKey<>(recordContext);
     }
 
     protected ForStValueState<Integer, String> buildForStValueState(String stateName)

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.api.common.state.v2.State;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.state.InternalStateFuture;
+import org.apache.flink.runtime.asyncprocessing.ContextKey;
+import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
+import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
+import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
+
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.RocksDB;
+
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+/** Base class for {@link ForStDBOperation} tests. */
+public class ForStDBOperationTestBase {
+    @TempDir private Path tmpDbDir;
+    protected RocksDB db;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        db = RocksDB.open(tmpDbDir.toAbsolutePath().toString());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (db != null) {
+            db.close();
+        }
+    }
+
+    protected ColumnFamilyHandle createColumnFamilyHandle(String columnFamilyName)
+            throws Exception {
+        byte[] nameBytes = columnFamilyName.getBytes(ConfigConstants.DEFAULT_CHARSET);
+        ColumnFamilyDescriptor columnFamilyDescriptor =
+                new ColumnFamilyDescriptor(nameBytes, new ColumnFamilyOptions());
+        return db.createColumnFamily(columnFamilyDescriptor);
+    }
+
+    StateRequestHandler buildMockStateRequestHandler() {
+
+        return new StateRequestHandler() {
+            @Override
+            public <IN, OUT> InternalStateFuture<OUT> handleRequest(
+                    @Nullable State state, StateRequestType type, @Nullable IN payload) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    protected ContextKey<Integer> buildContextKey(int i) {
+        return new ContextKey<>(i, KeyGroupRangeAssignment.assignToKeyGroup(i, 128));
+    }
+
+    protected ForStValueState<Integer, String> buildForStValueState(String stateName)
+            throws Exception {
+        ColumnFamilyHandle cf = createColumnFamilyHandle(stateName);
+        ValueStateDescriptor<String> valueStateDescriptor =
+                new ValueStateDescriptor<>(stateName, BasicTypeInfo.STRING_TYPE_INFO);
+        Supplier<SerializedCompositeKeyBuilder<Integer>> serializedKeyBuilder =
+                () -> new SerializedCompositeKeyBuilder<>(IntSerializer.INSTANCE, 2, 32);
+        Supplier<DataOutputSerializer> valueSerializerView = () -> new DataOutputSerializer(32);
+        Supplier<DataInputDeserializer> valueDeserializerView =
+                () -> new DataInputDeserializer(new byte[128]);
+        return new ForStValueState<>(
+                buildMockStateRequestHandler(),
+                cf,
+                valueStateDescriptor,
+                serializedKeyBuilder,
+                valueSerializerView,
+                valueDeserializerView);
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperationTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperationTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.state.forst;
 
-import org.apache.flink.runtime.asyncprocessing.ContextKey;
-
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperationTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.runtime.asyncprocessing.ContextKey;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.apache.flink.state.forst.ForStGeneralMultiGetOperation.GetRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit test for {@link ForStGeneralMultiGetOperation}. */
+public class ForStGeneralMultiGetOperationTest extends ForStDBOperationTestBase {
+
+    @Test
+    public void testValueStateMultiGet() throws Exception {
+        ForStValueState<Integer, String> valueState1 = buildForStValueState("test-multiGet-1");
+        ForStValueState<Integer, String> valueState2 = buildForStValueState("test-multiGet-2");
+        List<GetRequest<ContextKey<Integer>, String>> batchGetRequest = new ArrayList<>();
+        List<String> resultCheckList = new ArrayList<>();
+
+        int keyNum = 1000;
+        for (int i = 0; i < keyNum; i++) {
+            GetRequest<ContextKey<Integer>, String> request =
+                    GetRequest.of(buildContextKey(i), ((i % 2 == 0) ? valueState1 : valueState2));
+            batchGetRequest.add(request);
+            String value = (i % 10 != 0 ? String.valueOf(i) : null);
+            resultCheckList.add(value);
+            if (value == null) {
+                continue;
+            }
+            byte[] keyBytes = request.table.serializeKey(request.key);
+            byte[] valueBytes = request.table.serializeValue(value);
+            db.put(request.table.getColumnFamilyHandle(), keyBytes, valueBytes);
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        ForStGeneralMultiGetOperation<ContextKey<Integer>, String> generalMultiGetOperation =
+                new ForStGeneralMultiGetOperation<>(db, batchGetRequest, executor);
+        List<String> result = generalMultiGetOperation.process().get();
+
+        assertThat(result).isEqualTo(resultCheckList);
+
+        executor.shutdownNow();
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStWriteBatchOperationTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStWriteBatchOperationTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.runtime.asyncprocessing.ContextKey;
+
+import org.junit.jupiter.api.Test;
+import org.rocksdb.WriteOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.apache.flink.state.forst.ForStWriteBatchOperation.PutRequest;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit test for {@link ForStWriteBatchOperation}. */
+public class ForStWriteBatchOperationTest extends ForStDBOperationTestBase {
+
+    @Test
+    public void testValueStateWriteBatch() throws Exception {
+        ForStValueState<Integer, String> valueState1 = buildForStValueState("test-write-batch-1");
+        ForStValueState<Integer, String> valueState2 = buildForStValueState("test-write-batch-2");
+        List<PutRequest<ContextKey<Integer>, String>> batchPutRequest = new ArrayList<>();
+        int keyNum = 100;
+        for (int i = 0; i < keyNum; i++) {
+            batchPutRequest.add(
+                    PutRequest.of(
+                            buildContextKey(i),
+                            String.valueOf(i),
+                            ((i % 2 == 0) ? valueState1 : valueState2)));
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        ForStWriteBatchOperation<ContextKey<Integer>, String> writeBatchOperation =
+                new ForStWriteBatchOperation<>(db, batchPutRequest, new WriteOptions(), executor);
+        writeBatchOperation.process().get();
+
+        // check data correctness
+        for (PutRequest<ContextKey<Integer>, String> request : batchPutRequest) {
+            ForStInnerTable<ContextKey<Integer>, String> table = request.table;
+            byte[] keyBytes = table.serializeKey(request.key);
+            byte[] valueBytes = db.get(table.getColumnFamilyHandle(), keyBytes);
+            assertThat(table.deserializeValue(valueBytes)).isEqualTo(request.value);
+        }
+    }
+
+    @Test
+    public void testWriteBatchWithNullValue() throws Exception {
+        ForStValueState<Integer, String> valueState = buildForStValueState("test-write-batch");
+        List<PutRequest<ContextKey<Integer>, String>> batchPutRequest = new ArrayList<>();
+        // 1. write some data without null value
+        int keyNum = 100;
+        for (int i = 0; i < keyNum; i++) {
+            batchPutRequest.add(PutRequest.of(buildContextKey(i), String.valueOf(i), valueState));
+        }
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        ForStWriteBatchOperation<ContextKey<Integer>, String> writeBatchOperation =
+                new ForStWriteBatchOperation<>(db, batchPutRequest, new WriteOptions(), executor);
+        writeBatchOperation.process().get();
+
+        // 2. update data with null value
+        batchPutRequest.clear();
+        for (int i = 0; i < keyNum; i++) {
+            if (i % 8 == 0) {
+                batchPutRequest.add(PutRequest.of(buildContextKey(i), null, valueState));
+            } else {
+                batchPutRequest.add(
+                        PutRequest.of(buildContextKey(i), String.valueOf(i * 2), valueState));
+            }
+        }
+        ForStWriteBatchOperation<ContextKey<Integer>, String> writeBatchOperation2 =
+                new ForStWriteBatchOperation<>(db, batchPutRequest, new WriteOptions(), executor);
+        writeBatchOperation2.process().get();
+
+        // 3.  check data correctness
+        for (PutRequest<ContextKey<Integer>, String> request : batchPutRequest) {
+            ForStInnerTable<ContextKey<Integer>, String> table = request.table;
+            byte[] keyBytes = table.serializeKey(request.key);
+            byte[] valueBytes = db.get(table.getColumnFamilyHandle(), keyBytes);
+            String value = (valueBytes == null) ? null : table.deserializeValue(valueBytes);
+            assertThat(value).isEqualTo(request.value);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStWriteBatchOperationTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStWriteBatchOperationTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.state.forst;
 
-import org.apache.flink.runtime.asyncprocessing.ContextKey;
-
 import org.junit.jupiter.api.Test;
 import org.rocksdb.WriteOptions;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperator.java
@@ -68,7 +68,10 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
         // TODO: properly read config and setup
         final MailboxExecutor mailboxExecutor =
                 containingTask.getEnvironment().getMainMailboxExecutor();
-        this.asyncExecutionController = new AsyncExecutionController(mailboxExecutor, null);
+        int maxParallelism =
+                containingTask.getEnvironment().getTaskInfo().getMaxNumberOfParallelSubtasks();
+        this.asyncExecutionController =
+                new AsyncExecutionController(mailboxExecutor, null, maxParallelism);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
@@ -70,7 +70,9 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
             throws Exception {
         super.initializeState(streamTaskStateManager);
         // TODO: Read config and properly set.
-        this.asyncExecutionController = new AsyncExecutionController(mailboxExecutor, null);
+        int maxParallelism = getExecutionConfig().getMaxParallelism();
+        this.asyncExecutionController =
+                new AsyncExecutionController(mailboxExecutor, null, maxParallelism);
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
@@ -54,7 +54,7 @@ class InternalTimerServiceAsyncImplTest {
     void setup() throws Exception {
         asyncExecutionController =
                 new AsyncExecutionController(
-                        new SyncMailboxExecutor(), new TestStateExecutor(), 2, 10);
+                        new SyncMailboxExecutor(), new TestStateExecutor(), 2, 10, 128);
         // ensure arbitrary key is in the key group
         int totalKeyGroups = 128;
         KeyGroupRange testKeyGroupList = new KeyGroupRange(0, totalKeyGroups - 1);


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces the ForStValueState and support WriteBatchOperation and general MultiGetOperation for ForSt.


## Brief change log

  - Introduces the ForStValueState 
  - Support WriteBatchOperation and general MultiGetOperation for ForSt

## Verifying this change

This change added tests and can be verified  by  ForStWriteBatchOperationTest and ForStGeneralMultiGetOperationTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
