### PR TITLE
[FLINK-35039][rest] Use PUT method supported by YARN web proxy instead of POST

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
@@ -133,7 +133,7 @@ export class JobManagerService {
 
   createProfilingInstance(mode: string, duration: number): Observable<ProfilingDetail> {
     const requestParam = { mode, duration };
-    return this.httpClient.post<ProfilingDetail>(`${this.configService.BASE_URL}/jobmanager/profiler`, requestParam);
+    return this.httpClient.put<ProfilingDetail>(`${this.configService.BASE_URL}/jobmanager/profiler`, requestParam);
   }
 
   loadProfilingResult(filePath: string): Observable<Record<string, string>> {

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
@@ -127,7 +127,7 @@ export class TaskManagerService {
 
   createProfilingInstance(taskManagerId: string, mode: string, duration: number): Observable<ProfilingDetail> {
     const requestParam = { mode, duration };
-    return this.httpClient.post<ProfilingDetail>(
+    return this.httpClient.put<ProfilingDetail>(
       `${this.configService.BASE_URL}/taskmanagers/${taskManagerId}/profiler`,
       requestParam
     );


### PR DESCRIPTION
To repair the task submitted in the Yarn mode, you can use the Profiler on the webui