### PR TITLE
[BP][FLINK-35169][runtime] Recycle buffers to freeSegments before releasing data buffer for sort accumulator

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/SortBufferAccumulatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/SortBufferAccumulatorTest.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
 
+import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.hybrid.tiered.TestingTieredStorageMemoryManager;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageSubpartitionId;
 
 import org.junit.jupiter.api.AfterEach;
@@ -200,6 +203,47 @@ class SortBufferAccumulatorTest {
                 .isEqualTo(2);
         bufferAccumulator.close();
         assertThat(tieredStorageMemoryManager.numOwnerRequestedBuffer(bufferAccumulator)).isZero();
+    }
+
+    @Test
+    void testReuseRecycledBuffersWhenFlushDataBuffer() throws IOException {
+        int numBuffers = 10;
+        int numSubpartitions = 10;
+
+        AtomicInteger numRequestedBuffers = new AtomicInteger(0);
+        TestingTieredStorageMemoryManager memoryManager =
+                new TestingTieredStorageMemoryManager.Builder()
+                        .setRequestBufferBlockingFunction(
+                                owner -> {
+                                    numRequestedBuffers.incrementAndGet();
+                                    MemorySegment memorySegment =
+                                            globalPool.requestPooledMemorySegment();
+                                    // When flushing data from the data buffer, the buffers should
+                                    // not be requested from here anymore because the freeSegments
+                                    // can be reused before released.
+                                    assertThat(numRequestedBuffers.get() <= numBuffers).isTrue();
+                                    return new BufferBuilder(
+                                            memorySegment,
+                                            segment -> globalPool.requestPooledMemorySegment());
+                                })
+                        .build();
+
+        SortBufferAccumulator bufferAccumulator =
+                new SortBufferAccumulator(
+                        numSubpartitions, numBuffers, BUFFER_SIZE_BYTES, memoryManager, true);
+        bufferAccumulator.setup(
+                ((subpartition, buffer, numRemainingBuffers) -> buffer.recycleBuffer()));
+
+        for (int i = 0; i < numSubpartitions; i++) {
+            bufferAccumulator.receive(
+                    generateRandomData(10, new Random()),
+                    new TieredStorageSubpartitionId(i % numSubpartitions),
+                    Buffer.DataType.DATA_BUFFER,
+                    false);
+        }
+
+        // Trigger flushing buffers from data buffer.
+        bufferAccumulator.close();
     }
 
     private TieredStorageMemoryManagerImpl createStorageMemoryManager(int numBuffersInBufferPool)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Backport to Flink 1.19 for https://github.com/apache/flink/pull/24688#event-12553480360

*When using sortBufferAccumulator, we should recycle the buffers to freeSegments before releasing the data buffer. The reason is that when getting buffers from the DataBuffer, it may require more buffers than the current quantity available in freeSegments. Consequently, to ensure adequate buffers from DataBuffer, the flushed and recycled buffers should also be added to freeSegments for reuse.*


## Brief change log

  - *Reuse the recycled buffers before releasing data buffer for sort accumulator*


## Verifying this change


This change is already covered by added tests *SortBufferAccumulatorTest#testReuseRecycledBuffersWhenFlushDataBuffer*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)