### PR TITLE
[DRAFT][FLINK-35186][Runtime/State] Create State V2 from new StateDescriptor

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -548,4 +549,8 @@ public interface RuntimeContext {
      */
     @PublicEvolving
     TaskInfo getTaskInfo();
+
+    @Experimental
+    <T> org.apache.flink.api.common.state.v2.ValueState<T> getStateV2(
+            ValueStateDescriptor<T> stateProperties);
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.common.functions.util;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
@@ -242,5 +243,13 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
     @VisibleForTesting
     public String getAllocationIDAsString() {
         return taskInfo.getAllocationIDAsString();
+    }
+
+    @Override
+    @Experimental
+    public <T> org.apache.flink.api.common.state.v2.ValueState<T> getStateV2(
+            ValueStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException(
+                "This state is only accessible by functions executed on a KeyedStream");
     }
 }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
@@ -201,4 +201,10 @@ class CepRuntimeContext implements RuntimeContext {
     public <UK, UV> MapState<UK, UV> getMapState(final MapStateDescriptor<UK, UV> stateProperties) {
         throw new UnsupportedOperationException("State is not supported.");
     }
+
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ValueState<T> getStateV2(
+            final ValueStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException("State is not supported.");
+    }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
@@ -239,6 +239,12 @@ public final class SavepointRuntimeContext implements RuntimeContext {
         return keyedStateStore.getMapState(stateProperties);
     }
 
+    @Override
+    public <T> org.apache.flink.api.common.state.v2.ValueState<T> getStateV2(
+            ValueStateDescriptor<T> stateProperties) {
+        throw new UnsupportedOperationException("State is not supported in rich async functions.");
+    }
+
     public List<StateDescriptor<?, ?>> getStateDescriptors() {
         if (registeredDescriptors.isEmpty()) {
             return Collections.emptyList();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AbstractStateExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AbstractStateExecutor.java
@@ -20,20 +20,15 @@ package org.apache.flink.runtime.asyncprocessing;
 
 import org.apache.flink.annotation.Internal;
 
-import java.util.concurrent.CompletableFuture;
-
-/** Executor for executing batch {@link StateRequest}s. */
+/** Basic implementation of {@link StateExecutor}. */
 @Internal
-public interface StateExecutor {
-    /**
-     * Execute a batch of state requests.
-     *
-     * @param processingRequests the given batch of processing requests
-     * @return A future can determine whether execution has completed.
-     */
-    CompletableFuture<Boolean> executeBatchRequests(
-            Iterable<StateRequest<?, ?, ?>> processingRequests);
+public abstract class AbstractStateExecutor implements StateExecutor {
 
-    /** Bind an {@link AsyncExecutionController} with this executor. */
-    void bindAsyncExecutionController(AsyncExecutionController<?> asyncExecutionController);
+    protected AsyncExecutionController<?> asyncExecutionController;
+
+    /** Bind a {@link AsyncExecutionController} with this executor. */
+    @Override
+    public void bindAsyncExecutionController(AsyncExecutionController<?> asyncExecutionController) {
+        this.asyncExecutionController = asyncExecutionController;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
@@ -111,6 +111,7 @@ public class AsyncExecutionController<K> {
         this.maxInFlightRecordNum = maxInFlightRecords;
         this.stateRequestsBuffer = new StateRequestBuffer<>();
         this.inFlightRecordNum = new AtomicInteger(0);
+        stateExecutor.bindAsyncExecutionController(this);
         LOG.info(
                 "Create AsyncExecutionController: batchSize {}, maxInFlightRecordsNum {}",
                 batchSize,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
@@ -19,7 +19,9 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.runtime.asyncprocessing.StateExecutor;
+import org.apache.flink.runtime.state.v2.StateDescriptor;
 import org.apache.flink.util.Disposable;
 
 /**
@@ -37,4 +39,13 @@ public interface AsyncKeyedStateBackend extends Disposable {
      *     asynchronously.
      */
     StateExecutor createStateExecutor();
+
+    /**
+     * Create a state by a given state descriptor.
+     *
+     * @param stateDescriptor the given state descriptor.
+     * @return the created state.
+     * @param <S> The type of state.
+     */
+    <S extends State> S getState(StateDescriptor<?> stateDescriptor) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/KeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/KeyedStateStore.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.state.v2.ValueState;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
+
+import static java.util.Objects.requireNonNull;
+
+/** This contains methods for registering keyed state with a managed store. */
+public class KeyedStateStore {
+
+    private final AsyncKeyedStateBackend asyncKeyedStateBackend;
+
+    public KeyedStateStore(AsyncKeyedStateBackend asyncKeyedStateBackend) {
+        this.asyncKeyedStateBackend = asyncKeyedStateBackend;
+    }
+
+    public <T> ValueState<T> getState(ValueStateDescriptor<T> stateProperties) {
+        requireNonNull(stateProperties, "The state properties must not be null");
+        try {
+            return asyncKeyedStateBackend.getState(stateProperties);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while getting state", e);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptor.java
@@ -90,6 +90,12 @@ public abstract class StateDescriptor<T> implements Serializable {
         this.typeSerializer = typeInfo.createSerializer(serializerConfig);
     }
 
+    protected StateDescriptor(@Nonnull String stateId, @Nonnull TypeSerializer<T> serializer) {
+        this.stateId = checkNotNull(stateId, "stateId must not be null");
+        checkNotNull(serializer, "type serializer must not be null");
+        this.typeSerializer = serializer;
+    }
+
     // ------------------------------------------------------------------------
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptorConversionUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptorConversionUtil.java
@@ -16,24 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.asyncprocessing;
+package org.apache.flink.runtime.state.v2;
 
-import org.apache.flink.annotation.Internal;
+/**
+ * A util class that convert the {@link org.apache.flink.api.common.state.StateDescriptor} to the
+ * new {@link StateDescriptor}.
+ */
+public class StateDescriptorConversionUtil {
 
-import java.util.concurrent.CompletableFuture;
+    public static <T> ValueStateDescriptor<T> convert(
+            org.apache.flink.api.common.state.ValueStateDescriptor<T> oldDescriptor) {
+        return new ValueStateDescriptor<>(oldDescriptor.getName(), oldDescriptor.getSerializer());
+    }
 
-/** Executor for executing batch {@link StateRequest}s. */
-@Internal
-public interface StateExecutor {
-    /**
-     * Execute a batch of state requests.
-     *
-     * @param processingRequests the given batch of processing requests
-     * @return A future can determine whether execution has completed.
-     */
-    CompletableFuture<Boolean> executeBatchRequests(
-            Iterable<StateRequest<?, ?, ?>> processingRequests);
-
-    /** Bind an {@link AsyncExecutionController} with this executor. */
-    void bindAsyncExecutionController(AsyncExecutionController<?> asyncExecutionController);
+    private StateDescriptorConversionUtil() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ValueStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ValueStateDescriptor.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state.v2;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 /**
  * {@link StateDescriptor} for {@link ValueState}. This can be used to create partitioned value
@@ -51,6 +52,16 @@ public class ValueStateDescriptor<T> extends StateDescriptor<T> {
     public ValueStateDescriptor(
             String stateId, TypeInformation<T> typeInfo, SerializerConfig serializerConfig) {
         super(stateId, typeInfo, serializerConfig);
+    }
+
+    /**
+     * Creates a new {@code ValueStateDescriptor} with the given stateId and type.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param typeSerializer The serializer to serialize the value.
+     */
+    public ValueStateDescriptor(String stateId, TypeSerializer<T> typeSerializer) {
+        super(stateId, typeSerializer);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.asyncprocessing;
 
+import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.state.StateFutureUtils;
@@ -27,6 +28,7 @@ import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.v2.InternalValueState;
+import org.apache.flink.runtime.state.v2.StateDescriptor;
 import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
 import org.apache.flink.util.Preconditions;
 
@@ -415,6 +417,11 @@ class AsyncExecutionControllerTest {
                 }
 
                 @Override
+                public <S extends State> S getState(StateDescriptor<?> stateDescriptor) {
+                    return null;
+                }
+
+                @Override
                 public void dispose() {
                     // do nothing
                 }
@@ -426,7 +433,7 @@ class AsyncExecutionControllerTest {
      * A brief implementation of {@link StateExecutor}, to illustrate the interaction between AEC
      * and StateExecutor.
      */
-    static class TestStateExecutor implements StateExecutor {
+    static class TestStateExecutor extends AbstractStateExecutor {
 
         public TestStateExecutor() {}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
@@ -258,6 +258,13 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction
         public TaskInfo getTaskInfo() {
             return runtimeContext.getTaskInfo();
         }
+
+        @Override
+        public <T> org.apache.flink.api.common.state.v2.ValueState<T> getStateV2(
+                ValueStateDescriptor<T> stateProperties) {
+            throw new UnsupportedOperationException(
+                    "State is not supported in rich async functions.");
+        }
     }
 
     private static class RichAsyncFunctionIterationRuntimeContext

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -138,7 +138,7 @@ public abstract class AbstractStreamOperator<OUT>
      */
     protected transient KeySelector<?, ?> stateKeySelector2;
 
-    private transient StreamOperatorStateHandler stateHandler;
+    protected transient StreamOperatorStateHandler stateHandler;
 
     private transient InternalTimeServiceManager<?> timeServiceManager;
 
@@ -253,7 +253,7 @@ public abstract class AbstractStreamOperator<OUT>
     }
 
     @Override
-    public final void initializeState(StreamTaskStateInitializer streamTaskStateManager)
+    public void initializeState(StreamTaskStateInitializer streamTaskStateManager)
             throws Exception {
 
         final TypeSerializer<?> keySerializer =
@@ -285,6 +285,7 @@ public abstract class AbstractStreamOperator<OUT>
         timeServiceManager = context.internalTimerServiceManager();
         stateHandler.initializeOperatorState(this);
         runtimeContext.setKeyedStateStore(stateHandler.getKeyedStateStore().orElse(null));
+        runtimeContext.setKeyedStateStoreV2(stateHandler.getKeyedStateStoreV2().orElse(null));
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -102,7 +102,7 @@ public abstract class AbstractStreamOperatorV2<OUT>
     protected final ProcessingTimeService processingTimeService;
     protected final RecordAttributes[] lastRecordAttributes;
 
-    private StreamOperatorStateHandler stateHandler;
+    protected StreamOperatorStateHandler stateHandler;
     private InternalTimeServiceManager<?> timeServiceManager;
 
     public AbstractStreamOperatorV2(StreamOperatorParameters<OUT> parameters, int numberOfInputs) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.OperatorStateBackend;
@@ -71,4 +72,10 @@ public interface StreamOperatorStateContext {
      * are assigned to this operator. This method returns null for non-keyed operators.
      */
     CloseableIterable<KeyGroupStatePartitionStreamProvider> rawKeyedStateInputs();
+
+    /**
+     * Returns the async keyed state backend for the stream operator. This method returns null for
+     * non-keyed operators. Also returns null if the user-specified
+     */
+    AsyncKeyedStateBackend asyncKeyedStateBackend();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
@@ -24,7 +24,9 @@ import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.runtime.asyncprocessing.StateExecutor;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
@@ -64,6 +66,10 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
         super.initializeState(streamTaskStateManager);
         // TODO: Read config and properly set.
         this.asyncExecutionController = new AsyncExecutionController(mailboxExecutor, null);
+        final AsyncKeyedStateBackend keyedStateBackend = stateHandler.getAsyncKeyedStateBackend();
+        final StateExecutor stateExecutor = keyedStateBackend.createStateExecutor();
+        this.asyncExecutionController =
+                new AsyncExecutionController(mailboxExecutor, stateExecutor);
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.asyncprocessing.AbstractStateExecutor;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
-import org.apache.flink.runtime.asyncprocessing.StateExecutor;
 import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -152,7 +152,7 @@ public class AbstractAsyncStateStreamOperatorTest {
                     ((AbstractAsyncStateStreamOperator) testHarness.getOperator())
                             .getAsyncExecutionController();
             asyncExecutionController.setStateExecutor(
-                    new StateExecutor() {
+                    new AbstractStateExecutor() {
                         @Override
                         public CompletableFuture<Boolean> executeBatchRequests(
                                 Iterable<StateRequest<?, ?, ?>> processingRequests) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2Test.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2Test.java
@@ -23,8 +23,8 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.asyncprocessing.AbstractStateExecutor;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
-import org.apache.flink.runtime.asyncprocessing.StateExecutor;
 import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -164,7 +164,7 @@ public class AbstractAsyncStateStreamOperatorV2Test {
             AsyncExecutionController asyncExecutionController =
                     testOperator.getAsyncExecutionController();
             asyncExecutionController.setStateExecutor(
-                    new StateExecutor() {
+                    new AbstractStateExecutor() {
                         @Override
                         public CompletableFuture<Boolean> executeBatchRequests(
                                 Iterable<StateRequest<?, ?, ?>> processingRequests) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -76,6 +76,7 @@ import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DoneFuture;
@@ -2351,6 +2352,11 @@ public class StreamTaskTest {
                     @Override
                     public CheckpointableKeyedStateBackend<?> keyedStateBackend() {
                         return controller.keyedStateBackend();
+                    }
+
+                    @Override
+                    public AsyncKeyedStateBackend asyncKeyedStateBackend() {
+                        return controller.asyncKeyedStateBackend();
                     }
 
                     @Override


### PR DESCRIPTION
## This is only a draft for testing purpose, do not merge this

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
