### PR TITLE
[FLINK-35188][table-api] Introduce CatalogMaterializedTable and related interface to support materialized table

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/OperationExecutorFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/util/OperationExecutorFactory.java
@@ -101,6 +101,10 @@ import static org.apache.hadoop.hive.serde2.thrift.Type.VARCHAR_TYPE;
 /** Factory to create the operation executor. */
 public class OperationExecutorFactory {
 
+    // Hive dialect doesn't support materialized table currently.
+    private static final Set<TableKind> TABLE_KINDS =
+            new HashSet<>(Arrays.asList(TableKind.TABLE, TableKind.VIEW));
+
     public static Callable<ResultSet> createGetCatalogsExecutor(
             SqlGatewayService service, SessionHandle sessionHandle) {
         return () -> executeGetCatalogs(service, sessionHandle);
@@ -291,14 +295,13 @@ public class OperationExecutorFactory {
         Set<String> schemaNames =
                 filterAndSort(
                         service.listDatabases(sessionHandle, specifiedCatalogName), schemaName);
-        Set<TableKind> tableKinds = new HashSet<>(Arrays.asList(TableKind.values()));
 
         List<RowData> results = new ArrayList<>();
         for (String schema : schemaNames) {
             Set<TableInfo> tableInfos =
                     filterAndSort(
                             service.listTables(
-                                    sessionHandle, specifiedCatalogName, schema, tableKinds),
+                                    sessionHandle, specifiedCatalogName, schema, TABLE_KINDS),
                             candidates -> candidates.getIdentifier().getObjectName(),
                             tableName);
 
@@ -369,10 +372,7 @@ public class OperationExecutorFactory {
             Set<TableInfo> tableInfos =
                     filterAndSort(
                             service.listTables(
-                                    sessionHandle,
-                                    specifiedCatalogName,
-                                    schema,
-                                    new HashSet<>(Arrays.asList(TableKind.values()))),
+                                    sessionHandle, specifiedCatalogName, schema, TABLE_KINDS),
                             candidate -> candidate.getIdentifier().getObjectName(),
                             tableName);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -35,6 +35,8 @@ import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.table.catalog.exceptions.TablePartitionedException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.DynamicTableFactory;
 import org.apache.flink.table.factories.Factory;
@@ -65,6 +67,13 @@ public interface Catalog {
      * <p>This method enables bypassing the discovery process. Implementers can directly pass
      * internal catalog-specific objects to their own factory. For example, a custom {@link
      * CatalogTable} can be processed by a custom {@link DynamicTableFactory}.
+     *
+     * <p>If this catalog support to create materialized table, you should also override this method
+     * to provide {@link DynamicTableFactory} which help planner to find {@link DynamicTableSource}
+     * and {@link DynamicTableSink} correctly during compile optimization phase. If you don't
+     * override this method, you must specify the physical connector identifier that this catalog
+     * represents storage when create materialized table. Otherwise, the planner can't find the
+     * {@link DynamicTableFactory}.
      *
      * <p>Because all factories are interfaces, the returned {@link Factory} instance can implement
      * multiple supported extension points. An {@code instanceof} check is performed by the caller

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogBaseTable.java
@@ -39,6 +39,7 @@ public interface CatalogBaseTable {
     @PublicEvolving
     enum TableKind {
         TABLE,
+        MATERIALIZED_TABLE,
         VIEW
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Represents the unresolved metadata of a materialized table in a {@link Catalog}.
+ *
+ * <p>Materialized Table definition: In the context of streaming-batch unified storage, it provides
+ * full history data and incremental changelog. By defining the data's production business logic and
+ * freshness, data refresh is achieved through continuous or full refresh pipeline, while also
+ * possessing the capability for both batch and incremental consumption.
+ *
+ * <p>The metadata for {@link CatalogMaterializedTable} includes the following four main parts:
+ *
+ * <ul>
+ *   <li>Schema, comments, options and partition keys.
+ *   <li>Data freshness, which determines when the data is generated and becomes visible for user.
+ *   <li>Data production business logic, also known as the definition query.
+ *   <li>Background refresh pipeline, either through a flink streaming or periodic flink batch job,
+ *       it is initialized after materialized table is created.
+ * </ul>
+ */
+@PublicEvolving
+public interface CatalogMaterializedTable extends CatalogBaseTable {
+
+    /** Builder for configuring and creating instances of {@link CatalogMaterializedTable}. */
+    @PublicEvolving
+    static CatalogMaterializedTable.Builder newBuilder() {
+        return new CatalogMaterializedTable.Builder();
+    }
+
+    @Override
+    default TableKind getTableKind() {
+        return TableKind.MATERIALIZED_TABLE;
+    }
+
+    /**
+     * Check if the table is partitioned or not.
+     *
+     * @return true if the table is partitioned; otherwise, false
+     */
+    boolean isPartitioned();
+
+    /**
+     * Get the partition keys of the table. This will be an empty set if the table is not
+     * partitioned.
+     *
+     * @return partition keys of the table
+     */
+    List<String> getPartitionKeys();
+
+    /**
+     * Returns a copy of this {@code CatalogMaterializedTable} with given table options {@code
+     * options}.
+     *
+     * @return a new copy of this table with replaced table options
+     */
+    CatalogMaterializedTable copy(Map<String, String> options);
+
+    /**
+     * Returns a copy of this {@code CatalogDynamicTable} with given refresh info.
+     *
+     * @return a new copy of this table with replaced refresh info
+     */
+    CatalogMaterializedTable copy(
+            RefreshStatus refreshStatus,
+            String refreshHandlerDescription,
+            byte[] serializedRefreshHandler);
+
+    /** Return the snapshot specified for the table. Return Optional.empty() if not specified. */
+    Optional<Long> getSnapshot();
+
+    /**
+     * The definition query text of materialized table, text is expanded in contrast to the original
+     * SQL. This is needed because the context such as current DB is lost after the session, in
+     * which view is defined, is gone. Expanded query text takes care of this, as an example.
+     *
+     * <p>For example, for a materialized table that is defined in the context of "default" database
+     * with a query {@code select * from test1}, the expanded query text might become {@code select
+     * `test1`.`name`, `test1`.`value` from `default`.`test1`}, where table test1 resides in
+     * database "default" and has two columns ("name" and "value").
+     *
+     * @return the materialized table definition in expanded text.
+     */
+    String getDefinitionQuery();
+
+    /**
+     * Get the freshness of materialized table which is used to determine the physical refresh mode.
+     */
+    Duration getFreshness();
+
+    /** Get the logical refresh mode of materialized table. */
+    LogicalRefreshMode getLogicalRefreshMode();
+
+    /** Get the physical refresh mode of materialized table. */
+    RefreshMode getRefreshMode();
+
+    /** Get the refresh status of materialized table. */
+    RefreshStatus getRefreshStatus();
+
+    /** Return summary description of refresh handler. */
+    Optional<String> getRefreshHandlerDescription();
+
+    /**
+     * Return the serialized refresh handler of materialized table. This will not be used for
+     * describe table.
+     */
+    @Nullable
+    byte[] getSerializedRefreshHandler();
+
+    /** The logical refresh mode of materialized table. */
+    @PublicEvolving
+    enum LogicalRefreshMode {
+        /**
+         * The refresh pipeline will be executed in continuous mode, corresponding to {@link
+         * RefreshMode#CONTINUOUS}.
+         */
+        CONTINUOUS,
+
+        /**
+         * The refresh pipeline will be executed in full mode, corresponding to {@link
+         * RefreshMode#FULL}.
+         */
+        FULL,
+
+        /**
+         * The refresh pipeline mode is determined by freshness of materialized table, either {@link
+         * RefreshMode#FULL} or {@link RefreshMode#CONTINUOUS}.
+         */
+        AUTOMATIC
+    }
+
+    /** The physical refresh mode of materialized table. */
+    @PublicEvolving
+    enum RefreshMode {
+        CONTINUOUS,
+        FULL
+    }
+
+    /** Background refresh pipeline status of materialized table. */
+    @PublicEvolving
+    enum RefreshStatus {
+        INITIALIZING,
+        ACTIVATED,
+        SUSPENDED
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    /** Builder for configuring and creating instances of {@link CatalogMaterializedTable}. */
+    @PublicEvolving
+    class Builder {
+
+        private Schema schema;
+        private String comment;
+        private List<String> partitionKeys = Collections.emptyList();
+        private Map<String, String> options = Collections.emptyMap();
+        private @Nullable Long snapshot;
+        private String definitionQuery;
+        private Duration freshness;
+        private LogicalRefreshMode logicalRefreshMode;
+        private RefreshMode refreshMode;
+        private RefreshStatus refreshStatus;
+        private @Nullable String refreshHandlerDescription;
+        private @Nullable byte[] serializedRefreshHandler;
+
+        private Builder() {}
+
+        public Builder schema(Schema schema) {
+            this.schema = Preconditions.checkNotNull(schema, "Schema must not be null.");
+            return this;
+        }
+
+        public Builder comment(@Nullable String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        public Builder partitionKeys(List<String> partitionKeys) {
+            this.partitionKeys =
+                    Preconditions.checkNotNull(partitionKeys, "Partition keys must not be null.");
+            return this;
+        }
+
+        public Builder options(Map<String, String> options) {
+            this.options = Preconditions.checkNotNull(options, "Options must not be null.");
+            return this;
+        }
+
+        public Builder snapshot(@Nullable Long snapshot) {
+            this.snapshot = snapshot;
+            return this;
+        }
+
+        public Builder definitionQuery(String definitionQuery) {
+            this.definitionQuery =
+                    Preconditions.checkNotNull(
+                            definitionQuery, "Definition query must not be null.");
+            return this;
+        }
+
+        public Builder freshness(Duration freshness) {
+            this.freshness = Preconditions.checkNotNull(freshness, "Freshness must not be null.");
+            return this;
+        }
+
+        public Builder logicalRefreshMode(LogicalRefreshMode logicalRefreshMode) {
+            this.logicalRefreshMode =
+                    Preconditions.checkNotNull(
+                            logicalRefreshMode, "Logical refresh mode must not be null.");
+            return this;
+        }
+
+        public Builder refreshMode(RefreshMode refreshMode) {
+            this.refreshMode =
+                    Preconditions.checkNotNull(refreshMode, "Refresh mode must not be null.");
+            return this;
+        }
+
+        public Builder refreshStatus(RefreshStatus refreshStatus) {
+            this.refreshStatus =
+                    Preconditions.checkNotNull(refreshStatus, "Refresh status must not be null.");
+            return this;
+        }
+
+        public Builder refreshHandlerDescription(@Nullable String refreshHandlerDescription) {
+            this.refreshHandlerDescription = refreshHandlerDescription;
+            return this;
+        }
+
+        public Builder serializedRefreshHandler(@Nullable byte[] serializedRefreshHandler) {
+            this.serializedRefreshHandler = serializedRefreshHandler;
+            return this;
+        }
+
+        public CatalogMaterializedTable build() {
+            return new DefaultCatalogMaterializedTable(
+                    schema,
+                    comment,
+                    partitionKeys,
+                    options,
+                    snapshot,
+                    definitionQuery,
+                    freshness,
+                    logicalRefreshMode,
+                    refreshMode,
+                    refreshStatus,
+                    refreshHandlerDescription,
+                    serializedRefreshHandler);
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogMaterializedTable.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.Schema;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Default implementation of a {@link CatalogMaterializedTable}. */
+@Internal
+public class DefaultCatalogMaterializedTable implements CatalogMaterializedTable {
+
+    private final Schema schema;
+    private final @Nullable String comment;
+    private final List<String> partitionKeys;
+    private final Map<String, String> options;
+
+    private final @Nullable Long snapshot;
+
+    private final String definitionQuery;
+    private final Duration freshness;
+    private final LogicalRefreshMode logicalRefreshMode;
+    private final RefreshMode refreshMode;
+    private final RefreshStatus refreshStatus;
+    private final @Nullable String refreshHandlerDescription;
+    private final @Nullable byte[] serializedRefreshHandler;
+
+    protected DefaultCatalogMaterializedTable(
+            Schema schema,
+            @Nullable String comment,
+            List<String> partitionKeys,
+            Map<String, String> options,
+            @Nullable Long snapshot,
+            String definitionQuery,
+            Duration freshness,
+            LogicalRefreshMode logicalRefreshMode,
+            RefreshMode refreshMode,
+            RefreshStatus refreshStatus,
+            @Nullable String refreshHandlerDescription,
+            @Nullable byte[] serializedRefreshHandler) {
+        this.schema = checkNotNull(schema, "Schema must not be null.");
+        this.comment = comment;
+        this.partitionKeys = checkNotNull(partitionKeys, "Partition keys must not be null.");
+        this.options = checkNotNull(options, "Options must not be null.");
+        this.snapshot = snapshot;
+        this.definitionQuery = checkNotNull(definitionQuery, "Definition query must not be null.");
+        this.freshness = checkNotNull(freshness, "Freshness must not be null.");
+        this.logicalRefreshMode =
+                checkNotNull(logicalRefreshMode, "Logical refresh mode must not be null.");
+        this.refreshMode = checkNotNull(refreshMode, "Refresh mode must not be null.");
+        this.refreshStatus = checkNotNull(refreshStatus, "Refresh status must not be null.");
+        this.refreshHandlerDescription = refreshHandlerDescription;
+        this.serializedRefreshHandler = serializedRefreshHandler;
+
+        checkArgument(
+                options.entrySet().stream()
+                        .allMatch(e -> e.getKey() != null && e.getValue() != null),
+                "Options cannot have null keys or values.");
+    }
+
+    @Override
+    public Schema getUnresolvedSchema() {
+        return schema;
+    }
+
+    @Override
+    public String getComment() {
+        return comment != null ? comment : "";
+    }
+
+    @Override
+    public boolean isPartitioned() {
+        return !partitionKeys.isEmpty();
+    }
+
+    @Override
+    public List<String> getPartitionKeys() {
+        return partitionKeys;
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        return options;
+    }
+
+    @Override
+    public CatalogBaseTable copy() {
+        return new DefaultCatalogMaterializedTable(
+                schema,
+                comment,
+                partitionKeys,
+                options,
+                snapshot,
+                definitionQuery,
+                freshness,
+                logicalRefreshMode,
+                refreshMode,
+                refreshStatus,
+                refreshHandlerDescription,
+                serializedRefreshHandler);
+    }
+
+    @Override
+    public CatalogMaterializedTable copy(Map<String, String> options) {
+        return new DefaultCatalogMaterializedTable(
+                schema,
+                comment,
+                partitionKeys,
+                options,
+                snapshot,
+                definitionQuery,
+                freshness,
+                logicalRefreshMode,
+                refreshMode,
+                refreshStatus,
+                refreshHandlerDescription,
+                serializedRefreshHandler);
+    }
+
+    @Override
+    public CatalogMaterializedTable copy(
+            RefreshStatus refreshStatus,
+            String refreshHandlerDescription,
+            byte[] serializedRefreshHandler) {
+        return new DefaultCatalogMaterializedTable(
+                schema,
+                comment,
+                partitionKeys,
+                options,
+                snapshot,
+                definitionQuery,
+                freshness,
+                logicalRefreshMode,
+                refreshMode,
+                refreshStatus,
+                refreshHandlerDescription,
+                serializedRefreshHandler);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return Optional.of(getComment());
+    }
+
+    @Override
+    public Optional<String> getDetailedDescription() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Long> getSnapshot() {
+        return Optional.ofNullable(snapshot);
+    }
+
+    @Override
+    public String getDefinitionQuery() {
+        return definitionQuery;
+    }
+
+    @Override
+    public Duration getFreshness() {
+        return freshness;
+    }
+
+    @Override
+    public LogicalRefreshMode getLogicalRefreshMode() {
+        return logicalRefreshMode;
+    }
+
+    @Override
+    public RefreshMode getRefreshMode() {
+        return refreshMode;
+    }
+
+    @Override
+    public RefreshStatus getRefreshStatus() {
+        return refreshStatus;
+    }
+
+    @Override
+    public Optional<String> getRefreshHandlerDescription() {
+        return Optional.ofNullable(refreshHandlerDescription);
+    }
+
+    @Nullable
+    @Override
+    public byte[] getSerializedRefreshHandler() {
+        return serializedRefreshHandler;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultCatalogMaterializedTable that = (DefaultCatalogMaterializedTable) o;
+        return Objects.equals(schema, that.schema)
+                && Objects.equals(comment, that.comment)
+                && Objects.equals(partitionKeys, that.partitionKeys)
+                && Objects.equals(options, that.options)
+                && Objects.equals(snapshot, that.snapshot)
+                && Objects.equals(definitionQuery, that.definitionQuery)
+                && Objects.equals(freshness, that.freshness)
+                && logicalRefreshMode == that.logicalRefreshMode
+                && refreshMode == that.refreshMode
+                && refreshStatus == that.refreshStatus
+                && Objects.equals(refreshHandlerDescription, that.refreshHandlerDescription)
+                && Arrays.equals(serializedRefreshHandler, that.serializedRefreshHandler);
+    }
+
+    @Override
+    public int hashCode() {
+        int result =
+                Objects.hash(
+                        schema,
+                        comment,
+                        partitionKeys,
+                        options,
+                        snapshot,
+                        definitionQuery,
+                        freshness,
+                        logicalRefreshMode,
+                        refreshMode,
+                        refreshStatus,
+                        refreshHandlerDescription);
+        result = 31 * result + Arrays.hashCode(serializedRefreshHandler);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultCatalogMaterializedTable{"
+                + "schema="
+                + schema
+                + ", comment='"
+                + comment
+                + '\''
+                + ", partitionKeys="
+                + partitionKeys
+                + ", options="
+                + options
+                + ", snapshot="
+                + snapshot
+                + ", definitionQuery='"
+                + definitionQuery
+                + '\''
+                + ", freshness="
+                + freshness
+                + ", logicalRefreshMode="
+                + logicalRefreshMode
+                + ", refreshMode="
+                + refreshMode
+                + ", refreshStatus="
+                + refreshStatus
+                + ", refreshHandlerDescription='"
+                + refreshHandlerDescription
+                + '\''
+                + ", serializedRefreshHandler="
+                + Arrays.toString(serializedRefreshHandler)
+                + '}';
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogMaterializedTable.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A validated {@link CatalogMaterializedTable} that is backed by the original metadata coming from
+ * the {@link Catalog} but resolved by the framework.
+ *
+ * <p>Note: This will be converted to {@link ResolvedCatalogTable} by framework during planner
+ * optimize query phase.
+ */
+@PublicEvolving
+public class ResolvedCatalogMaterializedTable
+        implements ResolvedCatalogBaseTable<CatalogMaterializedTable>, CatalogMaterializedTable {
+
+    private final CatalogMaterializedTable origin;
+
+    private final ResolvedSchema resolvedSchema;
+
+    public ResolvedCatalogMaterializedTable(
+            CatalogMaterializedTable origin, ResolvedSchema resolvedSchema) {
+        this.origin =
+                Preconditions.checkNotNull(
+                        origin, "Original catalog materialized table must not be null.");
+        this.resolvedSchema =
+                Preconditions.checkNotNull(resolvedSchema, "Resolved schema must not be null.");
+    }
+
+    @Override
+    public Map<String, String> getOptions() {
+        return origin.getOptions();
+    }
+
+    @Override
+    public String getComment() {
+        return origin.getComment();
+    }
+
+    @Override
+    public CatalogBaseTable copy() {
+        return new ResolvedCatalogMaterializedTable(
+                (CatalogMaterializedTable) origin.copy(), resolvedSchema);
+    }
+
+    @Override
+    public ResolvedCatalogMaterializedTable copy(Map<String, String> options) {
+        return new ResolvedCatalogMaterializedTable(origin.copy(options), resolvedSchema);
+    }
+
+    @Override
+    public ResolvedCatalogMaterializedTable copy(
+            RefreshStatus refreshStatus,
+            String refreshHandlerDescription,
+            byte[] serializedRefreshHandler) {
+        return new ResolvedCatalogMaterializedTable(
+                origin.copy(refreshStatus, refreshHandlerDescription, serializedRefreshHandler),
+                resolvedSchema);
+    }
+
+    @Override
+    public Optional<String> getDescription() {
+        return origin.getDescription();
+    }
+
+    @Override
+    public Optional<String> getDetailedDescription() {
+        return origin.getDetailedDescription();
+    }
+
+    @Override
+    public boolean isPartitioned() {
+        return origin.isPartitioned();
+    }
+
+    @Override
+    public List<String> getPartitionKeys() {
+        return origin.getPartitionKeys();
+    }
+
+    @Override
+    public Optional<Long> getSnapshot() {
+        return origin.getSnapshot();
+    }
+
+    @Override
+    public CatalogMaterializedTable getOrigin() {
+        return origin;
+    }
+
+    @Override
+    public ResolvedSchema getResolvedSchema() {
+        return resolvedSchema;
+    }
+
+    @Override
+    public String getDefinitionQuery() {
+        return origin.getDefinitionQuery();
+    }
+
+    @Override
+    public Duration getFreshness() {
+        return origin.getFreshness();
+    }
+
+    @Override
+    public LogicalRefreshMode getLogicalRefreshMode() {
+        return origin.getLogicalRefreshMode();
+    }
+
+    @Override
+    public RefreshMode getRefreshMode() {
+        return origin.getRefreshMode();
+    }
+
+    @Override
+    public RefreshStatus getRefreshStatus() {
+        return origin.getRefreshStatus();
+    }
+
+    @Override
+    public Optional<String> getRefreshHandlerDescription() {
+        return origin.getRefreshHandlerDescription();
+    }
+
+    @Nullable
+    @Override
+    public byte[] getSerializedRefreshHandler() {
+        return origin.getSerializedRefreshHandler();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResolvedCatalogMaterializedTable that = (ResolvedCatalogMaterializedTable) o;
+        return Objects.equals(origin, that.origin)
+                && Objects.equals(resolvedSchema, that.resolvedSchema);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(origin, resolvedSchema);
+    }
+
+    @Override
+    public String toString() {
+        return "ResolvedCatalogMaterializedTable{"
+                + "origin="
+                + origin
+                + ", resolvedSchema="
+                + resolvedSchema
+                + '}';
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/RefreshHandler.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/RefreshHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.refresh;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.Catalog;
+
+/**
+ * This interface represents the meta information of current materialized table background refresh
+ * pipeline. The refresh mode maybe continuous or full, the meta information in the two modes is not
+ * consistent, so user need to implementation this interface according to different case.
+ *
+ * <p>In continuous mode, the meta information maybe contains { "clusterType": "yarn", "clusterId":
+ * "xxx", "jobId": "yyyy" }.
+ *
+ * <p>In full mode, the meta information maybe contains { "endpoint": "xxx", "workflowId": "yyy" }.
+ * Due to user may use different workflow scheduler in this mode, user should implement this
+ * interface according to their plugin.
+ *
+ * <p>This interface will be serialized to bytes by {@link RefreshHandlerSerializer}, then store to
+ * {@link Catalog} for further operation.
+ */
+@PublicEvolving
+public interface RefreshHandler {
+
+    /**
+     * Returns a string that summarizes this refresh handler meta information for printing to a
+     * console or log.
+     */
+    String asSummaryString();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/RefreshHandlerSerializer.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/RefreshHandlerSerializer.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.refresh;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.IOException;
+
+/** This interface is used to serialize and deserialize the {@link RefreshHandler}. */
+@PublicEvolving
+public interface RefreshHandlerSerializer<T extends RefreshHandler> {
+
+    /** Serialize the {@link RefreshHandler} instance to bytes. */
+    byte[] serialize(T refreshHandler) throws IOException;
+
+    /** Deserialize the bytes to a {@link RefreshHandler} instance. */
+    T deserialize(byte[] serializedBytes, ClassLoader cl)
+            throws IOException, ClassNotFoundException;
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce CatalogMaterializedTable and related interface to support materialized table, see https://issues.apache.org/jira/browse/FLINK-35188 for more detail.


## Brief change log

  - *Introduce CatalogMaterializedTable interface*
  - *Introduce RefreshHandler interface*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test CatalogBaseTableResolutionTest#testCatalogMaterializedTableResolution*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
