### PR TITLE
[hotfix] make sure run RecordContext#release() in Task thread.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/ReferenceCounted.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/ReferenceCounted.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.memory.MemoryUtils;
 
 import sun.misc.Unsafe;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -32,7 +33,7 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @Internal
 @ThreadSafe
-public abstract class ReferenceCounted {
+public abstract class ReferenceCounted<ReleaseHelper> {
 
     /** The "unsafe", which can be used to perform native memory accesses. */
     @SuppressWarnings({"restriction", "UseOfSunClasses"})
@@ -87,9 +88,13 @@ public abstract class ReferenceCounted {
     }
 
     public int release() {
+        return release(null);
+    }
+
+    public int release(@Nullable ReleaseHelper releaseHelper) {
         int r = unsafe.getAndAddInt(this, referenceOffset, -1) - 1;
         if (r == 0) {
-            referenceCountReachedZero();
+            referenceCountReachedZero(releaseHelper);
         }
         return r;
     }
@@ -99,5 +104,5 @@ public abstract class ReferenceCounted {
     }
 
     /** A method called when the reference count reaches zero. */
-    protected abstract void referenceCountReachedZero();
+    protected abstract void referenceCountReachedZero(@Nullable ReleaseHelper releaseHelper);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/ReferenceCountedTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/ReferenceCountedTest.java
@@ -57,7 +57,7 @@ class ReferenceCountedTest {
         assertThat(referenceCounted.getReferenceCount()).isEqualTo(0);
     }
 
-    private static class TestReferenceCounted extends ReferenceCounted {
+    private static class TestReferenceCounted extends ReferenceCounted<Void> {
         private boolean reachedZero = false;
 
         public TestReferenceCounted() {
@@ -65,7 +65,7 @@ class ReferenceCountedTest {
         }
 
         @Override
-        protected void referenceCountReachedZero() {
+        protected void referenceCountReachedZero(Void v) {
             reachedZero = true;
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

This is a internal hotfix within development of async state execution (see: FLIP-425).

## Brief change log

  - add a ReleaseHelper parameter to ReferenceCounted
  - RecordContext use disposer runner as release helper, when ref-count reach 0, it will be used run disposer
  - add a 'inCallbackRunner' parameter to StateFutureImpl#postComplete()
  - ContextStateFutureImpl#postComplete() pass director runner or callbackRunner to RecordContext#release() depends on 'inCallbackRunner'

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no