### PR TITLE
[FLINK-35215][core] Fix the bug when Kryo serialize length is 0

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NoFetchingInput.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NoFetchingInput.java
@@ -117,6 +117,10 @@ public class NoFetchingInput extends Input {
             throw new IllegalArgumentException("bytes cannot be null.");
         }
 
+        if (count == 0) {
+            return;
+        }
+
         try {
             int bytesRead = 0;
             int c;

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NoFetchingInput.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NoFetchingInput.java
@@ -73,7 +73,7 @@ public class NoFetchingInput extends Input {
         position = 0;
         int bytesRead = 0;
         int count;
-        while (bytesRead < required) {
+        while (true) {
             count = fill(buffer, bytesRead, required - bytesRead);
 
             if (count == -1) {
@@ -81,6 +81,9 @@ public class NoFetchingInput extends Input {
             }
 
             bytesRead += count;
+            if (bytesRead == required) {
+                break;
+            }
         }
         limit = required;
         return required;
@@ -118,7 +121,7 @@ public class NoFetchingInput extends Input {
             int bytesRead = 0;
             int c;
 
-            while (bytesRead < count) {
+            while (true) {
                 c = inputStream.read(bytes, offset + bytesRead, count - bytesRead);
 
                 if (c == -1) {
@@ -126,6 +129,10 @@ public class NoFetchingInput extends Input {
                 }
 
                 bytesRead += c;
+
+                if (bytesRead == count) {
+                    break;
+                }
             }
         } catch (IOException ex) {
             throw new KryoException(ex);


### PR DESCRIPTION
## What is the purpose of the change

The performance of [serializerKryo](http://flink-speed.xyz/timeline/#/?exe=1,6,12&ben=serializerKryo&extr=on&quarts=on&equid=off&env=3&revs=50) and [serializerKryoWithoutRegistration](http://flink-speed.xyz/timeline/#/?exe=12&ben=serializerKryoWithoutRegistration&extr=on&quarts=on&equid=off&env=3&revs=50) are regressed, I checked recent commits, and found [FLINK-34954](https://issues.apache.org/jira/browse/FLINK-34954) changed related logic.


## Brief change log

- The first commit: Revert "[FLINK-34954][core] Kryo Input bug fix" 
- The second commit: [FLINK-35215][core] Fix the bug when Kryo serialize length is 0
  - This PR reverts the FLINK-34954, and try to re-implement to avoid the performance regression.

