### PR TITLE
[FLINK-35217] Add missing fsync to #closeForCommit in some subclasses of RecoverableFsDataOutputStream.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/CommitterFromPersistRecoverableFsDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/CommitterFromPersistRecoverableFsDataOutputStream.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import java.io.IOException;
+
+/**
+ * {@link RecoverableFsDataOutputStream} with fixed implementation of {@link #closeForCommit()} that
+ * is based on using {@link #persist()} to ensure durability and creates the {@link
+ * org.apache.flink.core.fs.RecoverableFsDataOutputStream.Committer} from the corresponding {@link
+ * org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable}.
+ *
+ * @param <RESUME_RECOVERABLE> return type of #persist()
+ */
+public abstract class CommitterFromPersistRecoverableFsDataOutputStream<
+                RESUME_RECOVERABLE extends RecoverableWriter.ResumeRecoverable>
+        extends RecoverableFsDataOutputStream {
+
+    /** @see RecoverableFsDataOutputStream#persist() */
+    @Override
+    public abstract RESUME_RECOVERABLE persist() throws IOException;
+
+    /**
+     * @see RecoverableFsDataOutputStream#closeForCommit()
+     * @param recoverable a resume recoverable to create the committer from. Typically the parameter
+     *     is the return value of {@link #persist()}.
+     * @return the committer created from recoverable.
+     */
+    protected abstract Committer createCommitterFromResumeRecoverable(
+            RESUME_RECOVERABLE recoverable);
+
+    /**
+     * @see RecoverableFsDataOutputStream#closeForCommit()
+     * @implNote Calls persist to ensure durability of the written data and creates a committer
+     *     object from the return value of {@link #persist()}.
+     */
+    @Override
+    public final Committer closeForCommit() throws IOException {
+        Committer committer = createCommitterFromResumeRecoverable(persist());
+        close();
+        return committer;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStream.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStream.java
@@ -21,7 +21,6 @@ package org.apache.flink.core.fs.local;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter.CommitRecoverable;
-import org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -104,7 +103,7 @@ public class LocalRecoverableFsDataOutputStream extends RecoverableFsDataOutputS
     }
 
     @Override
-    public ResumeRecoverable persist() throws IOException {
+    public LocalRecoverable persist() throws IOException {
         // we call both flush and sync in order to ensure persistence on mounted
         // file systems, like NFS, EBS, EFS, ...
         flush();
@@ -115,9 +114,9 @@ public class LocalRecoverableFsDataOutputStream extends RecoverableFsDataOutputS
 
     @Override
     public Committer closeForCommit() throws IOException {
-        final long pos = getPos();
+        LocalCommitter localCommitter = new LocalCommitter(persist());
         close();
-        return new LocalCommitter(new LocalRecoverable(targetFile, tempFile, pos));
+        return localCommitter;
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/AbstractRecoverableFsDataOutputStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/AbstractRecoverableFsDataOutputStreamTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs.local;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.util.FileUtils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+/** Base class for testing implementations of {@link RecoverableFsDataOutputStream}. */
+public abstract class AbstractRecoverableFsDataOutputStreamTest {
+
+    public enum Event {
+        CLOSE,
+        FLUSH,
+        SYNC
+    }
+
+    @TempDir Path tmp;
+
+    /**
+     * Tests that #closeForCommit leads to a durable write to the temporary file and to target on
+     * commit.
+     */
+    @Test
+    public void testDurableWriteOnCommit() throws IOException {
+        // Setup
+        final int seed = 4711;
+        final Random random = new Random(seed);
+        final byte[] buffer = new byte[4 * 4096];
+        final List<LocalRecoverableFsDataOutputStreamTest.Event> testLog = new ArrayList<>();
+        final Path target = tmp.resolve("target");
+        final Path temp = tmp.resolve("temp");
+
+        Tuple2<RecoverableFsDataOutputStream, Closeable> testInstance =
+                createTestInstance(target, temp, testLog);
+
+        // Create test object
+        final RecoverableFsDataOutputStream testOutStreamInstance = testInstance.f0;
+
+        // Write test data
+        random.nextBytes(buffer);
+        testOutStreamInstance.write(buffer);
+
+        // Test closeForCommit
+        Assertions.assertTrue(testLog.isEmpty());
+        RecoverableFsDataOutputStream.Committer committer = testOutStreamInstance.closeForCommit();
+        Assertions.assertEquals(getExpectedResult(), testLog);
+
+        testInstance.f1.close();
+        Assertions.assertArrayEquals(buffer, FileUtils.readAllBytes(temp));
+
+        // Test commit
+        Assertions.assertFalse(target.toFile().exists());
+        committer.commit();
+        Assertions.assertTrue(target.toFile().exists());
+        Assertions.assertArrayEquals(buffer, FileUtils.readAllBytes(target));
+    }
+
+    public abstract Tuple2<RecoverableFsDataOutputStream, Closeable> createTestInstance(
+            Path target, Path temp, List<LocalRecoverableFsDataOutputStreamTest.Event> testLog)
+            throws IOException;
+
+    public List<Event> getExpectedResult() {
+        return Arrays.asList(
+                LocalRecoverableFsDataOutputStreamTest.Event.FLUSH,
+                LocalRecoverableFsDataOutputStreamTest.Event.SYNC,
+                LocalRecoverableFsDataOutputStreamTest.Event.CLOSE);
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStreamTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/local/LocalRecoverableFsDataOutputStreamTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs.local;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+/** Unit tests for {@link LocalRecoverableFsDataOutputStream}. */
+public class LocalRecoverableFsDataOutputStreamTest
+        extends AbstractRecoverableFsDataOutputStreamTest {
+
+    @Override
+    public Tuple2<RecoverableFsDataOutputStream, Closeable> createTestInstance(
+            Path target, Path temp, List<Event> testLog) throws IOException {
+        final FileChannel fileChannel =
+                new TestFileChannel(
+                        FileChannel.open(
+                                temp, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW),
+                        testLog);
+
+        final TestOutputStream fos =
+                new TestOutputStream(
+                        new BufferedOutputStream(Channels.newOutputStream(fileChannel)), testLog);
+
+        // Create test object
+        final RecoverableFsDataOutputStream testOutStreamInstance =
+                new LocalRecoverableFsDataOutputStream(
+                        target.toFile(), temp.toFile(), fileChannel, fos);
+
+        return new Tuple2<>(testOutStreamInstance, fos::actualClose);
+    }
+
+    private static class TestOutputStream extends FilterOutputStream {
+
+        private final List<Event> events;
+
+        public TestOutputStream(OutputStream out, List<Event> events) {
+            super(out);
+            this.events = events;
+        }
+
+        @Override
+        public void flush() throws IOException {
+            super.flush();
+            events.add(Event.FLUSH);
+        }
+
+        @Override
+        public void close() {
+            events.add(Event.CLOSE);
+            // Do nothing on close.
+        }
+
+        public void actualClose() throws IOException {
+            super.close();
+        }
+    }
+
+    static class TestFileChannel extends FileChannel {
+
+        final FileChannel delegate;
+
+        private final List<Event> events;
+
+        TestFileChannel(FileChannel delegate, List<Event> events) {
+            this.delegate = delegate;
+            this.events = events;
+        }
+
+        @Override
+        public int read(ByteBuffer dst) throws IOException {
+            return delegate.read(dst);
+        }
+
+        @Override
+        public long read(ByteBuffer[] dsts, int offset, int length) throws IOException {
+            return delegate.read(dsts, offset, length);
+        }
+
+        @Override
+        public int write(ByteBuffer src) throws IOException {
+            return delegate.write(src);
+        }
+
+        @Override
+        public long write(ByteBuffer[] srcs, int offset, int length) throws IOException {
+            return delegate.write(srcs, offset, length);
+        }
+
+        @Override
+        public long position() throws IOException {
+            return delegate.position();
+        }
+
+        @Override
+        public FileChannel position(long newPosition) throws IOException {
+            return delegate.position(newPosition);
+        }
+
+        @Override
+        public long size() throws IOException {
+            return delegate.size();
+        }
+
+        @Override
+        public FileChannel truncate(long size) throws IOException {
+            return delegate.truncate(size);
+        }
+
+        @Override
+        public void force(boolean metaData) throws IOException {
+            delegate.force(metaData);
+            events.add(Event.SYNC);
+        }
+
+        @Override
+        public long transferTo(long position, long count, WritableByteChannel target)
+                throws IOException {
+            return delegate.transferTo(position, count, target);
+        }
+
+        @Override
+        public long transferFrom(ReadableByteChannel src, long position, long count)
+                throws IOException {
+            return delegate.transferFrom(src, position, count);
+        }
+
+        @Override
+        public int read(ByteBuffer dst, long position) throws IOException {
+            return delegate.read(dst, position);
+        }
+
+        @Override
+        public int write(ByteBuffer src, long position) throws IOException {
+            return delegate.write(src, position);
+        }
+
+        @Override
+        public MappedByteBuffer map(MapMode mode, long position, long size) throws IOException {
+            return delegate.map(mode, position, size);
+        }
+
+        @Override
+        public FileLock lock(long position, long size, boolean shared) throws IOException {
+            return delegate.lock(position, size, shared);
+        }
+
+        @Override
+        public FileLock tryLock(long position, long size, boolean shared) throws IOException {
+            return delegate.tryLock(position, size, shared);
+        }
+
+        @Override
+        protected void implCloseChannel() {}
+    }
+}

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStream.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStream.java
@@ -63,6 +63,16 @@ public class AzureBlobFsRecoverableDataOutputStream
         this.out = fs.create(tempFile);
     }
 
+    /** Use only for testing! */
+    @VisibleForTesting
+    AzureBlobFsRecoverableDataOutputStream(
+            FileSystem fs, Path targetFile, Path tempFile, FSDataOutputStream out) {
+        this.fs = checkNotNull(fs);
+        this.targetFile = checkNotNull(targetFile);
+        this.tempFile = checkNotNull(tempFile);
+        this.out = out;
+    }
+
     AzureBlobFsRecoverableDataOutputStream(FileSystem fs, HadoopFsRecoverable recoverable)
             throws IOException {
         this.fs = checkNotNull(fs);
@@ -215,10 +225,8 @@ public class AzureBlobFsRecoverableDataOutputStream
     }
 
     @Override
-    public Committer closeForCommit() throws IOException {
-        ABFSCommitter abfsCommitter = new ABFSCommitter(fs, persist());
-        close();
-        return abfsCommitter;
+    protected Committer createCommitterFromResumeRecoverable(HadoopFsRecoverable recoverable) {
+        return new ABFSCommitter(fs, recoverable);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStream.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStream.java
@@ -216,10 +216,9 @@ public class AzureBlobFsRecoverableDataOutputStream
 
     @Override
     public Committer closeForCommit() throws IOException {
-        final long pos = getPos();
+        ABFSCommitter abfsCommitter = new ABFSCommitter(fs, persist());
         close();
-        return new AzureBlobFsRecoverableDataOutputStream.ABFSCommitter(
-                fs, createHadoopFsRecoverable(pos));
+        return abfsCommitter;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStreamTest.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStreamTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.local.AbstractRecoverableFsDataOutputStreamTest;
+import org.apache.flink.core.fs.local.LocalRecoverableFsDataOutputStreamTest;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+/** Unit tests for {@link AzureBlobFsRecoverableDataOutputStream}. */
+public class AzureBlobFsRecoverableDataOutputStreamTest
+        extends AbstractRecoverableFsDataOutputStreamTest {
+
+    @Override
+    public Tuple2<RecoverableFsDataOutputStream, Closeable> createTestInstance(
+            Path target, Path temp, List<Event> testLog) throws IOException {
+        final TestFSDataOutputStream fos =
+                new TestFSDataOutputStream(
+                        new BufferedOutputStream(Files.newOutputStream(temp)), testLog);
+
+        final AzureBlobFsRecoverableDataOutputStream testOutStreamInstance =
+                new AzureBlobFsRecoverableDataOutputStream(
+                        FileSystem.getLocal(new Configuration()),
+                        new org.apache.hadoop.fs.Path(target.toUri()),
+                        new org.apache.hadoop.fs.Path(temp.toUri()),
+                        fos);
+
+        return new Tuple2<>(testOutStreamInstance, fos::actualClose);
+    }
+
+    private static class TestFSDataOutputStream extends FSDataOutputStream {
+
+        private final List<Event> events;
+
+        public TestFSDataOutputStream(OutputStream out, List<Event> events) throws IOException {
+            super(out, new FileSystem.Statistics("test_stats"));
+            this.events = events;
+        }
+
+        @Override
+        public void hflush() throws IOException {
+            super.hflush();
+            events.add(Event.FLUSH);
+        }
+
+        @Override
+        public void hsync() throws IOException {
+            super.hsync();
+            events.add(Event.SYNC);
+        }
+
+        @Override
+        public void close() {
+            events.add(Event.CLOSE);
+            // Do nothing on close.
+        }
+
+        public void actualClose() throws IOException {
+            super.close();
+        }
+    }
+
+    @Override
+    public List<Event> getExpectedResult() {
+        // Seems that Azure does not require flush before sync, see
+        // https://github.com/apache/flink/pull/21508#discussion_r1064351162
+        return Arrays.asList(
+                LocalRecoverableFsDataOutputStreamTest.Event.SYNC,
+                LocalRecoverableFsDataOutputStreamTest.Event.CLOSE);
+    }
+}

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.fs.hdfs;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.CommitterFromPersistRecoverableFsDataOutputStream;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -30,7 +30,7 @@ import java.io.IOException;
 /** Base class for ABFS and Hadoop recoverable stream. */
 @Internal
 public abstract class BaseHadoopFsRecoverableFsDataOutputStream
-        extends RecoverableFsDataOutputStream {
+        extends CommitterFromPersistRecoverableFsDataOutputStream<HadoopFsRecoverable> {
 
     protected FileSystem fs;
 
@@ -77,9 +77,6 @@ public abstract class BaseHadoopFsRecoverableFsDataOutputStream
     public HadoopFsRecoverable createHadoopFsRecoverable(long pos) {
         return new HadoopFsRecoverable(targetFile, tempFile, pos + initialFileSize);
     }
-
-    @Override
-    public abstract Committer closeForCommit() throws IOException;
 
     @Override
     public void close() throws IOException {

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.fs.hdfs;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
-import org.apache.flink.core.fs.RecoverableWriter;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -70,12 +69,12 @@ public abstract class BaseHadoopFsRecoverableFsDataOutputStream
     }
 
     @Override
-    public RecoverableWriter.ResumeRecoverable persist() throws IOException {
+    public HadoopFsRecoverable persist() throws IOException {
         sync();
         return createHadoopFsRecoverable(getPos());
     }
 
-    public HadoopFsRecoverable createHadoopFsRecoverable(long pos) throws IOException {
+    public HadoopFsRecoverable createHadoopFsRecoverable(long pos) {
         return new HadoopFsRecoverable(targetFile, tempFile, pos + initialFileSize);
     }
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.fs.hdfs;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter.CommitRecoverable;
@@ -28,6 +29,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -66,6 +68,15 @@ class HadoopRecoverableFsDataOutputStream extends BaseHadoopFsRecoverableFsDataO
         this.out = fs.create(tempFile);
     }
 
+    @VisibleForTesting
+    HadoopRecoverableFsDataOutputStream(
+            FileSystem fs, Path targetFile, Path tempFile, FSDataOutputStream out) {
+        this.fs = checkNotNull(fs);
+        this.targetFile = checkNotNull(targetFile);
+        this.tempFile = checkNotNull(tempFile);
+        this.out = out;
+    }
+
     HadoopRecoverableFsDataOutputStream(FileSystem fs, HadoopFsRecoverable recoverable)
             throws IOException {
 
@@ -95,10 +106,8 @@ class HadoopRecoverableFsDataOutputStream extends BaseHadoopFsRecoverableFsDataO
     }
 
     @Override
-    public Committer closeForCommit() throws IOException {
-        HadoopFsCommitter hadoopFsCommitter = new HadoopFsCommitter(fs, persist());
-        close();
-        return hadoopFsCommitter;
+    protected Committer createCommitterFromResumeRecoverable(HadoopFsRecoverable recoverable) {
+        return new HadoopFsCommitter(fs, recoverable);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -96,9 +96,9 @@ class HadoopRecoverableFsDataOutputStream extends BaseHadoopFsRecoverableFsDataO
 
     @Override
     public Committer closeForCommit() throws IOException {
-        final long pos = getPos();
+        HadoopFsCommitter hadoopFsCommitter = new HadoopFsCommitter(fs, persist());
         close();
-        return new HadoopFsCommitter(fs, createHadoopFsRecoverable(pos));
+        return hadoopFsCommitter;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStreamTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.local.AbstractRecoverableFsDataOutputStreamTest;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/** Unit tests for {@link HadoopRecoverableFsDataOutputStream}. */
+public class HadoopRecoverableFsDataOutputStreamTest
+        extends AbstractRecoverableFsDataOutputStreamTest {
+
+    @Override
+    public Tuple2<RecoverableFsDataOutputStream, Closeable> createTestInstance(
+            Path target, Path temp, List<Event> testLog) throws IOException {
+        final TestFSDataOutputStream fos =
+                new TestFSDataOutputStream(
+                        new BufferedOutputStream(Files.newOutputStream(temp)), testLog);
+
+        final HadoopRecoverableFsDataOutputStream testOutStreamInstance =
+                new HadoopRecoverableFsDataOutputStream(
+                        FileSystem.getLocal(new Configuration()),
+                        new org.apache.hadoop.fs.Path(target.toUri()),
+                        new org.apache.hadoop.fs.Path(temp.toUri()),
+                        fos);
+
+        return new Tuple2<>(testOutStreamInstance, fos::actualClose);
+    }
+
+    private static class TestFSDataOutputStream extends FSDataOutputStream {
+
+        private final List<Event> events;
+
+        public TestFSDataOutputStream(OutputStream out, List<Event> events) throws IOException {
+            super(out, new FileSystem.Statistics("test_stats"));
+            this.events = events;
+        }
+
+        @Override
+        public void hflush() throws IOException {
+            super.hflush();
+            events.add(Event.FLUSH);
+        }
+
+        @Override
+        public void hsync() throws IOException {
+            super.hsync();
+            events.add(Event.SYNC);
+        }
+
+        @Override
+        public void close() {
+            events.add(Event.CLOSE);
+            // Do nothing on close.
+        }
+
+        public void actualClose() throws IOException {
+            super.close();
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Sync'ing back written data to disk is seemingly missing from some implementation of RecoverableFsDataOutputStream. This PR adds sync, typically by calling #persist() inside #closeForCommit.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
