### PR TITLE
[FLINK-34902][table] Fix IndexOutOfBoundsException for VALUES

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/PreValidateReWriter.scala
@@ -241,8 +241,12 @@ object PreValidateReWriter {
         }
         rewriteSelect(validator, sqlSelect, targetRowType, assignedFields, targetPosition)
       case SqlKind.VALUES =>
-        if (targetPosition.nonEmpty && call.operandCount() != targetPosition.size()) {
-          throw newValidationError(call, RESOURCE.columnCountMismatch())
+        call.getOperandList.toSeq.foreach {
+          case sqlCall: SqlCall => {
+            if (targetPosition.nonEmpty && sqlCall.getOperandList.size() != targetPosition.size()) {
+              throw newValidationError(call, RESOURCE.columnCountMismatch())
+            }
+          }
         }
         rewriteValues(call, targetRowType, assignedFields, targetPosition)
       case kind if SqlKind.SET_QUERY.contains(kind) =>

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.planner.utils.PlannerMocks;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /** Test for {@link FlinkCalciteSqlValidator}. */
 class FlinkCalciteSqlValidatorTest {
@@ -61,6 +62,55 @@ class FlinkCalciteSqlValidatorTest {
         assertThatThrownBy(() -> plannerMocks.getParser().parse("INSERT INTO t2 (a,b) SELECT 1"))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining(" Number of columns must match number of query columns");
+    }
+
+    @Test
+    void testInsertInto3() {
+        assertThatThrownBy(
+                        () ->
+                                plannerMocks
+                                        .getParser()
+                                        .parse("INSERT INTO t2 (a,b) VALUES (1,2), (3)"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(" Number of columns must match number of query columns");
+    }
+
+    @Test
+    void testInsertInto4() {
+        assertThatThrownBy(
+                        () ->
+                                plannerMocks
+                                        .getParser()
+                                        .parse("INSERT INTO t2 (a,b) VALUES (1), (2,3)"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(" Number of columns must match number of query columns");
+    }
+
+    @Test
+    void testInsertInto5() {
+        assertThatThrownBy(
+                        () ->
+                                plannerMocks
+                                        .getParser()
+                                        .parse("INSERT INTO t2 (a,b) VALUES (1,2), (3,4,5)"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(" Number of columns must match number of query columns");
+    }
+
+    @Test
+    void testInsertInto6() {
+        assertDoesNotThrow(
+                () -> {
+                    plannerMocks.getParser().parse("INSERT INTO t2 (a,b) VALUES (1,2), (3,4)");
+                });
+    }
+
+    @Test
+    void testInsertInto7() {
+        assertDoesNotThrow(
+                () -> {
+                    plannerMocks.getParser().parse("INSERT INTO t2 (a,b) Select 1, 2");
+                });
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidatorTest.java
@@ -51,21 +51,21 @@ class FlinkCalciteSqlValidatorTest {
     }
 
     @Test
-    void testInsertInto1() {
+    void testInsertIntoShouldColumnMismatchWithValues() {
         assertThatThrownBy(() -> plannerMocks.getParser().parse("INSERT INTO t2 (a,b) VALUES(1)"))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining(" Number of columns must match number of query columns");
     }
 
     @Test
-    void testInsertInto2() {
+    void testInsertIntoShouldColumnMismatchWithSelect() {
         assertThatThrownBy(() -> plannerMocks.getParser().parse("INSERT INTO t2 (a,b) SELECT 1"))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining(" Number of columns must match number of query columns");
     }
 
     @Test
-    void testInsertInto3() {
+    void testInsertIntoShouldColumnMismatchWithLastValue() {
         assertThatThrownBy(
                         () ->
                                 plannerMocks
@@ -76,7 +76,7 @@ class FlinkCalciteSqlValidatorTest {
     }
 
     @Test
-    void testInsertInto4() {
+    void testInsertIntoShouldColumnMismatchWithFirstValue() {
         assertThatThrownBy(
                         () ->
                                 plannerMocks
@@ -87,7 +87,7 @@ class FlinkCalciteSqlValidatorTest {
     }
 
     @Test
-    void testInsertInto5() {
+    void testInsertIntoShouldColumnMismatchWithMultiFieldValues() {
         assertThatThrownBy(
                         () ->
                                 plannerMocks
@@ -98,7 +98,7 @@ class FlinkCalciteSqlValidatorTest {
     }
 
     @Test
-    void testInsertInto6() {
+    void testInsertIntoShouldNotColumnMismatchWithValues() {
         assertDoesNotThrow(
                 () -> {
                     plannerMocks.getParser().parse("INSERT INTO t2 (a,b) VALUES (1,2), (3,4)");
@@ -106,10 +106,18 @@ class FlinkCalciteSqlValidatorTest {
     }
 
     @Test
-    void testInsertInto7() {
+    void testInsertIntoShouldNotColumnMismatchWithSelect() {
         assertDoesNotThrow(
                 () -> {
                     plannerMocks.getParser().parse("INSERT INTO t2 (a,b) Select 1, 2");
+                });
+    }
+
+    @Test
+    void testInsertIntoShouldNotColumnMismatchWithSingleColValues() {
+        assertDoesNotThrow(
+                () -> {
+                    plannerMocks.getParser().parse("INSERT INTO t2 (a) VALUES (1), (3)");
                 });
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this PR is to avoid wrong `IndexOutOfBoundsException` with Values.

For example, a query `INSERT INTO t_3_columns (id, name, num) VALUES ('id_0', 'name_0', 5);` should not throw an exception.


## Brief change log

  -  Fix the exception catching conditions with VALUES expression
  -  Add tests


## Verifying this change

`org.apache.flink.table.planner.calcite. FlinkCalciteSqlValidatorTest`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
