### PR TITLE
[FLINK-33210] Cleanup the lineage interface comments

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetConfigFacet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetConfigFacet.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaFacet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaFacet.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaField.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DatasetSchemaField.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageDataset.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageDataset.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageDatasetFacet.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageDatasetFacet.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageEdge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageEdge.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageGraph.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageVertex.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageVertex.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageVertexProvider.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/LineageVertexProvider.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/SourceLineageVertex.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/SourceLineageVertex.java
@@ -14,7 +14,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package org.apache.flink.streaming.api.lineage;


### PR DESCRIPTION
## What is the purpose of the change
Format the class comments of lineage interface classes


## Brief change log
  - Remove the unneeded empty line of class comments 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
