### PR TITLE
[FLINK-29797][flink-yarn] Fix fs.default-scheme will accidentally cau…

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1102,7 +1102,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
             fileUploader.registerSingleLocalResource(
                     flinkConfigFileName,
-                    new Path(tmpConfigurationFile.getAbsolutePath()),
+                    new Path(tmpConfigurationFile.toURI()),
                     "",
                     LocalResourceType.FILE,
                     true,


### PR DESCRIPTION
…se temporary flinkConfigFile treated as remote file. also fix [FLINK-33424]


## What is the purpose of the change
If user set fs.default-scheme to hdfs://namenode or s3://any, it will cause /tmp/flink-confxxxx FileNotFoundException.

Fix [FLINK-29797](https://issues.apache.org/jira/browse/FLINK-29797)

also fix [FLINK-33424](https://issues.apache.org/jira/browse/FLINK-33424)

## Brief change log

It is obvious that FileSystem will create a DistributedFileSystem while fs.default-scheme **NOT** set to file://.

It is obvious that temporary flink-conf.yaml or config.yaml file are created as LocalResource during submission to yarn.

### Before change
There is no big diffierence between  "job.graph" and flink conf file for registerSingleLocalResource except that 
`tmpJobGraphFile.toURI()` and `tmpConfigurationFile.getAbsolutePath()`

### After change
`tmpConfigurationFile.toURI()` will return correct path with `file://` scheme, so `registerSingleLocalResource` will not treate it as remote files.

### 

Please be aware of that `registerSingleLocalResource` in file [flink/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java at master · apache/flink (github.com)](https://github.com/apache/flink/blob/master/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java#L1106) has two similar code:

uploading **tmpConfigurationFile** and **tmpJobGraphFile** using different way to get path.

```
//Line: 1104
fileUploader.registerSingleLocalResource(
                    flinkConfigFileName,
                    new Path(tmpConfigurationFile.getAbsolutePath()),  //originally tmpConfigurationFile.toUri()
                    "",
                    LocalResourceType.FILE,
                    true,
                    true); 
```

[[FLINK-18362][yarn] Fix mistakenly merged commit 0e10fd5b8ee0 · apache/flink@a0227e2 (github.com)](https://github.com/apache/flink/commit/a0227e20430ee9eaff59464023de2385378f71ea#diff-02416e2d6ca99e1456f9c3949f3d7c2ac523d3fe25378620c09632e4aac34e4eL889)

https://github.com/apache/flink/commit/a0227e20430ee9eaff59464023de2385378f71ea

```
//Line: 1071              
fileUploader.registerSingleLocalResource(
                        jobGraphFilename,
                        new Path(tmpJobGraphFile.toURI()),
                        "",
                        LocalResourceType.FILE,
                        true,
                        false);
```

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yarn)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
