### PR TITLE
[FLINK-35161][state] Implement StateExecutor for ForStStateBackend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequest.java
@@ -51,7 +51,7 @@ public class StateRequest<K, IN, OUT> implements Serializable {
     /** The record context of this request. */
     private final RecordContext<K> context;
 
-    StateRequest(
+    public StateRequest(
             @Nullable State state,
             StateRequestType type,
             @Nullable IN payload,
@@ -64,17 +64,17 @@ public class StateRequest<K, IN, OUT> implements Serializable {
         this.context = context;
     }
 
-    StateRequestType getRequestType() {
+    public StateRequestType getRequestType() {
         return type;
     }
 
     @Nullable
-    IN getPayload() {
+    public IN getPayload() {
         return payload;
     }
 
     @Nullable
-    State getState() {
+    public State getState() {
         return state;
     }
 
@@ -82,7 +82,7 @@ public class StateRequest<K, IN, OUT> implements Serializable {
         return stateFuture;
     }
 
-    RecordContext<K> getRecordContext() {
+    public RecordContext<K> getRecordContext() {
         return context;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestContainer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestContainer.java
@@ -18,28 +18,19 @@
 
 package org.apache.flink.runtime.asyncprocessing;
 
-import org.apache.flink.annotation.Internal;
+/**
+ * A container which is used to hold {@link StateRequest}s. The role of {@code
+ * StateRequestContainer} is to serve as an intermediary carrier for data transmission between the
+ * runtime layer and the state layer. It stores the stateRequest from the runtime layer, which is
+ * then processed by the state layer.
+ *
+ * <p>Notice that the {@code StateRequestContainer} may not be thread-safe.
+ */
+public interface StateRequestContainer {
 
-import java.util.concurrent.CompletableFuture;
+    /** Preserve a stateRequest into the {@code StateRequestContainer}. */
+    void offer(StateRequest<?, ?, ?> stateRequest);
 
-/** Executor for executing batch {@link StateRequest}s. */
-@Internal
-public interface StateExecutor {
-    /**
-     * Execute a batch of state requests.
-     *
-     * @param stateRequestContainer The StateRequestContainer which holds the given batch of
-     *     processing requests.
-     * @return A future can determine whether execution has completed.
-     */
-    CompletableFuture<Void> executeBatchRequests(StateRequestContainer stateRequestContainer);
-
-    /**
-     * Create a {@link StateRequestContainer} which is used to hold the batched {@link
-     * StateRequest}.
-     */
-    StateRequestContainer createStateRequestContainer();
-
-    /** Shutdown the StateExecutor, and new committed state execution requests will be rejected. */
-    void shutdown();
+    /** Returns whether the container is empty. */
+    boolean isEmpty();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -552,10 +552,12 @@ class AsyncExecutionControllerTest {
 
         @Override
         @SuppressWarnings({"unchecked", "rawtypes"})
-        public CompletableFuture<Boolean> executeBatchRequests(
-                Iterable<StateRequest<?, ?, ?>> processingRequests) {
-            CompletableFuture<Boolean> future = new CompletableFuture<>();
-            for (StateRequest request : processingRequests) {
+        public CompletableFuture<Void> executeBatchRequests(
+                StateRequestContainer stateRequestContainer) {
+            Preconditions.checkArgument(stateRequestContainer instanceof MockStateRequestContainer);
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            for (StateRequest request :
+                    ((MockStateRequestContainer) stateRequestContainer).getStateRequestList()) {
                 if (request.getRequestType() == StateRequestType.VALUE_GET) {
                     Preconditions.checkState(request.getState() != null);
                     TestValueState state = (TestValueState) request.getState();
@@ -574,8 +576,16 @@ class AsyncExecutionControllerTest {
                     throw new UnsupportedOperationException("Unsupported request type");
                 }
             }
-            future.complete(true);
+            future.complete(null);
             return future;
         }
+
+        @Override
+        public StateRequestContainer createStateRequestContainer() {
+            return new MockStateRequestContainer();
+        }
+
+        @Override
+        public void shutdown() {}
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/MockStateRequestContainer.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/MockStateRequestContainer.java
@@ -18,28 +18,25 @@
 
 package org.apache.flink.runtime.asyncprocessing;
 
-import org.apache.flink.annotation.Internal;
+import java.util.ArrayList;
+import java.util.List;
 
-import java.util.concurrent.CompletableFuture;
+/** The mocked {@link StateRequestContainer} for testing. */
+public class MockStateRequestContainer implements StateRequestContainer {
 
-/** Executor for executing batch {@link StateRequest}s. */
-@Internal
-public interface StateExecutor {
-    /**
-     * Execute a batch of state requests.
-     *
-     * @param stateRequestContainer The StateRequestContainer which holds the given batch of
-     *     processing requests.
-     * @return A future can determine whether execution has completed.
-     */
-    CompletableFuture<Void> executeBatchRequests(StateRequestContainer stateRequestContainer);
+    private final List<StateRequest<?, ?, ?>> stateRequestList = new ArrayList<>();
 
-    /**
-     * Create a {@link StateRequestContainer} which is used to hold the batched {@link
-     * StateRequest}.
-     */
-    StateRequestContainer createStateRequestContainer();
+    @Override
+    public void offer(StateRequest<?, ?, ?> stateRequest) {
+        stateRequestList.add(stateRequest);
+    }
 
-    /** Shutdown the StateExecutor, and new committed state execution requests will be rejected. */
-    void shutdown();
+    @Override
+    public boolean isEmpty() {
+        return stateRequestList.isEmpty();
+    }
+
+    public List<StateRequest<?, ?, ?>> getStateRequestList() {
+        return stateRequestList;
+    }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBGetRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBGetRequest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.core.state.InternalStateFuture;
+
+import org.rocksdb.ColumnFamilyHandle;
+
+import java.io.IOException;
+
+/**
+ * The Get access request for ForStDB.
+ *
+ * @param <K> The type of key in get access request.
+ * @param <V> The type of value returned by get request.
+ */
+public class ForStDBGetRequest<K, V> {
+
+    private final K key;
+    private final ForStInnerTable<K, V> table;
+    private final InternalStateFuture<V> future;
+
+    private ForStDBGetRequest(K key, ForStInnerTable<K, V> table, InternalStateFuture<V> future) {
+        this.key = key;
+        this.table = table;
+        this.future = future;
+    }
+
+    public byte[] buildSerializedKey() throws IOException {
+        return table.serializeKey(key);
+    }
+
+    public ColumnFamilyHandle getColumnFamilyHandle() {
+        return table.getColumnFamilyHandle();
+    }
+
+    public void completeStateFuture(byte[] bytesValue) throws IOException {
+        if (bytesValue == null) {
+            future.complete(null);
+            return;
+        }
+        V value = table.deserializeValue(bytesValue);
+        future.complete(value);
+    }
+
+    static <K, V> ForStDBGetRequest<K, V> of(
+            K key, ForStInnerTable<K, V> table, InternalStateFuture<V> future) {
+        return new ForStDBGetRequest<>(key, table, future);
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBOperation.java
@@ -26,16 +26,14 @@ import java.util.concurrent.CompletableFuture;
  * Data access operation to ForStDB. This interface is used to encapsulate the DB access operations
  * formed after grouping state access. For more information about “Grouping state access”, please
  * refer to FLIP-426.
- *
- * @param <OUT> The type of output for DB access.
  */
 @Internal
-public interface ForStDBOperation<OUT> {
+public interface ForStDBOperation {
 
     /**
      * Process the ForStDB access requests.
      *
-     * @return Processing result.
+     * @return The future which indicates whether the operation is completed.
      */
-    CompletableFuture<OUT> process();
+    CompletableFuture<Void> process();
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBPutRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBPutRequest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.core.state.InternalStateFuture;
+
+import org.rocksdb.ColumnFamilyHandle;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+/**
+ * The Put access request for ForStDB.
+ *
+ * @param <K> The type of key in put access request.
+ * @param <V> The type of value in put access request.
+ */
+public class ForStDBPutRequest<K, V> {
+
+    private final K key;
+    @Nullable private final V value;
+    private final ForStInnerTable<K, V> table;
+    private final InternalStateFuture<Void> future;
+
+    private ForStDBPutRequest(
+            K key, V value, ForStInnerTable<K, V> table, InternalStateFuture<Void> future) {
+        this.key = key;
+        this.value = value;
+        this.table = table;
+        this.future = future;
+    }
+
+    public boolean valueIsNull() {
+        return value == null;
+    }
+
+    public ColumnFamilyHandle getColumnFamilyHandle() {
+        return table.getColumnFamilyHandle();
+    }
+
+    public byte[] buildSerializedKey() throws IOException {
+        return table.serializeKey(key);
+    }
+
+    public byte[] buildSerializedValue() throws IOException {
+        assert value != null;
+        return table.serializeValue(value);
+    }
+
+    public void completeStateFuture() {
+        future.complete(null);
+    }
+
+    /**
+     * If the value of the ForStDBPutRequest is null, then the request will signify the deletion of
+     * the data associated with that key.
+     */
+    static <K, V> ForStDBPutRequest<K, V> of(
+            K key,
+            @Nullable V value,
+            ForStInnerTable<K, V> table,
+            InternalStateFuture<Void> future) {
+        return new ForStDBPutRequest<>(key, value, table, future);
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStInnerTable.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStInnerTable.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.state.forst;
 
+import org.apache.flink.runtime.asyncprocessing.StateRequest;
+
 import org.rocksdb.ColumnFamilyHandle;
 
 import java.io.IOException;
@@ -63,4 +65,22 @@ public interface ForStInnerTable<K, V> {
      * @throws IOException Thrown if the deserialization encountered an I/O related error.
      */
     V deserializeValue(byte[] value) throws IOException;
+
+    /**
+     * Build a {@link ForStDBGetRequest} that belong to this {@code ForStInnerTable} with the given
+     * stateRequest.
+     *
+     * @param stateRequest The given stateRequest.
+     * @return The corresponding ForSt GetRequest.
+     */
+    ForStDBGetRequest<K, V> buildDBGetRequest(StateRequest<?, ?, ?> stateRequest);
+
+    /**
+     * Build a {@link ForStDBPutRequest} that belong to {@code ForStInnerTable} with the given
+     * stateRequest.
+     *
+     * @param stateRequest The given stateRequest.
+     * @return The corresponding ForSt PutRequest.
+     */
+    ForStDBPutRequest<K, V> buildDBPutRequest(StateRequest<?, ?, ?> stateRequest);
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateExecutor.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateExecutor.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.runtime.asyncprocessing.StateExecutor;
+import org.apache.flink.runtime.asyncprocessing.StateRequest;
+import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.apache.flink.util.concurrent.FutureUtils;
+
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * The {@link StateExecutor} implementation which executing batch {@link StateRequest}s for
+ * ForStStateBackend.
+ */
+public class ForStStateExecutor implements StateExecutor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForStStateExecutor.class);
+
+    /**
+     * The coordinator thread which schedules the execution of multiple batches of stateRequests.
+     * The number of coordinator threads is 1 to ensure that multiple batches of stateRequests can
+     * be executed sequentially.
+     */
+    private final ExecutorService coordinatorThread;
+
+    /** The worker thread that actually executes the {@link StateRequest}s. */
+    private final ExecutorService workerThreads;
+
+    private final RocksDB db;
+
+    private final WriteOptions writeOptions;
+
+    public ForStStateExecutor(int ioParallelism, RocksDB db, WriteOptions writeOptions) {
+        this.coordinatorThread =
+                Executors.newSingleThreadScheduledExecutor(
+                        new ExecutorThreadFactory("ForSt-StateExecutor-Coordinator"));
+        this.workerThreads =
+                Executors.newFixedThreadPool(
+                        ioParallelism, new ExecutorThreadFactory("ForSt-StateExecutor-IO"));
+        this.db = db;
+        this.writeOptions = writeOptions;
+    }
+
+    @Override
+    public CompletableFuture<Void> executeBatchRequests(
+            StateRequestContainer stateRequestContainer) {
+        Preconditions.checkArgument(stateRequestContainer instanceof ForStStateRequestClassifier);
+        ForStStateRequestClassifier stateRequestClassifier =
+                (ForStStateRequestClassifier) stateRequestContainer;
+        return CompletableFuture.supplyAsync(
+                () -> {
+                    long startTime = System.currentTimeMillis();
+                    List<CompletableFuture<Void>> futures = new ArrayList<>(2);
+                    List<ForStDBPutRequest<?, ?>> putRequests =
+                            stateRequestClassifier.pollDbPutRequests();
+                    if (!putRequests.isEmpty()) {
+                        ForStWriteBatchOperation writeOperations =
+                                new ForStWriteBatchOperation(
+                                        db, putRequests, writeOptions, workerThreads);
+                        futures.add(writeOperations.process());
+                    }
+
+                    List<ForStDBGetRequest<?, ?>> getRequests =
+                            stateRequestClassifier.pollDbGetRequests();
+                    if (!getRequests.isEmpty()) {
+                        ForStGeneralMultiGetOperation getOperations =
+                                new ForStGeneralMultiGetOperation(db, getRequests, workerThreads);
+                        futures.add(getOperations.process());
+                    }
+
+                    try {
+                        FutureUtils.waitForAll(futures).get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        throw new FlinkRuntimeException(
+                                "Exception when executing ForSt writeBatch or multiGet operation",
+                                e);
+                    }
+                    long duration = System.currentTimeMillis() - startTime;
+                    LOG.debug(
+                            "Complete executing a batch of state requests, putRequest size {}, getRequest size {}, duration {} ms",
+                            putRequests.size(),
+                            getRequests.size(),
+                            duration);
+                    return null;
+                },
+                coordinatorThread);
+    }
+
+    @Override
+    public StateRequestContainer createStateRequestContainer() {
+        return new ForStStateRequestClassifier();
+    }
+
+    @Override
+    public void shutdown() {
+        workerThreads.shutdown();
+        coordinatorThread.shutdown();
+        LOG.info("Shutting down the ForStStateExecutor.");
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateRequestClassifier.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateRequestClassifier.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.runtime.asyncprocessing.StateRequest;
+import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
+import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The ForSt {@link StateRequestContainer} which can classify the state requests by ForStDB
+ * requestType (Get、Put or Iterator).
+ */
+public class ForStStateRequestClassifier implements StateRequestContainer {
+
+    private final List<ForStDBGetRequest<?, ?>> dbGetRequests;
+
+    private final List<ForStDBPutRequest<?, ?>> dbPutRequests;
+
+    public ForStStateRequestClassifier() {
+        this.dbGetRequests = new ArrayList<>();
+        this.dbPutRequests = new ArrayList<>();
+    }
+
+    @Override
+    public void offer(StateRequest<?, ?, ?> stateRequest) {
+        convertStateRequestsToForStDBRequests(stateRequest);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return dbGetRequests.isEmpty() && dbPutRequests.isEmpty();
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private void convertStateRequestsToForStDBRequests(StateRequest<?, ?, ?> stateRequest) {
+        StateRequestType stateRequestType = stateRequest.getRequestType();
+        switch (stateRequestType) {
+            case VALUE_GET:
+                {
+                    ForStValueState<?, ?> forStValueState =
+                            (ForStValueState<?, ?>) stateRequest.getState();
+                    dbGetRequests.add(forStValueState.buildDBGetRequest(stateRequest));
+                    return;
+                }
+            case VALUE_UPDATE:
+                {
+                    ForStValueState<?, ?> forStValueState =
+                            (ForStValueState<?, ?>) stateRequest.getState();
+                    dbPutRequests.add(forStValueState.buildDBPutRequest(stateRequest));
+                    return;
+                }
+            case CLEAR:
+                {
+                    if (stateRequest.getState() instanceof ForStValueState) {
+                        ForStValueState<?, ?> forStValueState =
+                                (ForStValueState<?, ?>) stateRequest.getState();
+                        dbPutRequests.add(forStValueState.buildDBPutRequest(stateRequest));
+                        return;
+                    } else {
+                        throw new UnsupportedOperationException(
+                                "The State "
+                                        + stateRequest.getState().getClass()
+                                        + " doesn't yet support the clear method.");
+                    }
+                }
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported state request type:" + stateRequestType);
+        }
+    }
+
+    public List<ForStDBGetRequest<?, ?>> pollDbGetRequests() {
+        return dbGetRequests;
+    }
+
+    public List<ForStDBPutRequest<?, ?>> pollDbPutRequests() {
+        return dbPutRequests;
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStWriteBatchOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStWriteBatchOperation.java
@@ -22,26 +22,19 @@ import org.rocksdb.RocksDB;
 import org.rocksdb.WriteBatch;
 import org.rocksdb.WriteOptions;
 
-import javax.annotation.Nullable;
-
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 
-/**
- * The writeBatch operation implementation for ForStDB.
- *
- * @param <K> The type of key in put access request.
- * @param <V> The type of value in put access request.
- */
-public class ForStWriteBatchOperation<K, V> implements ForStDBOperation<Void> {
+/** The writeBatch operation implementation for ForStDB. */
+public class ForStWriteBatchOperation implements ForStDBOperation {
 
     private static final int PER_RECORD_ESTIMATE_BYTES = 100;
 
     private final RocksDB db;
 
-    private final List<PutRequest<K, V>> batchRequest;
+    private final List<ForStDBPutRequest<?, ?>> batchRequest;
 
     private final WriteOptions writeOptions;
 
@@ -49,7 +42,7 @@ public class ForStWriteBatchOperation<K, V> implements ForStDBOperation<Void> {
 
     ForStWriteBatchOperation(
             RocksDB db,
-            List<PutRequest<K, V>> batchRequest,
+            List<ForStDBPutRequest<?, ?>> batchRequest,
             WriteOptions writeOptions,
             Executor executor) {
         this.db = db;
@@ -64,46 +57,27 @@ public class ForStWriteBatchOperation<K, V> implements ForStDBOperation<Void> {
                 () -> {
                     try (WriteBatch writeBatch =
                             new WriteBatch(batchRequest.size() * PER_RECORD_ESTIMATE_BYTES)) {
-                        for (PutRequest<K, V> request : batchRequest) {
-                            ForStInnerTable<K, V> table = request.table;
-                            if (request.value == null) {
+                        for (ForStDBPutRequest<?, ?> request : batchRequest) {
+                            if (request.valueIsNull()) {
                                 // put(key, null) == delete(key)
                                 writeBatch.delete(
-                                        table.getColumnFamilyHandle(),
-                                        table.serializeKey(request.key));
+                                        request.getColumnFamilyHandle(),
+                                        request.buildSerializedKey());
                             } else {
                                 writeBatch.put(
-                                        table.getColumnFamilyHandle(),
-                                        table.serializeKey(request.key),
-                                        table.serializeValue(request.value));
+                                        request.getColumnFamilyHandle(),
+                                        request.buildSerializedKey(),
+                                        request.buildSerializedValue());
                             }
                         }
                         db.write(writeOptions, writeBatch);
+                        for (ForStDBPutRequest<?, ?> request : batchRequest) {
+                            request.completeStateFuture();
+                        }
                     } catch (Exception e) {
                         throw new CompletionException("Error while adding data to ForStDB", e);
                     }
                 },
                 executor);
-    }
-
-    /** The Put access request for ForStDB. */
-    static class PutRequest<K, V> {
-        final K key;
-        @Nullable final V value;
-        final ForStInnerTable<K, V> table;
-
-        private PutRequest(K key, V value, ForStInnerTable<K, V> table) {
-            this.key = key;
-            this.value = value;
-            this.table = table;
-        }
-
-        /**
-         * If the value of the PutRequest is null, then the request will signify the deletion of the
-         * data associated with that key.
-         */
-        static <K, V> PutRequest<K, V> of(K key, @Nullable V value, ForStInnerTable<K, V> table) {
-            return new PutRequest<>(key, value, table);
-        }
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.api.common.state.v2.State;
+import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.configuration.ConfigConstants;
@@ -42,6 +43,10 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.RocksDB;
 
 import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /** Base class for {@link ForStDBOperation} tests. */
@@ -103,5 +108,46 @@ public class ForStDBOperationTestBase {
                 serializedKeyBuilder,
                 valueSerializerView,
                 valueDeserializerView);
+    }
+
+    static class TestStateFuture<T> implements InternalStateFuture<T> {
+
+        public CompletableFuture<T> future = new CompletableFuture<>();
+
+        @Override
+        public <U> StateFuture<U> thenApply(Function<? super T, ? extends U> fn) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public StateFuture<Void> thenAccept(Consumer<? super T> action) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U> StateFuture<U> thenCompose(
+                Function<? super T, ? extends StateFuture<U>> action) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U, V> StateFuture<V> thenCombine(
+                StateFuture<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void complete(T result) {
+            future.complete(result);
+        }
+
+        public T getCompletedResult() throws Exception {
+            return future.get();
+        }
+
+        @Override
+        public void thenSyncAccept(Consumer<? super T> action) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.runtime.asyncprocessing.StateRequest;
+import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
+import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.state.v2.InternalKeyedState;
+
+import org.junit.jupiter.api.Test;
+import org.rocksdb.WriteOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit test for {@link ForStStateExecutor}. */
+public class ForStStateExecutorTest extends ForStDBOperationTestBase {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testExecuteValueStateRequest() throws Exception {
+        ForStStateExecutor forStStateExecutor = new ForStStateExecutor(4, db, new WriteOptions());
+        ForStValueState<Integer, String> state1 = buildForStValueState("value-state-1");
+        ForStValueState<Integer, String> state2 = buildForStValueState("value-state-2");
+
+        StateRequestContainer stateRequestContainer =
+                forStStateExecutor.createStateRequestContainer();
+        assertTrue(stateRequestContainer.isEmpty());
+
+        // 1. Update value state: keyRange [0, keyNum)
+        int keyNum = 1000;
+        for (int i = 0; i < keyNum; i++) {
+            ForStValueState<Integer, String> state = (i % 2 == 0 ? state1 : state2);
+            stateRequestContainer.offer(
+                    buildStateRequest(state, StateRequestType.VALUE_UPDATE, i, "test-" + i, i * 2));
+        }
+
+        forStStateExecutor.executeBatchRequests(stateRequestContainer);
+
+        List<StateRequest<?, ?, ?>> checkList = new ArrayList<>();
+        stateRequestContainer = forStStateExecutor.createStateRequestContainer();
+        // 2. Get value state: keyRange [0, keyNum)
+        //    Update value state: keyRange [keyNum, keyNum + 100]
+        for (int i = 0; i < keyNum; i++) {
+            ForStValueState<Integer, String> state = (i % 2 == 0 ? state1 : state2);
+            StateRequest<?, ?, ?> getRequest =
+                    buildStateRequest(state, StateRequestType.VALUE_GET, i, null, i * 2);
+            stateRequestContainer.offer(getRequest);
+            checkList.add(getRequest);
+        }
+        for (int i = keyNum; i < keyNum + 100; i++) {
+            ForStValueState<Integer, String> state = (i % 2 == 0 ? state1 : state2);
+            stateRequestContainer.offer(
+                    buildStateRequest(state, StateRequestType.VALUE_UPDATE, i, "test-" + i, i * 2));
+        }
+        forStStateExecutor.executeBatchRequests(stateRequestContainer).get();
+
+        // 3. Check value state Get result : [0, keyNum)
+        for (StateRequest<?, ?, ?> getRequest : checkList) {
+            assertThat(getRequest.getRequestType()).isEqualTo(StateRequestType.VALUE_GET);
+            int key = (Integer) getRequest.getRecordContext().getKey();
+            assertThat(getRequest.getRecordContext().getRecord()).isEqualTo(key * 2);
+            assertThat(((TestStateFuture<String>) getRequest.getFuture()).getCompletedResult())
+                    .isEqualTo("test-" + key);
+        }
+
+        // 4. Clear value state:  keyRange [keyNum - 100, keyNum)
+        //    Update state with null-value : keyRange [keyNum, keyNum + 100]
+        stateRequestContainer = forStStateExecutor.createStateRequestContainer();
+        for (int i = keyNum - 100; i < keyNum; i++) {
+            ForStValueState<Integer, String> state = (i % 2 == 0 ? state1 : state2);
+            stateRequestContainer.offer(
+                    buildStateRequest(state, StateRequestType.CLEAR, i, null, i * 2));
+        }
+        for (int i = keyNum; i < keyNum + 100; i++) {
+            ForStValueState<Integer, String> state = (i % 2 == 0 ? state1 : state2);
+            stateRequestContainer.offer(
+                    buildStateRequest(state, StateRequestType.VALUE_UPDATE, i, null, i * 2));
+        }
+        forStStateExecutor.executeBatchRequests(stateRequestContainer);
+
+        // 5. Check that the deleted value is null :  keyRange [keyNum - 100, keyNum + 100)
+        stateRequestContainer = forStStateExecutor.createStateRequestContainer();
+        checkList.clear();
+        for (int i = keyNum - 100; i < keyNum + 100; i++) {
+            ForStValueState<Integer, String> state = (i % 2 == 0 ? state1 : state2);
+            StateRequest<?, ?, ?> getRequest =
+                    buildStateRequest(state, StateRequestType.VALUE_GET, i, null, i * 2);
+            stateRequestContainer.offer(getRequest);
+            checkList.add(getRequest);
+        }
+        forStStateExecutor.executeBatchRequests(stateRequestContainer);
+        for (StateRequest<?, ?, ?> getRequest : checkList) {
+            assertThat(getRequest.getRequestType()).isEqualTo(StateRequestType.VALUE_GET);
+            assertThat(((TestStateFuture<String>) getRequest.getFuture()).getCompletedResult())
+                    .isEqualTo(null);
+        }
+        forStStateExecutor.shutdown();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private <K, V, R> StateRequest<?, ?, ?> buildStateRequest(
+            InternalKeyedState<K, V> innerTable,
+            StateRequestType requestType,
+            K key,
+            V value,
+            R record) {
+        int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(key, 128);
+        RecordContext<K> recordContext = new RecordContext<>(record, key, t -> {}, keyGroup);
+        TestStateFuture stateFuture = new TestStateFuture<>();
+        return new StateRequest<>(innerTable, requestType, value, stateFuture, recordContext);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
@@ -23,8 +23,6 @@ import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.RecordContext;
-import org.apache.flink.runtime.asyncprocessing.StateExecutor;
-import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
@@ -32,14 +30,13 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.MockStateExecutor;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -54,7 +51,7 @@ class InternalTimerServiceAsyncImplTest {
     void setup() throws Exception {
         asyncExecutionController =
                 new AsyncExecutionController(
-                        new SyncMailboxExecutor(), new TestStateExecutor(), 128, 2, 1000L, 10);
+                        new SyncMailboxExecutor(), new MockStateExecutor(), 128, 2, 1000L, 10);
         // ensure arbitrary key is in the key group
         int totalKeyGroups = 128;
         KeyGroupRange testKeyGroupList = new KeyGroupRange(0, totalKeyGroups - 1);
@@ -206,16 +203,6 @@ class InternalTimerServiceAsyncImplTest {
         @Override
         public Object getCurrentKey() {
             return key;
-        }
-    }
-
-    private static class TestStateExecutor implements StateExecutor {
-        public TestStateExecutor() {}
-
-        @Override
-        public CompletableFuture<Boolean> executeBatchRequests(
-                Iterable<StateRequest<?, ?, ?>> processingRequests) {
-            return CompletableFuture.completedFuture(true);
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorTest.java
@@ -23,8 +23,6 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
-import org.apache.flink.runtime.asyncprocessing.StateExecutor;
-import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
@@ -43,7 +41,6 @@ import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -153,17 +150,7 @@ public class AbstractAsyncStateStreamOperatorTest {
             AsyncExecutionController asyncExecutionController =
                     ((AbstractAsyncStateStreamOperator) testHarness.getOperator())
                             .getAsyncExecutionController();
-            asyncExecutionController.setStateExecutor(
-                    new StateExecutor() {
-                        @Override
-                        public CompletableFuture<Boolean> executeBatchRequests(
-                                Iterable<StateRequest<?, ?, ?>> processingRequests) {
-                            for (StateRequest request : processingRequests) {
-                                request.getFuture().complete(true);
-                            }
-                            return CompletableFuture.completedFuture(true);
-                        }
-                    });
+            asyncExecutionController.setStateExecutor(new MockStateExecutor());
             ((AbstractAsyncStateStreamOperator<String>) testHarness.getOperator())
                     .setAsyncKeyedContextElement(
                             new StreamRecord<>(Tuple2.of(5, "5")), new TestKeySelector());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2Test.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2Test.java
@@ -24,8 +24,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
-import org.apache.flink.runtime.asyncprocessing.StateExecutor;
-import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.CheckpointType;
@@ -53,7 +51,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -165,17 +162,7 @@ public class AbstractAsyncStateStreamOperatorV2Test {
                     CheckpointStorageLocationReference.getDefault();
             AsyncExecutionController asyncExecutionController =
                     testOperator.getAsyncExecutionController();
-            asyncExecutionController.setStateExecutor(
-                    new StateExecutor() {
-                        @Override
-                        public CompletableFuture<Boolean> executeBatchRequests(
-                                Iterable<StateRequest<?, ?, ?>> processingRequests) {
-                            for (StateRequest request : processingRequests) {
-                                request.getFuture().complete(true);
-                            }
-                            return CompletableFuture.completedFuture(true);
-                        }
-                    });
+            asyncExecutionController.setStateExecutor(new MockStateExecutor());
             testOperator.setAsyncKeyedContextElement(
                     new StreamRecord<>(Tuple2.of(5, "5")), new TestKeySelector());
             asyncExecutionController.handleRequest(null, StateRequestType.VALUE_GET, null);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/MockStateExecutor.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/MockStateExecutor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.operators.asyncprocessing;
+
+import org.apache.flink.runtime.asyncprocessing.MockStateRequestContainer;
+import org.apache.flink.runtime.asyncprocessing.StateExecutor;
+import org.apache.flink.runtime.asyncprocessing.StateRequest;
+import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
+import org.apache.flink.util.Preconditions;
+
+import java.util.concurrent.CompletableFuture;
+
+/** The mocked {@link StateExecutor} for testing. */
+public class MockStateExecutor implements StateExecutor {
+
+    @Override
+    public CompletableFuture<Void> executeBatchRequests(
+            StateRequestContainer stateRequestContainer) {
+        Preconditions.checkArgument(stateRequestContainer instanceof MockStateRequestContainer);
+        for (StateRequest<?, ?, ?> request :
+                ((MockStateRequestContainer) stateRequestContainer).getStateRequestList()) {
+            request.getFuture().complete(null);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public StateRequestContainer createStateRequestContainer() {
+        return new MockStateRequestContainer();
+    }
+
+    @Override
+    public void shutdown() {}
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request implements the StateExecutor for ForStStatebackend, which groups the remote state access to optimize performance. Please refer to FLIP-426 for more details.

## Brief change log

- Refactor ForStGeneralMultiGetOperation and ForStWriteBatchOperation
- Implements the StateExecutor for ForStStatebackend

## Verifying this change

This change added tests and can be verified by ForStStateExecutorTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  not applicable 
