### PR TITLE
[FLINK-35195][table] Support the execution of create materialized table in continuous refresh mode

### DIFF
--- a/docs/content.zh/docs/dev/table/config.md
+++ b/docs/content.zh/docs/dev/table/config.md
@@ -134,6 +134,12 @@ Flink SQL> SET 'table.exec.mini-batch.size' = '5000';
 
 {{< generated/table_config_configuration >}}
 
+### Materialized Table 配置
+
+以下配置可以用于调整 Materialized Table 的行为。
+
+{{< generated/materialized_table_config_configuration >}}
+
 ### SQL Client 配置
 
 以下配置可以用于调整 sql client 的行为。

--- a/docs/content/docs/dev/table/config.md
+++ b/docs/content/docs/dev/table/config.md
@@ -149,6 +149,12 @@ The following options can be used to adjust the behavior of the table planner.
 
 {{< generated/table_config_configuration >}}
 
+### Materialized Table Options
+
+The following options can be used to adjust the behavior of the materialized table.
+
+{{< generated/materialized_table_config_configuration >}}
+
 ### SQL Client Options
 
 The following options can be used to adjust the behavior of the sql client.

--- a/docs/layouts/shortcodes/generated/materialized_table_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/materialized_table_config_configuration.html
@@ -1,0 +1,24 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>materialized-table.refresh-mode.freshness-threshold</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">30 min</td>
+            <td>Duration</td>
+            <td>Specifies a time threshold for determining the materialized table refresh mode. If the materialized table defined FRESHNESS is below this threshold, it run in continuous mode. Otherwise, it switches to full refresh mode.</td>
+        </tr>
+        <tr>
+            <td><h5>partition.fields.#.date-formatter</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specifies the time partition formatter for the partitioned materialized table, where '#' denotes a string-based partition field name. This serves as a hint to the framework regarding which partition to refresh in full refresh mode.</td>
+        </tr>
+    </tbody>
+</table>

--- a/flink-table/flink-sql-gateway/pom.xml
+++ b/flink-table/flink-sql-gateway/pom.xml
@@ -127,6 +127,12 @@
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-filesystem-test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.service.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.gateway.api.operation.OperationHandle;
+import org.apache.flink.table.gateway.api.results.ResultSet;
+import org.apache.flink.table.gateway.service.operation.OperationExecutor;
+import org.apache.flink.table.gateway.service.result.ResultFetcher;
+import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableChangeOperation;
+import org.apache.flink.table.operations.materializedtable.CreateMaterializedTableOperation;
+import org.apache.flink.table.operations.materializedtable.DropMaterializedTableOperation;
+import org.apache.flink.table.operations.materializedtable.MaterializedTableOperation;
+import org.apache.flink.table.refresh.ContinuousRefreshHandler;
+import org.apache.flink.table.refresh.ContinuousRefreshHandlerSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.api.common.RuntimeExecutionMode.STREAMING;
+import static org.apache.flink.configuration.DeploymentOptions.TARGET;
+import static org.apache.flink.configuration.ExecutionOptions.RUNTIME_MODE;
+import static org.apache.flink.configuration.PipelineOptions.NAME;
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL;
+import static org.apache.flink.table.api.internal.TableResultInternal.TABLE_RESULT_OK;
+
+/** Manager is responsible for execute the {@link MaterializedTableOperation}. */
+@Internal
+public class MaterializedTableManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MaterializedTableManager.class);
+
+    public static ResultFetcher callMaterializedTableOperation(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            MaterializedTableOperation op,
+            String statement) {
+        if (op instanceof CreateMaterializedTableOperation) {
+            return callCreateMaterializedTableOperation(
+                    operationExecutor, handle, (CreateMaterializedTableOperation) op);
+        }
+        throw new SqlExecutionException(
+                String.format(
+                        "Unsupported Operation %s for materialized table.", op.asSummaryString()));
+    }
+
+    private static ResultFetcher callCreateMaterializedTableOperation(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            CreateMaterializedTableOperation createMaterializedTableOperation) {
+        CatalogMaterializedTable materializedTable =
+                createMaterializedTableOperation.getCatalogMaterializedTable();
+        if (CatalogMaterializedTable.RefreshMode.CONTINUOUS == materializedTable.getRefreshMode()) {
+            createMaterializedInContinuousMode(
+                    operationExecutor, handle, createMaterializedTableOperation);
+        } else {
+            throw new SqlExecutionException(
+                    "Only support create materialized table in continuous refresh mode currently.");
+        }
+        // Just return ok for unify different refresh job info of continuous and full mode, user
+        // should get the refresh job info via desc table.
+        return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
+    }
+
+    private static void createMaterializedInContinuousMode(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            CreateMaterializedTableOperation createMaterializedTableOperation) {
+        // create materialized table first
+        operationExecutor.callExecutableOperation(handle, createMaterializedTableOperation);
+
+        ObjectIdentifier materializedTableIdentifier =
+                createMaterializedTableOperation.getTableIdentifier();
+        CatalogMaterializedTable catalogMaterializedTable =
+                createMaterializedTableOperation.getCatalogMaterializedTable();
+
+        // Set job name, runtime mode, checkpoint interval
+        // TODO: Set minibatch related optimization options.
+        Configuration customConfig = new Configuration();
+        String jobName =
+                String.format(
+                        "Materialized_table_%s_continuous_refresh_job",
+                        materializedTableIdentifier.asSerializableString());
+        customConfig.set(NAME, jobName);
+        customConfig.set(RUNTIME_MODE, STREAMING);
+        customConfig.set(CHECKPOINTING_INTERVAL, catalogMaterializedTable.getFreshness());
+
+        String insertStatement =
+                String.format(
+                        "INSERT INTO %s %s",
+                        materializedTableIdentifier, catalogMaterializedTable.getDefinitionQuery());
+        try {
+            // submit flink streaming job
+            ResultFetcher resultFetcher =
+                    operationExecutor.executeStatement(handle, insertStatement);
+
+            // get execution.target and jobId, currently doesn't support yarn and k8s, so doesn't
+            // get clusterId
+            List<RowData> results = fetchAllResults(resultFetcher);
+            String jobId = results.get(0).getString(0).toString();
+            String executeTarget =
+                    operationExecutor.getSessionContext().getSessionConf().get(TARGET);
+            ContinuousRefreshHandler continuousRefreshHandler =
+                    new ContinuousRefreshHandler(executeTarget, jobId);
+            byte[] serializedBytes =
+                    ContinuousRefreshHandlerSerializer.INSTANCE.serialize(continuousRefreshHandler);
+
+            // update RefreshHandler to Catalog
+            CatalogMaterializedTable updatedMaterializedTable =
+                    catalogMaterializedTable.copy(
+                            CatalogMaterializedTable.RefreshStatus.ACTIVATED,
+                            continuousRefreshHandler.asSummaryString(),
+                            serializedBytes);
+            List<TableChange> tableChanges = new ArrayList<>();
+            tableChanges.add(
+                    TableChange.modifyRefreshStatus(
+                            CatalogMaterializedTable.RefreshStatus.ACTIVATED));
+            tableChanges.add(
+                    TableChange.modifyRefreshHandler(
+                            continuousRefreshHandler.asSummaryString(), serializedBytes));
+
+            AlterMaterializedTableChangeOperation alterMaterializedTableChangeOperation =
+                    new AlterMaterializedTableChangeOperation(
+                            materializedTableIdentifier, tableChanges, updatedMaterializedTable);
+            operationExecutor.callExecutableOperation(
+                    handle, alterMaterializedTableChangeOperation);
+        } catch (Exception e) {
+            // drop materialized table while submit flink streaming job occur exception. Thus, weak
+            // atomicity is guaranteed
+            operationExecutor.callExecutableOperation(
+                    handle,
+                    new DropMaterializedTableOperation(materializedTableIdentifier, true, false));
+            // log and throw exception
+            LOG.error(
+                    "Submit continuous refresh job for materialized table {} occur exception.",
+                    materializedTableIdentifier,
+                    e);
+            throw new TableException(
+                    String.format(
+                            "Submit continuous refresh job for materialized table %s occur exception.",
+                            materializedTableIdentifier),
+                    e);
+        }
+    }
+
+    private static List<RowData> fetchAllResults(ResultFetcher resultFetcher) {
+        Long token = 0L;
+        List<RowData> results = new ArrayList<>();
+        while (token != null) {
+            ResultSet result = resultFetcher.fetchResults(token, Integer.MAX_VALUE);
+            results.addAll(result.getData());
+            token = result.getNextToken();
+        }
+        return results;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.service;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.gateway.api.operation.OperationHandle;
+import org.apache.flink.table.gateway.api.session.SessionEnvironment;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.api.utils.MockedEndpointVersion;
+import org.apache.flink.table.gateway.service.utils.IgnoreExceptionHandler;
+import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
+import org.apache.flink.table.gateway.service.utils.SqlGatewayServiceExtension;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.flink.table.catalog.CommonCatalogOptions.TABLE_CATALOG_STORE_KIND;
+import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.awaitOperationTermination;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ITCase for materialized table related statement via {@link SqlGatewayServiceImpl}. Use a separate
+ * test class rather than adding test cases to {@link SqlGatewayServiceITCase}, both because the
+ * syntax related to Materialized table is relatively independent, and to try to avoid conflicts
+ * with the code in {@link SqlGatewayServiceITCase}.
+ */
+public class MaterializedTableStatementITCase {
+
+    private static final String FILE_CATALOG_STORE = "file_store";
+    private static final String TEST_CATALOG_PREFIX = "test_catalog";
+    private static final String TEST_DEFAULT_DATABASE = "test_db";
+
+    private static final AtomicLong COUNTER = new AtomicLong(0);
+
+    @RegisterExtension
+    @Order(1)
+    static final MiniClusterExtension MINI_CLUSTER =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(2)
+                            .build());
+
+    @RegisterExtension
+    @Order(2)
+    static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
+            new SqlGatewayServiceExtension(MINI_CLUSTER::getClientConfiguration);
+
+    @RegisterExtension
+    @Order(3)
+    static final TestExecutorExtension<ExecutorService> EXECUTOR_EXTENSION =
+            new TestExecutorExtension<>(
+                    () ->
+                            Executors.newCachedThreadPool(
+                                    new ExecutorThreadFactory(
+                                            "SqlGatewayService Test Pool",
+                                            IgnoreExceptionHandler.INSTANCE)));
+
+    private static SqlGatewayServiceImpl service;
+    private static SessionEnvironment defaultSessionEnvironment;
+    private static Path baseCatalogPath;
+
+    private String fileSystemCatalogPath;
+    private String fileSystemCatalogName;
+
+    @BeforeAll
+    static void setUp(@TempDir Path temporaryFolder) throws Exception {
+        service = (SqlGatewayServiceImpl) SQL_GATEWAY_SERVICE_EXTENSION.getService();
+
+        // initialize file catalog store path
+        Path fileCatalogStore = temporaryFolder.resolve(FILE_CATALOG_STORE);
+        Files.createDirectory(fileCatalogStore);
+        Map<String, String> catalogStoreOptions = new HashMap<>();
+        catalogStoreOptions.put(TABLE_CATALOG_STORE_KIND.key(), "file");
+        catalogStoreOptions.put("table.catalog-store.file.path", fileCatalogStore.toString());
+
+        // initialize test-filesystem catalog base path
+        baseCatalogPath = temporaryFolder.resolve(TEST_CATALOG_PREFIX);
+        Files.createDirectory(baseCatalogPath);
+
+        defaultSessionEnvironment =
+                SessionEnvironment.newBuilder()
+                        .addSessionConfig(catalogStoreOptions)
+                        .setSessionEndpointVersion(MockedEndpointVersion.V1)
+                        .build();
+    }
+
+    @BeforeEach
+    void before() throws Exception {
+        String randomStr = String.valueOf(COUNTER.incrementAndGet());
+        // initialize test-filesystem catalog path with random uuid
+        Path fileCatalogPath = baseCatalogPath.resolve(randomStr);
+        Files.createDirectory(fileCatalogPath);
+        Path dbPath = fileCatalogPath.resolve(TEST_DEFAULT_DATABASE);
+        Files.createDirectory(dbPath);
+
+        fileSystemCatalogPath = fileCatalogPath.toString();
+        fileSystemCatalogName = TEST_CATALOG_PREFIX + randomStr;
+    }
+
+    @Test
+    void testCreateMaterializedTableInContinuousMode() throws Exception {
+        // initialize session handle, create test-filesystem catalog and register it to catalog
+        // store
+        SessionHandle sessionHandle = initializeSession();
+
+        String materializedTableDDL =
+                "CREATE MATERIALIZED TABLE users_shops"
+                        + " PARTITIONED BY (ds)\n"
+                        + " WITH(\n"
+                        + "   'format' = 'debezium-json'\n"
+                        + " )\n"
+                        + " FRESHNESS = INTERVAL '30' SECOND\n"
+                        + " AS SELECT \n"
+                        + "  user_id,\n"
+                        + "  shop_id,\n"
+                        + "  ds,\n"
+                        + "  SUM (payment_amount_cents) AS payed_buy_fee_sum,\n"
+                        + "  SUM (1) AS pv\n"
+                        + " FROM (\n"
+                        + "    SELECT user_id, shop_id, DATE_FORMAT(order_created_at, 'yyyy-MM-dd') AS ds, payment_amount_cents FROM datagenSource"
+                        + " ) AS tmp\n"
+                        + " GROUP BY (user_id, shop_id, ds)";
+        OperationHandle materializedTableHandle =
+                service.executeStatement(
+                        sessionHandle, materializedTableDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, materializedTableHandle);
+
+        // validate materialized table: schema, refresh mode, refresh status, refresh handler,
+        // doesn't check the data because it generates randomly.
+        ResolvedCatalogMaterializedTable actualMaterializedTable =
+                (ResolvedCatalogMaterializedTable)
+                        service.getTable(
+                                sessionHandle,
+                                ObjectIdentifier.of(
+                                        fileSystemCatalogName,
+                                        TEST_DEFAULT_DATABASE,
+                                        "users_shops"));
+
+        // Expected schema
+        ResolvedSchema expectedSchema =
+                ResolvedSchema.of(
+                        Arrays.asList(
+                                Column.physical("user_id", DataTypes.BIGINT()),
+                                Column.physical("shop_id", DataTypes.BIGINT()),
+                                Column.physical("ds", DataTypes.STRING()),
+                                Column.physical("payed_buy_fee_sum", DataTypes.BIGINT()),
+                                Column.physical("pv", DataTypes.INT().notNull())));
+
+        assertThat(actualMaterializedTable.getResolvedSchema()).isEqualTo(expectedSchema);
+        assertThat(actualMaterializedTable.getFreshness()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(actualMaterializedTable.getLogicalRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC);
+        assertThat(actualMaterializedTable.getRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.RefreshMode.CONTINUOUS);
+        assertThat(actualMaterializedTable.getRefreshStatus())
+                .isEqualTo(CatalogMaterializedTable.RefreshStatus.ACTIVATED);
+        assertThat(actualMaterializedTable.getRefreshHandlerDescription()).isNotEmpty();
+        assertThat(actualMaterializedTable.getSerializedRefreshHandler()).isNotEmpty();
+    }
+
+    @Test
+    void testCreateMaterializedTableInFullMode() {
+        // initialize session handle, create test-filesystem catalog and register it to catalog
+        // store
+        SessionHandle sessionHandle = initializeSession();
+
+        String materializedTableDDL =
+                "CREATE MATERIALIZED TABLE users_shops"
+                        + " PARTITIONED BY (ds)\n"
+                        + " WITH(\n"
+                        + "   'format' = 'debezium-json'\n"
+                        + " )\n"
+                        + " FRESHNESS = INTERVAL '1' DAY\n"
+                        + " AS SELECT \n"
+                        + "  user_id,\n"
+                        + "  shop_id,\n"
+                        + "  ds,\n"
+                        + "  SUM (payment_amount_cents) AS payed_buy_fee_sum,\n"
+                        + "  SUM (1) AS pv\n"
+                        + " FROM (\n"
+                        + "    SELECT user_id, shop_id, DATE_FORMAT(order_created_at, 'yyyy-MM-dd') AS ds, payment_amount_cents FROM datagenSource"
+                        + " ) AS tmp\n"
+                        + " GROUP BY (user_id, shop_id, ds)";
+        OperationHandle materializedTableHandle =
+                service.executeStatement(
+                        sessionHandle, materializedTableDDL, -1, new Configuration());
+
+        assertThatThrownBy(
+                        () ->
+                                awaitOperationTermination(
+                                        service, sessionHandle, materializedTableHandle))
+                .rootCause()
+                .isInstanceOf(SqlExecutionException.class)
+                .hasMessage(
+                        "Only support create materialized table in continuous refresh mode currently.");
+    }
+
+    private SessionHandle initializeSession() {
+        SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
+        String catalogDDL =
+                String.format(
+                        "CREATE CATALOG %s\n"
+                                + "WITH (\n"
+                                + "  'type' = 'test-filesystem',\n"
+                                + "  'path' = '%s',\n"
+                                + "  'default-database' = '%s'\n"
+                                + "  )",
+                        fileSystemCatalogName, fileSystemCatalogPath, TEST_DEFAULT_DATABASE);
+        service.configureSession(sessionHandle, catalogDDL, -1);
+        service.configureSession(
+                sessionHandle, String.format("USE CATALOG %s", fileSystemCatalogName), -1);
+
+        // create source table
+        String dataGenSource =
+                "CREATE TABLE datagenSource (\n"
+                        + "  order_id BIGINT,\n"
+                        + "  order_number VARCHAR(20),\n"
+                        + "  user_id BIGINT,\n"
+                        + "  shop_id BIGINT,\n"
+                        + "  product_id BIGINT,\n"
+                        + "  status BIGINT,\n"
+                        + "  order_type BIGINT,\n"
+                        + "  order_created_at TIMESTAMP,\n"
+                        + "  payment_amount_cents BIGINT\n"
+                        + ")\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'datagen',\n"
+                        + "  'rows-per-second' = '10'\n"
+                        + ")";
+        service.configureSession(sessionHandle, dataGenSource, -1);
+        return sessionHandle;
+    }
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlConstraintValidator.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlConstraintValidator.java
@@ -89,7 +89,7 @@ public class SqlConstraintValidator {
     }
 
     /** Check table constraint. */
-    private static void validate(SqlTableConstraint constraint) throws SqlValidateException {
+    public static void validate(SqlTableConstraint constraint) throws SqlValidateException {
         if (constraint.isUnique()) {
             throw new SqlValidateException(
                     constraint.getParserPosition(), "UNIQUE constraint is not supported yet");

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateMaterializedTable.java
@@ -132,7 +132,6 @@ public class SqlCreateMaterializedTable extends SqlCreate {
         return freshness;
     }
 
-    @Nullable
     public Optional<SqlLiteral> getRefreshMode() {
         return Optional.ofNullable(refreshMode);
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/MaterializedTableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/MaterializedTableConfigOptions.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.ConfigOption;
+
+import java.time.Duration;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/**
+ * This class holds {@link org.apache.flink.configuration.ConfigOption}s used by table module for
+ * materialized table.
+ */
+@PublicEvolving
+public class MaterializedTableConfigOptions {
+
+    private MaterializedTableConfigOptions() {}
+
+    public static final String PARTITION_FIELDS = "partition.fields";
+    public static final String DATE_FORMATTER = "date-formatter";
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<Duration> MATERIALIZED_TABLE_FRESHNESS_THRESHOLD =
+            key("materialized-table.refresh-mode.freshness-threshold")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(30))
+                    .withDescription(
+                            "Specifies a time threshold for determining the materialized table refresh mode."
+                                    + " If the materialized table defined FRESHNESS is below this threshold, it run in continuous mode."
+                                    + " Otherwise, it switches to full refresh mode.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+    public static final ConfigOption<String> PARTITION_FIELDS_DATE_FORMATTER =
+            key(String.format("%s.#.%s", PARTITION_FIELDS, DATE_FORMATTER))
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Specifies the time partition formatter for the partitioned materialized table, where '#' denotes a string-based partition field name."
+                                    + " This serves as a hint to the framework regarding which partition to refresh in full refresh mode.");
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1151,7 +1151,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                 (catalog, path) -> {
                     final CatalogBaseTable resolvedTable = resolveCatalogBaseTable(table);
                     catalog.alterTable(path, resolvedTable, ignoreIfNotExists);
-                    if (resolvedTable instanceof CatalogTable) {
+                    if (resolvedTable instanceof CatalogTable
+                            || resolvedTable instanceof CatalogMaterializedTable) {
                         catalogModificationListeners.forEach(
                                 listener ->
                                         listener.onEvent(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableChangeOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableChangeOperation.java
@@ -58,7 +58,9 @@ public class AlterTableChangeOperation extends AlterTableOperation {
     @Override
     public String asSummaryString() {
         String changes =
-                tableChanges.stream().map(this::toString).collect(Collectors.joining(",\n"));
+                tableChanges.stream()
+                        .map(AlterTableChangeOperation::toString)
+                        .collect(Collectors.joining(",\n"));
         return String.format(
                 "ALTER TABLE %s%s\n%s",
                 ignoreIfTableNotExists ? "IF EXISTS " : "",
@@ -66,7 +68,7 @@ public class AlterTableChangeOperation extends AlterTableOperation {
                 changes);
     }
 
-    private String toString(TableChange tableChange) {
+    public static String toString(TableChange tableChange) {
         if (tableChange instanceof TableChange.SetOption) {
             TableChange.SetOption setChange = (TableChange.SetOption) tableChange;
             return String.format("  SET '%s' = '%s'", setChange.getKey(), setChange.getValue());

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableChangeOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableChangeOperation.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.operations.ddl.AlterTableChangeOperation;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Alter materialized table with new table definition and table changes represents the modification.
+ */
+@Internal
+public class AlterMaterializedTableChangeOperation extends AlterMaterializedTableOperation {
+
+    private final List<TableChange> tableChanges;
+    private final CatalogMaterializedTable catalogMaterializedTable;
+
+    public AlterMaterializedTableChangeOperation(
+            ObjectIdentifier tableIdentifier,
+            List<TableChange> tableChanges,
+            CatalogMaterializedTable catalogMaterializedTable) {
+        super(tableIdentifier);
+        this.tableChanges = tableChanges;
+        this.catalogMaterializedTable = catalogMaterializedTable;
+    }
+
+    public List<TableChange> getTableChanges() {
+        return tableChanges;
+    }
+
+    public CatalogMaterializedTable getCatalogMaterializedTable() {
+        return catalogMaterializedTable;
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        ctx.getCatalogManager()
+                .alterTable(
+                        getCatalogMaterializedTable(),
+                        getTableChanges().stream()
+                                .map(TableChange.class::cast)
+                                .collect(Collectors.toList()),
+                        getTableIdentifier(),
+                        false);
+        return TableResultImpl.TABLE_RESULT_OK;
+    }
+
+    @Override
+    public String asSummaryString() {
+        String changes =
+                tableChanges.stream()
+                        .map(
+                                tableChange -> {
+                                    if (tableChange
+                                            instanceof TableChange.MaterializedTableChange) {
+                                        return toString(
+                                                (TableChange.MaterializedTableChange) tableChange);
+                                    } else {
+                                        return AlterTableChangeOperation.toString(tableChange);
+                                    }
+                                })
+                        .collect(Collectors.joining(",\n"));
+        return String.format(
+                "ALTER MATERIALIZED TABLE %s\n%s", tableIdentifier.asSummaryString(), changes);
+    }
+
+    private String toString(TableChange.MaterializedTableChange tableChange) {
+        if (tableChange instanceof TableChange.ModifyRefreshStatus) {
+            TableChange.ModifyRefreshStatus refreshStatus =
+                    (TableChange.ModifyRefreshStatus) tableChange;
+            return String.format(
+                    "  MODIFY REFRESH STATUS TO '%s'", refreshStatus.getRefreshStatus());
+        } else if (tableChange instanceof TableChange.ModifyRefreshHandler) {
+            TableChange.ModifyRefreshHandler refreshHandler =
+                    (TableChange.ModifyRefreshHandler) tableChange;
+            return String.format(
+                    "  MODIFY REFRESH HANDLER DESCRIPTION TO '%s'",
+                    refreshHandler.getRefreshHandlerDesc());
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format("Unknown materialized table change: %s.", tableChange));
+        }
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableOperation.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.ddl.AlterOperation;
+
+/**
+ * Abstract Operation to describe all ALTER MATERIALIZED TABLE statements such as rename table /set
+ * properties.
+ */
+@Internal
+public abstract class AlterMaterializedTableOperation
+        implements AlterOperation, MaterializedTableOperation {
+
+    protected final ObjectIdentifier tableIdentifier;
+
+    public AlterMaterializedTableOperation(ObjectIdentifier tableIdentifier) {
+        this.tableIdentifier = tableIdentifier;
+    }
+
+    public ObjectIdentifier getTableIdentifier() {
+        return tableIdentifier;
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/CreateMaterializedTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/CreateMaterializedTableOperation.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+import org.apache.flink.table.operations.ddl.CreateOperation;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Operation to describe a CREATE MATERIALIZED TABLE statement. */
+@Internal
+public class CreateMaterializedTableOperation
+        implements CreateOperation, MaterializedTableOperation {
+
+    private final ObjectIdentifier tableIdentifier;
+    private final CatalogMaterializedTable materializedTable;
+
+    public CreateMaterializedTableOperation(
+            ObjectIdentifier tableIdentifier, ResolvedCatalogMaterializedTable materializedTable) {
+        this.tableIdentifier = tableIdentifier;
+        this.materializedTable = materializedTable;
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        // create materialized table in catalog
+        ctx.getCatalogManager().createTable(materializedTable, tableIdentifier, false);
+        return TableResultImpl.TABLE_RESULT_OK;
+    }
+
+    public ObjectIdentifier getTableIdentifier() {
+        return tableIdentifier;
+    }
+
+    public CatalogMaterializedTable getCatalogMaterializedTable() {
+        return materializedTable;
+    }
+
+    @Override
+    public String asSummaryString() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("materializedTable", materializedTable);
+        params.put("identifier", tableIdentifier);
+
+        return OperationUtils.formatWithChildren(
+                "CREATE MATERIALIZED TABLE",
+                params,
+                Collections.emptyList(),
+                Operation::asSummaryString);
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/DropMaterializedTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/DropMaterializedTableOperation.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+import org.apache.flink.table.operations.ddl.DropTableOperation;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Operation to describe a DROP MATERIALIZED TABLE statement. */
+@Internal
+public class DropMaterializedTableOperation extends DropTableOperation
+        implements MaterializedTableOperation {
+
+    public DropMaterializedTableOperation(
+            ObjectIdentifier tableIdentifier, boolean ifExists, boolean isTemporary) {
+        super(tableIdentifier, ifExists, isTemporary);
+    }
+
+    @Override
+    public String asSummaryString() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("identifier", getTableIdentifier());
+        params.put("IfExists", isIfExists());
+        params.put("isTemporary", isTemporary());
+
+        return OperationUtils.formatWithChildren(
+                "DROP MATERIALIZED TABLE",
+                params,
+                Collections.emptyList(),
+                Operation::asSummaryString);
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/MaterializedTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/MaterializedTableOperation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.operations.Operation;
+
+/** The marker interface for materialized table. */
+@Internal
+public interface MaterializedTableOperation extends Operation {}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogMaterializedTable.java
@@ -182,4 +182,17 @@ public class ResolvedCatalogMaterializedTable
                 + resolvedSchema
                 + '}';
     }
+
+    /** Convert this object to a {@link ResolvedCatalogTable} object for planner optimize query. */
+    public ResolvedCatalogTable toResolvedCatalogTable() {
+        return new ResolvedCatalogTable(
+                CatalogTable.newBuilder()
+                        .schema(getUnresolvedSchema())
+                        .comment(getComment())
+                        .partitionKeys(getPartitionKeys())
+                        .options(getOptions())
+                        .snapshot(getSnapshot().orElse(null))
+                        .build(),
+                getResolvedSchema());
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/TableChange.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/TableChange.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /** {@link TableChange} represents the modification of the table. */
@@ -307,6 +308,29 @@ public interface TableChange {
      */
     static ResetOption reset(String key) {
         return new ResetOption(key);
+    }
+
+    /**
+     * A table change to modify materialized table refresh status.
+     *
+     * @param refreshStatus the modified refresh status.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyRefreshStatus modifyRefreshStatus(
+            CatalogMaterializedTable.RefreshStatus refreshStatus) {
+        return new ModifyRefreshStatus(refreshStatus);
+    }
+
+    /**
+     * A table change to modify materialized table refresh handler.
+     *
+     * @param refreshHandlerDesc the modified refresh handler description.
+     * @param refreshHandlerBytes the modified refresh handler bytes.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyRefreshHandler modifyRefreshHandler(
+            String refreshHandlerDesc, byte[] refreshHandlerBytes) {
+        return new ModifyRefreshHandler(refreshHandlerDesc, refreshHandlerBytes);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -1094,6 +1118,102 @@ public interface TableChange {
         @Override
         public String toString() {
             return String.format("AFTER %s", EncodingUtils.escapeIdentifier(column));
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Materialized table change
+    // --------------------------------------------------------------------------------------------
+    /** {@link MaterializedTableChange} represents the modification of the materialized table. */
+    @PublicEvolving
+    interface MaterializedTableChange extends TableChange {}
+
+    /** A table change to modify materialized table refresh status. */
+    @PublicEvolving
+    class ModifyRefreshStatus implements MaterializedTableChange {
+
+        private final CatalogMaterializedTable.RefreshStatus refreshStatus;
+
+        public ModifyRefreshStatus(CatalogMaterializedTable.RefreshStatus refreshStatus) {
+            this.refreshStatus = refreshStatus;
+        }
+
+        public CatalogMaterializedTable.RefreshStatus getRefreshStatus() {
+            return refreshStatus;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ModifyRefreshStatus that = (ModifyRefreshStatus) o;
+            return refreshStatus == that.refreshStatus;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(refreshStatus);
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyRefreshStatus{" + "refreshStatus=" + refreshStatus + '}';
+        }
+    }
+
+    /** A table change to modify materialized table refresh handler. */
+    @PublicEvolving
+    class ModifyRefreshHandler implements MaterializedTableChange {
+
+        private final String refreshHandlerDesc;
+        private final byte[] refreshHandlerBytes;
+
+        public ModifyRefreshHandler(String refreshHandlerDesc, byte[] refreshHandlerBytes) {
+            this.refreshHandlerDesc = refreshHandlerDesc;
+            this.refreshHandlerBytes = refreshHandlerBytes;
+        }
+
+        public String getRefreshHandlerDesc() {
+            return refreshHandlerDesc;
+        }
+
+        public byte[] getRefreshHandlerBytes() {
+            return refreshHandlerBytes;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ModifyRefreshHandler that = (ModifyRefreshHandler) o;
+            return Objects.equals(refreshHandlerDesc, that.refreshHandlerDesc)
+                    && Arrays.equals(refreshHandlerBytes, that.refreshHandlerBytes);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(refreshHandlerDesc);
+            result = 31 * result + Arrays.hashCode(refreshHandlerBytes);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "ModifyRefreshHandler{"
+                    + "refreshHandlerDesc='"
+                    + refreshHandlerDesc
+                    + '\''
+                    + ", refreshHandlerBytes="
+                    + Arrays.toString(refreshHandlerBytes)
+                    + '}';
         }
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/ContinuousRefreshHandler.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/ContinuousRefreshHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.refresh;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Serializable;
+
+/** Embedded continuous refresh handler of Flink streaming job for materialized table. */
+@Internal
+public class ContinuousRefreshHandler implements RefreshHandler, Serializable {
+
+    // TODO: add clusterId for yarn and k8s resource manager
+    private final String executionTarget;
+    private final String jobId;
+
+    public ContinuousRefreshHandler(String executionTarget, String jobId) {
+        this.executionTarget = executionTarget;
+        this.jobId = jobId;
+    }
+
+    public String getExecutionTarget() {
+        return executionTarget;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format("{\n executionTarget: %s,\n jobId: %s\n}", executionTarget, jobId);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/ContinuousRefreshHandlerSerializer.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/ContinuousRefreshHandlerSerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.refresh;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+
+/** Serializer for {@link ContinuousRefreshHandler}. */
+@Internal
+public class ContinuousRefreshHandlerSerializer
+        implements RefreshHandlerSerializer<ContinuousRefreshHandler> {
+
+    public static final ContinuousRefreshHandlerSerializer INSTANCE =
+            new ContinuousRefreshHandlerSerializer();
+
+    @Override
+    public byte[] serialize(ContinuousRefreshHandler refreshHandler) throws IOException {
+        return InstantiationUtil.serializeObject(refreshHandler);
+    }
+
+    @Override
+    public ContinuousRefreshHandler deserialize(byte[] serializedBytes, ClassLoader cl)
+            throws IOException, ClassNotFoundException {
+        return InstantiationUtil.deserializeObject(serializedBytes, cl);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -90,7 +90,7 @@ class DatabaseCalciteSchema extends FlinkSchema {
         return table.map(
                         lookupResult ->
                                 new CatalogSchemaTable(
-                                        lookupResult,
+                                        lookupResult.toCatalogTable(),
                                         getStatistic(lookupResult, identifier),
                                         isStreamingMode))
                 .orElse(null);
@@ -102,6 +102,7 @@ class DatabaseCalciteSchema extends FlinkSchema {
                 contextResolvedTable.getResolvedTable();
         switch (resolvedBaseTable.getTableKind()) {
             case TABLE:
+            case MATERIALIZED_TABLE:
                 return FlinkStatistic.unknown(resolvedBaseTable.getResolvedSchema())
                         .tableStats(extractTableStats(contextResolvedTable, identifier))
                         .build();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.operations;
 
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.calcite.SqlToRexConverter;
@@ -43,6 +44,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig;
+
 /** An implementation of {@link SqlNodeConverter.ConvertContext}. */
 public class SqlNodeConvertContext implements SqlNodeConverter.ConvertContext {
 
@@ -52,6 +55,11 @@ public class SqlNodeConvertContext implements SqlNodeConverter.ConvertContext {
     public SqlNodeConvertContext(FlinkPlannerImpl flinkPlanner, CatalogManager catalogManager) {
         this.flinkPlanner = flinkPlanner;
         this.catalogManager = catalogManager;
+    }
+
+    @Override
+    public TableConfig getTableConfig() {
+        return unwrapTableConfig(flinkPlanner.cluster());
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -734,7 +734,9 @@ public class SqlNodeToOperationConversion {
 
         UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(targetTablePath);
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-        ContextResolvedTable contextResolvedTable = catalogManager.getTableOrError(identifier);
+        // If it is materialized table, convert it to catalog table for query optimize
+        ContextResolvedTable contextResolvedTable =
+                catalogManager.getTableOrError(identifier).toCatalogTable();
 
         PlannerQueryOperation query =
                 (PlannerQueryOperation)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateMaterializedTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateMaterializedTableConverter.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.SqlConstraintValidator;
+import org.apache.flink.sql.parser.ddl.SqlCreateMaterializedTable;
+import org.apache.flink.sql.parser.ddl.SqlRefreshMode;
+import org.apache.flink.sql.parser.ddl.SqlTableOption;
+import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
+import org.apache.flink.sql.parser.error.SqlValidateException;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.CreateMaterializedTableOperation;
+import org.apache.flink.table.planner.operations.PlannerQueryOperation;
+import org.apache.flink.table.planner.utils.MaterializedTableUtils;
+import org.apache.flink.table.planner.utils.OperationConverterUtils;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.MATERIALIZED_TABLE_FRESHNESS_THRESHOLD;
+
+/** A converter for {@link SqlCreateMaterializedTable}. */
+public class SqlCreateMaterializedTableConverter
+        implements SqlNodeConverter<SqlCreateMaterializedTable> {
+
+    @Override
+    public Operation convertSqlNode(
+            SqlCreateMaterializedTable sqlCreateMaterializedTable, ConvertContext context) {
+        UnresolvedIdentifier unresolvedIdentifier =
+                UnresolvedIdentifier.of(sqlCreateMaterializedTable.fullTableName());
+        ObjectIdentifier identifier =
+                context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+
+        // get comment
+        String tableComment =
+                OperationConverterUtils.getTableComment(sqlCreateMaterializedTable.getComment());
+
+        // get options
+        Map<String, String> options = new HashMap<>();
+        sqlCreateMaterializedTable
+                .getPropertyList()
+                .getList()
+                .forEach(
+                        p ->
+                                options.put(
+                                        ((SqlTableOption) p).getKeyString(),
+                                        ((SqlTableOption) p).getValueString()));
+
+        // get freshness
+        Duration freshness =
+                MaterializedTableUtils.getMaterializedTableFreshness(
+                        sqlCreateMaterializedTable.getFreshness());
+
+        // get refresh mode
+        SqlRefreshMode sqlRefreshMode = null;
+        if (sqlCreateMaterializedTable.getRefreshMode().isPresent()) {
+            sqlRefreshMode =
+                    sqlCreateMaterializedTable
+                            .getRefreshMode()
+                            .get()
+                            .getValueAs(SqlRefreshMode.class);
+        }
+        CatalogMaterializedTable.LogicalRefreshMode logicalRefreshMode =
+                MaterializedTableUtils.deriveLogicalRefreshMode(sqlRefreshMode);
+        // only MATERIALIZED_TABLE_FRESHNESS_THRESHOLD configured in flink conf yaml work, so we get
+        // it from rootConfiguration instead of table config
+        CatalogMaterializedTable.RefreshMode refreshMode =
+                MaterializedTableUtils.deriveRefreshMode(
+                        context.getTableConfig()
+                                .getRootConfiguration()
+                                .get(MATERIALIZED_TABLE_FRESHNESS_THRESHOLD),
+                        freshness,
+                        logicalRefreshMode);
+
+        // get query schema and definition query
+        SqlNode validateQuery =
+                context.getSqlValidator().validate(sqlCreateMaterializedTable.getAsQuery());
+        PlannerQueryOperation queryOperation =
+                new PlannerQueryOperation(
+                        context.toRelRoot(validateQuery).project(),
+                        () -> context.toQuotedSqlString(validateQuery));
+        String definitionQuery =
+                context.expandSqlIdentifiers(queryOperation.asSerializableString());
+
+        // get schema
+        ResolvedSchema resolvedSchema = queryOperation.getResolvedSchema();
+        Schema.Builder builder = Schema.newBuilder().fromResolvedSchema(resolvedSchema);
+
+        // get and verify partition key
+        List<String> partitionKeys =
+                sqlCreateMaterializedTable.getPartitionKeyList().getList().stream()
+                        .map(p -> ((SqlIdentifier) p).getSimple())
+                        .collect(Collectors.toList());
+        verifyPartitioningColumnsExist(resolvedSchema, partitionKeys);
+
+        // verify and build primary key
+        sqlCreateMaterializedTable
+                .getTableConstraint()
+                .ifPresent(
+                        sqlTableConstraint ->
+                                verifyAndBuildPrimaryKey(
+                                        builder, resolvedSchema, sqlTableConstraint));
+
+        CatalogMaterializedTable materializedTable =
+                CatalogMaterializedTable.newBuilder()
+                        .schema(builder.build())
+                        .comment(tableComment)
+                        .partitionKeys(partitionKeys)
+                        .options(options)
+                        .definitionQuery(definitionQuery)
+                        .freshness(freshness)
+                        .logicalRefreshMode(logicalRefreshMode)
+                        .refreshMode(refreshMode)
+                        .refreshStatus(CatalogMaterializedTable.RefreshStatus.INITIALIZING)
+                        .build();
+
+        return new CreateMaterializedTableOperation(
+                identifier,
+                context.getCatalogManager().resolveCatalogMaterializedTable(materializedTable));
+    }
+
+    private static void verifyPartitioningColumnsExist(
+            ResolvedSchema resolvedSchema, List<String> partitionKeys) {
+        for (String partitionKey : partitionKeys) {
+            if (!resolvedSchema.getColumn(partitionKey).isPresent()) {
+                throw new ValidationException(
+                        String.format(
+                                "Partition column '%s' not defined in the query schema. Available columns: [%s].",
+                                partitionKey,
+                                resolvedSchema.getColumnNames().stream()
+                                        .collect(Collectors.joining("', '", "'", "'"))));
+            }
+        }
+    }
+
+    private static void verifyAndBuildPrimaryKey(
+            Schema.Builder schemaBuilder,
+            ResolvedSchema resolvedSchema,
+            SqlTableConstraint sqlTableConstraint) {
+        // check constraint type
+        try {
+            SqlConstraintValidator.validate(sqlTableConstraint);
+        } catch (SqlValidateException e) {
+            throw new ValidationException(
+                    String.format("Primary key validation failed: %s.", e.getMessage()), e);
+        }
+
+        List<String> primaryKeyColumns = Arrays.asList(sqlTableConstraint.getColumnNames());
+        for (String columnName : primaryKeyColumns) {
+            Optional<Column> columnOptional = resolvedSchema.getColumn(columnName);
+            if (!columnOptional.isPresent()) {
+                throw new ValidationException(
+                        String.format(
+                                "Primary key column '%s' not defined in the query schema. Available columns: [%s].",
+                                columnName,
+                                resolvedSchema.getColumnNames().stream()
+                                        .collect(Collectors.joining("', '", "'", "'"))));
+            }
+
+            if (columnOptional.get().getDataType().getLogicalType().isNullable()) {
+                throw new ValidationException(
+                        String.format(
+                                "Could not create a PRIMARY KEY with nullable column '%s'.\n"
+                                        + "A PRIMARY KEY column must be declared on non-nullable physical columns.",
+                                columnName));
+            }
+        }
+
+        // build primary key
+        String constraintName =
+                sqlTableConstraint
+                        .getConstraintName()
+                        .orElseGet(
+                                () ->
+                                        primaryKeyColumns.stream()
+                                                .collect(Collectors.joining("_", "PK_", "")));
+        schemaBuilder.primaryKeyNamed(constraintName, primaryKeyColumns);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverter.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.planner.operations.converters;
 
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.planner.utils.Expander;
@@ -71,6 +73,9 @@ public interface SqlNodeConverter<S extends SqlNode> {
 
     /** Context of {@link SqlNodeConverter}. */
     interface ConvertContext {
+
+        /** Returns the {@link TableConfig} defined in {@link TableEnvironment}. */
+        TableConfig getTableConfig();
 
         /** Returns the {@link SqlValidator} in the convert context. */
         SqlValidator getSqlValidator();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -56,6 +56,7 @@ public class SqlNodeConverters {
         register(new SqlShowCreateCatalogConverter());
         register(new SqlDescribeCatalogConverter());
         register(new SqlDescribeJobConverter());
+        register(new SqlCreateMaterializedTableConverter());
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/MaterializedTableUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/MaterializedTableUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.sql.parser.ddl.SqlRefreshMode;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+
+import org.apache.calcite.sql.SqlIntervalLiteral;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+
+import java.time.Duration;
+
+/** The utils for materialized table. */
+@Internal
+public class MaterializedTableUtils {
+
+    public static Duration getMaterializedTableFreshness(SqlIntervalLiteral sqlIntervalLiteral) {
+        if (sqlIntervalLiteral.signum() < 0) {
+            throw new ValidationException(
+                    "Materialized table freshness doesn't support negative value.");
+        }
+        if (sqlIntervalLiteral.getTypeName().getFamily() != SqlTypeFamily.INTERVAL_DAY_TIME) {
+            throw new ValidationException(
+                    "Materialized table freshness only support SECOND, MINUTE, HOUR, DAY as the time unit.");
+        }
+
+        SqlIntervalLiteral.IntervalValue intervalValue =
+                sqlIntervalLiteral.getValueAs(SqlIntervalLiteral.IntervalValue.class);
+        long interval = Long.parseLong(intervalValue.getIntervalLiteral());
+        switch (intervalValue.getIntervalQualifier().typeName()) {
+            case INTERVAL_DAY:
+                return Duration.ofDays(interval);
+            case INTERVAL_HOUR:
+                return Duration.ofHours(interval);
+            case INTERVAL_MINUTE:
+                return Duration.ofMinutes(interval);
+            case INTERVAL_SECOND:
+                return Duration.ofSeconds(interval);
+            default:
+                throw new ValidationException(
+                        "Materialized table freshness only support SECOND, MINUTE, HOUR, DAY as the time unit.");
+        }
+    }
+
+    public static CatalogMaterializedTable.LogicalRefreshMode deriveLogicalRefreshMode(
+            SqlRefreshMode sqlRefreshMode) {
+        if (sqlRefreshMode == null) {
+            return CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC;
+        }
+
+        switch (sqlRefreshMode) {
+            case FULL:
+                return CatalogMaterializedTable.LogicalRefreshMode.FULL;
+            case CONTINUOUS:
+                return CatalogMaterializedTable.LogicalRefreshMode.CONTINUOUS;
+            default:
+                throw new ValidationException(
+                        String.format("Unsupported logical refresh mode: %s.", sqlRefreshMode));
+        }
+    }
+
+    public static CatalogMaterializedTable.RefreshMode deriveRefreshMode(
+            Duration threshold,
+            Duration definedFreshness,
+            CatalogMaterializedTable.LogicalRefreshMode definedRefreshMode) {
+        // If the refresh mode is specified manually, use it directly.
+        if (definedRefreshMode == CatalogMaterializedTable.LogicalRefreshMode.FULL) {
+            return CatalogMaterializedTable.RefreshMode.FULL;
+        } else if (definedRefreshMode == CatalogMaterializedTable.LogicalRefreshMode.CONTINUOUS) {
+            return CatalogMaterializedTable.RefreshMode.CONTINUOUS;
+        }
+
+        // derive the actual refresh mode via defined freshness
+        if (definedFreshness.compareTo(threshold) <= 0) {
+            return CatalogMaterializedTable.RefreshMode.CONTINUOUS;
+        } else {
+            return CatalogMaterializedTable.RefreshMode.FULL;
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.CreateMaterializedTableOperation;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for the materialized table statements for {@link SqlNodeToOperationConversion}. */
+public class SqlMaterializedTableNodeToOperationConverterTest
+        extends SqlNodeToOperationConversionTestBase {
+
+    @Test
+    public void testCreateMaterializedTable() {
+        final String sql =
+                "CREATE MATERIALIZED TABLE mtbl1 (\n"
+                        + "   CONSTRAINT ct1 PRIMARY KEY(a) NOT ENFORCED"
+                        + ")\n"
+                        + "COMMENT 'materialized table comment'\n"
+                        + "PARTITIONED BY (a, d)\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'filesystem', \n"
+                        + "  'format' = 'json'\n"
+                        + ")\n"
+                        + "FRESHNESS = INTERVAL '30' SECOND\n"
+                        + "REFRESH_MODE = FULL\n"
+                        + "AS SELECT * FROM t1";
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(CreateMaterializedTableOperation.class);
+
+        CreateMaterializedTableOperation op = (CreateMaterializedTableOperation) operation;
+        CatalogMaterializedTable materializedTable = op.getCatalogMaterializedTable();
+        assertThat(materializedTable).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "filesystem");
+        options.put("format", "json");
+        CatalogMaterializedTable expected =
+                CatalogMaterializedTable.newBuilder()
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("a", DataTypes.BIGINT().notNull())
+                                        .column("b", DataTypes.VARCHAR(Integer.MAX_VALUE))
+                                        .column("c", DataTypes.INT())
+                                        .column("d", DataTypes.VARCHAR(Integer.MAX_VALUE))
+                                        .primaryKeyNamed("ct1", Collections.singletonList("a"))
+                                        .build())
+                        .comment("materialized table comment")
+                        .options(options)
+                        .partitionKeys(Arrays.asList("a", "d"))
+                        .freshness(Duration.ofSeconds(30))
+                        .logicalRefreshMode(CatalogMaterializedTable.LogicalRefreshMode.FULL)
+                        .refreshMode(CatalogMaterializedTable.RefreshMode.FULL)
+                        .refreshStatus(CatalogMaterializedTable.RefreshStatus.INITIALIZING)
+                        .definitionQuery(
+                                "SELECT `t1`.`a`, `t1`.`b`, `t1`.`c`, `t1`.`d`\n"
+                                        + "FROM `builtin`.`default`.`t1` AS `t1`")
+                        .build();
+
+        assertThat(((ResolvedCatalogMaterializedTable) materializedTable).getOrigin())
+                .isEqualTo(expected);
+    }
+
+    @Test
+    public void testContinuousRefreshMode() {
+        // test continuous mode derived by specify freshness automatically
+        final String sql =
+                "CREATE MATERIALIZED TABLE mtbl1\n"
+                        + "FRESHNESS = INTERVAL '30' SECOND\n"
+                        + "AS SELECT * FROM t1";
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(CreateMaterializedTableOperation.class);
+
+        CreateMaterializedTableOperation op = (CreateMaterializedTableOperation) operation;
+        CatalogMaterializedTable materializedTable = op.getCatalogMaterializedTable();
+        assertThat(materializedTable).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+
+        assertThat(materializedTable.getLogicalRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC);
+        assertThat(materializedTable.getRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.RefreshMode.CONTINUOUS);
+
+        // test continuous mode by manual specify
+        final String sql2 =
+                "CREATE MATERIALIZED TABLE mtbl1\n"
+                        + "FRESHNESS = INTERVAL '30' DAY\n"
+                        + "REFRESH_MODE = CONTINUOUS\n"
+                        + "AS SELECT * FROM t1";
+        Operation operation2 = parse(sql2);
+        assertThat(operation2).isInstanceOf(CreateMaterializedTableOperation.class);
+
+        CreateMaterializedTableOperation op2 = (CreateMaterializedTableOperation) operation2;
+        CatalogMaterializedTable materializedTable2 = op2.getCatalogMaterializedTable();
+        assertThat(materializedTable2).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+
+        assertThat(materializedTable2.getLogicalRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.CONTINUOUS);
+        assertThat(materializedTable2.getRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.RefreshMode.CONTINUOUS);
+    }
+
+    @Test
+    public void testFullRefreshMode() {
+        // test full mode derived by specify freshness automatically
+        final String sql =
+                "CREATE MATERIALIZED TABLE mtbl1\n"
+                        + "FRESHNESS = INTERVAL '1' DAY\n"
+                        + "AS SELECT * FROM t1";
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(CreateMaterializedTableOperation.class);
+
+        CreateMaterializedTableOperation op = (CreateMaterializedTableOperation) operation;
+        CatalogMaterializedTable materializedTable = op.getCatalogMaterializedTable();
+        assertThat(materializedTable).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+
+        assertThat(materializedTable.getLogicalRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC);
+        assertThat(materializedTable.getRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.RefreshMode.FULL);
+
+        // test full mode by manual specify
+        final String sql2 =
+                "CREATE MATERIALIZED TABLE mtbl1\n"
+                        + "FRESHNESS = INTERVAL '30' SECOND\n"
+                        + "REFRESH_MODE = FULL\n"
+                        + "AS SELECT * FROM t1";
+        Operation operation2 = parse(sql2);
+        assertThat(operation2).isInstanceOf(CreateMaterializedTableOperation.class);
+
+        CreateMaterializedTableOperation op2 = (CreateMaterializedTableOperation) operation2;
+        CatalogMaterializedTable materializedTable2 = op2.getCatalogMaterializedTable();
+        assertThat(materializedTable2).isInstanceOf(ResolvedCatalogMaterializedTable.class);
+
+        assertThat(materializedTable2.getLogicalRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.FULL);
+        assertThat(materializedTable2.getRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.RefreshMode.FULL);
+    }
+
+    @Test
+    public void testCreateMaterializedTableWithInvalidPrimaryKey() {
+        // test unsupported constraint
+        final String sql =
+                "CREATE MATERIALIZED TABLE mtbl1 (\n"
+                        + "   CONSTRAINT ct1 UNIQUE(a) NOT ENFORCED"
+                        + ")\n"
+                        + "FRESHNESS = INTERVAL '30' SECOND\n"
+                        + "AS SELECT * FROM t1";
+
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Primary key validation failed: UNIQUE constraint is not supported yet.");
+
+        // test primary key not defined in source table
+        final String sql2 =
+                "CREATE MATERIALIZED TABLE mtbl1 (\n"
+                        + "   CONSTRAINT ct1 PRIMARY KEY(e) NOT ENFORCED"
+                        + ")\n"
+                        + "FRESHNESS = INTERVAL '30' SECOND\n"
+                        + "AS SELECT * FROM t1";
+
+        assertThatThrownBy(() -> parse(sql2))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Primary key column 'e' not defined in the query schema. Available columns: ['a', 'b', 'c', 'd'].");
+
+        // test primary key with nullable source column
+        final String sql3 =
+                "CREATE MATERIALIZED TABLE mtbl1 (\n"
+                        + "   CONSTRAINT ct1 PRIMARY KEY(d) NOT ENFORCED"
+                        + ")\n"
+                        + "FRESHNESS = INTERVAL '30' SECOND\n"
+                        + "AS SELECT * FROM t1";
+
+        assertThatThrownBy(() -> parse(sql3))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Could not create a PRIMARY KEY with nullable column 'd'.");
+    }
+
+    @Test
+    public void testCreateMaterializedTableWithInvalidPartitionKey() {
+        final String sql =
+                "CREATE MATERIALIZED TABLE mtbl1\n"
+                        + "PARTITIONED BY (a, e)\n"
+                        + "FRESHNESS = INTERVAL '30' SECOND\n"
+                        + "REFRESH_MODE = FULL\n"
+                        + "AS SELECT * FROM t1";
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Partition column 'e' not defined in the query schema. Available columns: ['a', 'b', 'c', 'd'].");
+    }
+
+    @Test
+    public void testCreateMaterializedTableWithInvalidFreshnessType() {
+        // test negative freshness value
+        final String sql =
+                "CREATE MATERIALIZED TABLE mtbl1\n"
+                        + "FRESHNESS = INTERVAL -'30' SECOND\n"
+                        + "REFRESH_MODE = FULL\n"
+                        + "AS SELECT * FROM t1";
+        assertThatThrownBy(() -> parse(sql))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Materialized table freshness doesn't support negative value.");
+
+        // test unsupported freshness type
+        final String sql2 =
+                "CREATE MATERIALIZED TABLE mtbl1\n"
+                        + "FRESHNESS = INTERVAL '30' YEAR\n"
+                        + "AS SELECT * FROM t1";
+        assertThatThrownBy(() -> parse(sql2))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Materialized table freshness only support SECOND, MINUTE, HOUR, DAY as the time unit.");
+
+        // test unsupported freshness type
+        final String sql3 =
+                "CREATE MATERIALIZED TABLE mtbl1\n"
+                        + "FRESHNESS = INTERVAL '30' DAY TO HOUR\n"
+                        + "AS SELECT * FROM t1";
+        assertThatThrownBy(() -> parse(sql3))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Materialized table freshness only support SECOND, MINUTE, HOUR, DAY as the time unit.");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversionTestBase.java
@@ -107,7 +107,7 @@ public class SqlNodeToOperationConversionTestBase {
                 Schema.newBuilder()
                         .fromResolvedSchema(
                                 ResolvedSchema.of(
-                                        Column.physical("a", DataTypes.BIGINT()),
+                                        Column.physical("a", DataTypes.BIGINT().notNull()),
                                         Column.physical("b", DataTypes.VARCHAR(Integer.MAX_VALUE)),
                                         Column.physical("c", DataTypes.INT()),
                                         Column.physical("d", DataTypes.VARCHAR(Integer.MAX_VALUE))))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlRTASNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlRTASNodeToOperationConverterTest.java
@@ -126,7 +126,7 @@ public class SqlRTASNodeToOperationConverterTest extends SqlNodeToOperationConve
                 .fromFields(
                         new String[] {"a", "b", "c", "d"},
                         new AbstractDataType[] {
-                            DataTypes.BIGINT(),
+                            DataTypes.BIGINT().notNull(),
                             DataTypes.STRING(),
                             DataTypes.INT(),
                             DataTypes.STRING()

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/main/java/org/apache/flink/table/file/testutils/TestFileSystemTableFactory.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/main/java/org/apache/flink/table/file/testutils/TestFileSystemTableFactory.java
@@ -22,10 +22,14 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.file.table.FileSystemTableFactory;
 import org.apache.flink.connector.file.table.TestFileSystemTableSource;
 import org.apache.flink.connector.file.table.factories.BulkReaderFormatFactory;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.file.testutils.catalog.TestFileSystemCatalog;
+
+import java.util.Collections;
 
 /** Test filesystem {@link Factory}. */
 @Internal
@@ -40,9 +44,21 @@ public class TestFileSystemTableFactory extends FileSystemTableFactory {
 
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
+        final boolean isFileSystemTable =
+                TestFileSystemCatalog.isFileSystemTable(context.getCatalogTable().getOptions());
+        if (!isFileSystemTable) {
+            return FactoryUtil.createDynamicTableSource(
+                    null,
+                    context.getObjectIdentifier(),
+                    context.getCatalogTable(),
+                    Collections.emptyMap(),
+                    context.getConfiguration(),
+                    context.getClassLoader(),
+                    context.isTemporary());
+        }
+
         FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
         validate(helper);
-
         return new TestFileSystemTableSource(
                 context.getObjectIdentifier(),
                 context.getPhysicalRowDataType(),
@@ -50,5 +66,22 @@ public class TestFileSystemTableFactory extends FileSystemTableFactory {
                 helper.getOptions(),
                 discoverDecodingFormat(context, BulkReaderFormatFactory.class),
                 discoverDecodingFormat(context, DeserializationFormatFactory.class));
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        final boolean isFileSystemTable =
+                TestFileSystemCatalog.isFileSystemTable(context.getCatalogTable().getOptions());
+        if (!isFileSystemTable) {
+            return FactoryUtil.createDynamicTableSink(
+                    null,
+                    context.getObjectIdentifier(),
+                    context.getCatalogTable(),
+                    Collections.emptyMap(),
+                    context.getConfiguration(),
+                    context.getClassLoader(),
+                    context.isTemporary());
+        }
+        return super.createDynamicTableSink(context);
     }
 }

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogITCase.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogITCase.java
@@ -20,11 +20,13 @@ package org.apache.flink.table.file.testutils.catalog;
 
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -44,7 +46,6 @@ public class TestFileSystemCatalogITCase extends TestFileSystemCatalogTestBase {
                         isStreamingMode
                                 ? EnvironmentSettings.inStreamingMode()
                                 : EnvironmentSettings.inBatchMode());
-
         tEnv.registerCatalog(TEST_CATALOG, catalog);
         tEnv.useCatalog(TEST_CATALOG);
 
@@ -84,6 +85,80 @@ public class TestFileSystemCatalogITCase extends TestFileSystemCatalogTestBase {
                         Row.of(1003L, "user3", "ciao", "2021-06-10 10:02:00"),
                         Row.of(1004L, "user4", "你好", "2021-06-10 10:03:00"));
 
-        assertThat(expected).isEqualTo((Lists.newArrayList(result)));
+        assertThat(Lists.newArrayList(result)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testReadDatagenTable(boolean isStreamingMode) {
+        TableEnvironment tEnv =
+                TableEnvironment.create(
+                        isStreamingMode
+                                ? EnvironmentSettings.inStreamingMode()
+                                : EnvironmentSettings.inBatchMode());
+        tEnv.registerCatalog(TEST_CATALOG, catalog);
+        tEnv.useCatalog(TEST_CATALOG);
+
+        tEnv.executeSql(
+                "CREATE TABLE datagenSource (\n"
+                        + "  id BIGINT,\n"
+                        + "  user_name STRING,\n"
+                        + "  message STRING,\n"
+                        + "  log_ts STRING\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'datagen',\n"
+                        + "  'number-of-rows' = '10'\n"
+                        + ")");
+
+        tEnv.getConfig().getConfiguration().setString("parallelism.default", "1");
+        CloseableIterator<Row> result =
+                tEnv.executeSql(
+                                String.format(
+                                        "SELECT * FROM %s.%s.datagenSource",
+                                        TEST_CATALOG, TEST_DEFAULT_DATABASE))
+                        .collect();
+
+        // assert query result size
+        assertThat(Lists.newArrayList(result).size()).isEqualTo(10);
+    }
+
+    @Test
+    public void testWriteTestValuesSinkTable() throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
+        tEnv.registerCatalog(TEST_CATALOG, catalog);
+        tEnv.useCatalog(TEST_CATALOG);
+
+        tEnv.executeSql(
+                "CREATE TABLE valueSink (\n"
+                        + "  id BIGINT,\n"
+                        + "  user_name STRING,\n"
+                        + "  message STRING,\n"
+                        + "  log_ts STRING\n"
+                        + ") WITH (\n"
+                        + "  'connector' = 'values'\n"
+                        + ")");
+
+        tEnv.getConfig().getConfiguration().setString("parallelism.default", "1");
+        tEnv.getConfig().getConfiguration().setString("parallelism.default", "1");
+        tEnv.executeSql(
+                        String.format(
+                                "INSERT INTO %s.%s.valueSink VALUES\n"
+                                        + "(1001, 'user1', 'hello world', '2021-06-10 10:00:00'),\n"
+                                        + "(1002, 'user2', 'hi', '2021-06-10 10:01:00'),\n"
+                                        + "(1003, 'user3', 'ciao', '2021-06-10 10:02:00'),\n"
+                                        + "(1004, 'user4', '你好', '2021-06-10 10:03:00')",
+                                TEST_CATALOG, TEST_DEFAULT_DATABASE))
+                .await();
+
+        // assert query result size
+        List<Row> expected =
+                Arrays.asList(
+                        Row.of(1001L, "user1", "hello world", "2021-06-10 10:00:00"),
+                        Row.of(1002L, "user2", "hi", "2021-06-10 10:01:00"),
+                        Row.of(1003L, "user3", "ciao", "2021-06-10 10:02:00"),
+                        Row.of(1004L, "user4", "你好", "2021-06-10 10:03:00"));
+
+        List<Row> actual = TestValuesTableFactory.getRawResults("valueSink");
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogTest.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogTest.java
@@ -257,6 +257,44 @@ public class TestFileSystemCatalogTest extends TestFileSystemCatalogTestBase {
     }
 
     @Test
+    public void testCreateAndGetGenericTable() throws Exception {
+        ObjectPath tablePath = new ObjectPath(TEST_DEFAULT_DATABASE, "tb1");
+        // test create datagen table
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "datagen");
+        options.put("number-of-rows", "10");
+        ResolvedCatalogTable datagenResolvedTable =
+                new ResolvedCatalogTable(
+                        CatalogTable.newBuilder()
+                                .schema(CREATE_SCHEMA)
+                                .comment("test generic table")
+                                .options(options)
+                                .build(),
+                        CREATE_RESOLVED_SCHEMA);
+
+        catalog.createTable(tablePath, datagenResolvedTable, true);
+
+        // test table exist
+        assertThat(catalog.tableExists(tablePath)).isTrue();
+
+        // test get table
+        CatalogBaseTable actualTable = catalog.getTable(tablePath);
+
+        // validate table type
+        assertThat(actualTable.getTableKind()).isEqualTo(CatalogBaseTable.TableKind.TABLE);
+        // validate schema
+        assertThat(actualTable.getUnresolvedSchema().resolve(new TestSchemaResolver()))
+                .isEqualTo(CREATE_RESOLVED_SCHEMA);
+        // validate options
+        assertThat(actualTable.getOptions()).isEqualTo(options);
+
+        // test create exist table
+        assertThrows(
+                TableAlreadyExistException.class,
+                () -> catalog.createTable(tablePath, datagenResolvedTable, false));
+    }
+
+    @Test
     public void testListTable() throws Exception {
         ObjectPath tablePath1 = new ObjectPath(TEST_DEFAULT_DATABASE, "tb1");
         ObjectPath tablePath2 = new ObjectPath(TEST_DEFAULT_DATABASE, "tb2");


### PR DESCRIPTION
## What is the purpose of the change

*Support the execution of create materialized table in continuous refresh mode*

## Brief change log

  - *Support the execution of create materialized table in continuous refresh mode*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests in MaterializedTableStatementITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
