### PR TITLE
[FLINK-33212][runtime] add job status changed listener for lineage

### DIFF
--- a/docs/content/docs/deployment/advanced/job_status_listener.md
+++ b/docs/content/docs/deployment/advanced/job_status_listener.md
@@ -1,0 +1,81 @@
+
+---
+title: "Job Status Changed Listener"
+nav-title: job-status-listener
+nav-parent_id: advanced
+nav-pos: 3
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## Job status changed listener
+Flink provides a pluggable interface for users to register their custom logic for handling with the job status changes in which lineage info about source/sink is provided.
+This enables users to implement their own flink lineage reporter to send lineage info to third party data lineage systems for example Datahub and Openlineage.
+
+The job status changed listeners are triggered every time status change happened for the application. The data lineage info is included in the JobCreatedEvent.
+
+### Implement a plugin for your custom enricher
+
+To implement a custom JobStatusChangedListener plugin, you need to:
+
+- Add your own JobStatusChangedListener by implementing the {{< gh_link file="/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListener.java" name="JobStatusChangedListener" >}} interface.
+
+- Add your own JobStatusChangedListenerFactory by implementing the {{< gh_link file="/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListenerFactory.java" name="JobStatusChangedListenerFactory" >}} interface.
+
+- Add a service entry. Create a file `META-INF/services/org.apache.flink.core.execution.JobStatusChangedListenerFactory` which contains the class name of your job status changed listener factory class (see [Java Service Loader](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html) docs for more details).
+
+
+Then, create a jar which includes your `JobStatusChangedListener`, `JobStatusChangedListenerFactory`, `META-INF/services/` and all external dependencies.
+Make a directory in `plugins/` of your Flink distribution with an arbitrary name, e.g. "job-status-changed-listener", and put the jar into this directory.
+See [Flink Plugin]({{< ref "docs/deployment/filesystems/plugins" >}}) for more details.
+
+JobStatusChangedListenerFactory example:
+
+``` java
+package org.apache.flink.test.execution;
+
+public static class TestingJobStatusChangedListenerFactory
+        implements JobStatusChangedListenerFactory {
+
+    @Override
+    public JobStatusChangedListener createListener(Context context) {
+        return new TestingJobStatusChangedListener();
+    }
+}
+```
+
+JobStatusChangedListener example:
+
+``` java
+package org.apache.flink.test.execution;
+
+private static class TestingJobStatusChangedListener implements JobStatusChangedListener {
+
+    @Override
+    public void onEvent(JobStatusChangedEvent event) {
+        statusChangedEvents.add(event);
+    }
+}
+```
+
+### Configuration
+
+Flink components loads JobStatusChangedListener plugins at startup. To make sure your JobStatusChangedListeners are loaded all class names should be defined as part of [execution.job-status-changed-listeners]({{< ref "docs/deployment/config#execution.job-status-changed-listeners" >}}).
+  If this configuration is empty, NO enrichers will be started. Example:
+```
+    execution.job-status-changed-listeners = org.apache.flink.test.execution.TestingJobStatusChangedListenerFactory
+```

--- a/docs/layouts/shortcodes/generated/deployment_configuration.html
+++ b/docs/layouts/shortcodes/generated/deployment_configuration.html
@@ -21,6 +21,12 @@
             <td>Custom JobListeners to be registered with the execution environment. The registered listeners cannot have constructors with arguments.</td>
         </tr>
         <tr>
+            <td><h5>execution.job-status-changed-listeners</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>When job is created or its status is changed, Flink will generate job event and notify job status changed listener.</td>
+        </tr>
+        <tr>
             <td><h5>execution.program-config.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
@@ -79,6 +79,7 @@ public class EmbeddedExecutorFactory implements PipelineExecutorFactory {
         return new EmbeddedExecutor(
                 submittedJobIds,
                 dispatcherGateway,
+                configuration,
                 (jobId, userCodeClassloader) -> {
                     final Time timeout =
                             Time.milliseconds(

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/WebSubmissionExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/WebSubmissionExecutorFactory.java
@@ -75,6 +75,7 @@ public class WebSubmissionExecutorFactory implements PipelineExecutorFactory {
         return new EmbeddedExecutor(
                 submittedJobIds,
                 dispatcherGateway,
+                configuration,
                 (jobId, userCodeClassloader) -> new WebSubmissionJobClient(jobId));
     }
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutorFactory.java
@@ -40,6 +40,6 @@ public class RemoteExecutorFactory implements PipelineExecutorFactory {
 
     @Override
     public PipelineExecutor getExecutor(final Configuration configuration) {
-        return new RemoteExecutor();
+        return new RemoteExecutor(configuration);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -78,6 +78,14 @@ public class DeploymentOptions {
                             "Custom JobListeners to be registered with the execution environment."
                                     + " The registered listeners cannot have constructors with arguments.");
 
+    public static final ConfigOption<List<String>> JOB_STATUS_CHANGED_LISTENERS =
+            key("execution.job-status-changed-listeners")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "When job is created or its status is changed, Flink will generate job event and notify job status changed listener.");
+
     public static final ConfigOption<Boolean> SHUTDOWN_ON_APPLICATION_FINISH =
             ConfigOptions.key("execution.shutdown-on-application-finish")
                     .booleanType()

--- a/flink-core/src/main/java/org/apache/flink/core/execution/DefaultJobExecutionStatusEvent.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/DefaultJobExecutionStatusEvent.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+
+import javax.annotation.Nullable;
+
+/** Default implementation for {@link JobExecutionStatusEvent}. */
+@Internal
+public class DefaultJobExecutionStatusEvent implements JobExecutionStatusEvent {
+    private final JobID jobId;
+    private final String jobName;
+    private final JobStatus oldStatus;
+    private final JobStatus newStatus;
+    @Nullable private final Throwable cause;
+
+    public DefaultJobExecutionStatusEvent(
+            JobID jobId,
+            String jobName,
+            JobStatus oldStatus,
+            JobStatus newStatus,
+            @Nullable Throwable cause) {
+        this.jobId = jobId;
+        this.jobName = jobName;
+        this.oldStatus = oldStatus;
+        this.newStatus = newStatus;
+        this.cause = cause;
+    }
+
+    @Override
+    public JobStatus oldStatus() {
+        return oldStatus;
+    }
+
+    @Override
+    public JobStatus newStatus() {
+        return newStatus;
+    }
+
+    @Nullable
+    @Override
+    public Throwable exception() {
+        return cause;
+    }
+
+    @Override
+    public JobID jobId() {
+        return jobId;
+    }
+
+    @Override
+    public String jobName() {
+        return jobName;
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobExecutionStatusEvent.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobExecutionStatusEvent.java
@@ -16,22 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.client.deployment.executors;
+package org.apache.flink.core.execution;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.deployment.StandaloneClientFactory;
-import org.apache.flink.client.deployment.StandaloneClusterId;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.execution.PipelineExecutor;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobStatus;
 
-/** The {@link PipelineExecutor} to be used when executing a job on an already running cluster. */
-@Internal
-public class RemoteExecutor
-        extends AbstractSessionClusterExecutor<StandaloneClusterId, StandaloneClientFactory> {
+import javax.annotation.Nullable;
 
-    public static final String NAME = "remote";
+/** Job execution status event. */
+@PublicEvolving
+public interface JobExecutionStatusEvent extends JobStatusChangedEvent {
+    /** Old status for job. */
+    JobStatus oldStatus();
 
-    public RemoteExecutor(Configuration configuration) {
-        super(new StandaloneClientFactory(), configuration);
-    }
+    /** New status for job. */
+    JobStatus newStatus();
+
+    /** Exception for job. */
+    @Nullable
+    Throwable exception();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedEvent.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedEvent.java
@@ -16,22 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.client.deployment.executors;
+package org.apache.flink.core.execution;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.deployment.StandaloneClientFactory;
-import org.apache.flink.client.deployment.StandaloneClusterId;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.execution.PipelineExecutor;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.JobID;
 
-/** The {@link PipelineExecutor} to be used when executing a job on an already running cluster. */
-@Internal
-public class RemoteExecutor
-        extends AbstractSessionClusterExecutor<StandaloneClusterId, StandaloneClientFactory> {
+/** Basic job status event. */
+@PublicEvolving
+public interface JobStatusChangedEvent {
 
-    public static final String NAME = "remote";
+    JobID jobId();
 
-    public RemoteExecutor(Configuration configuration) {
-        super(new StandaloneClientFactory(), configuration);
-    }
+    String jobName();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListener.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListener.java
@@ -16,22 +16,17 @@
  * limitations under the License.
  */
 
-package org.apache.flink.client.deployment.executors;
+package org.apache.flink.core.execution;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.deployment.StandaloneClientFactory;
-import org.apache.flink.client.deployment.StandaloneClusterId;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.execution.PipelineExecutor;
+import org.apache.flink.annotation.PublicEvolving;
 
-/** The {@link PipelineExecutor} to be used when executing a job on an already running cluster. */
-@Internal
-public class RemoteExecutor
-        extends AbstractSessionClusterExecutor<StandaloneClusterId, StandaloneClientFactory> {
+/**
+ * When job is created or its status is changed, Flink will generate job event and notify job status
+ * changed listener.
+ */
+@PublicEvolving
+public interface JobStatusChangedListener {
 
-    public static final String NAME = "remote";
-
-    public RemoteExecutor(Configuration configuration) {
-        super(new StandaloneClientFactory(), configuration);
-    }
+    /* Event will be fired when job status is changed. */
+    void onEvent(JobStatusChangedEvent event);
 }

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListenerFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListenerFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+
+import java.util.concurrent.Executor;
+
+/** Factory for job status changed listener. */
+@PublicEvolving
+public interface JobStatusChangedListenerFactory {
+
+    JobStatusChangedListener createListener(Context context);
+
+    @PublicEvolving
+    interface Context {
+        /*
+         * Configuration for the factory to create listener, users can add customized options to flink and get them here to create the listener. For
+         * example, users can add rest address for datahub to the configuration, and get it when they need to create http client for the listener.
+         */
+        Configuration getConfiguration();
+
+        /**
+         * User classloader for the flink application.
+         *
+         * @return
+         */
+        ClassLoader getUserClassLoader();
+
+        /*
+         * Get an Executor pool for the listener to run async operations that can potentially be IO-heavy. `JobMaster` will provide an independent executor
+         * for io operations and it won't block the main-thread. All tasks submitted to the executor will be executed in parallel, and when the job ends,
+         * previously submitted tasks will be executed, but no new tasks will be accepted.
+         */
+        Executor getIOExecutor();
+    }
+}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListenerUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/JobStatusChangedListenerUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.execution;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.configuration.DeploymentOptions.JOB_STATUS_CHANGED_LISTENERS;
+
+/** Util class for {@link JobStatusChangedListener}. */
+@Internal
+public final class JobStatusChangedListenerUtils {
+    /**
+     * Create job status changed listeners from configuration for job.
+     *
+     * @param configuration The job configuration.
+     * @return the job status changed listeners.
+     */
+    public static List<JobStatusChangedListener> createJobStatusChangedListeners(
+            ClassLoader userClassLoader, Configuration configuration, Executor ioExecutor) {
+        List<String> jobStatusChangedListeners = configuration.get(JOB_STATUS_CHANGED_LISTENERS);
+        if (jobStatusChangedListeners == null || jobStatusChangedListeners.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return jobStatusChangedListeners.stream()
+                .map(
+                        fac -> {
+                            try {
+                                return InstantiationUtil.instantiate(
+                                                fac,
+                                                JobStatusChangedListenerFactory.class,
+                                                userClassLoader)
+                                        .createListener(
+                                                new JobStatusChangedListenerFactory.Context() {
+                                                    @Override
+                                                    public Configuration getConfiguration() {
+                                                        return configuration;
+                                                    }
+
+                                                    @Override
+                                                    public ClassLoader getUserClassLoader() {
+                                                        return userClassLoader;
+                                                    }
+
+                                                    @Override
+                                                    public Executor getIOExecutor() {
+                                                        return ioExecutor;
+                                                    }
+                                                });
+                            } catch (FlinkException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                .collect(Collectors.toList());
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.executors;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.client.deployment.executors.AbstractSessionClusterExecutor;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
@@ -31,7 +32,7 @@ public class KubernetesSessionClusterExecutor
 
     public static final String NAME = KubernetesDeploymentTarget.SESSION.getName();
 
-    public KubernetesSessionClusterExecutor() {
-        super(new KubernetesClusterClientFactory());
+    public KubernetesSessionClusterExecutor(Configuration configuration) {
+        super(new KubernetesClusterClientFactory(), configuration);
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutorFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutorFactory.java
@@ -44,6 +44,6 @@ public class KubernetesSessionClusterExecutorFactory implements PipelineExecutor
 
     @Override
     public PipelineExecutor getExecutor(@Nonnull final Configuration configuration) {
-        return new KubernetesSessionClusterExecutor();
+        return new KubernetesSessionClusterExecutor(configuration);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -27,6 +27,8 @@ import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.DefaultJobExecutionStatusEvent;
+import org.apache.flink.core.execution.JobStatusChangedListener;
 import org.apache.flink.core.execution.JobStatusHook;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
@@ -302,6 +304,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     private final TaskDeploymentDescriptorFactory taskDeploymentDescriptorFactory;
 
+    private final List<JobStatusChangedListener> jobStatusChangedListeners;
+
     // --------------------------------------------------------------------------------------------
     //   Constructors
     // --------------------------------------------------------------------------------------------
@@ -327,7 +331,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
             ExecutionJobVertex.Factory executionJobVertexFactory,
             List<JobStatusHook> jobStatusHooks,
             MarkPartitionFinishedStrategy markPartitionFinishedStrategy,
-            TaskDeploymentDescriptorFactory taskDeploymentDescriptorFactory) {
+            TaskDeploymentDescriptorFactory taskDeploymentDescriptorFactory,
+            List<JobStatusChangedListener> jobStatusChangedListeners) {
 
         this.jobType = jobType;
         this.executionGraphId = new ExecutionGraphID();
@@ -397,6 +402,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         this.markPartitionFinishedStrategy = markPartitionFinishedStrategy;
 
         this.taskDeploymentDescriptorFactory = checkNotNull(taskDeploymentDescriptorFactory);
+
+        this.jobStatusChangedListeners = checkNotNull(jobStatusChangedListeners);
 
         LOG.info(
                 "Created execution graph {} for job {}.",
@@ -1164,7 +1171,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                     error);
 
             stateTimestamps[newState.ordinal()] = System.currentTimeMillis();
-            notifyJobStatusChange(newState);
+            notifyJobStatusChange(current, newState, error);
             notifyJobStatusHooks(newState, error);
             return true;
         } else {
@@ -1599,7 +1606,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         }
     }
 
-    private void notifyJobStatusChange(JobStatus newState) {
+    private void notifyJobStatusChange(
+            JobStatus oldState, JobStatus newState, @Nullable Throwable cause) {
         if (jobStatusListeners.size() > 0) {
             final long timestamp = System.currentTimeMillis();
 
@@ -1610,6 +1618,14 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                     LOG.warn("Error while notifying JobStatusListener", t);
                 }
             }
+        }
+
+        if (jobStatusChangedListeners.size() > 0) {
+            jobStatusChangedListeners.forEach(
+                    listener ->
+                            listener.onEvent(
+                                    new DefaultJobExecutionStatusEvent(
+                                            getJobID(), getJobName(), oldState, newState, cause)));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.core.execution.JobStatusChangedListener;
+import org.apache.flink.core.execution.JobStatusChangedListenerUtils;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.blob.BlobWriter;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
@@ -141,6 +143,10 @@ public class DefaultExecutionGraphBuilder {
             throw new JobException("Could not create the TaskDeploymentDescriptorFactory.", e);
         }
 
+        final List<JobStatusChangedListener> jobStatusChangedListeners =
+                JobStatusChangedListenerUtils.createJobStatusChangedListeners(
+                        classLoader, jobManagerConfig, ioExecutor);
+
         // create a new execution graph, if none exists so far
         final DefaultExecutionGraph executionGraph =
                 new DefaultExecutionGraph(
@@ -164,7 +170,8 @@ public class DefaultExecutionGraphBuilder {
                         executionJobVertexFactory,
                         jobGraph.getJobStatusHooks(),
                         markPartitionFinishedStrategy,
-                        taskDeploymentDescriptorFactory);
+                        taskDeploymentDescriptorFactory,
+                        jobStatusChangedListeners);
 
         // set the basic properties
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.lineage.LineageGraph;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.OutputFormatOperatorFactory;
 import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
@@ -134,6 +135,7 @@ public class StreamGraph implements Pipeline {
     private boolean dynamic;
 
     private boolean autoParallelismEnabled;
+    private LineageGraph lineageGraph;
 
     public StreamGraph(
             Configuration jobConfiguration,
@@ -226,6 +228,10 @@ public class StreamGraph implements Pipeline {
 
     public void setTimeCharacteristic(TimeCharacteristic timeCharacteristic) {
         this.timeCharacteristic = timeCharacteristic;
+    }
+
+    public LineageGraph getLineageGraph() {
+        return lineageGraph;
     }
 
     public GlobalStreamExchangeMode getGlobalStreamExchangeMode() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/execution/DefaultJobCreatedEvent.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/execution/DefaultJobCreatedEvent.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.execution;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.streaming.api.lineage.LineageGraph;
+
+/** Default implementation for {@link JobCreatedEvent}. */
+@Internal
+public class DefaultJobCreatedEvent implements JobCreatedEvent {
+    private final JobID jobId;
+    private final String jobName;
+    private final LineageGraph lineageGraph;
+    private final RuntimeExecutionMode executionMode;
+
+    public DefaultJobCreatedEvent(
+            JobID jobId,
+            String jobName,
+            LineageGraph lineageGraph,
+            RuntimeExecutionMode executionMode) {
+        this.jobId = jobId;
+        this.jobName = jobName;
+        this.lineageGraph = lineageGraph;
+        this.executionMode = executionMode;
+    }
+
+    @Override
+    public JobID jobId() {
+        return jobId;
+    }
+
+    @Override
+    public String jobName() {
+        return jobName;
+    }
+
+    @Override
+    public LineageGraph lineageGraph() {
+        return lineageGraph;
+    }
+
+    @Override
+    public RuntimeExecutionMode executionMode() {
+        return executionMode;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/execution/JobCreatedEvent.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/execution/JobCreatedEvent.java
@@ -16,22 +16,20 @@
  * limitations under the License.
  */
 
-package org.apache.flink.client.deployment.executors;
+package org.apache.flink.streaming.runtime.execution;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.deployment.StandaloneClientFactory;
-import org.apache.flink.client.deployment.StandaloneClusterId;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.execution.PipelineExecutor;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.core.execution.JobStatusChangedEvent;
+import org.apache.flink.streaming.api.lineage.LineageGraph;
 
-/** The {@link PipelineExecutor} to be used when executing a job on an already running cluster. */
-@Internal
-public class RemoteExecutor
-        extends AbstractSessionClusterExecutor<StandaloneClusterId, StandaloneClientFactory> {
+/** Basic job created event. */
+@PublicEvolving
+public interface JobCreatedEvent extends JobStatusChangedEvent {
 
-    public static final String NAME = "remote";
+    /* Lineage for the current job. */
+    LineageGraph lineageGraph();
 
-    public RemoteExecutor(Configuration configuration) {
-        super(new StandaloneClientFactory(), configuration);
-    }
+    /* Runtime execution mode for the job, STREAMING/BATCH/AUTOMATIC. */
+    RuntimeExecutionMode executionMode();
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/execution/JobStatusChangedListenerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/execution/JobStatusChangedListenerITCase.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.execution;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.DefaultJobExecutionStatusEvent;
+import org.apache.flink.core.execution.JobExecutionStatusEvent;
+import org.apache.flink.core.execution.JobStatusChangedEvent;
+import org.apache.flink.core.execution.JobStatusChangedListener;
+import org.apache.flink.core.execution.JobStatusChangedListenerFactory;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.runtime.execution.DefaultJobCreatedEvent;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runners.MethodSorters;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.configuration.DeploymentOptions.JOB_STATUS_CHANGED_LISTENERS;
+import static org.apache.flink.runtime.testutils.CommonTestUtils.waitForAllTaskRunning;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for job status changed listener. */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class JobStatusChangedListenerITCase extends TestLogger {
+    private static final int PARALLELISM = 4;
+    @ClassRule public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+    @ClassRule
+    public static final MiniClusterWithClientResource MINI_CLUSTER =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(createConfiguration())
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(PARALLELISM)
+                            .build());
+
+    private static List<JobStatusChangedEvent> statusChangedEvents = new ArrayList<>();
+
+    @Before
+    public void setup() {
+        statusChangedEvents.clear();
+    }
+
+    @Test
+    public void testJobStatusChangedForSucceededApplication() throws Exception {
+        Configuration configuration = createConfiguration();
+        try (StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration)) {
+            List<String> sourceValues = Arrays.asList("a", "b", "c");
+            List<String> resultValues = new ArrayList<>();
+            try (CloseableIterator<String> iterator =
+                    env.fromCollection(sourceValues).executeAndCollect()) {
+                while (iterator.hasNext()) {
+                    resultValues.add(iterator.next());
+                }
+            }
+            assertThat(resultValues).containsExactlyInAnyOrder(sourceValues.toArray(new String[0]));
+        }
+
+        verifyEventMetaData();
+        statusChangedEvents.forEach(
+                event -> {
+                    if (event instanceof DefaultJobExecutionStatusEvent) {
+                        JobExecutionStatusEvent status = (JobExecutionStatusEvent) event;
+                        assertThat(
+                                        (status.oldStatus() == JobStatus.CREATED
+                                                        && status.newStatus() == JobStatus.RUNNING)
+                                                || (status.oldStatus() == JobStatus.RUNNING
+                                                        && status.newStatus()
+                                                                == JobStatus.FINISHED))
+                                .isTrue();
+                    } else {
+                        DefaultJobCreatedEvent createdEvent = (DefaultJobCreatedEvent) event;
+                        assertThat(createdEvent.executionMode())
+                                .isEqualTo(RuntimeExecutionMode.STREAMING);
+                    }
+                });
+    }
+
+    @Test
+    public void testJobStatusChangedForFailedApplication() throws Exception {
+        Configuration configuration = createConfiguration();
+
+        try (StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration)) {
+            env.setParallelism(PARALLELISM);
+            env.getConfig().setRestartStrategy(RestartStrategies.noRestart());
+            env.addSource(new FastFailureSourceFunction()).addSink(new SleepingSink());
+
+            StreamGraph streamGraph = env.getStreamGraph();
+            JobGraph jobGraph = streamGraph.getJobGraph();
+
+            ClusterClient<?> client = MINI_CLUSTER.getClusterClient();
+            JobID jobID = client.submitJob(jobGraph).get();
+            while (!client.getJobStatus(jobID).get().equals(JobStatus.FAILED)) {}
+        } catch (Exception e) {
+            // Expected failure due to exception.
+        }
+
+        verifyEventMetaData();
+        statusChangedEvents.forEach(
+                event -> {
+                    JobExecutionStatusEvent status = (JobExecutionStatusEvent) event;
+                    assertThat(
+                                    (status.oldStatus() == JobStatus.CREATED
+                                                    && status.newStatus() == JobStatus.RUNNING)
+                                            || (status.oldStatus() == JobStatus.RUNNING
+                                                    && status.newStatus() == JobStatus.FAILING)
+                                            || (status.oldStatus() == JobStatus.FAILING
+                                                    && status.newStatus() == JobStatus.FAILED))
+                            .isTrue();
+                });
+    }
+
+    @Test
+    public void testJobStatusChangedForCancelledApplication() throws Exception {
+        Configuration configuration = createConfiguration();
+
+        try (StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration)) {
+            final DataStream<Long> source = env.addSource(new InfiniteLongSourceFunction());
+            source.addSink(new SleepingSink());
+
+            StreamGraph streamGraph = env.getStreamGraph();
+            JobGraph jobGraph = streamGraph.getJobGraph();
+
+            ClusterClient<?> client = MINI_CLUSTER.getClusterClient();
+            JobID jobID = client.submitJob(jobGraph).get();
+            waitForAllTaskRunning(MINI_CLUSTER.getMiniCluster(), jobID, false);
+
+            Thread.sleep(100);
+            client.cancel(jobID).get();
+            while (!client.getJobStatus(jobID).get().equals(JobStatus.CANCELED)) {}
+        }
+
+        verifyEventMetaData();
+        statusChangedEvents.forEach(
+                event -> {
+                    JobExecutionStatusEvent status = (JobExecutionStatusEvent) event;
+                    assertThat(
+                                    (status.oldStatus() == JobStatus.CREATED
+                                                    && status.newStatus() == JobStatus.RUNNING)
+                                            || (status.oldStatus() == JobStatus.RUNNING
+                                                    && status.newStatus() == JobStatus.CANCELLING)
+                                            || (status.oldStatus() == JobStatus.CANCELLING
+                                                    && status.newStatus() == JobStatus.CANCELED))
+                            .isTrue();
+                });
+    }
+
+    void verifyEventMetaData() {
+        assertThat(statusChangedEvents.size()).isEqualTo(3);
+        assertThat(statusChangedEvents.get(0).jobId())
+                .isEqualTo(statusChangedEvents.get(1).jobId());
+        assertThat(statusChangedEvents.get(0).jobName())
+                .isEqualTo(statusChangedEvents.get(1).jobName());
+
+        assertThat(statusChangedEvents.get(1).jobId())
+                .isEqualTo(statusChangedEvents.get(2).jobId());
+        assertThat(statusChangedEvents.get(1).jobName())
+                .isEqualTo(statusChangedEvents.get(2).jobName());
+    }
+
+    /** Testing job status changed listener factory. */
+    public static class TestingJobStatusChangedListenerFactory
+            implements JobStatusChangedListenerFactory {
+
+        @Override
+        public JobStatusChangedListener createListener(Context context) {
+            return new TestingJobStatusChangedListener();
+        }
+    }
+
+    /** Testing job status changed listener. */
+    private static class TestingJobStatusChangedListener implements JobStatusChangedListener {
+
+        @Override
+        public void onEvent(JobStatusChangedEvent event) {
+            statusChangedEvents.add(event);
+        }
+    }
+
+    private static Configuration createConfiguration() {
+        Configuration configuration = new Configuration();
+        configuration.set(
+                JOB_STATUS_CHANGED_LISTENERS,
+                Collections.singletonList(TestingJobStatusChangedListenerFactory.class.getName()));
+
+        return configuration;
+    }
+
+    private static class FastFailureSourceFunction implements SourceFunction<Long> {
+
+        @Override
+        public void run(SourceContext<Long> ctx) throws Exception {
+            throw new RuntimeException("Failed to execute.");
+        }
+
+        @Override
+        public void cancel() {}
+    }
+
+    private static class InfiniteLongSourceFunction implements SourceFunction<Long> {
+        private volatile boolean running = true;
+
+        @Override
+        public void run(SourceContext<Long> ctx) throws Exception {
+            long next = 0;
+            while (running) {
+                synchronized (ctx.getCheckpointLock()) {
+                    ctx.collect(next++);
+                }
+            }
+        }
+
+        @Override
+        public void cancel() {
+            running = false;
+        }
+    }
+
+    private static class SleepingSink implements SinkFunction<Long> {
+        @Override
+        public void invoke(Long value, Context context) throws Exception {
+            Thread.sleep(1_000);
+        }
+    }
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutor.java
@@ -20,6 +20,7 @@ package org.apache.flink.yarn.executors;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.client.deployment.executors.AbstractSessionClusterExecutor;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.yarn.YarnClusterClientFactory;
 import org.apache.flink.yarn.configuration.YarnDeploymentTarget;
@@ -33,7 +34,7 @@ public class YarnSessionClusterExecutor
 
     public static final String NAME = YarnDeploymentTarget.SESSION.getName();
 
-    public YarnSessionClusterExecutor() {
-        super(new YarnClusterClientFactory());
+    public YarnSessionClusterExecutor(Configuration configuration) {
+        super(new YarnClusterClientFactory(), configuration);
     }
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutorFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutorFactory.java
@@ -45,7 +45,7 @@ public class YarnSessionClusterExecutorFactory implements PipelineExecutorFactor
     @Override
     public PipelineExecutor getExecutor(@Nonnull final Configuration configuration) {
         try {
-            return new YarnSessionClusterExecutor();
+            return new YarnSessionClusterExecutor(configuration);
         } catch (NoClassDefFoundError e) {
             throw new IllegalStateException(YarnDeploymentTarget.ERROR_MESSAGE);
         }


### PR DESCRIPTION
## What is the purpose of the change
This PR is to implement the job status changed listener for lineage in FLIP-314. This PR use class loader to load listeners in pipeline executors, including LocalExecutor, EmbeddedExecutor for application mode and AbstractSessionClusterExecutor for session cluster. When job graph submission is successfully, the JobCreatedEvent with lineage info will be published to listeners. During the runtime, job status change info will also be published to listeners.


## Brief change log
  -  Add interfaces for job status change listener  
  -  Add Events and configs for job status listener.
  - Add logic pipeline executors for notifying the job created event for local, application mode, and session cluster.

## Verifying this change

This change added tests and can be verified as follows:

  - The end to end test is covered by JobStatusListenerITCase 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
