### PR TITLE
[FLINK-35302][rest] Ignore unknown fields in REST request deserialization

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/AbstractHandler.java
@@ -76,7 +76,7 @@ public abstract class AbstractHandler<
 
     protected final Logger log = LoggerFactory.getLogger(getClass());
 
-    protected static final ObjectMapper MAPPER = RestMapperUtils.getStrictObjectMapper();
+    protected static final ObjectMapper MAPPER = RestMapperUtils.getFlexibleObjectMapper();
 
     /**
      * Other response payload overhead (in bytes). If we truncate response payload, we should leave

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/FileUploadHandlerITCase.java
@@ -331,8 +331,8 @@ class FileUploadHandlerITCase {
                         fileHandler.getMessageHeaders().getTargetRestEndpointURL(),
                         new MultipartUploadExtension.TestRequestBody());
         try (Response response = client.newCall(jsonRequest).execute()) {
-            // JSON payload did not match expected format
-            assertThat(response.code()).isEqualTo(HttpResponseStatus.BAD_REQUEST.code());
+            // explicitly rejected by the test handler implementation
+            assertThat(response.code()).isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR.code());
         }
 
         Request fileRequest =
@@ -347,8 +347,9 @@ class FileUploadHandlerITCase {
                         fileHandler.getMessageHeaders().getTargetRestEndpointURL(),
                         new MultipartUploadExtension.TestRequestBody());
         try (Response response = client.newCall(mixedRequest).execute()) {
-            // JSON payload did not match expected format
-            assertThat(response.code()).isEqualTo(HttpResponseStatus.BAD_REQUEST.code());
+            // unknown field in TestRequestBody is ignored
+            assertThat(response.code())
+                    .isEqualTo(fileHandler.getMessageHeaders().getResponseStatusCode().code());
         }
 
         verifyNoFileIsRegisteredToDeleteOnExitHook();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/AbstractHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.handler;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.rest.FlinkHttpObjectAggregator;
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.handler.router.RouteResult;
@@ -43,10 +44,14 @@ import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPipeline;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponse;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpStatusClass;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
 import org.apache.flink.shaded.netty4.io.netty.util.Attribute;
 import org.apache.flink.shaded.netty4.io.netty.util.AttributeKey;
@@ -58,6 +63,7 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -68,6 +74,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -180,6 +187,62 @@ class AbstractHandlerTest {
         assertThat(Files.exists(file)).isTrue();
         requestProcessingCompleteFuture.complete(null);
         assertThat(Files.exists(file)).isFalse();
+    }
+
+    @Test
+    void testIgnoringUnknownFields() {
+        RestfulGateway mockRestfulGateway = new TestingRestfulGateway.Builder().build();
+
+        CompletableFuture<Void> requestProcessingCompleteFuture = new CompletableFuture<>();
+        TestHandler handler =
+                new TestHandler(requestProcessingCompleteFuture, mockGatewayRetriever);
+
+        RouteResult<?> routeResult =
+                new RouteResult<>("", "", Collections.emptyMap(), Collections.emptyMap(), "");
+        String requestBody = "{\"unknown_field_should_be_ignore\": true}";
+        HttpRequest request =
+                new DefaultFullHttpRequest(
+                        HttpVersion.HTTP_1_1,
+                        HttpMethod.POST,
+                        TestHandler.TestHeaders.INSTANCE.getTargetRestEndpointURL(),
+                        Unpooled.wrappedBuffer(requestBody.getBytes(StandardCharsets.UTF_8)));
+        RoutedRequest<?> routerRequest = new RoutedRequest<>(routeResult, request);
+
+        AtomicReference<HttpResponse> response = new AtomicReference<>();
+
+        FlinkHttpObjectAggregator aggregator =
+                new FlinkHttpObjectAggregator(
+                        RestOptions.SERVER_MAX_CONTENT_LENGTH.defaultValue(),
+                        Collections.emptyMap());
+        ChannelPipeline pipeline = mock(ChannelPipeline.class);
+        when(pipeline.get(eq(FlinkHttpObjectAggregator.class))).thenReturn(aggregator);
+
+        ChannelFuture succeededFuture = mock(ChannelFuture.class);
+        when(succeededFuture.isSuccess()).thenReturn(true);
+
+        Attribute<FileUploads> attribute = new SimpleAttribute();
+        Channel channel = mock(Channel.class);
+        when(channel.attr(any(AttributeKey.class))).thenReturn(attribute);
+
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        when(context.pipeline()).thenReturn(pipeline);
+        when(context.channel()).thenReturn(channel);
+        when(context.write(any()))
+                .thenAnswer(
+                        invocation -> {
+                            if (invocation.getArguments().length > 0
+                                    && invocation.getArgument(0) instanceof HttpResponse) {
+                                response.set(invocation.getArgument(0));
+                            }
+                            return succeededFuture;
+                        });
+        when(context.writeAndFlush(any())).thenReturn(succeededFuture);
+
+        handler.respondAsLeader(context, routerRequest, mockRestfulGateway);
+        assertThat(
+                        response.get() == null
+                                || response.get().status().codeClass() == HttpStatusClass.SUCCESS)
+                .isTrue();
     }
 
     private static class SimpleAttribute implements Attribute<FileUploads> {


### PR DESCRIPTION

## What is the purpose of the change

This PR makes REST server ignoring unknown fields when deserializing request body, which is helpful in some senarios where a centralized REST client of newer version (contains additional fields in request) communicates with REST servers of various versions, potentially an old version that doesn't recognize additional fields.

Related to #23930 , in which compatibility between old version client and new version server was solved.

## Brief change log

- change ObjectMapper for AbstractHandler to flexible ObjectMapper ignoring unknown fields

## Verifying this change


This change added tests and can be verified as follows:
- unit test AbstractHandlerTest#testIgnoringUnknownFields

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
