### PR TITLE
[FLINK-35198][table] Support the execution of refresh materialized table

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -113,6 +113,7 @@ import static org.apache.flink.table.functions.FunctionKind.SCALAR;
 import static org.apache.flink.table.gateway.api.results.ResultSet.ResultType.PAYLOAD;
 import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.awaitOperationTermination;
 import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.createInitializedSession;
+import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.fetchAllResults;
 import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.fetchResults;
 import static org.apache.flink.table.utils.UserDefinedFunctions.GENERATED_LOWER_UDF_CLASS;
 import static org.apache.flink.table.utils.UserDefinedFunctions.GENERATED_LOWER_UDF_CODE;
@@ -324,7 +325,7 @@ public class SqlGatewayServiceITCase {
         awaitOperationTermination(service, sessionHandle, operationHandle);
 
         List<RowData> expectedData = getDefaultResultSet().getData();
-        List<RowData> actualData = fetchAllResults(sessionHandle, operationHandle);
+        List<RowData> actualData = fetchAllResults(service, sessionHandle, operationHandle);
         assertThat(actualData).isEqualTo(expectedData);
 
         service.closeOperation(sessionHandle, operationHandle);
@@ -401,7 +402,7 @@ public class SqlGatewayServiceITCase {
                         -1,
                         Configuration.fromMap(Collections.singletonMap(key, value)));
 
-        List<RowData> settings = fetchAllResults(sessionHandle, operationHandle);
+        List<RowData> settings = fetchAllResults(service, sessionHandle, operationHandle);
 
         assertThat(settings)
                 .contains(
@@ -436,7 +437,7 @@ public class SqlGatewayServiceITCase {
         OperationHandle insertOperationHandle =
                 service.executeStatement(sessionHandle, insertSql, -1, configuration);
 
-        List<RowData> results = fetchAllResults(sessionHandle, insertOperationHandle);
+        List<RowData> results = fetchAllResults(service, sessionHandle, insertOperationHandle);
         assertThat(results.size()).isEqualTo(1);
         String jobId = results.get(0).getString(0).toString();
 
@@ -446,7 +447,7 @@ public class SqlGatewayServiceITCase {
         OperationHandle stopOperationHandle =
                 service.executeStatement(sessionHandle, stopSql, -1, configuration);
 
-        List<RowData> stopResults = fetchAllResults(sessionHandle, stopOperationHandle);
+        List<RowData> stopResults = fetchAllResults(service, sessionHandle, stopOperationHandle);
         assertThat(stopResults.size()).isEqualTo(1);
         if (hasSavepoint) {
             String savepoint = stopResults.get(0).getString(0).toString();
@@ -485,7 +486,7 @@ public class SqlGatewayServiceITCase {
         OperationHandle insertsOperationHandle =
                 service.executeStatement(sessionHandle, insertSql, -1, configuration);
         String jobId =
-                fetchAllResults(sessionHandle, insertsOperationHandle)
+                fetchAllResults(service, sessionHandle, insertsOperationHandle)
                         .get(0)
                         .getString(0)
                         .toString();
@@ -496,7 +497,7 @@ public class SqlGatewayServiceITCase {
         OperationHandle showJobsOperationHandle1 =
                 service.executeStatement(sessionHandle, "SHOW JOBS", -1, configuration);
 
-        List<RowData> result = fetchAllResults(sessionHandle, showJobsOperationHandle1);
+        List<RowData> result = fetchAllResults(service, sessionHandle, showJobsOperationHandle1);
         RowData jobRow =
                 result.stream()
                         .filter(row -> jobId.equals(row.getString(0).toString()))
@@ -532,7 +533,7 @@ public class SqlGatewayServiceITCase {
         OperationHandle insertsOperationHandle =
                 service.executeStatement(sessionHandle, insertSql, -1, configuration);
         String jobId =
-                fetchAllResults(sessionHandle, insertsOperationHandle)
+                fetchAllResults(service, sessionHandle, insertsOperationHandle)
                         .get(0)
                         .getString(0)
                         .toString();
@@ -547,7 +548,7 @@ public class SqlGatewayServiceITCase {
                         -1,
                         configuration);
 
-        List<RowData> result = fetchAllResults(sessionHandle, describeJobOperationHandle);
+        List<RowData> result = fetchAllResults(service, sessionHandle, describeJobOperationHandle);
         RowData jobRow =
                 result.stream()
                         .filter(row -> jobId.equals(row.getString(0).toString()))
@@ -1163,18 +1164,5 @@ public class SqlGatewayServiceITCase {
             List<String> expectedCompletionHints) {
         assertThat(service.completeStatement(sessionHandle, incompleteSql, incompleteSql.length()))
                 .isEqualTo(expectedCompletionHints);
-    }
-
-    private List<RowData> fetchAllResults(
-            SessionHandle sessionHandle, OperationHandle operationHandle) {
-        Long token = 0L;
-        List<RowData> results = new ArrayList<>();
-        while (token != null) {
-            ResultSet result =
-                    service.fetchResults(sessionHandle, operationHandle, token, Integer.MAX_VALUE);
-            results.addAll(result.getData());
-            token = result.getNextToken();
-        }
-        return results;
     }
 }

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManagerTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManagerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.service.materializedtable;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link MaterializedTableManager}. */
+class MaterializedTableManagerTest {
+
+    @Test
+    void testGetManuallyRefreshStatement() {
+        String tableIdentifier = "my_materialized_table";
+        String query = "SELECT * FROM my_source_table";
+        assertThat(
+                        MaterializedTableManager.getManuallyRefreshStatement(
+                                tableIdentifier, query, Collections.emptyMap()))
+                .isEqualTo(
+                        "INSERT OVERWRITE my_materialized_table\n"
+                                + "  SELECT * FROM (SELECT * FROM my_source_table)");
+
+        Map<String, String> partitionSpec = new LinkedHashMap<>();
+        partitionSpec.put("k1", "v1");
+        partitionSpec.put("k2", "v2");
+        assertThat(
+                        MaterializedTableManager.getManuallyRefreshStatement(
+                                tableIdentifier, query, partitionSpec))
+                .isEqualTo(
+                        "INSERT OVERWRITE my_materialized_table\n"
+                                + "  SELECT * FROM (SELECT * FROM my_source_table)\n"
+                                + "  WHERE k1 = 'v1' AND k2 = 'v2'");
+    }
+}

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/utils/SqlGatewayServiceTestUtil.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/utils/SqlGatewayServiceTestUtil.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.gateway.service.utils;
 
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.gateway.api.SqlGatewayService;
 import org.apache.flink.table.gateway.api.operation.OperationHandle;
 import org.apache.flink.table.gateway.api.results.ResultSet;
@@ -29,6 +30,9 @@ import org.apache.flink.table.gateway.api.utils.MockedEndpointVersion;
 import org.apache.flink.table.gateway.service.SqlGatewayServiceITCase;
 import org.apache.flink.table.gateway.service.SqlGatewayServiceImpl;
 import org.apache.flink.table.gateway.service.SqlGatewayServiceStatementITCase;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /** Test util for {@link SqlGatewayServiceITCase} and {@link SqlGatewayServiceStatementITCase}. */
 public class SqlGatewayServiceTestUtil {
@@ -83,5 +87,20 @@ public class SqlGatewayServiceTestUtil {
                 .getSession(sessionHandle)
                 .getOperationManager()
                 .awaitOperationTermination(operationHandle);
+    }
+
+    public static List<RowData> fetchAllResults(
+            SqlGatewayService service,
+            SessionHandle sessionHandle,
+            OperationHandle operationHandle) {
+        Long token = 0L;
+        List<RowData> results = new ArrayList<>();
+        while (token != null) {
+            ResultSet result =
+                    service.fetchResults(sessionHandle, operationHandle, token, Integer.MAX_VALUE);
+            results.addAll(result.getData());
+            token = result.getNextToken();
+        }
+        return results;
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterMaterializedTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterMaterializedTable.java
@@ -48,6 +48,10 @@ public abstract class SqlAlterMaterializedTable extends SqlCall {
         return tableIdentifier;
     }
 
+    public String[] fullTableName() {
+        return tableIdentifier.names.toArray(new String[0]);
+    }
+
     @Override
     public SqlOperator getOperator() {
         return OPERATOR;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterMaterializedTableRefresh.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterMaterializedTableRefresh.java
@@ -25,8 +25,6 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.ImmutableNullableList;
 
-import javax.annotation.Nullable;
-
 import java.util.List;
 
 /**
@@ -38,7 +36,7 @@ public class SqlAlterMaterializedTableRefresh extends SqlAlterMaterializedTable 
     private final SqlNodeList partitionSpec;
 
     public SqlAlterMaterializedTableRefresh(
-            SqlParserPos pos, SqlIdentifier tableName, @Nullable SqlNodeList partitionSpec) {
+            SqlParserPos pos, SqlIdentifier tableName, SqlNodeList partitionSpec) {
         super(pos, tableName);
         this.partitionSpec = partitionSpec;
     }
@@ -52,14 +50,13 @@ public class SqlAlterMaterializedTableRefresh extends SqlAlterMaterializedTable 
     public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
         super.unparse(writer, leftPrec, rightPrec);
         writer.keyword("REFRESH");
-        if (partitionSpec != null && partitionSpec.size() > 0) {
+        if (!partitionSpec.isEmpty()) {
             writer.keyword("PARTITION");
             partitionSpec.unparse(
                     writer, getOperator().getLeftPrec(), getOperator().getRightPrec());
         }
     }
 
-    @Nullable
     public SqlNodeList getPartitionSpec() {
         return partitionSpec;
     }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterMaterializedTableRefresh.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterMaterializedTableRefresh.java
@@ -58,4 +58,9 @@ public class SqlAlterMaterializedTableRefresh extends SqlAlterMaterializedTable 
                     writer, getOperator().getLeftPrec(), getOperator().getRightPrec());
         }
     }
+
+    @Nullable
+    public SqlNodeList getPartitionSpec() {
+        return partitionSpec;
+    }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/OperationUtils.java
@@ -145,7 +145,11 @@ public class OperationUtils {
     }
 
     public static String formatPartitionSpec(CatalogPartitionSpec spec) {
-        return spec.getPartitionSpec().entrySet().stream()
+        return formatPartitionSpec(spec.getPartitionSpec());
+    }
+
+    public static String formatPartitionSpec(Map<String, String> spec) {
+        return spec.entrySet().stream()
                 .map(entry -> entry.getKey() + "=" + entry.getValue())
                 .collect(Collectors.joining(", "));
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableRefreshOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableRefreshOperation.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Map;
+
+/**
+ * Operation to describe clause like: ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name
+ * REFRESH [PARTITION (key1=val1, key2=val2, ...)].
+ */
+@Internal
+public class AlterMaterializedTableRefreshOperation extends AlterMaterializedTableOperation {
+
+    private final Map<String, String> partitionSpec;
+
+    public AlterMaterializedTableRefreshOperation(
+            ObjectIdentifier tableIdentifier, Map<String, String> partitionSpec) {
+        super(tableIdentifier);
+        this.partitionSpec = partitionSpec;
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        // execute AlterMaterializedTableRefreshOperation in SqlGateway OperationExecutor.
+        // see more at MaterializedTableManager#callAlterMaterializedTableRefreshOperation
+        throw new UnsupportedOperationException(
+                "AlterMaterializedTableRefreshOperation does not support ExecutableOperation yet.");
+    }
+
+    public Map<String, String> getPartitionSpec() {
+        return partitionSpec;
+    }
+
+    @Override
+    public String asSummaryString() {
+        StringBuilder sb =
+                new StringBuilder(
+                        String.format("ALTER MATERIALIZED TABLE %s REFRESH", tableIdentifier));
+        if (!partitionSpec.isEmpty()) {
+            sb.append(
+                    String.format(
+                            " PARTITION (%s)", OperationUtils.formatPartitionSpec(partitionSpec)));
+        }
+
+        return sb.toString();
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableRefreshConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableRefreshConverter.java
@@ -18,15 +18,13 @@
 
 package org.apache.flink.table.planner.operations.converters;
 
-import org.apache.flink.sql.parser.SqlProperty;
+import org.apache.flink.sql.parser.SqlPartitionUtils;
 import org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableRefresh;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableRefreshOperation;
-import org.apache.flink.util.Preconditions;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** A converter for {@link SqlAlterMaterializedTableRefresh}. */
@@ -39,17 +37,8 @@ public class SqlAlterMaterializedTableRefreshConverter
         ObjectIdentifier identifier =
                 context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
 
-        Map<String, String> partitionSpec = new LinkedHashMap<>();
-        if (node.getPartitionSpec() != null) {
-            node.getPartitionSpec()
-                    .forEach(
-                            spec -> {
-                                Preconditions.checkArgument(spec instanceof SqlProperty);
-                                SqlProperty property = (SqlProperty) spec;
-                                partitionSpec.put(
-                                        property.getKeyString(), property.getValueString());
-                            });
-        }
+        Map<String, String> partitionSpec =
+                SqlPartitionUtils.getPartitionKVs(node.getPartitionSpec());
 
         return new AlterMaterializedTableRefreshOperation(identifier, partitionSpec);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableRefreshConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableRefreshConverter.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.SqlProperty;
+import org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableRefresh;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableRefreshOperation;
+import org.apache.flink.util.Preconditions;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** A converter for {@link SqlAlterMaterializedTableRefresh}. */
+public class SqlAlterMaterializedTableRefreshConverter
+        implements SqlNodeConverter<SqlAlterMaterializedTableRefresh> {
+
+    @Override
+    public Operation convertSqlNode(SqlAlterMaterializedTableRefresh node, ConvertContext context) {
+        UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(node.fullTableName());
+        ObjectIdentifier identifier =
+                context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+
+        Map<String, String> partitionSpec = new LinkedHashMap<>();
+        if (node.getPartitionSpec() != null) {
+            node.getPartitionSpec()
+                    .forEach(
+                            spec -> {
+                                Preconditions.checkArgument(spec instanceof SqlProperty);
+                                SqlProperty property = (SqlProperty) spec;
+                                partitionSpec.put(
+                                        property.getKeyString(), property.getValueString());
+                            });
+        }
+
+        return new AlterMaterializedTableRefreshOperation(identifier, partitionSpec);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -57,6 +57,7 @@ public class SqlNodeConverters {
         register(new SqlDescribeCatalogConverter());
         register(new SqlDescribeJobConverter());
         register(new SqlCreateMaterializedTableConverter());
+        register(new SqlAlterMaterializedTableRefreshConverter());
     }
 
     /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -24,7 +24,10 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableRefreshOperation;
 import org.apache.flink.table.operations.materializedtable.CreateMaterializedTableOperation;
+
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
 
 import org.junit.jupiter.api.Test;
 
@@ -255,5 +258,32 @@ public class SqlMaterializedTableNodeToOperationConverterTest
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining(
                         "Materialized table freshness only support SECOND, MINUTE, HOUR, DAY as the time unit.");
+    }
+
+    @Test
+    public void testAlterMaterializedTableRefreshOperationWithPartitionSpec() {
+        final String sql =
+                "ALTER MATERIALIZED TABLE mtbl1 REFRESH PARITITON (ds1 = '1', ds2 = '2')";
+
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(AlterMaterializedTableRefreshOperation.class);
+
+        AlterMaterializedTableRefreshOperation op =
+                (AlterMaterializedTableRefreshOperation) operation;
+        assertThat(op.getTableIdentifier().toString()).isEqualTo("default.mtbl1");
+        assertThat(op.getPartitionSpec()).isEqualTo(ImmutableMap.of("ds1", "1", "ds2", "2"));
+    }
+
+    @Test
+    public void testAlterMaterializedTableRefreshOperationWithoutPartitionSpec() {
+        final String sql = "ALTER MATERIALIZED TABLE mtbl1 REFRESH)";
+
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(AlterMaterializedTableRefreshOperation.class);
+
+        AlterMaterializedTableRefreshOperation op =
+                (AlterMaterializedTableRefreshOperation) operation;
+        assertThat(op.getTableIdentifier().toString()).isEqualTo("default.mtbl1");
+        assertThat(op.getPartitionSpec()).isEmpty();
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -263,27 +263,27 @@ public class SqlMaterializedTableNodeToOperationConverterTest
     @Test
     public void testAlterMaterializedTableRefreshOperationWithPartitionSpec() {
         final String sql =
-                "ALTER MATERIALIZED TABLE mtbl1 REFRESH PARITITON (ds1 = '1', ds2 = '2')";
+                "ALTER MATERIALIZED TABLE mtbl1 REFRESH PARTITION (ds1 = '1', ds2 = '2')";
 
         Operation operation = parse(sql);
         assertThat(operation).isInstanceOf(AlterMaterializedTableRefreshOperation.class);
 
         AlterMaterializedTableRefreshOperation op =
                 (AlterMaterializedTableRefreshOperation) operation;
-        assertThat(op.getTableIdentifier().toString()).isEqualTo("default.mtbl1");
+        assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`mtbl1`");
         assertThat(op.getPartitionSpec()).isEqualTo(ImmutableMap.of("ds1", "1", "ds2", "2"));
     }
 
     @Test
     public void testAlterMaterializedTableRefreshOperationWithoutPartitionSpec() {
-        final String sql = "ALTER MATERIALIZED TABLE mtbl1 REFRESH)";
+        final String sql = "ALTER MATERIALIZED TABLE mtbl1 REFRESH";
 
         Operation operation = parse(sql);
         assertThat(operation).isInstanceOf(AlterMaterializedTableRefreshOperation.class);
 
         AlterMaterializedTableRefreshOperation op =
                 (AlterMaterializedTableRefreshOperation) operation;
-        assertThat(op.getTableIdentifier().toString()).isEqualTo("default.mtbl1");
+        assertThat(op.getTableIdentifier().toString()).isEqualTo("`builtin`.`default`.`mtbl1`");
         assertThat(op.getPartitionSpec()).isEmpty();
     }
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/junit5/MiniClusterExtension.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/junit5/MiniClusterExtension.java
@@ -312,10 +312,6 @@ public final class MiniClusterExtension
         return internalMiniClusterExtension.getMiniCluster().isRunning();
     }
 
-    public MiniCluster getMiniCluster() {
-        return internalMiniClusterExtension.getMiniCluster();
-    }
-
     private static class CloseableParameter<T extends AutoCloseable>
             implements ExtensionContext.Store.CloseableResource {
         private final T autoCloseable;

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/junit5/MiniClusterExtension.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/junit5/MiniClusterExtension.java
@@ -312,6 +312,10 @@ public final class MiniClusterExtension
         return internalMiniClusterExtension.getMiniCluster().isRunning();
     }
 
+    public MiniCluster getMiniCluster() {
+        return internalMiniClusterExtension.getMiniCluster();
+    }
+
     private static class CloseableParameter<T extends AutoCloseable>
             implements ExtensionContext.Store.CloseableResource {
         private final T autoCloseable;


### PR DESCRIPTION
## What is the purpose of the change

Support the execution of refresh materialized table.

## Brief change log

  - *Add execution in sql gateway*
  - *Add operation in table-api&table-planner*
  - *Add tests*


## Verifying this change

Some tests are added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
