### PR TITLE
 [FLINK-35306][test] Migrate flink-tests-java17 module to JUnit5 and assertj to solve jdk17 compile fails

### DIFF
--- a/flink-tests-java17/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoRecordSerializerUpgradeTestSpecifications.java
+++ b/flink-tests-java17/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoRecordSerializerUpgradeTestSpecifications.java
@@ -27,10 +27,9 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerUpgradeTestBase;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 
-import org.hamcrest.Matcher;
+import org.assertj.core.api.Condition;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** A {@link TypeSerializerUpgradeTestBase} for the {@link PojoSerializer}. */
 class PojoRecordSerializerUpgradeTestSpecifications {
@@ -58,7 +57,7 @@ class PojoRecordSerializerUpgradeTestSpecifications {
             TypeSerializer<PojoBeforeUpgrade> serializer =
                     TypeExtractor.createTypeInfo(PojoBeforeUpgrade.class)
                             .createSerializer(new SerializerConfigImpl());
-            assertSame(PojoSerializer.class, serializer.getClass());
+            assertThat(serializer.getClass()).isSameAs(PojoSerializer.class);
             return serializer;
         }
 
@@ -81,18 +80,19 @@ class PojoRecordSerializerUpgradeTestSpecifications {
             TypeSerializer<PojoAfterUpgrade> serializer =
                     TypeExtractor.createTypeInfo(PojoAfterUpgrade.class)
                             .createSerializer(new SerializerConfigImpl());
-            assertSame(PojoSerializer.class, serializer.getClass());
+            assertThat(serializer.getClass()).isSameAs(PojoSerializer.class);
             return serializer;
         }
 
         @Override
-        public Matcher<PojoAfterUpgrade> testDataMatcher() {
-            return is(new PojoAfterUpgrade(911108, "Gordon"));
+        public Condition<PojoAfterUpgrade> testDataCondition() {
+            return new Condition<>(
+                    new PojoAfterUpgrade(911108, "Gordon")::equals, "value is (911108, Gordon)");
         }
 
         @Override
-        public Matcher<TypeSerializerSchemaCompatibility<PojoAfterUpgrade>>
-                schemaCompatibilityMatcher(FlinkVersion version) {
+        public Condition<TypeSerializerSchemaCompatibility<PojoAfterUpgrade>>
+                schemaCompatibilityCondition(FlinkVersion version) {
             return TypeSerializerConditions.isCompatibleAsIs();
         }
     }
@@ -110,7 +110,7 @@ class PojoRecordSerializerUpgradeTestSpecifications {
             TypeSerializer<RecordBeforeMigration> serializer =
                     TypeExtractor.createTypeInfo(RecordBeforeMigration.class)
                             .createSerializer(new SerializerConfigImpl());
-            assertSame(PojoSerializer.class, serializer.getClass());
+            assertThat(serializer.getClass()).isSameAs(PojoSerializer.class);
             return serializer;
         }
 
@@ -133,18 +133,20 @@ class PojoRecordSerializerUpgradeTestSpecifications {
             TypeSerializer<RecordAfterSchemaUpgrade> serializer =
                     TypeExtractor.createTypeInfo(RecordAfterSchemaUpgrade.class)
                             .createSerializer(new SerializerConfigImpl());
-            assertSame(PojoSerializer.class, serializer.getClass());
+            assertThat(serializer.getClass()).isSameAs(PojoSerializer.class);
             return serializer;
         }
 
         @Override
-        public Matcher<RecordAfterSchemaUpgrade> testDataMatcher() {
-            return is(new RecordAfterSchemaUpgrade("Gordon", 0, null));
+        public Condition<RecordAfterSchemaUpgrade> testDataCondition() {
+            return new Condition<>(
+                    new RecordAfterSchemaUpgrade("Gordon", 0, null)::equals,
+                    "value is (Gordon, 0 ,null)");
         }
 
         @Override
-        public Matcher<TypeSerializerSchemaCompatibility<RecordAfterSchemaUpgrade>>
-                schemaCompatibilityMatcher(FlinkVersion version) {
+        public Condition<TypeSerializerSchemaCompatibility<RecordAfterSchemaUpgrade>>
+                schemaCompatibilityCondition(FlinkVersion version) {
             return TypeSerializerConditions.isCompatibleAfterMigration();
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

Flink cannot compile with jdk17

https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=59380&view=results fails and benchmark with 17 fails as well

Reason: TypeSerializerUpgradeTestBase.UpgradeVerifier updates the schemaCompatibilityMatcher method name to schemaCompatibilityCondition, but some subclasses didn't change it, such as: PojoRecordSerializerUpgradeTestSpecifications.PojoToRecordVerifier.

It belongs to flink-tests-java17 module, and it doesn't compile by default.

it's related to https://github.com/apache/flink/pull/24603



## Brief change log

[FLINK-35306][test] Update some methods in flink-tests-java17 to solve jdk17 compile fails


