### PR TITLE
[FLINK-32087][checkpoint] Introduce space amplification statistics of file merging

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/LogicalFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/LogicalFile.java
@@ -90,6 +90,7 @@ public class LogicalFile {
         this.length = length;
         this.subtaskKey = subtaskKey;
         physicalFile.incRefCount();
+        physicalFile.incSize(length);
     }
 
     public LogicalFileId getFileId() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManagerTest.java
@@ -56,9 +56,11 @@ public class AcrossCheckpointFileMergingSnapshotManagerTest
             assertThat(file2.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
             assertThat(file2).isNotEqualTo(file1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
 
             // return for reuse
             fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
 
             // allocate for another subtask
             PhysicalFile file3 =
@@ -67,6 +69,7 @@ public class AcrossCheckpointFileMergingSnapshotManagerTest
             assertThat(file3.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.SHARED));
             assertThat(file3).isNotEqualTo(file1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(3);
 
             // allocate for another checkpoint
             PhysicalFile file4 =
@@ -75,16 +78,20 @@ public class AcrossCheckpointFileMergingSnapshotManagerTest
             assertThat(file4.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
             assertThat(file4).isEqualTo(file1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(3);
 
             // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
             file4.incSize(fmsm.maxPhysicalFileSize);
             fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 1, file4);
+            // file4 is discarded because it's size is bigger than maxPhysicalFileSize
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
             PhysicalFile file5 =
                     fmsm.getOrCreatePhysicalFileForCheckpoint(
                             subtaskKey1, 1, CheckpointedStateScope.SHARED);
             assertThat(file5.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
             assertThat(file5).isNotEqualTo(file4);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(3);
 
             // Secondly, we try private state
             PhysicalFile file6 =
@@ -92,6 +99,7 @@ public class AcrossCheckpointFileMergingSnapshotManagerTest
                             subtaskKey1, 1, CheckpointedStateScope.EXCLUSIVE);
             assertThat(file6.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(4);
 
             // allocate another
             PhysicalFile file7 =
@@ -100,9 +108,11 @@ public class AcrossCheckpointFileMergingSnapshotManagerTest
             assertThat(file7.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
             assertThat(file7).isNotEqualTo(file5);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(5);
 
             // return for reuse
             fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file6);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(5);
 
             // allocate for another checkpoint
             PhysicalFile file8 =
@@ -111,9 +121,11 @@ public class AcrossCheckpointFileMergingSnapshotManagerTest
             assertThat(file8.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
             assertThat(file8).isEqualTo(file6);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(5);
 
             // return for reuse
             fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file8);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(5);
 
             // allocate for this checkpoint but another subtask
             PhysicalFile file9 =
@@ -122,16 +134,19 @@ public class AcrossCheckpointFileMergingSnapshotManagerTest
             assertThat(file9.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE));
             assertThat(file9).isEqualTo(file6);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(5);
 
             // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
             file9.incSize(fmsm.maxPhysicalFileSize);
             fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 2, file9);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(4);
             PhysicalFile file10 =
                     fmsm.getOrCreatePhysicalFileForCheckpoint(
                             subtaskKey1, 2, CheckpointedStateScope.SHARED);
             assertThat(file10.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
             assertThat(file10).isNotEqualTo(file9);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(5);
 
             assertThat(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE))
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
@@ -140,33 +155,44 @@ public class AcrossCheckpointFileMergingSnapshotManagerTest
 
     @Test
     public void testCheckpointNotification() throws Exception {
-        try (FileMergingSnapshotManager fmsm = createFileMergingSnapshotManager(checkpointBaseDir);
+        try (FileMergingSnapshotManagerBase fmsm =
+                        (FileMergingSnapshotManagerBase)
+                                createFileMergingSnapshotManager(checkpointBaseDir);
                 CloseableRegistry closeableRegistry = new CloseableRegistry()) {
             FileMergingCheckpointStateOutputStream cp1Stream =
                     writeCheckpointAndGetStream(1, fmsm, closeableRegistry);
             SegmentFileStateHandle cp1StateHandle = cp1Stream.closeAndGetHandle();
             fmsm.notifyCheckpointComplete(subtaskKey1, 1);
             assertFileInManagedDir(fmsm, cp1StateHandle);
-
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(1);
             // complete checkpoint-2
             FileMergingCheckpointStateOutputStream cp2Stream =
                     writeCheckpointAndGetStream(2, fmsm, closeableRegistry);
             SegmentFileStateHandle cp2StateHandle = cp2Stream.closeAndGetHandle();
             fmsm.notifyCheckpointComplete(subtaskKey1, 2);
             assertFileInManagedDir(fmsm, cp2StateHandle);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(2);
 
             // subsume checkpoint-1
             assertThat(fileExists(cp1StateHandle)).isTrue();
             fmsm.notifyCheckpointSubsumed(subtaskKey1, 1);
             assertThat(fileExists(cp1StateHandle)).isTrue();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(1);
 
             // abort checkpoint-3
             FileMergingCheckpointStateOutputStream cp3Stream =
                     writeCheckpointAndGetStream(3, fmsm, closeableRegistry);
             SegmentFileStateHandle cp3StateHandle = cp3Stream.closeAndGetHandle();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(2);
             assertFileInManagedDir(fmsm, cp3StateHandle);
             fmsm.notifyCheckpointAborted(subtaskKey1, 3);
             assertThat(fileExists(cp3StateHandle)).isTrue();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(1);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManagerTest.java
@@ -49,6 +49,7 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
                             subtaskKey1, 0, CheckpointedStateScope.SHARED);
             assertThat(file1.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
             // allocate another
             PhysicalFile file2 =
                     fmsm.getOrCreatePhysicalFileForCheckpoint(
@@ -56,9 +57,11 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
             assertThat(file2.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
             assertThat(file2).isNotEqualTo(file1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
 
             // return for reuse
             fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
 
             // allocate for another subtask
             PhysicalFile file3 =
@@ -67,6 +70,7 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
             assertThat(file3.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.SHARED));
             assertThat(file3).isNotEqualTo(file1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(3);
 
             // allocate for another checkpoint
             PhysicalFile file4 =
@@ -75,6 +79,7 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
             assertThat(file4.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
             assertThat(file4).isNotEqualTo(file1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(4);
 
             // allocate for this checkpoint
             PhysicalFile file5 =
@@ -83,16 +88,19 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
             assertThat(file5.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
             assertThat(file5).isEqualTo(file1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(4);
 
             // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
             file5.incSize(fmsm.maxPhysicalFileSize);
             fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file5);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(3);
             PhysicalFile file6 =
                     fmsm.getOrCreatePhysicalFileForCheckpoint(
                             subtaskKey1, 0, CheckpointedStateScope.SHARED);
             assertThat(file6.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
             assertThat(file6).isNotEqualTo(file5);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(4);
 
             // Secondly, we try private state
             PhysicalFile file7 =
@@ -100,6 +108,7 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
                             subtaskKey1, 0, CheckpointedStateScope.EXCLUSIVE);
             assertThat(file7.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(5);
 
             // allocate another
             PhysicalFile file8 =
@@ -108,9 +117,11 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
             assertThat(file8.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
             assertThat(file8).isNotEqualTo(file6);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(6);
 
             // return for reuse
             fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file7);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(6);
 
             // allocate for another checkpoint
             PhysicalFile file9 =
@@ -119,6 +130,7 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
             assertThat(file9.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
             assertThat(file9).isNotEqualTo(file7);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(7);
 
             // allocate for this checkpoint but another subtask
             PhysicalFile file10 =
@@ -127,16 +139,19 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
             assertThat(file10.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE));
             assertThat(file10).isEqualTo(file7);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(7);
 
             // a physical file whose size is bigger than maxPhysicalFileSize cannot be reused
             file10.incSize(fmsm.maxPhysicalFileSize);
             fmsm.returnPhysicalFileForNextReuse(subtaskKey1, 0, file10);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(6);
             PhysicalFile file11 =
                     fmsm.getOrCreatePhysicalFileForCheckpoint(
                             subtaskKey1, 0, CheckpointedStateScope.SHARED);
             assertThat(file11.getFilePath().getParent())
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.SHARED));
             assertThat(file11).isNotEqualTo(file10);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(7);
 
             assertThat(fmsm.getManagedDir(subtaskKey2, CheckpointedStateScope.EXCLUSIVE))
                     .isEqualTo(fmsm.getManagedDir(subtaskKey1, CheckpointedStateScope.EXCLUSIVE));
@@ -145,13 +160,17 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
 
     @Test
     public void testCheckpointNotification() throws Exception {
-        try (FileMergingSnapshotManager fmsm = createFileMergingSnapshotManager(checkpointBaseDir);
+        try (FileMergingSnapshotManagerBase fmsm =
+                        (FileMergingSnapshotManagerBase)
+                                createFileMergingSnapshotManager(checkpointBaseDir);
                 CloseableRegistry closeableRegistry = new CloseableRegistry()) {
             FileMergingCheckpointStateOutputStream cp1Stream =
                     writeCheckpointAndGetStream(1, fmsm, closeableRegistry);
             SegmentFileStateHandle cp1StateHandle = cp1Stream.closeAndGetHandle();
             fmsm.notifyCheckpointComplete(subtaskKey1, 1);
             assertFileInManagedDir(fmsm, cp1StateHandle);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(1);
 
             // complete checkpoint-2
             FileMergingCheckpointStateOutputStream cp2Stream =
@@ -159,19 +178,28 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
             SegmentFileStateHandle cp2StateHandle = cp2Stream.closeAndGetHandle();
             fmsm.notifyCheckpointComplete(subtaskKey1, 2);
             assertFileInManagedDir(fmsm, cp2StateHandle);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(2);
 
             // subsume checkpoint-1
             assertThat(fileExists(cp1StateHandle)).isTrue();
             fmsm.notifyCheckpointSubsumed(subtaskKey1, 1);
             assertThat(fileExists(cp1StateHandle)).isFalse();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(1);
 
             // abort checkpoint-3
             FileMergingCheckpointStateOutputStream cp3Stream =
                     writeCheckpointAndGetStream(3, fmsm, closeableRegistry);
             SegmentFileStateHandle cp3StateHandle = cp3Stream.closeAndGetHandle();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(2);
+
             assertFileInManagedDir(fmsm, cp3StateHandle);
             fmsm.notifyCheckpointAborted(subtaskKey1, 3);
             assertThat(fileExists(cp3StateHandle)).isFalse();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(1);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileMergingCheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FileMergingCheckpointStateOutputStreamTest.java
@@ -90,7 +90,10 @@ public class FileMergingCheckpointStateOutputStreamTest {
                             FileSystem.WriteMode.NO_OVERWRITE);
             physicalFile =
                     new PhysicalFile(
-                            streamAndPath.stream(), physicalFilePath, (path) -> {}, EXCLUSIVE);
+                            streamAndPath.stream(),
+                            physicalFilePath,
+                            (path, size) -> {},
+                            EXCLUSIVE);
         }
         isPhysicalFileProvided = false;
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR introduces space amplification statistics of file merging.


## Brief change log

- Add `SpaceStat` class in `FileMergingSnapshotManager`.
- Update `SpaceStat` on physical/logical files's creation/deletion


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:
  - Add `FileMergingSnapshotManagerTestBase#testSpaceStat`
  - Update `FileMergingSnapshotManagerTestBase#testRestore`
  - Update `testCreateAndReuseFiles/testCheckpointNotification`
  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
