### PR TITLE
[FLINK-35197][table] Support the execution of supsend&resume materialized table in continuous refresh mode

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
@@ -25,7 +25,17 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointConfigHeaders;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointConfigInfo;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatistics;
+import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointingStatisticsHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
+import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
@@ -43,12 +53,15 @@ import org.apache.flink.table.gateway.service.utils.IgnoreExceptionHandler;
 import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
 import org.apache.flink.table.gateway.service.utils.SqlGatewayServiceExtension;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.refresh.ContinuousRefreshHandler;
+import org.apache.flink.table.refresh.ContinuousRefreshHandlerSerializer;
 import org.apache.flink.test.junit5.InjectClusterClient;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
@@ -73,6 +86,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.apache.flink.table.catalog.CommonCatalogOptions.TABLE_CATALOG_STORE_KIND;
 import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.awaitOperationTermination;
 import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.fetchAllResults;
+import static org.apache.flink.test.util.TestUtils.waitUntilAllTasksAreRunning;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -155,8 +169,22 @@ public class MaterializedTableStatementITCase {
         fileSystemCatalogName = TEST_CATALOG_PREFIX + randomStr;
     }
 
+    @AfterEach
+    void after(@InjectClusterClient RestClusterClient<?> restClusterClient) throws Exception {
+        // cancel all running jobs for releasing mini cluster resources
+        for (JobStatusMessage j : restClusterClient.listJobs().get()) {
+            // cancel all continuous refresh jobs
+            if (j.getJobName().endsWith("continuous_refresh_job")
+                    && (j.getJobState() == JobStatus.RUNNING
+                            || j.getJobState() == JobStatus.CREATED)) {
+                restClusterClient.cancel(j.getJobId()).get();
+            }
+        }
+    }
+
     @Test
-    void testCreateMaterializedTableInContinuousMode() throws Exception {
+    void testCreateMaterializedTableInContinuousMode(
+            @InjectClusterClient RestClusterClient<?> restClusterClient) throws Exception {
         // initialize session handle, create test-filesystem catalog and register it to catalog
         // store
         SessionHandle sessionHandle = initializeSession();
@@ -214,6 +242,27 @@ public class MaterializedTableStatementITCase {
                 .isEqualTo(CatalogMaterializedTable.RefreshStatus.ACTIVATED);
         assertThat(actualMaterializedTable.getRefreshHandlerDescription()).isNotEmpty();
         assertThat(actualMaterializedTable.getSerializedRefreshHandler()).isNotEmpty();
+
+        ContinuousRefreshHandler activeRefreshHandler =
+                ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
+                        actualMaterializedTable.getSerializedRefreshHandler(),
+                        getClass().getClassLoader());
+
+        waitUntilAllTasksAreRunning(
+                restClusterClient, JobID.fromHexString(activeRefreshHandler.getJobId()));
+
+        // check the background job is running
+        String describeJobDDL = String.format("DESCRIBE JOB '%s'", activeRefreshHandler.getJobId());
+        OperationHandle describeJobHandle =
+                service.executeStatement(sessionHandle, describeJobDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, describeJobHandle);
+        List<RowData> jobResults = fetchAllResults(service, sessionHandle, describeJobHandle);
+        assertThat(jobResults.get(0).getString(2).toString()).isEqualTo("RUNNING");
+
+        // get checkpoint interval
+        long checkpointInterval =
+                getCheckpointIntervalConfig(restClusterClient, activeRefreshHandler.getJobId());
+        assertThat(checkpointInterval).isEqualTo(30 * 1000);
     }
 
     @Test
@@ -467,6 +516,210 @@ public class MaterializedTableStatementITCase {
                                 + "ds2");
     }
 
+    @Test
+    void testAlterMaterializedTableSuspendAndResume(
+            @TempDir Path temporaryPath,
+            @InjectClusterClient RestClusterClient<?> restClusterClient)
+            throws Exception {
+        // initialize session handle, create test-filesystem catalog and register it to catalog
+        // store
+        SessionHandle sessionHandle = initializeSession();
+
+        String materializedTableDDL =
+                "CREATE MATERIALIZED TABLE users_shops"
+                        + " PARTITIONED BY (ds)\n"
+                        + " WITH(\n"
+                        + "   'format' = 'debezium-json'\n"
+                        + " )\n"
+                        + " FRESHNESS = INTERVAL '30' SECOND\n"
+                        + " AS SELECT \n"
+                        + "  user_id,\n"
+                        + "  shop_id,\n"
+                        + "  ds,\n"
+                        + "  SUM (payment_amount_cents) AS payed_buy_fee_sum,\n"
+                        + "  SUM (1) AS pv\n"
+                        + " FROM (\n"
+                        + "    SELECT user_id, shop_id, DATE_FORMAT(order_created_at, 'yyyy-MM-dd') AS ds, payment_amount_cents FROM datagenSource"
+                        + " ) AS tmp\n"
+                        + " GROUP BY (user_id, shop_id, ds)";
+
+        OperationHandle materializedTableHandle =
+                service.executeStatement(
+                        sessionHandle, materializedTableDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, materializedTableHandle);
+
+        ResolvedCatalogMaterializedTable activeMaterializedTable =
+                (ResolvedCatalogMaterializedTable)
+                        service.getTable(
+                                sessionHandle,
+                                ObjectIdentifier.of(
+                                        fileSystemCatalogName,
+                                        TEST_DEFAULT_DATABASE,
+                                        "users_shops"));
+
+        assertThat(activeMaterializedTable.getRefreshStatus())
+                .isEqualTo(CatalogMaterializedTable.RefreshStatus.ACTIVATED);
+
+        ContinuousRefreshHandler activeRefreshHandler =
+                ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
+                        activeMaterializedTable.getSerializedRefreshHandler(),
+                        getClass().getClassLoader());
+
+        waitUntilAllTasksAreRunning(
+                restClusterClient, JobID.fromHexString(activeRefreshHandler.getJobId()));
+
+        // set up savepoint dir
+        String savepointDir = temporaryPath.toString();
+        String alterJobSavepointDDL =
+                String.format("SET 'state.savepoints.dir' = 'file://%s'", savepointDir);
+        OperationHandle alterMaterializedTableSavepointHandle =
+                service.executeStatement(
+                        sessionHandle, alterJobSavepointDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableSavepointHandle);
+
+        // suspend materialized table
+        String alterMaterializedTableSuspendDDL = "ALTER MATERIALIZED TABLE users_shops SUSPEND";
+        OperationHandle alterMaterializedTableSuspendHandle =
+                service.executeStatement(
+                        sessionHandle, alterMaterializedTableSuspendDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableSuspendHandle);
+
+        ResolvedCatalogMaterializedTable suspendMaterializedTable =
+                (ResolvedCatalogMaterializedTable)
+                        service.getTable(
+                                sessionHandle,
+                                ObjectIdentifier.of(
+                                        fileSystemCatalogName,
+                                        TEST_DEFAULT_DATABASE,
+                                        "users_shops"));
+
+        assertThat(suspendMaterializedTable.getRefreshStatus())
+                .isEqualTo(CatalogMaterializedTable.RefreshStatus.SUSPENDED);
+
+        // check background job is stopped
+        byte[] refreshHandler = suspendMaterializedTable.getSerializedRefreshHandler();
+        ContinuousRefreshHandler suspendRefreshHandler =
+                ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
+                        refreshHandler, getClass().getClassLoader());
+        String suspendJobId = suspendRefreshHandler.getJobId();
+
+        String describeJobDDL = String.format("DESCRIBE JOB '%s'", suspendJobId);
+        OperationHandle describeJobHandle =
+                service.executeStatement(sessionHandle, describeJobDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableSuspendHandle);
+        List<RowData> jobResults = fetchAllResults(service, sessionHandle, describeJobHandle);
+        assertThat(jobResults.get(0).getString(2).toString()).isEqualTo("FINISHED");
+
+        // check savepoint is created
+        assertThat(suspendRefreshHandler.getRestorePath()).isNotEmpty();
+        String actualSavepointPath = suspendRefreshHandler.getRestorePath().get();
+
+        // resume materialized table
+        String alterMaterializedTableResumeDDL =
+                "ALTER MATERIALIZED TABLE users_shops RESUME WITH ('debezium-json.ignore-parse-errors' = 'true')";
+        OperationHandle alterMaterializedTableResumeHandle =
+                service.executeStatement(
+                        sessionHandle, alterMaterializedTableResumeDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, alterMaterializedTableResumeHandle);
+
+        ResolvedCatalogMaterializedTable resumedCatalogMaterializedTable =
+                (ResolvedCatalogMaterializedTable)
+                        service.getTable(
+                                sessionHandle,
+                                ObjectIdentifier.of(
+                                        fileSystemCatalogName,
+                                        TEST_DEFAULT_DATABASE,
+                                        "users_shops"));
+        assertThat(resumedCatalogMaterializedTable.getOptions())
+                .doesNotContainKey("debezium-json.ignore-parse-errors");
+        assertThat(resumedCatalogMaterializedTable.getRefreshStatus())
+                .isEqualTo(CatalogMaterializedTable.RefreshStatus.ACTIVATED);
+
+        // check background job is running
+        refreshHandler = resumedCatalogMaterializedTable.getSerializedRefreshHandler();
+        ContinuousRefreshHandler resumeRefreshHandler =
+                ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
+                        refreshHandler, getClass().getClassLoader());
+        String resumeJobId = resumeRefreshHandler.getJobId();
+        String describeResumeJobDDL = String.format("DESCRIBE JOB '%s'", resumeJobId);
+        OperationHandle describeResumeJobHandle =
+                service.executeStatement(
+                        sessionHandle, describeResumeJobDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, describeResumeJobHandle);
+        jobResults = fetchAllResults(service, sessionHandle, describeResumeJobHandle);
+        assertThat(jobResults.get(0).getString(2).toString()).isEqualTo("RUNNING");
+
+        // check resumed job is restored from savepoint
+        Optional<String> actualRestorePath =
+                getJobRestoreSavepointPath(restClusterClient, resumeJobId);
+        assertThat(actualRestorePath).isNotEmpty();
+        assertThat(actualRestorePath.get()).isEqualTo(actualSavepointPath);
+    }
+
+    @Test
+    void testAlterMaterializedTableWithoutSavepointDirConfigured(
+            @InjectClusterClient RestClusterClient<?> restClusterClient) throws Exception {
+        // initialize session handle, create test-filesystem catalog and register it to catalog
+        // store
+        SessionHandle sessionHandle = initializeSession();
+
+        String materializedTableDDL =
+                "CREATE MATERIALIZED TABLE users_shops"
+                        + " PARTITIONED BY (ds)\n"
+                        + " WITH(\n"
+                        + "   'format' = 'debezium-json'\n"
+                        + " )\n"
+                        + " FRESHNESS = INTERVAL '30' SECOND\n"
+                        + " AS SELECT \n"
+                        + "  user_id,\n"
+                        + "  shop_id,\n"
+                        + "  ds,\n"
+                        + "  SUM (payment_amount_cents) AS payed_buy_fee_sum,\n"
+                        + "  SUM (1) AS pv\n"
+                        + " FROM (\n"
+                        + "    SELECT user_id, shop_id, DATE_FORMAT(order_created_at, 'yyyy-MM-dd') AS ds, payment_amount_cents FROM datagenSource"
+                        + " ) AS tmp\n"
+                        + " GROUP BY (user_id, shop_id, ds)";
+
+        OperationHandle materializedTableHandle =
+                service.executeStatement(
+                        sessionHandle, materializedTableDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, materializedTableHandle);
+
+        ResolvedCatalogMaterializedTable activeMaterializedTable =
+                (ResolvedCatalogMaterializedTable)
+                        service.getTable(
+                                sessionHandle,
+                                ObjectIdentifier.of(
+                                        fileSystemCatalogName,
+                                        TEST_DEFAULT_DATABASE,
+                                        "users_shops"));
+        waitUntilAllTasksAreRunning(
+                restClusterClient,
+                JobID.fromHexString(
+                        ContinuousRefreshHandlerSerializer.INSTANCE
+                                .deserialize(
+                                        activeMaterializedTable.getSerializedRefreshHandler(),
+                                        getClass().getClassLoader())
+                                .getJobId()));
+
+        // suspend materialized table
+        String alterMaterializedTableSuspendDDL = "ALTER MATERIALIZED TABLE users_shops SUSPEND";
+        OperationHandle alterMaterializedTableSuspendHandle =
+                service.executeStatement(
+                        sessionHandle, alterMaterializedTableSuspendDDL, -1, new Configuration());
+        assertThatThrownBy(
+                        () ->
+                                awaitOperationTermination(
+                                        service,
+                                        sessionHandle,
+                                        alterMaterializedTableSuspendHandle))
+                .rootCause()
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "Savepoint directory is not configured, can't stop job with savepoint.");
+    }
+
     private SessionHandle initializeSession() {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         String catalogDDL =
@@ -508,5 +761,52 @@ public class MaterializedTableStatementITCase {
                 service.executeStatement(sessionHandle, query, -1, new Configuration());
 
         return fetchAllResults(service, sessionHandle, queryHandle);
+    }
+
+    private long getCheckpointIntervalConfig(RestClusterClient<?> restClusterClient, String jobId)
+            throws Exception {
+        CheckpointConfigInfo checkpointConfigInfo =
+                sendJobRequest(
+                        restClusterClient,
+                        CheckpointConfigHeaders.getInstance(),
+                        EmptyRequestBody.getInstance(),
+                        jobId);
+        return RestMapperUtils.getStrictObjectMapper()
+                .readTree(
+                        RestMapperUtils.getStrictObjectMapper()
+                                .writeValueAsString(checkpointConfigInfo))
+                .get("interval")
+                .asLong();
+    }
+
+    private Optional<String> getJobRestoreSavepointPath(
+            RestClusterClient<?> restClusterClient, String jobId) throws Exception {
+        CheckpointingStatistics checkpointingStatistics =
+                sendJobRequest(
+                        restClusterClient,
+                        CheckpointingStatisticsHeaders.getInstance(),
+                        EmptyRequestBody.getInstance(),
+                        jobId);
+
+        CheckpointingStatistics.RestoredCheckpointStatistics restoredCheckpointStatistics =
+                checkpointingStatistics.getLatestCheckpoints().getRestoredCheckpointStatistics();
+        return restoredCheckpointStatistics != null
+                ? Optional.ofNullable(restoredCheckpointStatistics.getExternalPath())
+                : Optional.empty();
+    }
+
+    private static <M extends JobMessageParameters, R extends RequestBody, P extends ResponseBody>
+            P sendJobRequest(
+                    RestClusterClient<?> restClusterClient,
+                    MessageHeaders<R, P, M> headers,
+                    R requestBody,
+                    String jobId)
+                    throws Exception {
+        M jobMessageParameters = headers.getUnresolvedMessageParameters();
+        jobMessageParameters.jobPathParameter.resolve(JobID.fromHexString(jobId));
+
+        return restClusterClient
+                .sendRequest(headers, jobMessageParameters, requestBody)
+                .get(5, TimeUnit.SECONDS);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableResumeOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableResumeOperation.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.OperationUtils;
+
+import java.util.Map;
+
+/** Operation to describe a ALTER MATERIALIZED TABLE ... SUSPEND statement. */
+@Internal
+public class AlterMaterializedTableResumeOperation extends AlterMaterializedTableOperation {
+
+    private final Map<String, String> dynamicOptions;
+
+    public AlterMaterializedTableResumeOperation(
+            ObjectIdentifier tableIdentifier, Map<String, String> options) {
+        super(tableIdentifier);
+        this.dynamicOptions = options;
+    }
+
+    public Map<String, String> getDynamicOptions() {
+        return dynamicOptions;
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        throw new UnsupportedOperationException(
+                "AlterMaterializedTableResumeOperation doesn't support ExecutableOperation yet.");
+    }
+
+    @Override
+    public String asSummaryString() {
+        StringBuilder builder =
+                new StringBuilder(
+                        String.format(
+                                "ALTER MATERIALIZED TABLE %s RESUME",
+                                tableIdentifier.asSummaryString()));
+        if (!dynamicOptions.isEmpty()) {
+            builder.append(
+                    String.format(" WITH (%s)", OperationUtils.formatProperties(dynamicOptions)));
+        }
+        return builder.toString();
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableSuspendOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableSuspendOperation.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+/** Operation to describe a ALTER MATERIALIZED TABLE ... SUSPEND statement. */
+@Internal
+public class AlterMaterializedTableSuspendOperation extends AlterMaterializedTableOperation {
+
+    public AlterMaterializedTableSuspendOperation(ObjectIdentifier tableIdentifier) {
+        super(tableIdentifier);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        throw new UnsupportedOperationException(
+                "AlterMaterializedTableResumeOperation doesn't support ExecutableOperation yet.");
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format(
+                "ALTER MATERIALIZED TABLE %s SUSPEND", tableIdentifier.asSummaryString());
+    }
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.catalog;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.TableColumn;
@@ -26,6 +27,8 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.resolver.ExpressionResolver.ExpressionResolverBuilder;
 import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
+import org.apache.flink.table.refresh.ContinuousRefreshHandler;
+import org.apache.flink.table.refresh.ContinuousRefreshHandlerSerializer;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.utils.CatalogManagerMocks;
@@ -45,6 +48,7 @@ import java.util.Map;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
 import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_DATABASE;
+import static org.apache.flink.table.utils.EncodingUtils.encodeBytesToBase64;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.HamcrestCondition.matching;
@@ -142,6 +146,13 @@ class CatalogBaseTableResolutionTest {
                     UniqueConstraint.primaryKey(
                             "primary_constraint", Collections.singletonList("id")));
 
+    private static final ContinuousRefreshHandler CONTINUOUS_REFRESH_HANDLER =
+            new ContinuousRefreshHandler("remote", JobID.generate().toHexString());
+
+    private static final String DEFINITION_QUERY =
+            String.format(
+                    "SELECT id, region, county FROM %s.%s.T", DEFAULT_CATALOG, DEFAULT_DATABASE);
+
     private static final ResolvedSchema RESOLVED_VIEW_SCHEMA =
             new ResolvedSchema(
                     Arrays.asList(
@@ -200,7 +211,7 @@ class CatalogBaseTableResolutionTest {
     }
 
     @Test
-    void testPropertyDeSerialization() {
+    void testPropertyDeSerialization() throws Exception {
         final CatalogTable table = CatalogTable.fromProperties(catalogTableAsProperties());
 
         final ResolvedCatalogTable resolvedTable =
@@ -209,6 +220,35 @@ class CatalogBaseTableResolutionTest {
         assertThat(resolvedTable.toProperties()).isEqualTo(catalogTableAsProperties());
 
         assertThat(resolvedTable.getResolvedSchema()).isEqualTo(RESOLVED_TABLE_SCHEMA);
+
+        // test materialized table de/serialization
+        final CatalogMaterializedTable catalogMaterializedTable =
+                CatalogPropertiesUtil.deserializeCatalogMaterializedTable(
+                        catalogMaterializedTableAsProperties());
+        final ResolvedCatalogMaterializedTable resolvedCatalogMaterializedTable =
+                resolveCatalogBaseTable(
+                        ResolvedCatalogMaterializedTable.class, catalogMaterializedTable);
+        assertThat(
+                        CatalogPropertiesUtil.serializeCatalogMaterializedTable(
+                                resolvedCatalogMaterializedTable))
+                .isEqualTo(catalogMaterializedTableAsProperties());
+
+        assertThat(resolvedCatalogMaterializedTable.getResolvedSchema())
+                .isEqualTo(RESOLVED_MATERIALIZED_TABLE_SCHEMA);
+        assertThat(resolvedCatalogMaterializedTable.getFreshness())
+                .isEqualTo(Duration.ofSeconds(30));
+        assertThat(resolvedCatalogMaterializedTable.getDefinitionQuery())
+                .isEqualTo(DEFINITION_QUERY);
+        assertThat(resolvedCatalogMaterializedTable.getLogicalRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.CONTINUOUS);
+        assertThat(resolvedCatalogMaterializedTable.getRefreshMode())
+                .isEqualTo(CatalogMaterializedTable.RefreshMode.CONTINUOUS);
+        assertThat(resolvedCatalogMaterializedTable.getRefreshStatus())
+                .isEqualTo(CatalogMaterializedTable.RefreshStatus.INITIALIZING);
+        byte[] expectedBytes =
+                ContinuousRefreshHandlerSerializer.INSTANCE.serialize(CONTINUOUS_REFRESH_HANDLER);
+        assertThat(resolvedCatalogMaterializedTable.getSerializedRefreshHandler())
+                .isEqualTo(expectedBytes);
     }
 
     @Test
@@ -365,6 +405,37 @@ class CatalogBaseTableResolutionTest {
         properties.put("connector", "custom");
         properties.put("comment", "This is an example table.");
         properties.put("snapshot", "1688918400000");
+
+        return properties;
+    }
+
+    private static Map<String, String> catalogMaterializedTableAsProperties() throws Exception {
+        // add base properties
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("schema.0.name", "id");
+        properties.put("schema.0.data-type", "INT NOT NULL");
+        properties.put("schema.1.name", "region");
+        properties.put("schema.1.data-type", "VARCHAR(200)");
+        properties.put("schema.1.comment", "This is a region column.");
+        properties.put("schema.2.name", "county");
+        properties.put("schema.2.data-type", "VARCHAR(200)");
+        properties.put("schema.3.name", "topic");
+        properties.put("schema.3.data-type", "VARCHAR(200)");
+        properties.put("schema.3.comment", "");
+        properties.put("schema.primary-key.name", "primary_constraint");
+        properties.put("schema.primary-key.columns", "id");
+        properties.put("freshness", "PT30S");
+        properties.put("logical-refresh-mode", "CONTINUOUS");
+        properties.put("refresh-mode", "CONTINUOUS");
+        properties.put("refresh-status", "INITIALIZING");
+        properties.put("definition-query", DEFINITION_QUERY);
+
+        // put refresh handler
+        properties.put(
+                "refresh-handler-bytes",
+                encodeBytesToBase64(
+                        ContinuousRefreshHandlerSerializer.INSTANCE.serialize(
+                                CONTINUOUS_REFRESH_HANDLER)));
         return properties;
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -32,7 +32,6 @@ import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,6 +48,8 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.apache.flink.table.utils.EncodingUtils.decodeBase64ToBytes;
+import static org.apache.flink.table.utils.EncodingUtils.encodeBytesToBase64;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Utilities for de/serializing {@link Catalog} objects into a map of string properties. */
@@ -159,9 +160,8 @@ public final class CatalogPropertiesUtil {
             if (resolvedMaterializedTable.getSerializedRefreshHandler() != null) {
                 properties.put(
                         REFRESH_HANDLER_BYTES,
-                        new String(
-                                resolvedMaterializedTable.getSerializedRefreshHandler(),
-                                StandardCharsets.UTF_8));
+                        encodeBytesToBase64(
+                                resolvedMaterializedTable.getSerializedRefreshHandler()));
             }
 
             return properties;
@@ -248,7 +248,7 @@ public final class CatalogPropertiesUtil {
             final @Nullable byte[] refreshHandlerBytes =
                     StringUtils.isNullOrWhitespaceOnly(refreshHandlerStringBytes)
                             ? null
-                            : refreshHandlerStringBytes.getBytes(StandardCharsets.UTF_8);
+                            : decodeBase64ToBytes(refreshHandlerStringBytes);
 
             CatalogMaterializedTable.Builder builder = CatalogMaterializedTable.newBuilder();
             builder.schema(schema)

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/ContinuousRefreshHandler.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/ContinuousRefreshHandler.java
@@ -20,7 +20,10 @@ package org.apache.flink.table.refresh;
 
 import org.apache.flink.annotation.Internal;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
+import java.util.Optional;
 
 /** Embedded continuous refresh handler of Flink streaming job for materialized table. */
 @Internal
@@ -30,9 +33,18 @@ public class ContinuousRefreshHandler implements RefreshHandler, Serializable {
     private final String executionTarget;
     private final String jobId;
 
+    private @Nullable final String restorePath;
+
     public ContinuousRefreshHandler(String executionTarget, String jobId) {
         this.executionTarget = executionTarget;
         this.jobId = jobId;
+        this.restorePath = null;
+    }
+
+    public ContinuousRefreshHandler(String executionTarget, String jobId, String restorePath) {
+        this.executionTarget = executionTarget;
+        this.jobId = jobId;
+        this.restorePath = restorePath;
     }
 
     public String getExecutionTarget() {
@@ -43,8 +55,16 @@ public class ContinuousRefreshHandler implements RefreshHandler, Serializable {
         return jobId;
     }
 
+    public Optional<String> getRestorePath() {
+        return Optional.ofNullable(restorePath);
+    }
+
     @Override
     public String asSummaryString() {
-        return String.format("{\n executionTarget: %s,\n jobId: %s\n}", executionTarget, jobId);
+        return String.format(
+                "{\njobId=%s,\n executionTarget=%s%s\n}",
+                jobId,
+                executionTarget,
+                restorePath == null ? "" : ",\n restorePath=" + restorePath);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableResumeConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableResumeConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableResume;
+import org.apache.flink.sql.parser.ddl.SqlTableOption;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableResumeOperation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** A converter for {@link SqlAlterMaterializedTableResume}. */
+public class SqlAlterMaterializedTableResumeConverter
+        implements SqlNodeConverter<SqlAlterMaterializedTableResume> {
+    @Override
+    public Operation convertSqlNode(
+            SqlAlterMaterializedTableResume sqlAlterMaterializedTableResume,
+            ConvertContext context) {
+        UnresolvedIdentifier unresolvedIdentifier =
+                UnresolvedIdentifier.of(sqlAlterMaterializedTableResume.fullTableName());
+        ObjectIdentifier identifier =
+                context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+
+        // get table options
+        Map<String, String> options = new HashMap<>();
+        sqlAlterMaterializedTableResume
+                .getPropertyList()
+                .getList()
+                .forEach(
+                        p ->
+                                options.put(
+                                        ((SqlTableOption) p).getKeyString(),
+                                        ((SqlTableOption) p).getValueString()));
+        return new AlterMaterializedTableResumeOperation(identifier, options);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableSuspendConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableSuspendConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableSuspend;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableSuspendOperation;
+
+/** A converter for {@link SqlAlterMaterializedTableSuspend}. */
+public class SqlAlterMaterializedTableSuspendConverter
+        implements SqlNodeConverter<SqlAlterMaterializedTableSuspend> {
+    @Override
+    public Operation convertSqlNode(SqlAlterMaterializedTableSuspend node, ConvertContext context) {
+        UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(node.fullTableName());
+        ObjectIdentifier identifier =
+                context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+        return new AlterMaterializedTableSuspendOperation(identifier);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -59,6 +59,8 @@ public class SqlNodeConverters {
         register(new SqlDescribeJobConverter());
         register(new SqlCreateMaterializedTableConverter());
         register(new SqlAlterMaterializedTableRefreshConverter());
+        register(new SqlAlterMaterializedTableSuspendConverter());
+        register(new SqlAlterMaterializedTableResumeConverter());
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

*Support the execution of suspend & resume materialized table in continuous refresh mode*


## Brief change log

  - *Fix incomplete serialization and deserialization of materialized tables*
  - *Support convert alter materialized table suspend/resume nodes to operations*
  - *Support the execution of suspend, resume materialized table in continuous refresh mode*


## Verifying this change
-In order to test the repair of incomplete serialization and deserialization of materialized tables, some relevant logic in org.apache.flink.table.catalog.CatalogBaseTableResolutionTest#testPropertyDeSerialization has been added.

- For the execution of suspend and resume materialized table can be verifed by the new added test case  org.apache.flink.table.gateway.service.MaterializedTableStatementITCase#testAlterMaterializedTableSuspendAndResume

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( Will add in a separate PR.)
