### PR TITLE
[FLINK-35047][state] Shutdown StateExecutors when ForStKeyedStateBackend is closed

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
@@ -90,7 +90,7 @@ public class AsyncExecutionController<K> implements StateRequestHandler {
     private final StateFutureFactory<K> stateFutureFactory;
 
     /** The state executor where the {@link StateRequest} is actually executed. */
-    final StateExecutor stateExecutor;
+    private final StateExecutor stateExecutor;
 
     /** The corresponding context that currently runs in task thread. */
     RecordContext<K> currentContext;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateExecutor.java
@@ -22,7 +22,12 @@ import org.apache.flink.annotation.Internal;
 
 import java.util.concurrent.CompletableFuture;
 
-/** Executor for executing batch {@link StateRequest}s. */
+/**
+ * Executor for executing batch {@link StateRequest}s.
+ *
+ * <p>Notice that the owner who create the {@code StateExecutor} is responsible for shutting down it
+ * when it is no longer in use.
+ */
 @Internal
 public interface StateExecutor {
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
@@ -58,6 +58,9 @@ public interface AsyncKeyedStateBackend extends Disposable, Closeable {
      * Creates a {@code StateExecutor} which supports to execute a batch of state requests
      * asynchronously.
      *
+     * <p>Notice that the {@code AsyncKeyedStateBackend} is responsible for shutting down the
+     * StateExecutors created by itself when they are no longer in use.
+     *
      * @return a {@code StateExecutor} which supports to execute a batch of state requests
      *     asynchronously.
      */


### PR DESCRIPTION
## What is the purpose of the change

This pull request shuts down the ForStStateExecutors when ForStKeyedStateBackend is disposed.

## Brief change log

- Shutdown the StateExecutors in ForStKeyedStateBackend.

## Verifying this change


This change is already covered by existing tests, such as ForStStateBackendConfigTest and AsyncExecutionControllerTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
