### PR TITLE
[FLINK-35041][test] Fix the IncrementalRemoteKeyedStateHandleTest.testSharedStateReRegistration failed

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -343,7 +343,11 @@ public class CheckpointTestUtils {
     private static StreamStateHandle createDummySegmentFileStateHandle(
             Random rnd, boolean isEmpty) {
         return isEmpty
-                ? TestingSegmentFileStateHandle.EMPTY_INSTANCE
+                ? new TestingSegmentFileStateHandle(
+                        new Path(UUID.randomUUID().toString()),
+                        0,
+                        0,
+                        CheckpointedStateScope.EXCLUSIVE)
                 : new TestingSegmentFileStateHandle(
                         new Path(String.valueOf(createRandomUUID(rnd))),
                         0,
@@ -355,10 +359,6 @@ public class CheckpointTestUtils {
             implements DiscardRecordedStateObject {
 
         private static final long serialVersionUID = 1L;
-
-        private static final TestingSegmentFileStateHandle EMPTY_INSTANCE =
-                new TestingSegmentFileStateHandle(
-                        new Path("empty"), 0, 0, CheckpointedStateScope.EXCLUSIVE);
 
         private boolean disposed;
 


### PR DESCRIPTION
## What is the purpose of the change

IncrementalRemoteKeyedStateHandleTest.testSharedStateReRegistration failed

Reason:

TestingSegmentFileStateHandle.EMPTY_INSTANCE is static, it means other test can update disposed field. IncrementalRemoteKeyedStateHandleTest.testSharedStateReRegistration will check the disposed of this static TestingSegmentFileStateHandle.EMPTY_INSTANCE.

So disposed is unexpected.


## Brief change log


- [FLINK-35041][test] Fix the IncrementalRemoteKeyedStateHandleTest.testSharedStateReRegistration failed
 - TestingSegmentFileStateHandle object shouldn't be shared in global scope.


