### PR TITLE
[hotfix][test] Fix InstantiationUtilTest cannot find assertFalse

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/util/InstantiationUtilTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/InstantiationUtilTest.java
@@ -116,8 +116,9 @@ class InstantiationUtilTest {
      * Test that {@link InstantiationUtil} class per se does not have a nullary public constructor.
      */
     @Test
-    public void testHasNullaryConstructorFalse() {
-        assertFalse(InstantiationUtil.hasPublicNullaryConstructor(InstantiationUtil.class));
+    void testHasNullaryConstructorFalse() {
+        assertThat(InstantiationUtil.hasPublicNullaryConstructor(InstantiationUtil.class))
+                .isFalse();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

The master branch cannot build success.

https://github.com/apache/flink/pull/24670 doesn't rebase the master branch before merging, and other PR added `InstantiationUtilTest#testHasNullaryConstructorFalse` to use the assertFalse.

But https://github.com/apache/flink/pull/24670 removed the import assertFalse, so master branch cannot compile.


## Brief change log

Migrate the assertFalse to assertThat.
