### PR TITLE
[FLINK-34108][table] Add built-in URL_ENCODE and URL_DECODE function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -350,6 +350,12 @@ string:
   - sql: LOCATE(string1, string2[, integer])
     table: STRING1.locate(STRING2[, INTEGER])
     description: Returns the position of the first occurrence of string1 in string2 after position integer. Returns 0 if not found. Returns NULL if any of arguments is NULL.
+  - sql: URL_DECODE(string)
+    table: STRING.urlDecode()
+    description: Decodes a string in 'application/x-www-form-urlencoded' format using a specific encoding scheme.
+  - sql: URL_ENCODE(string)
+    table: STRING.urlEncode()
+    description: Translates a string into 'application/x-www-form-urlencoded' format using a specific encoding scheme.
   - sql: PARSE_URL(string1, string2[, string3])
     table: STRING1.parseUrl(STRING2[, STRING3])
     description: |

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -354,12 +354,12 @@ string:
     table: STRING.urlDecode()
     description:
       Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8 encoding scheme.
-      If input is NULL, or there is an issue with the decoding process(such as encountering an illegal escape pattern), or the encoding scheme is not supported, the function returns NULL.
+      If the input is NULL, or there is an issue with the decoding process(such as encountering an illegal escape pattern), or the encoding scheme is not supported, the function returns NULL.
   - sql: URL_ENCODE(string)
     table: STRING.urlEncode()
     description:
       Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8 encoding scheme.
-      If input is NULL, or there is an issue with the encoding process, or the encoding scheme is not supported, will return NULL.
+      If the input is NULL, or there is an issue with the encoding process, or the encoding scheme is not supported, will return NULL.
   - sql: PARSE_URL(string1, string2[, string3])
     table: STRING1.parseUrl(STRING2[, STRING3])
     description: |

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -353,14 +353,13 @@ string:
   - sql: URL_DECODE(string)
     table: STRING.urlDecode()
     description:
-      Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8 encoding scheme, will be null if input is null.
-      If there is an issue with the decoding process, such as encountering an illegal escape pattern, the function returns the original input value.
-      If the encoding scheme is not supported, an error will be reported.
+      Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8 encoding scheme.
+      If input is NULL, or there is an issue with the decoding process(such as encountering an illegal escape pattern), or the encoding scheme is not supported, the function returns NULL.
   - sql: URL_ENCODE(string)
     table: STRING.urlEncode()
     description:
-      Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8 encoding scheme, will be null if input is null.
-      If there is an issue with the encoding process or the encoding scheme is not supported, an error will be reported.
+      Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8 encoding scheme.
+      If input is NULL, or there is an issue with the encoding process, or the encoding scheme is not supported, will return NULL.
   - sql: PARSE_URL(string1, string2[, string3])
     table: STRING1.parseUrl(STRING2[, STRING3])
     description: |

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -352,10 +352,15 @@ string:
     description: Returns the position of the first occurrence of string1 in string2 after position integer. Returns 0 if not found. Returns NULL if any of arguments is NULL.
   - sql: URL_DECODE(string)
     table: STRING.urlDecode()
-    description: Decodes a string in 'application/x-www-form-urlencoded' format using a specific encoding scheme.
+    description:
+      Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8 encoding scheme, will be null if input is null.
+      If there is an issue with the decoding process, such as encountering an illegal escape pattern, the function returns the original input value.
+      If the encoding scheme is not supported, an error will be reported.
   - sql: URL_ENCODE(string)
     table: STRING.urlEncode()
-    description: Translates a string into 'application/x-www-form-urlencoded' format using a specific encoding scheme.
+    description:
+      Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8 encoding scheme, will be null if input is null.
+      If there is an issue with the encoding process or the encoding scheme is not supported, an error will be reported.
   - sql: PARSE_URL(string1, string2[, string3])
     table: STRING1.parseUrl(STRING2[, STRING3])
     description: |

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -451,14 +451,13 @@ string:
   - sql: URL_DECODE(string)
     table: STRING.urlDecode()
     description:
-      使用 UTF-8 编码方案对“application/x-www-form-urlencoded”格式的给定字符串进行解码，如果输入为 null，则该字符串将为 null。
-      如果解码过程出现问题，例如遇到非法转义模式，该函数将返回原始输入值。
-      如果不支持该编码方案，则会报错。
+      使用 UTF-8 编码方案对“application/x-www-form-urlencoded”格式的给定字符串进行解码。
+      如果输入为 NULL，或者解码过程出现问题（例如遇到非法转义模式或者不支持该编码方案），该函数将返回 NULL。
   - sql: URL_ENCODE(string)
     table: STRING.urlEncode()
     description:
-      使用 UTF-8 编码方案将字符串转换为“application/x-www-form-urlencoded”格式，如果输入为 null，则将为 null。
-      如果编码过程出现问题或者不支持编码方案，则会报告错误。
+      使用 UTF-8 编码方案将字符串转换为“application/x-www-form-urlencoded”格式。
+      如果输入为 NULL，或者编码过程出现问题，或者不支持编码方案，则会返回 NULL。
   - sql: PARSE_URL(string1, string2[, string3])
     table: STRING1.parseUrl(STRING2[, STRING3])
     description: |

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -448,6 +448,17 @@ string:
     table: STRING1.locate(STRING2[, INTEGER])
     description: |
       返回 string2 中 string1 在位置 integer 之后第一次出现的位置。未找到返回 0。如果有任一参数为 `NULL` 则返回 `NULL`。
+  - sql: URL_DECODE(string)
+    table: STRING.urlDecode()
+    description:
+      使用 UTF-8 编码方案对“application/x-www-form-urlencoded”格式的给定字符串进行解码，如果输入为 null，则该字符串将为 null。
+      如果解码过程出现问题，例如遇到非法转义模式，该函数将返回原始输入值。
+      如果不支持该编码方案，则会报错。
+  - sql: URL_ENCODE(string)
+    table: STRING.urlEncode()
+    description:
+      使用 UTF-8 编码方案将字符串转换为“application/x-www-form-urlencoded”格式，如果输入为 null，则将为 null。
+      如果编码过程出现问题或者不支持编码方案，则会报告错误。
   - sql: PARSE_URL(string1, string2[, string3])
     table: STRING1.parseUrl(STRING2[, STRING3])
     description: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -188,6 +188,8 @@ string functions
     Expression.right
     Expression.instr
     Expression.locate
+    Expression.url_decode
+    Expression.url_encode
     Expression.parse_url
     Expression.ltrim
     Expression.rtrim

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1273,6 +1273,18 @@ class Expression(Generic[T]):
         else:
             return _ternary_op("locate")(self, s, pos)
 
+    def url_decode(self) -> 'Expression[str]':
+        """
+        Decodes a string in 'application/x-www-form-urlencoded' format using a specific encoding scheme.
+        """
+        return _unary_op("urlDecode")(self)
+
+    def url_encode(self) -> 'Expression[str]':
+        """
+        Translates a string into 'application/x-www-form-urlencoded' format using a specific encoding scheme.
+        """
+        return _unary_op("urlEncode")(self)
+
     def parse_url(self, part_to_extract: Union[str, 'Expression[str]'],
                   key: Union[str, 'Expression[str]'] = None) -> 'Expression[str]':
         """

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1276,8 +1276,8 @@ class Expression(Generic[T]):
     def url_decode(self) -> 'Expression[str]':
         """
         Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8
-        encoding scheme. If input is null, or there is an issue with the decoding process(such
-        as encountering an illegal escape pattern), or the encoding scheme is not supported,
+        encoding scheme. If the input is null, or there is an issue with the decoding process
+        (such as encountering an illegal escape pattern), or the encoding scheme is not supported,
         the function returns null.
         """
         return _unary_op("urlDecode")(self)
@@ -1285,7 +1285,7 @@ class Expression(Generic[T]):
     def url_encode(self) -> 'Expression[str]':
         """
         Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8
-        encoding scheme. If input is null, or there is an issue with the encoding process, or
+        encoding scheme. If the input is null, or there is an issue with the encoding process, or
         the encoding scheme is not supported, will return null.
         """
         return _unary_op("urlEncode")(self)

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1275,13 +1275,20 @@ class Expression(Generic[T]):
 
     def url_decode(self) -> 'Expression[str]':
         """
-        Decodes a string in 'application/x-www-form-urlencoded' format using a specific encoding scheme.
+        Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8
+        encoding scheme, will be null if input is null.
+        If there is an issue with the decoding process, such as encountering an illegal escape
+        pattern, the function returns the original input value.
+        If the encoding scheme is not supported, an error will be reported.
         """
         return _unary_op("urlDecode")(self)
 
     def url_encode(self) -> 'Expression[str]':
         """
-        Translates a string into 'application/x-www-form-urlencoded' format using a specific encoding scheme.
+        Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8
+        encoding scheme, will be null if input is null.
+        If there is an issue with the encoding process or the encoding scheme is not supported,
+        an error will be reported.
         """
         return _unary_op("urlEncode")(self)
 

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1276,19 +1276,17 @@ class Expression(Generic[T]):
     def url_decode(self) -> 'Expression[str]':
         """
         Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8
-        encoding scheme, will be null if input is null.
-        If there is an issue with the decoding process, such as encountering an illegal escape
-        pattern, the function returns the original input value.
-        If the encoding scheme is not supported, an error will be reported.
+        encoding scheme. If input is null, or there is an issue with the decoding process(such
+        as encountering an illegal escape pattern), or the encoding scheme is not supported,
+        the function returns null.
         """
         return _unary_op("urlDecode")(self)
 
     def url_encode(self) -> 'Expression[str]':
         """
         Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8
-        encoding scheme, will be null if input is null.
-        If there is an issue with the encoding process or the encoding scheme is not supported,
-        an error will be reported.
+        encoding scheme. If input is null, or there is an issue with the encoding process, or
+        the encoding scheme is not supported, will return null.
         """
         return _unary_op("urlEncode")(self)
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1190,8 +1190,9 @@ public abstract class BaseExpressions<InType, OutType> {
 
     /**
      * Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8 encoding
-     * scheme. If input is null, or there is an issue with the decoding process(such as encountering
-     * an illegal escape pattern), or the encoding scheme is not supported, will return null.
+     * scheme. If the input is null, or there is an issue with the decoding process(such as
+     * encountering an illegal escape pattern), or the encoding scheme is not supported, will return
+     * null.
      */
     public OutType urlDecode() {
         return toApiSpecificExpression(unresolvedCall(URL_DECODE, toExpr()));
@@ -1199,7 +1200,7 @@ public abstract class BaseExpressions<InType, OutType> {
 
     /**
      * Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8 encoding
-     * scheme. If input is null, or there is an issue with the encoding process, or the encoding
+     * scheme. If the input is null, or there is an issue with the encoding process, or the encoding
      * scheme is not supported, will return null.
      */
     public OutType urlEncode() {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -193,6 +193,8 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRIM;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRUNCATE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRY_CAST;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.UPPER;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.URL_DECODE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.URL_ENCODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.VAR_POP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.VAR_SAMP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.WINDOW_END;
@@ -1184,6 +1186,22 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType locate(InType str, InType pos) {
         return toApiSpecificExpression(
                 unresolvedCall(LOCATE, toExpr(), objectToExpression(str), objectToExpression(pos)));
+    }
+
+    /**
+     * Decodes a string in 'application/x-www-form-urlencoded' format using a specific encoding
+     * scheme.
+     */
+    public OutType urlDecode() {
+        return toApiSpecificExpression(unresolvedCall(URL_DECODE, toExpr()));
+    }
+
+    /**
+     * Translates a string into 'application/x-www-form-urlencoded' format using a specific encoding
+     * scheme.
+     */
+    public OutType urlEncode() {
+        return toApiSpecificExpression(unresolvedCall(URL_ENCODE, toExpr()));
     }
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1190,9 +1190,8 @@ public abstract class BaseExpressions<InType, OutType> {
 
     /**
      * Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8 encoding
-     * scheme, will be null if input is null. If there is an issue with the decoding process, such
-     * as encountering an illegal escape pattern, the function returns the original input value. If
-     * the encoding scheme is not supported, an error will be reported.
+     * scheme. If input is null, or there is an issue with the decoding process(such as encountering
+     * an illegal escape pattern), or the encoding scheme is not supported, will return null.
      */
     public OutType urlDecode() {
         return toApiSpecificExpression(unresolvedCall(URL_DECODE, toExpr()));
@@ -1200,8 +1199,8 @@ public abstract class BaseExpressions<InType, OutType> {
 
     /**
      * Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8 encoding
-     * scheme, will be null if input is null. If there is an issue with the encoding process or the
-     * encoding scheme is not supported, an error will be reported.
+     * scheme. If input is null, or there is an issue with the encoding process, or the encoding
+     * scheme is not supported, will return null.
      */
     public OutType urlEncode() {
         return toApiSpecificExpression(unresolvedCall(URL_ENCODE, toExpr()));

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1189,16 +1189,19 @@ public abstract class BaseExpressions<InType, OutType> {
     }
 
     /**
-     * Decodes a string in 'application/x-www-form-urlencoded' format using a specific encoding
-     * scheme.
+     * Decodes a given string in 'application/x-www-form-urlencoded' format using the UTF-8 encoding
+     * scheme, will be null if input is null. If there is an issue with the decoding process, such
+     * as encountering an illegal escape pattern, the function returns the original input value. If
+     * the encoding scheme is not supported, an error will be reported.
      */
     public OutType urlDecode() {
         return toApiSpecificExpression(unresolvedCall(URL_DECODE, toExpr()));
     }
 
     /**
-     * Translates a string into 'application/x-www-form-urlencoded' format using a specific encoding
-     * scheme.
+     * Translates a string into 'application/x-www-form-urlencoded' format using the UTF-8 encoding
+     * scheme, will be null if input is null. If there is an issue with the encoding process or the
+     * encoding scheme is not supported, an error will be reported.
      */
     public OutType urlEncode() {
         return toApiSpecificExpression(unresolvedCall(URL_ENCODE, toExpr()));

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -436,7 +436,7 @@ public final class BuiltInFunctionDefinitions {
                     .name("url_decode")
                     .kind(SCALAR)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
-                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING().nullable())))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.UrlDecodeFunction")
                     .build();
@@ -446,7 +446,7 @@ public final class BuiltInFunctionDefinitions {
                     .name("url_encode")
                     .kind(SCALAR)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
-                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING().nullable())))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.UrlEncodeFunction")
                     .build();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -431,6 +431,26 @@ public final class BuiltInFunctionDefinitions {
                     .runtimeClass("org.apache.flink.table.runtime.functions.scalar.SplitFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition URL_DECODE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("url_decode")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.UrlDecodeFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition URL_ENCODE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("url_encode")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.UrlEncodeFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition INTERNAL_REPLICATE_ROWS =
             BuiltInFunctionDefinition.newBuilder()
                     .name("$REPLICATE_ROWS$1")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/UrlFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/UrlFunctionsITCase.java
@@ -20,8 +20,6 @@ package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.DataTypes.STRING;
@@ -29,90 +27,73 @@ import static org.apache.flink.table.api.Expressions.$;
 
 public class UrlFunctionsITCase extends BuiltInFunctionTestBase {
 
-    private static TestSetSpec urlDecodeSpec() {
-        return TestSetSpec.forFunction(BuiltInFunctionDefinitions.URL_DECODE)
-                .onFieldsWithData(
-                        "https%3A%2F%2Fflink.apache.org%2F",
-                        "https://flink.apache.org/",
-                        "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd",
-                        null,
-                        "aaaa",
-                        "inva+lid%3A%2F%2Fuser%3Apass%40host%2Ffile%3Bparam%3Fquery%3Bp2",
-                        "")
-                .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING(), STRING(), STRING())
-                .testResult(
-                        $("f0").urlDecode(),
-                        "url_decode(f0)",
-                        "https://flink.apache.org/",
-                        STRING())
-                .testResult(
-                        $("f1").urlEncode().urlDecode(),
-                        "url_decode(url_encode(f1))",
-                        "https://flink.apache.org/",
-                        STRING())
-                .testResult(
-                        $("f1").urlDecode(),
-                        "url_decode(f1)",
-                        "https://flink.apache.org/",
-                        STRING())
-                .testResult($("f2").urlDecode(), "url_decode(f2)", "http://test?a=b&c=d", STRING())
-                .testResult($("f3").urlDecode(), "url_decode(f3)", null, STRING().nullable())
-                .testResult($("f4").urlDecode(), "url_decode(f4)", "aaaa", STRING())
-                .testResult(
-                        $("f5").urlDecode(),
-                        "url_decode(f5)",
-                        "inva lid://user:pass@host/file;param?query;p2",
-                        STRING())
-                .testResult($("f6").urlDecode(), "url_decode(f6)", "", STRING());
-    }
-
-    private static TestSetSpec urlEncodeSpec() {
-        return TestSetSpec.forFunction(BuiltInFunctionDefinitions.URL_DECODE)
-                .onFieldsWithData(
-                        "https://flink.apache.org/",
-                        "https%3A%2F%2Fflink.apache.org%2F",
-                        "http://test?a=b&c=d",
-                        null,
-                        "aaaa",
-                        "inva lid://user:pass@host/file;param?query;p2",
-                        "")
-                .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING(), STRING(), STRING())
-                .testResult(
-                        $("f0").urlEncode(),
-                        "url_encode(f0)",
-                        "https%3A%2F%2Fflink.apache.org%2F",
-                        STRING())
-                .testResult(
-                        $("f0").urlDecode().urlEncode(),
-                        "url_encode(url_decode(f0))",
-                        "https%3A%2F%2Fflink.apache.org%2F",
-                        STRING())
-                .testResult(
-                        $("f1").urlEncode(),
-                        "url_encode(f1)",
-                        "https%253A%252F%252Fflink.apache.org%252F",
-                        STRING())
-                .testResult(
-                        $("f2").urlEncode(),
-                        "url_encode(f2)",
-                        "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd",
-                        STRING())
-                .testResult($("f3").urlEncode(), "url_encode(f3)", null, STRING().nullable())
-                .testResult($("f4").urlEncode(), "url_encode(f4)", "aaaa", STRING())
-                .testResult(
-                        $("f5").urlEncode(),
-                        "url_encode(f5)",
-                        "inva+lid%3A%2F%2Fuser%3Apass%40host%2Ffile%3Bparam%3Fquery%3Bp2",
-                        STRING())
-                .testResult($("f6").urlEncode(), "url_encode(f6)", "", STRING());
-    }
-
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
-        final List<TestSetSpec> testCases = new ArrayList<>();
-        testCases.add(urlDecodeSpec());
-        testCases.add(urlEncodeSpec());
 
-        return testCases.stream();
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.URL_DECODE)
+                        .onFieldsWithData(
+                                "https%3A%2F%2Fflink.apache.org%2F",
+                                "https://flink.apache.org/",
+                                "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd",
+                                null,
+                                "inva+lid%3A%2F%2Fuser%3Apass%40host%2Ffile%3Bparam%3Fquery%3Bp2",
+                                "")
+                        .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING(), STRING())
+                        .testResult(
+                                $("f0").urlDecode(),
+                                "url_decode(f0)",
+                                "https://flink.apache.org/",
+                                STRING())
+                        .testResult(
+                                $("f1").urlDecode(),
+                                "url_decode(f1)",
+                                "https://flink.apache.org/",
+                                STRING())
+                        .testResult(
+                                $("f2").urlDecode(),
+                                "url_decode(f2)",
+                                "http://test?a=b&c=d",
+                                STRING())
+                        .testResult(
+                                $("f3").urlDecode(), "url_decode(f3)", null, STRING().nullable())
+                        .testResult(
+                                $("f4").urlDecode(),
+                                "url_decode(f4)",
+                                "inva lid://user:pass@host/file;param?query;p2",
+                                STRING())
+                        .testResult($("f5").urlDecode(), "url_decode(f5)", "", STRING()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.URL_DECODE)
+                        .onFieldsWithData(
+                                "https://flink.apache.org/",
+                                "https%3A%2F%2Fflink.apache.org%2F",
+                                "http://test?a=b&c=d",
+                                null,
+                                "inva lid://user:pass@host/file;param?query;p2",
+                                "")
+                        .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING(), STRING())
+                        .testResult(
+                                $("f0").urlEncode(),
+                                "url_encode(f0)",
+                                "https%3A%2F%2Fflink.apache.org%2F",
+                                STRING())
+                        .testResult(
+                                $("f1").urlEncode(),
+                                "url_encode(f1)",
+                                "https%253A%252F%252Fflink.apache.org%252F",
+                                STRING())
+                        .testResult(
+                                $("f2").urlEncode(),
+                                "url_encode(f2)",
+                                "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd",
+                                STRING())
+                        .testResult(
+                                $("f3").urlEncode(), "url_encode(f3)", null, STRING().nullable())
+                        .testResult(
+                                $("f4").urlEncode(),
+                                "url_encode(f4)",
+                                "inva+lid%3A%2F%2Fuser%3Apass%40host%2Ffile%3Bparam%3Fquery%3Bp2",
+                                STRING())
+                        .testResult($("f5").urlEncode(), "url_encode(f5)", "", STRING()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/UrlFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/UrlFunctionsITCase.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.Expressions.$;
+
+public class UrlFunctionsITCase extends BuiltInFunctionTestBase {
+
+    private static TestSetSpec urlDecodeSpec() {
+        return TestSetSpec.forFunction(BuiltInFunctionDefinitions.URL_DECODE)
+                .onFieldsWithData(
+                        "https%3A%2F%2Fflink.apache.org%2F",
+                        "https://flink.apache.org/",
+                        "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd",
+                        null,
+                        "aaaa",
+                        "inva+lid%3A%2F%2Fuser%3Apass%40host%2Ffile%3Bparam%3Fquery%3Bp2",
+                        "")
+                .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING(), STRING(), STRING())
+                .testResult(
+                        $("f0").urlDecode(),
+                        "url_decode(f0)",
+                        "https://flink.apache.org/",
+                        STRING())
+                .testResult(
+                        $("f1").urlEncode().urlDecode(),
+                        "url_decode(url_encode(f1))",
+                        "https://flink.apache.org/",
+                        STRING())
+                .testResult(
+                        $("f1").urlDecode(),
+                        "url_decode(f1)",
+                        "https://flink.apache.org/",
+                        STRING())
+                .testResult($("f2").urlDecode(), "url_decode(f2)", "http://test?a=b&c=d", STRING())
+                .testResult($("f3").urlDecode(), "url_decode(f3)", null, STRING().nullable())
+                .testResult($("f4").urlDecode(), "url_decode(f4)", "aaaa", STRING())
+                .testResult(
+                        $("f5").urlDecode(),
+                        "url_decode(f5)",
+                        "inva lid://user:pass@host/file;param?query;p2",
+                        STRING())
+                .testResult($("f6").urlDecode(), "url_decode(f6)", "", STRING());
+    }
+
+    private static TestSetSpec urlEncodeSpec() {
+        return TestSetSpec.forFunction(BuiltInFunctionDefinitions.URL_DECODE)
+                .onFieldsWithData(
+                        "https://flink.apache.org/",
+                        "https%3A%2F%2Fflink.apache.org%2F",
+                        "http://test?a=b&c=d",
+                        null,
+                        "aaaa",
+                        "inva lid://user:pass@host/file;param?query;p2",
+                        "")
+                .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING(), STRING(), STRING())
+                .testResult(
+                        $("f0").urlEncode(),
+                        "url_encode(f0)",
+                        "https%3A%2F%2Fflink.apache.org%2F",
+                        STRING())
+                .testResult(
+                        $("f0").urlDecode().urlEncode(),
+                        "url_encode(url_decode(f0))",
+                        "https%3A%2F%2Fflink.apache.org%2F",
+                        STRING())
+                .testResult(
+                        $("f1").urlEncode(),
+                        "url_encode(f1)",
+                        "https%253A%252F%252Fflink.apache.org%252F",
+                        STRING())
+                .testResult(
+                        $("f2").urlEncode(),
+                        "url_encode(f2)",
+                        "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd",
+                        STRING())
+                .testResult($("f3").urlEncode(), "url_encode(f3)", null, STRING().nullable())
+                .testResult($("f4").urlEncode(), "url_encode(f4)", "aaaa", STRING())
+                .testResult(
+                        $("f5").urlEncode(),
+                        "url_encode(f5)",
+                        "inva+lid%3A%2F%2Fuser%3Apass%40host%2Ffile%3Bparam%3Fquery%3Bp2",
+                        STRING())
+                .testResult($("f6").urlEncode(), "url_encode(f6)", "", STRING());
+    }
+
+    @Override
+    Stream<TestSetSpec> getTestSetSpecs() {
+        final List<TestSetSpec> testCases = new ArrayList<>();
+        testCases.add(urlDecodeSpec());
+        testCases.add(urlEncodeSpec());
+
+        return testCases.stream();
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/UrlFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/UrlFunctionsITCase.java
@@ -35,11 +35,10 @@ public class UrlFunctionsITCase extends BuiltInFunctionTestBase {
                         .onFieldsWithData(
                                 "https%3A%2F%2Fflink.apache.org%2F",
                                 "https://flink.apache.org/",
-                                "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd",
                                 null,
                                 "inva+lid%3A%2F%2Fuser%3Apass%40host%2Ffile%3Bparam%3Fquery%3Bp2",
                                 "")
-                        .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING(), STRING())
+                        .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING())
                         .testResult(
                                 $("f0").urlDecode(),
                                 "url_decode(f0)",
@@ -51,27 +50,21 @@ public class UrlFunctionsITCase extends BuiltInFunctionTestBase {
                                 "https://flink.apache.org/",
                                 STRING())
                         .testResult(
-                                $("f2").urlDecode(),
-                                "url_decode(f2)",
-                                "http://test?a=b&c=d",
-                                STRING())
+                                $("f2").urlDecode(), "url_decode(f2)", null, STRING().nullable())
                         .testResult(
-                                $("f3").urlDecode(), "url_decode(f3)", null, STRING().nullable())
-                        .testResult(
-                                $("f4").urlDecode(),
-                                "url_decode(f4)",
+                                $("f3").urlDecode(),
+                                "url_decode(f3)",
                                 "inva lid://user:pass@host/file;param?query;p2",
                                 STRING())
-                        .testResult($("f5").urlDecode(), "url_decode(f5)", "", STRING()),
-                TestSetSpec.forFunction(BuiltInFunctionDefinitions.URL_DECODE)
+                        .testResult($("f4").urlDecode(), "url_decode(f4)", "", STRING()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.URL_ENCODE)
                         .onFieldsWithData(
                                 "https://flink.apache.org/",
                                 "https%3A%2F%2Fflink.apache.org%2F",
-                                "http://test?a=b&c=d",
                                 null,
                                 "inva lid://user:pass@host/file;param?query;p2",
                                 "")
-                        .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING(), STRING())
+                        .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING())
                         .testResult(
                                 $("f0").urlEncode(),
                                 "url_encode(f0)",
@@ -83,17 +76,12 @@ public class UrlFunctionsITCase extends BuiltInFunctionTestBase {
                                 "https%253A%252F%252Fflink.apache.org%252F",
                                 STRING())
                         .testResult(
-                                $("f2").urlEncode(),
-                                "url_encode(f2)",
-                                "http%3A%2F%2Ftest%3Fa%3Db%26c%3Dd",
-                                STRING())
+                                $("f2").urlEncode(), "url_encode(f2)", null, STRING().nullable())
                         .testResult(
-                                $("f3").urlEncode(), "url_encode(f3)", null, STRING().nullable())
-                        .testResult(
-                                $("f4").urlEncode(),
-                                "url_encode(f4)",
+                                $("f3").urlEncode(),
+                                "url_encode(f3)",
                                 "inva+lid%3A%2F%2Fuser%3Apass%40host%2Ffile%3Bparam%3Fquery%3Bp2",
                                 STRING())
-                        .testResult($("f5").urlEncode(), "url_encode(f5)", "", STRING()));
+                        .testResult($("f4").urlEncode(), "url_encode(f4)", "", STRING()));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/UrlFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/UrlFunctionsITCase.java
@@ -37,8 +37,9 @@ public class UrlFunctionsITCase extends BuiltInFunctionTestBase {
                                 "https://flink.apache.org/",
                                 null,
                                 "inva+lid%3A%2F%2Fuser%3Apass%40host%2Ffile%3Bparam%3Fquery%3Bp2",
-                                "")
-                        .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING())
+                                "",
+                                "illegal escape pattern test%")
+                        .andDataTypes(STRING(), STRING(), STRING(), STRING(), STRING(), STRING())
                         .testResult(
                                 $("f0").urlDecode(),
                                 "url_decode(f0)",
@@ -56,7 +57,8 @@ public class UrlFunctionsITCase extends BuiltInFunctionTestBase {
                                 "url_decode(f3)",
                                 "inva lid://user:pass@host/file;param?query;p2",
                                 STRING())
-                        .testResult($("f4").urlDecode(), "url_decode(f4)", "", STRING()),
+                        .testResult($("f4").urlDecode(), "url_decode(f4)", "", STRING())
+                        .testResult($("f5").urlDecode(), "url_decode(f5)", null, STRING()),
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.URL_ENCODE)
                         .onFieldsWithData(
                                 "https://flink.apache.org/",

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nullable;
 
@@ -39,13 +40,16 @@ public class UrlDecodeFunction extends BuiltInScalarFunction {
     }
 
     public @Nullable StringData eval(StringData value) {
+        if (value == null) {
+            return null;
+        }
         final Charset charset = StandardCharsets.UTF_8;
         try {
             return StringData.fromString(URLDecoder.decode(value.toString(), charset.name()));
         } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(
+            throw new FlinkRuntimeException(
                     "Failed to decode value: " + value + " with charset: " + charset.name(), e);
-        } catch (RuntimeException e) {
+        } catch (FlinkRuntimeException e) {
             return value;
         }
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
@@ -39,7 +39,7 @@ public class UrlDecodeFunction extends BuiltInScalarFunction {
         super(BuiltInFunctionDefinitions.URL_DECODE, context);
     }
 
-    public @Nullable StringData eval(StringData value) {
+    public @Nullable StringData eval(StringData value) throws FlinkRuntimeException {
         if (value == null) {
             return null;
         }
@@ -49,7 +49,7 @@ public class UrlDecodeFunction extends BuiltInScalarFunction {
         } catch (UnsupportedEncodingException e) {
             throw new FlinkRuntimeException(
                     "Failed to decode value: " + value + " with charset: " + charset.name(), e);
-        } catch (FlinkRuntimeException e) {
+        } catch (RuntimeException e) {
             return value;
         }
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
-import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nullable;
 
@@ -46,11 +45,8 @@ public class UrlDecodeFunction extends BuiltInScalarFunction {
         final Charset charset = StandardCharsets.UTF_8;
         try {
             return StringData.fromString(URLDecoder.decode(value.toString(), charset.name()));
-        } catch (UnsupportedEncodingException e) {
-            throw new FlinkRuntimeException(
-                    "Failed to decode value: " + value + " with charset: " + charset.name(), e);
-        } catch (RuntimeException e) {
-            return value;
+        } catch (UnsupportedEncodingException | RuntimeException e) {
+            return null;
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+import javax.annotation.Nullable;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#URL_DECODE}. */
+@Internal
+public class UrlDecodeFunction extends BuiltInScalarFunction {
+
+    public UrlDecodeFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.URL_DECODE, context);
+    }
+
+    public @Nullable StringData eval(StringData value) {
+        final Charset charset = StandardCharsets.UTF_8;
+        try {
+            return StringData.fromString(URLDecoder.decode(value.toString(), charset.name()));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(
+                    "Failed to decode value: " + value + " with charset: " + charset.name(), e);
+        } catch (RuntimeException e) {
+            return value;
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
@@ -39,7 +39,7 @@ public class UrlDecodeFunction extends BuiltInScalarFunction {
         super(BuiltInFunctionDefinitions.URL_DECODE, context);
     }
 
-    public @Nullable StringData eval(StringData value) throws FlinkRuntimeException {
+    public @Nullable StringData eval(StringData value) {
         if (value == null) {
             return null;
         }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
@@ -23,6 +23,9 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.io.UnsupportedEncodingException;
@@ -33,6 +36,7 @@ import java.nio.charset.StandardCharsets;
 /** Implementation of {@link BuiltInFunctionDefinitions#URL_DECODE}. */
 @Internal
 public class UrlDecodeFunction extends BuiltInScalarFunction {
+    private static final Logger LOG = LoggerFactory.getLogger(UrlDecodeFunction.class);
 
     public UrlDecodeFunction(SpecializedFunction.SpecializedContext context) {
         super(BuiltInFunctionDefinitions.URL_DECODE, context);
@@ -46,6 +50,11 @@ public class UrlDecodeFunction extends BuiltInScalarFunction {
         try {
             return StringData.fromString(URLDecoder.decode(value.toString(), charset.name()));
         } catch (UnsupportedEncodingException | RuntimeException e) {
+            LOG.error(
+                    "Failed to decode the input: {} with charset: {}, and the exception details: ",
+                    value,
+                    charset.name(),
+                    e);
             return null;
         }
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nullable;
 
@@ -48,7 +49,7 @@ public class UrlEncodeFunction extends BuiltInScalarFunction {
         try {
             value = URLEncoder.encode(url.toString(), charset.name());
         } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(
+            throw new FlinkRuntimeException(
                     "Failed to encode URL: " + url + " with charset: " + charset.name(), e);
         }
         return StringData.fromString(value);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+import javax.annotation.Nullable;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#URL_ENCODE}. */
+@Internal
+public class UrlEncodeFunction extends BuiltInScalarFunction {
+
+    public UrlEncodeFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.URL_ENCODE, context);
+    }
+
+    public @Nullable StringData eval(StringData url) {
+        if (url == null) {
+            return null;
+        }
+        final Charset charset = StandardCharsets.UTF_8;
+        String value;
+
+        try {
+            value = URLEncoder.encode(url.toString(), charset.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(
+                    "Failed to encode URL: " + url + " with charset: " + charset.name(), e);
+        }
+        return StringData.fromString(value);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
-import org.apache.flink.util.FlinkRuntimeException;
 
 import javax.annotation.Nullable;
 
@@ -44,14 +43,11 @@ public class UrlEncodeFunction extends BuiltInScalarFunction {
             return null;
         }
         final Charset charset = StandardCharsets.UTF_8;
-        String value;
 
         try {
-            value = URLEncoder.encode(url.toString(), charset.name());
+            return StringData.fromString(URLEncoder.encode(url.toString(), charset.name()));
         } catch (UnsupportedEncodingException e) {
-            throw new FlinkRuntimeException(
-                    "Failed to encode URL: " + url + " with charset: " + charset.name(), e);
+            return null;
         }
-        return StringData.fromString(value);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
@@ -23,6 +23,9 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.annotation.Nullable;
 
 import java.io.UnsupportedEncodingException;
@@ -33,6 +36,7 @@ import java.nio.charset.StandardCharsets;
 /** Implementation of {@link BuiltInFunctionDefinitions#URL_ENCODE}. */
 @Internal
 public class UrlEncodeFunction extends BuiltInScalarFunction {
+    private static final Logger LOG = LoggerFactory.getLogger(UrlEncodeFunction.class);
 
     public UrlEncodeFunction(SpecializedFunction.SpecializedContext context) {
         super(BuiltInFunctionDefinitions.URL_ENCODE, context);
@@ -43,10 +47,14 @@ public class UrlEncodeFunction extends BuiltInScalarFunction {
             return null;
         }
         final Charset charset = StandardCharsets.UTF_8;
-
         try {
             return StringData.fromString(URLEncoder.encode(url.toString(), charset.name()));
         } catch (UnsupportedEncodingException e) {
+            LOG.error(
+                    "Failed to encode the input: {} with charset: {}, and the exception details: ",
+                    url,
+                    charset.name(),
+                    e);
             return null;
         }
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

issue: https://issues.apache.org/jira/browse/FLINK-34108

This is an implementation of URL_ENCODE and URL_DECODE

1. URL_ENCODE: Translates a string into 'application/x-www-form-urlencoded' format using a specific encoding scheme(UTF-8).
2. URL_DECODE: Decodes a string in 'application/x-www-form-urlencoded' format using a specific encoding scheme(UTF-8).

## Brief change log

1. **URL_ENCODE**

- Syntax: 
url_encode(url)

- Arguments: 
url: a string represents a URL

- Returns: 
translates a string into 'application/x-www-form-urlencoded' format using a specific encoding scheme(UTF-8), will be null if the input is null or encode failed.

- Examples:

```
url = 'https://flink.apache.org/'
SQL: url_encode(url)
TableAPI: url.urlEncode()

output: 'https%3A%2F%2Fflink.apache.org%2F'
```

2. **URL_DECODE**

- Syntax: 
url_decode(value)

- Arguments: 
value: a URL encoded

- Returns: 
decodes a string in 'application/x-www-form-urlencoded' format using a specific encoding scheme(UTF-8), will be null if the input is null or decode failed.

- Examples:

```
value = 'https%3A%2F%2Fflink.apache.org%2F'
SQL: url_decode(value)
TableAPI: value.urlDecode()

output: 'https://flink.apache.org/'
```
## Verifying this change

- This change added tests in UrlFunctionITCase.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
