### PR TITLE
[FLINK-35332][yarn] Removed setting rest.address to the actual IP add…

### DIFF
--- a/flink-dist/src/main/resources/config.yaml
+++ b/flink-dist/src/main/resources/config.yaml
@@ -179,7 +179,7 @@ rest:
   #
   # To enable this, set the bind address to one that has access to outside-facing
   # network interface, such as 0.0.0.0.
-  bind-address: localhost
+  # bind-address: localhost
   # # The port to which the REST client connects to. If rest.bind-port has
   # # not been specified, then the server will bind to this port as well.
   # port: 8081

--- a/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
@@ -133,7 +133,7 @@ class BashJavaUtilsITCase extends JavaBashTestBase {
 
     @Test
     void testGetConfiguration() throws Exception {
-        int expectedResultLines = 26;
+        int expectedResultLines = 25;
         String[] commands = {
             RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
             BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
@@ -209,7 +209,7 @@ class BashJavaUtilsITCase extends JavaBashTestBase {
 
     @Test
     void testGetConfigurationRemoveKey() throws Exception {
-        int expectedResultLines = 24;
+        int expectedResultLines = 23;
         String[] commands = {
             RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
             BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
@@ -226,7 +226,7 @@ class BashJavaUtilsITCase extends JavaBashTestBase {
 
     @Test
     void testGetConfigurationRemoveKeyValue() throws Exception {
-        int expectedResultLines = 24;
+        int expectedResultLines = 23;
         String[] commands = {
             RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
             BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
@@ -243,7 +243,7 @@ class BashJavaUtilsITCase extends JavaBashTestBase {
 
     @Test
     void testGetConfigurationRemoveKeyValueNotMatchingValue() throws Exception {
-        int expectedResultLines = 26;
+        int expectedResultLines = 25;
         String[] commands = {
             RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
             BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
@@ -260,7 +260,7 @@ class BashJavaUtilsITCase extends JavaBashTestBase {
 
     @Test
     void testGetConfigurationReplaceKeyValue() throws Exception {
-        int expectedResultLines = 26;
+        int expectedResultLines = 25;
         String[] commands = {
             RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
             BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),
@@ -277,7 +277,7 @@ class BashJavaUtilsITCase extends JavaBashTestBase {
 
     @Test
     void testGetConfigurationReplaceKeyValueNotMatchingValue() throws Exception {
-        int expectedResultLines = 26;
+        int expectedResultLines = 25;
         String[] commands = {
             RUN_BASH_JAVA_UTILS_CMD_SCRIPT,
             BashJavaUtils.Command.UPDATE_AND_GET_FLINK_CONFIGURATION.toString(),

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java
@@ -62,7 +62,9 @@ public class YarnEntrypointUtils {
 
         configuration.set(JobManagerOptions.ADDRESS, hostname);
         configuration.set(RestOptions.ADDRESS, hostname);
-        configuration.set(RestOptions.BIND_ADDRESS, hostname);
+        if (!configuration.contains(RestOptions.BIND_ADDRESS)) {
+            configuration.set(RestOptions.BIND_ADDRESS, hostname);
+        }
 
         if (!configuration.contains(RestOptions.BIND_PORT)) {
             // set the REST port to 0 to select it randomly

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtilsTest.java
@@ -90,6 +90,24 @@ class YarnEntrypointUtilsTest {
     }
 
     @Test
+    void testRestBindingAddressUnspecified() throws IOException {
+        final Configuration initialConfiguration = new Configuration();
+        final Configuration configuration = loadConfiguration(initialConfiguration);
+
+        assertThat(configuration.get(RestOptions.BIND_ADDRESS)).isEqualTo("foobar");
+    }
+
+    @Test
+    void testRestBindingAddressSpecified() throws Exception {
+        final Configuration initialConfiguration = new Configuration();
+        final String bindingAddress = "0.0.0.0";
+        initialConfiguration.set(RestOptions.BIND_ADDRESS, bindingAddress);
+        final Configuration configuration = loadConfiguration(initialConfiguration);
+
+        assertThat(configuration.get(RestOptions.BIND_ADDRESS)).isEqualTo(bindingAddress);
+    }
+
+    @Test
     void testParsingValidKerberosEnv() throws IOException {
         final Configuration initialConfiguration = new Configuration();
         Map<String, String> env = new HashMap<>();


### PR DESCRIPTION
…ress of the Yarn NodeManager in order to support dual network environment

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Removed setting rest.address to the actual IP address of the Yarn NodeManager in order to support dual network environment.

Given the Hadoop Yarn cluster with dual networks:
* 192.168.x.x: For data transfer. Speed: 10Gbps.
* 10.x.x.x: For management only. Speed: 1Gbps.

A client outside the Hadoop Yarn cluster is configured, with management network only(10.x.x.x) and data transfer high speed network not accessible. To reproduce, we sumbit a Flink job from this client(Batch word count for example), the job can be successfully submitted but the result cannot be retrieved, with the exception: Connection refused: {jobmanager_hostname}:{jm_port}. The root cause is the job manager rest address is bind to its actual address (192.168.x.x) rather than 0.0.0.0. Manually setting rest.bind-address does not work.

One of the changes in Flink-24474 in YarnEntrypointUtils overwrites RestOptions.BIND_ADDRESS to the node's actual address. This change should be reverted.

## Brief change log

- flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnEntrypointUtils.java

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

Compiled and passed manually test.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
