### PR TITLE
[FLINK-35153][State] Internal async list/map state and corresponding state descriptor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
@@ -249,7 +249,7 @@ public class AsyncExecutionController<K> implements StateRequestHandler {
      *
      * @param force whether to trigger requests in force.
      */
-    void triggerIfNeeded(boolean force) {
+    public void triggerIfNeeded(boolean force) {
         if (!force && stateRequestsBuffer.activeQueueSize() < batchSize) {
             return;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStoreV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStoreV2.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.v2;
 
+import org.apache.flink.api.common.state.v2.ListState;
 import org.apache.flink.api.common.state.v2.MapState;
 import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
@@ -36,6 +37,16 @@ public class DefaultKeyedStateStoreV2 implements KeyedStateStoreV2 {
 
     @Override
     public <T> ValueState<T> getValueState(@Nonnull ValueStateDescriptor<T> stateProperties) {
+        Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
+        try {
+            return asyncKeyedStateBackend.createState(stateProperties);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while getting state", e);
+        }
+    }
+
+    @Override
+    public <T> ListState<T> getListState(@Nonnull ListStateDescriptor<T> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
             return asyncKeyedStateBackend.createState(stateProperties);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStoreV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStoreV2.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.v2;
 
+import org.apache.flink.api.common.state.v2.MapState;
 import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.util.Preconditions;
@@ -35,6 +36,17 @@ public class DefaultKeyedStateStoreV2 implements KeyedStateStoreV2 {
 
     @Override
     public <T> ValueState<T> getValueState(@Nonnull ValueStateDescriptor<T> stateProperties) {
+        Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
+        try {
+            return asyncKeyedStateBackend.createState(stateProperties);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while getting state", e);
+        }
+    }
+
+    @Override
+    public <UK, UV> MapState<UK, UV> getMapState(
+            @Nonnull MapStateDescriptor<UK, UV> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
             return asyncKeyedStateBackend.createState(stateProperties);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalListState.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.state.v2.ListState;
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.state.v2.StateIterator;
+import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
+import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+
+import java.util.List;
+
+/**
+ * A default implementation of {@link ListState} which delegates all async requests to {@link
+ * StateRequestHandler}.
+ *
+ * @param <K> The type of key the state is associated to.
+ * @param <V> The type of values kept internally in state.
+ */
+public class InternalListState<K, V> extends InternalKeyedState<K, V> implements ListState<V> {
+
+    public InternalListState(
+            StateRequestHandler stateRequestHandler, ListStateDescriptor<V> stateDescriptor) {
+        super(stateRequestHandler, stateDescriptor);
+    }
+
+    @Override
+    public StateFuture<StateIterator<V>> asyncGet() {
+        return handleRequest(StateRequestType.MERGING_GET, null);
+    }
+
+    @Override
+    public StateFuture<Void> asyncAdd(V value) {
+        return handleRequest(StateRequestType.MERGING_ADD, value);
+    }
+
+    @Override
+    public StateFuture<Void> asyncUpdate(List<V> values) {
+        return handleRequest(StateRequestType.LIST_UPDATE, values);
+    }
+
+    @Override
+    public StateFuture<Void> asyncAddAll(List<V> values) {
+        return handleRequest(StateRequestType.LIST_ADD_ALL, values);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/InternalMapState.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.state.v2.MapState;
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.state.v2.StateIterator;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
+import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+
+import java.util.Map;
+
+/**
+ * A default implementation of {@link MapState} which delegates all async requests to {@link
+ * StateRequestHandler}.
+ *
+ * @param <K> The type of partitioned key the state is associated to.
+ * @param <UK> The type of user key of this state.
+ * @param <V> The type of values kept internally in state.
+ */
+public class InternalMapState<K, UK, V> extends InternalKeyedState<K, V>
+        implements MapState<UK, V> {
+
+    public InternalMapState(
+            StateRequestHandler stateRequestHandler, MapStateDescriptor<UK, V> stateDescriptor) {
+        super(stateRequestHandler, stateDescriptor);
+    }
+
+    @Override
+    public StateFuture<V> asyncGet(UK key) {
+        return handleRequest(StateRequestType.MAP_GET, key);
+    }
+
+    @Override
+    public StateFuture<Void> asyncPut(UK key, V value) {
+        return handleRequest(StateRequestType.MAP_PUT, Tuple2.of(key, value));
+    }
+
+    @Override
+    public StateFuture<Void> asyncPutAll(Map<UK, V> map) {
+        return handleRequest(StateRequestType.MAP_PUT_ALL, map);
+    }
+
+    @Override
+    public StateFuture<Void> asyncRemove(UK key) {
+        return handleRequest(StateRequestType.MAP_REMOVE, key);
+    }
+
+    @Override
+    public StateFuture<Boolean> asyncContains(UK key) {
+        return handleRequest(StateRequestType.MAP_CONTAINS, key);
+    }
+
+    @Override
+    public StateFuture<StateIterator<Map.Entry<UK, V>>> asyncEntries() {
+        return handleRequest(StateRequestType.MAP_ITER, null);
+    }
+
+    @Override
+    public StateFuture<StateIterator<UK>> asyncKeys() {
+        return handleRequest(StateRequestType.MAP_ITER_KEY, null);
+    }
+
+    @Override
+    public StateFuture<StateIterator<V>> asyncValues() {
+        return handleRequest(StateRequestType.MAP_ITER_VALUE, null);
+    }
+
+    @Override
+    public StateFuture<Boolean> asyncIsEmpty() {
+        return handleRequest(StateRequestType.MAP_IS_EMPTY, null);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/KeyedStateStoreV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/KeyedStateStoreV2.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.v2.ListState;
 import org.apache.flink.api.common.state.v2.MapState;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.state.v2.ValueState;
@@ -44,6 +45,19 @@ public interface KeyedStateStoreV2 {
      * @return The partitioned state object.
      */
     <T> ValueState<T> getValueState(@Nonnull ValueStateDescriptor<T> stateProperties);
+
+    /**
+     * Gets a handle to the system's key / value list state. This state is optimized for state that
+     * holds lists. One can adds elements to the list, or retrieve the list as a whole. This state
+     * is only accessible if the function is executed on a KeyedStream.
+     *
+     * @param stateProperties The descriptor defining the properties of the state.
+     * @param <T> The type of value stored in the state.
+     * @return The partitioned state object.
+     * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
+     *     function (function is not part os a KeyedStream).
+     */
+    <T> ListState<T> getListState(@Nonnull ListStateDescriptor<T> stateProperties);
 
     /**
      * Gets a handle to the system's key/value map state. This state is only accessible if the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/KeyedStateStoreV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/KeyedStateStoreV2.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state.v2;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.v2.MapState;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.state.v2.ValueState;
 
@@ -43,4 +44,17 @@ public interface KeyedStateStoreV2 {
      * @return The partitioned state object.
      */
     <T> ValueState<T> getValueState(@Nonnull ValueStateDescriptor<T> stateProperties);
+
+    /**
+     * Gets a handle to the system's key/value map state. This state is only accessible if the
+     * function is executed on a KeyedStream.
+     *
+     * @param stateProperties The descriptor defining the properties of the state.
+     * @param <UK> The type of the user keys stored in the state.
+     * @param <UV> The type of the user values stored in the state.
+     * @return The partitioned state object.
+     * @throws UnsupportedOperationException Thrown, if no partitioned state is available for the
+     *     function (function is not part of a KeyedStream).
+     */
+    <UK, UV> MapState<UK, UV> getMapState(@Nonnull MapStateDescriptor<UK, UV> stateProperties);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ListStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ListStateDescriptor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.serialization.SerializerConfig;
+import org.apache.flink.api.common.state.v2.ListState;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+/**
+ * {@link StateDescriptor} for {@link ListState}. This can be used to create partitioned list state
+ * internally.
+ *
+ * @param <T> The type of each value that the list state can hold.
+ */
+public class ListStateDescriptor<T> extends StateDescriptor<T> {
+
+    /**
+     * Creates a new {@code ListStateDescriptor} with the given stateId and type.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param typeInfo The type of the values in the state.
+     */
+    public ListStateDescriptor(String stateId, TypeInformation<T> typeInfo) {
+        super(stateId, typeInfo);
+    }
+
+    /**
+     * Creates a new {@code ListStateDescriptor} with the given stateId and type.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param typeInfo The type of the values in the state.
+     * @param serializerConfig The serializer related config used to generate {@code
+     *     TypeSerializer}.
+     */
+    public ListStateDescriptor(
+            String stateId, TypeInformation<T> typeInfo, SerializerConfig serializerConfig) {
+        super(stateId, typeInfo, serializerConfig);
+    }
+
+    @Override
+    public Type getType() {
+        return Type.LIST;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/MapStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/MapStateDescriptor.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.serialization.SerializerConfig;
+import org.apache.flink.api.common.serialization.SerializerConfigImpl;
+import org.apache.flink.api.common.state.v2.MapState;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import javax.annotation.Nonnull;
+
+/**
+ * {@link StateDescriptor} for {@link MapState}. This can be used to create partitioned map state
+ * internally.
+ *
+ * @param <UK> The type of the user key for this map state.
+ * @param <UV> The type of the values that the map state can hold.
+ */
+public class MapStateDescriptor<UK, UV> extends StateDescriptor<UV> {
+
+    /** The serializer for the user key. */
+    @Nonnull private final TypeSerializer<UK> userKeySerializer;
+
+    /**
+     * Creates a new {@code MapStateDescriptor} with the given stateId and type.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param userKeyTypeInfo The type of the user keys in the state.
+     * @param userValueTypeInfo The type of the values in the state.
+     */
+    public MapStateDescriptor(
+            String stateId,
+            TypeInformation<UK> userKeyTypeInfo,
+            TypeInformation<UV> userValueTypeInfo) {
+        this(stateId, userKeyTypeInfo, userValueTypeInfo, new SerializerConfigImpl());
+    }
+
+    /**
+     * Creates a new {@code MapStateDescriptor} with the given stateId and type.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param userKeyTypeInfo The type of the user keys in the state.
+     * @param userValueTypeInfo The type of the values in the state.
+     * @param serializerConfig The serializer related config used to generate {@code
+     *     TypeSerializer}.
+     */
+    public MapStateDescriptor(
+            String stateId,
+            TypeInformation<UK> userKeyTypeInfo,
+            TypeInformation<UV> userValueTypeInfo,
+            SerializerConfig serializerConfig) {
+        super(stateId, userValueTypeInfo, serializerConfig);
+        this.userKeySerializer = userKeyTypeInfo.createSerializer(serializerConfig);
+    }
+
+    @Nonnull
+    public TypeSerializer<UK> getUserKeySerializer() {
+        return userKeySerializer.duplicate();
+    }
+
+    @Override
+    public Type getType() {
+        return Type.MAP;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final boolean equals(Object o) {
+        return super.equals(o)
+                && userKeySerializer.equals(((MapStateDescriptor<UK, UV>) o).userKeySerializer);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptor.java
@@ -122,12 +122,12 @@ public abstract class StateDescriptor<T> implements Serializable {
     // ------------------------------------------------------------------------
 
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         return stateId.hashCode() + 31 * getClass().hashCode();
     }
 
     @Override
-    public final boolean equals(Object o) {
+    public boolean equals(Object o) {
         if (o == this) {
             return true;
         } else if (o != null && o.getClass() == this.getClass()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalKeyedStateTestBase.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.state.v2.State;
+import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
+import org.apache.flink.runtime.asyncprocessing.StateExecutor;
+import org.apache.flink.runtime.asyncprocessing.StateRequest;
+import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
+import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
+import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.StateBackend;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Tests for the common/shared functionality of {@link InternalKeyedState}. */
+public class InternalKeyedStateTestBase {
+
+    @SuppressWarnings({"rawtypes"})
+    AsyncExecutionController aec;
+
+    TestStateExecutor testStateExecutor;
+
+    AtomicReference<Throwable> exception;
+
+    @BeforeEach
+    void setup() {
+        testStateExecutor = (TestStateExecutor) createStateExecutor();
+        aec =
+                new AsyncExecutionController<>(
+                        new SyncMailboxExecutor(),
+                        (a, b) -> {
+                            exception.set(b);
+                        },
+                        testStateExecutor,
+                        1,
+                        1,
+                        1000,
+                        1);
+        exception = new AtomicReference<>(null);
+    }
+
+    @AfterEach
+    void after() {
+        assertThat(exception.get()).isNull();
+    }
+
+    private StateExecutor createStateExecutor() {
+        TestAsyncStateBackend testAsyncStateBackend = new TestAsyncStateBackend();
+        assertThat(testAsyncStateBackend.supportsAsyncKeyedStateBackend()).isTrue();
+        return testAsyncStateBackend.createAsyncKeyedStateBackend(null).createStateExecutor();
+    }
+
+    <IN> void validateRequestRun(
+            @Nullable State state, StateRequestType type, @Nullable IN payload) {
+        aec.triggerIfNeeded(true);
+        testStateExecutor.validate(state, type, payload);
+        assertThat(testStateExecutor.receivedRequest.isEmpty()).isTrue();
+    }
+
+    /**
+     * A brief implementation of {@link StateBackend} which illustrates the interaction between AEC
+     * and StateBackend.
+     */
+    static class TestAsyncStateBackend implements StateBackend {
+
+        @Override
+        public <K> CheckpointableKeyedStateBackend<K> createKeyedStateBackend(
+                KeyedStateBackendParameters<K> parameters) throws Exception {
+            throw new UnsupportedOperationException("Don't support createKeyedStateBackend yet");
+        }
+
+        @Override
+        public OperatorStateBackend createOperatorStateBackend(
+                OperatorStateBackendParameters parameters) throws Exception {
+            throw new UnsupportedOperationException("Don't support createOperatorStateBackend yet");
+        }
+
+        @Override
+        public boolean supportsAsyncKeyedStateBackend() {
+            return true;
+        }
+
+        @Override
+        public <K> AsyncKeyedStateBackend createAsyncKeyedStateBackend(
+                KeyedStateBackendParameters<K> parameters) {
+            return new AsyncKeyedStateBackend() {
+                @Override
+                public void close() throws IOException {}
+
+                @Override
+                public void setup(@Nonnull StateRequestHandler stateRequestHandler) {}
+
+                @Nonnull
+                @Override
+                public <SV, S extends State> S createState(@Nonnull StateDescriptor<SV> stateDesc)
+                        throws Exception {
+                    return null;
+                }
+
+                @Override
+                public StateExecutor createStateExecutor() {
+                    return new TestStateExecutor();
+                }
+
+                @Override
+                public void dispose() {
+                    // do nothing
+                }
+            };
+        }
+    }
+
+    /**
+     * A brief implementation of {@link StateExecutor}, to illustrate the interaction between AEC
+     * and StateExecutor.
+     */
+    static class TestStateExecutor implements StateExecutor {
+
+        private Deque<StateRequest<?, ?, ?>> receivedRequest;
+
+        TestStateExecutor() {
+            receivedRequest = new ConcurrentLinkedDeque<>();
+        }
+
+        <IN> void validate(@Nullable State state, StateRequestType type, @Nullable IN payload) {
+            assertThat(receivedRequest.isEmpty()).isFalse();
+            StateRequest<?, ?, ?> request = receivedRequest.pop();
+            assertThat(request.getState()).isEqualTo(state);
+            assertThat(request.getRequestType()).isEqualTo(type);
+            assertThat(request.getPayload()).isEqualTo(payload);
+        }
+
+        @Override
+        public CompletableFuture<Void> executeBatchRequests(
+                StateRequestContainer stateRequestContainer) {
+            receivedRequest.addAll(((TestStateRequestContainer) stateRequestContainer).requests);
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            future.complete(null);
+            return future;
+        }
+
+        @Override
+        public StateRequestContainer createStateRequestContainer() {
+            return new TestStateRequestContainer();
+        }
+
+        @Override
+        public void shutdown() {}
+
+        static class TestStateRequestContainer implements StateRequestContainer {
+            ArrayList<StateRequest<?, ?, ?>> requests = new ArrayList<>();
+
+            @Override
+            public void offer(StateRequest<?, ?, ?> stateRequest) {
+                requests.add(stateRequest);
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return requests.isEmpty();
+            }
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalListStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalListStateTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Tests for {@link InternalListState}. */
+public class InternalListStateTest extends InternalKeyedStateTestBase {
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testEachOperation() {
+        ListStateDescriptor<Integer> descriptor =
+                new ListStateDescriptor<>("testState", BasicTypeInfo.INT_TYPE_INFO);
+        InternalListState<String, Integer> listState = new InternalListState<>(aec, descriptor);
+        aec.setCurrentContext(aec.buildContext("test", "test"));
+
+        listState.asyncClear();
+        validateRequestRun(listState, StateRequestType.CLEAR, null);
+
+        listState.asyncGet();
+        validateRequestRun(listState, StateRequestType.MERGING_GET, null);
+
+        listState.asyncAdd(1);
+        validateRequestRun(listState, StateRequestType.MERGING_ADD, 1);
+
+        List<Integer> list = new ArrayList<>();
+        listState.asyncUpdate(list);
+        validateRequestRun(listState, StateRequestType.LIST_UPDATE, list);
+
+        list = new ArrayList<>();
+        listState.asyncAddAll(list);
+        validateRequestRun(listState, StateRequestType.LIST_ADD_ALL, list);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalMapStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalMapStateTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Tests for {@link InternalMapState}. */
+public class InternalMapStateTest extends InternalKeyedStateTestBase {
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testEachOperation() {
+        MapStateDescriptor<String, Integer> descriptor =
+                new MapStateDescriptor<>(
+                        "testState", BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        InternalMapState<String, String, Integer> mapState =
+                new InternalMapState<>(aec, descriptor);
+        aec.setCurrentContext(aec.buildContext("test", "test"));
+
+        mapState.asyncClear();
+        validateRequestRun(mapState, StateRequestType.CLEAR, null);
+
+        mapState.asyncGet("key1");
+        validateRequestRun(mapState, StateRequestType.MAP_GET, "key1");
+
+        mapState.asyncPut("key2", 2);
+        validateRequestRun(mapState, StateRequestType.MAP_PUT, Tuple2.of("key2", 2));
+
+        Map<String, Integer> map = new HashMap<>();
+        mapState.asyncPutAll(map);
+        validateRequestRun(mapState, StateRequestType.MAP_PUT_ALL, map);
+
+        mapState.asyncRemove("key3");
+        validateRequestRun(mapState, StateRequestType.MAP_REMOVE, "key3");
+
+        mapState.asyncContains("key4");
+        validateRequestRun(mapState, StateRequestType.MAP_CONTAINS, "key4");
+
+        mapState.asyncEntries();
+        validateRequestRun(mapState, StateRequestType.MAP_ITER, null);
+
+        mapState.asyncKeys();
+        validateRequestRun(mapState, StateRequestType.MAP_ITER_KEY, null);
+
+        mapState.asyncValues();
+        validateRequestRun(mapState, StateRequestType.MAP_ITER_VALUE, null);
+
+        mapState.asyncIsEmpty();
+        validateRequestRun(mapState, StateRequestType.MAP_IS_EMPTY, null);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalValueStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalValueStateTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link InternalValueState}. */
+public class InternalValueStateTest extends InternalKeyedStateTestBase {
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testEachOperation() {
+        ValueStateDescriptor<Integer> descriptor =
+                new ValueStateDescriptor<>("testState", BasicTypeInfo.INT_TYPE_INFO);
+        InternalValueState<String, Integer> valueState = new InternalValueState<>(aec, descriptor);
+        aec.setCurrentContext(aec.buildContext("test", "test"));
+
+        valueState.asyncClear();
+        validateRequestRun(valueState, StateRequestType.CLEAR, null);
+
+        valueState.asyncValue();
+        validateRequestRun(valueState, StateRequestType.VALUE_GET, null);
+
+        valueState.asyncUpdate(1);
+        validateRequestRun(valueState, StateRequestType.VALUE_UPDATE, 1);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/ListStateDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/ListStateDescriptorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.core.testutils.CommonTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ListStateDescriptor}. */
+public class ListStateDescriptorTest {
+
+    @Test
+    void testHashCodeAndEquals() throws Exception {
+        final String name = "testName";
+
+        ListStateDescriptor<Integer> original =
+                new ListStateDescriptor<>(name, BasicTypeInfo.INT_TYPE_INFO);
+        ListStateDescriptor<Integer> same =
+                new ListStateDescriptor<>(name, BasicTypeInfo.INT_TYPE_INFO);
+        ListStateDescriptor<Integer> sameBySerializer =
+                new ListStateDescriptor<>(name, BasicTypeInfo.INT_TYPE_INFO);
+
+        // test that hashCode() works on state descriptors with initialized and uninitialized
+        // serializers
+        assertThat(same).hasSameHashCodeAs(original);
+        assertThat(sameBySerializer).hasSameHashCodeAs(original);
+
+        assertThat(same).isEqualTo(original);
+        assertThat(sameBySerializer).isEqualTo(original);
+
+        // equality with a clone
+        ListStateDescriptor<Integer> clone = CommonTestUtils.createCopySerializable(original);
+        assertThat(clone).isEqualTo(original);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/MapStateDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/MapStateDescriptorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.core.testutils.CommonTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link MapStateDescriptor}. */
+public class MapStateDescriptorTest {
+
+    @Test
+    void testHashCodeAndEquals() throws Exception {
+        final String name = "testName";
+
+        MapStateDescriptor<String, Integer> original =
+                new MapStateDescriptor<>(
+                        name, BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        MapStateDescriptor<String, Integer> same =
+                new MapStateDescriptor<>(
+                        name, BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+        MapStateDescriptor<String, Integer> sameBySerializer =
+                new MapStateDescriptor<>(
+                        name, BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
+
+        // test that hashCode() works on state descriptors with initialized and uninitialized
+        // serializers
+        assertThat(same).hasSameHashCodeAs(original);
+        assertThat(sameBySerializer).hasSameHashCodeAs(original);
+
+        assertThat(same).isEqualTo(original);
+        assertThat(sameBySerializer).isEqualTo(original);
+
+        // equality with a clone
+        MapStateDescriptor<String, Integer> clone =
+                CommonTestUtils.createCopySerializable(original);
+        assertThat(clone).isEqualTo(original);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/ValueStateDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/ValueStateDescriptorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.core.testutils.CommonTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ValueStateDescriptor}. */
+public class ValueStateDescriptorTest {
+
+    @Test
+    void testHashCodeAndEquals() throws Exception {
+        final String name = "testName";
+
+        ValueStateDescriptor<String> original =
+                new ValueStateDescriptor<>(name, BasicTypeInfo.STRING_TYPE_INFO);
+        ValueStateDescriptor<String> same =
+                new ValueStateDescriptor<>(name, BasicTypeInfo.STRING_TYPE_INFO);
+        ValueStateDescriptor<String> sameBySerializer =
+                new ValueStateDescriptor<>(name, BasicTypeInfo.STRING_TYPE_INFO);
+
+        // test that hashCode() works on state descriptors with initialized and uninitialized
+        // serializers
+        assertThat(same).hasSameHashCodeAs(original);
+        assertThat(sameBySerializer).hasSameHashCodeAs(original);
+
+        assertThat(same).isEqualTo(original);
+        assertThat(sameBySerializer).isEqualTo(original);
+
+        // equality with a clone
+        ValueStateDescriptor<String> clone = CommonTestUtils.createCopySerializable(original);
+        assertThat(clone).isEqualTo(original);
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -256,6 +256,13 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
         return keyedStateStoreV2.getValueState(stateProperties);
     }
 
+    public <T> org.apache.flink.api.common.state.v2.ListState<T> getListState(
+            org.apache.flink.runtime.state.v2.ListStateDescriptor<T> stateProperties) {
+        KeyedStateStoreV2 keyedStateStoreV2 =
+                checkPreconditionsAndGetKeyedStateStoreV2(stateProperties);
+        return keyedStateStoreV2.getListState(stateProperties);
+    }
+
     public <UK, UV> org.apache.flink.api.common.state.v2.MapState<UK, UV> getMapState(
             org.apache.flink.runtime.state.v2.MapStateDescriptor<UK, UV> stateProperties) {
         KeyedStateStoreV2 keyedStateStoreV2 =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -256,6 +256,13 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
         return keyedStateStoreV2.getValueState(stateProperties);
     }
 
+    public <UK, UV> org.apache.flink.api.common.state.v2.MapState<UK, UV> getMapState(
+            org.apache.flink.runtime.state.v2.MapStateDescriptor<UK, UV> stateProperties) {
+        KeyedStateStoreV2 keyedStateStoreV2 =
+                checkPreconditionsAndGetKeyedStateStoreV2(stateProperties);
+        return keyedStateStoreV2.getMapState(stateProperties);
+    }
+
     private KeyedStateStoreV2 checkPreconditionsAndGetKeyedStateStoreV2(
             org.apache.flink.runtime.state.v2.StateDescriptor<?> stateDescriptor) {
         checkNotNull(stateDescriptor, "The state properties must not be null");

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -274,6 +274,30 @@ class StreamingRuntimeContextTest {
     }
 
     @Test
+    void testV2ListStateInstantiation() throws Exception {
+        final ExecutionConfig config = new ExecutionConfig();
+        SerializerConfig serializerConfig = config.getSerializerConfig();
+        serializerConfig.registerKryoType(Path.class);
+
+        final AtomicReference<Object> descriptorCapture = new AtomicReference<>();
+
+        StreamingRuntimeContext context = createRuntimeContext(descriptorCapture, config);
+        org.apache.flink.runtime.state.v2.ListStateDescriptor<TaskInfo> descr =
+                new org.apache.flink.runtime.state.v2.ListStateDescriptor<>(
+                        "name", TypeInformation.of(TaskInfo.class), serializerConfig);
+        context.getListState(descr);
+
+        org.apache.flink.runtime.state.v2.ListStateDescriptor<?> descrIntercepted =
+                (org.apache.flink.runtime.state.v2.ListStateDescriptor<?>) descriptorCapture.get();
+        TypeSerializer<?> serializer = descrIntercepted.getSerializer();
+
+        // check that the Path class is really registered, i.e., the execution config was applied
+        assertThat(serializer).isInstanceOf(KryoSerializer.class);
+        assertThat(((KryoSerializer<?>) serializer).getKryo().getRegistration(Path.class).getId())
+                .isPositive();
+    }
+
+    @Test
     void testV2MapStateInstantiation() throws Exception {
         final ExecutionConfig config = new ExecutionConfig();
         SerializerConfig serializerConfig = config.getSerializerConfig();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -249,7 +249,7 @@ class StreamingRuntimeContextTest {
     }
 
     @Test
-    void testAsyncValueStateInstantiation() throws Exception {
+    void testV2ValueStateInstantiation() throws Exception {
 
         final ExecutionConfig config = new ExecutionConfig();
         SerializerConfig serializerConfig = config.getSerializerConfig();
@@ -265,6 +265,34 @@ class StreamingRuntimeContextTest {
 
         org.apache.flink.runtime.state.v2.ValueStateDescriptor<?> descrIntercepted =
                 (org.apache.flink.runtime.state.v2.ValueStateDescriptor<?>) descriptorCapture.get();
+        TypeSerializer<?> serializer = descrIntercepted.getSerializer();
+
+        // check that the Path class is really registered, i.e., the execution config was applied
+        assertThat(serializer).isInstanceOf(KryoSerializer.class);
+        assertThat(((KryoSerializer<?>) serializer).getKryo().getRegistration(Path.class).getId())
+                .isPositive();
+    }
+
+    @Test
+    void testV2MapStateInstantiation() throws Exception {
+        final ExecutionConfig config = new ExecutionConfig();
+        SerializerConfig serializerConfig = config.getSerializerConfig();
+        serializerConfig.registerKryoType(Path.class);
+
+        final AtomicReference<Object> descriptorCapture = new AtomicReference<>();
+
+        StreamingRuntimeContext context = createRuntimeContext(descriptorCapture, config);
+        org.apache.flink.runtime.state.v2.MapStateDescriptor<String, TaskInfo> descr =
+                new org.apache.flink.runtime.state.v2.MapStateDescriptor<>(
+                        "name",
+                        TypeInformation.of(String.class),
+                        TypeInformation.of(TaskInfo.class),
+                        serializerConfig);
+        context.getMapState(descr);
+
+        org.apache.flink.runtime.state.v2.MapStateDescriptor<?, ?> descrIntercepted =
+                (org.apache.flink.runtime.state.v2.MapStateDescriptor<?, ?>)
+                        descriptorCapture.get();
         TypeSerializer<?> serializer = descrIntercepted.getSerializer();
 
         // check that the Path class is really registered, i.e., the execution config was applied


### PR DESCRIPTION
## What is the purpose of the change

This PR provides the definition of `StateDescriptor` and simple implementation for `List` and `Map` state in `State V2`.

## Brief change log
 - Tests for `ValueState` and `ValueStateDescriptor`
 - Definition and tests for `MapState` and `MapStateDescriptor`
 - Definition and tests for `ListState` and `ListStateDescriptor`

## Verifying this change

Added UT for each new introduced class.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
