### PR TITLE
[FLINK-35361]Delete Flinkhistory files that failed to write to the lo…

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandler.java
@@ -169,6 +169,7 @@ public class HistoryServerStaticFileServerHandler
                     }
                 } catch (Throwable t) {
                     LOG.error("error while responding", t);
+                    file.delete();
                 } finally {
                     if (!success) {
                         LOG.debug("Unable to load requested file {} from classloader", requestPath);


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds a code: when Flink History writes a file failed or writes a file incompleted in local , it will delete the local file to avoid the Flink History webui page will be opened failed or be displayed abnormalities*


## Brief change log

  - *When the file written failed or imcompleted in local, delete it*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
