### PR TITLE
[FLINK-35358][clients] Reintroduce recursive JAR listing in classpath load from "usrlib"

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/DefaultPackagedProgramRetriever.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DefaultPackagedProgramRetriever.java
@@ -114,7 +114,7 @@ public class DefaultPackagedProgramRetriever implements PackagedProgramRetriever
         List<URL> userClasspaths;
         try {
             final List<URL> classpathsFromUserLibDir =
-                    getClasspathsFromUserDir(userLibDir, jarFile);
+                    getClasspathsFromUserLibDir(userLibDir, jarFile);
             final List<URL> classpathsFromUserArtifactDir =
                     getClasspathsFromArtifacts(userArtifacts, jarFile);
             final List<URL> classpathsFromConfiguration =
@@ -231,13 +231,13 @@ public class DefaultPackagedProgramRetriever implements PackagedProgramRetriever
         }
     }
 
-    private static List<URL> getClasspathsFromUserDir(
-            @Nullable File userDir, @Nullable File jarFile) throws IOException {
-        if (userDir == null) {
+    private static List<URL> getClasspathsFromUserLibDir(
+            @Nullable File userLibDir, @Nullable File jarFile) throws IOException {
+        if (userLibDir == null) {
             return Collections.emptyList();
         }
 
-        try (Stream<Path> files = Files.list(userDir.toPath())) {
+        try (Stream<Path> files = Files.walk(userLibDir.toPath())) {
             return getClasspathsFromArtifacts(files, jarFile);
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

With https://github.com/apache/flink/commit/e63aa12252843d0098a56f3091b28d48aff5b5af in Flink 1.19 an unintentional change were introduced, that now the `DefaultPackagedProgramRetriever` only loads JARs from the root level of the `usrlib` directory.

This change reverts that behavior to search directories in a recursive manner, and adds a test case to cover such scenario.


## Brief change log

  - `Flies#list` -> `Files#walk` in `DefaultPackagedProgramRetriever`.
  - Add test case in `DefaultPackagedProgramRetrieverITCase`.


## Verifying this change

Added relevant IT case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no