### PR TITLE
[BP-1.19][FLINK-35358][clients] Reintroduce recursive JAR listing in classpath load from "usrlib"

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/DefaultPackagedProgramRetriever.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/DefaultPackagedProgramRetriever.java
@@ -114,7 +114,7 @@ public class DefaultPackagedProgramRetriever implements PackagedProgramRetriever
         List<URL> userClasspaths;
         try {
             final List<URL> classpathsFromUserLibDir =
-                    getClasspathsFromUserDir(userLibDir, jarFile);
+                    getClasspathsFromUserLibDir(userLibDir, jarFile);
             final List<URL> classpathsFromUserArtifactDir =
                     getClasspathsFromArtifacts(userArtifacts, jarFile);
             final List<URL> classpathsFromConfiguration =
@@ -231,13 +231,13 @@ public class DefaultPackagedProgramRetriever implements PackagedProgramRetriever
         }
     }
 
-    private static List<URL> getClasspathsFromUserDir(
-            @Nullable File userDir, @Nullable File jarFile) throws IOException {
-        if (userDir == null) {
+    private static List<URL> getClasspathsFromUserLibDir(
+            @Nullable File userLibDir, @Nullable File jarFile) throws IOException {
+        if (userLibDir == null) {
             return Collections.emptyList();
         }
 
-        try (Stream<Path> files = Files.list(userDir.toPath())) {
+        try (Stream<Path> files = Files.walk(userLibDir.toPath())) {
             return getClasspathsFromArtifacts(files, jarFile);
         }
     }


### PR DESCRIPTION
1.19 backport of https://github.com/apache/flink/pull/24791.