### PR TITLE
[FLINK-35225][Web] Remove Execution mode in Flink WebUI

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/configuration/job-configuration.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/configuration/job-configuration.component.html
@@ -28,10 +28,6 @@
   >
     <tbody>
       <tr>
-        <td><strong>Execution mode</strong></td>
-        <td>{{ config['execution-config']['execution-mode'] }}</td>
-      </tr>
-      <tr>
         <td><strong>Max. number of execution retries</strong></td>
         <td>{{ config['execution-config']['restart-strategy'] }}</td>
       </tr>


### PR DESCRIPTION
## What is the purpose of the change

See [FLIP-441](https://cwiki.apache.org/confluence/display/FLINK/FLIP-441%3A+Show+the+JobType+and+remove+Execution+Mode+on+Flink+WebUI
)
## Brief change log

- [FLINK-35225][Web] Remove Execution mode in Flink WebUI


## Verifying this change

Before this PR, the web UI still show the Execution mode.

<img width="1280" alt="image" src="https://github.com/apache/flink/assets/38427477/81d4df71-22a3-4379-8d63-b8e91d755f8a">


After this PR, Execution mode is removed in web UI.

<img width="1207" alt="image" src="https://github.com/apache/flink/assets/38427477/abe37c86-ccd4-4377-b6ea-74701eb48cde">

