### PR TITLE
[FLINK-35289][core] Batch mode onTimer should support processing ts

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TestProcessingTimeService.java
@@ -20,8 +20,10 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.Preconditions;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -39,6 +41,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public class TestProcessingTimeService implements TimerService {
 
     private volatile long currentTime = Long.MIN_VALUE;
+
+    private List<Long> accessedCurrentTimes = new ArrayList<>();
 
     private volatile boolean isTerminated;
     private volatile boolean isQuiesced;
@@ -89,7 +93,12 @@ public class TestProcessingTimeService implements TimerService {
 
     @Override
     public long getCurrentProcessingTime() {
+        accessedCurrentTimes.add(currentTime);
         return currentTime;
+    }
+
+    public List<Long> getAccessedCurrentTimes() {
+        return accessedCurrentTimes;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Fix incorrect timestamp of stream elements collected from onTimer in batch mode. 
In batch mode, `onTimer` calls will be processed at the end of the data. As a result, whichever timer registered by the users, they will all be triggered at the end. Therefore, it makes sense to trigger them with the processing time timestamp.

## Brief change log

  - Adjust the timer processing logic of `BatchExecutionInternalTimeService`
  - Adjust tests


## Verifying this change

Via tests in `BatchExecutionInternalTimeServiceTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
