### PR TITLE
[FLINK-32828][1.19] Partition aware watermark not handled correctly shortly after job start up from checkpoint or savepoint

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
@@ -61,15 +61,7 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
     private CompletableFuture<Void> availableFuture;
 
     public MockSourceReader() {
-        this(false, false);
-    }
-
-    public MockSourceReader(boolean waitingForMoreSplits, boolean markIdleOnNoSplits) {
-        this(
-                waitingForMoreSplits
-                        ? WaitingForSplits.WAIT_UNTIL_ALL_SPLITS_ASSIGNED
-                        : WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS,
-                markIdleOnNoSplits);
+        this(WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS, false);
     }
 
     public MockSourceReader(

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceSplit.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceSplit.java
@@ -84,10 +84,11 @@ public class MockSourceSplit implements SourceSplit, Serializable {
     }
 
     /** Add a record to this split. */
-    public void addRecord(int record) {
+    public MockSourceSplit addRecord(int record) {
         if (!records.offer(record)) {
             throw new IllegalStateException("Failed to add record to split.");
         }
+        return this;
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorAlignmentTest.java
@@ -311,7 +311,7 @@ class SourceOperatorAlignmentTest {
         assertThat(events).isEmpty();
     }
 
-    private static class PunctuatedGenerator implements WatermarkGenerator<Integer> {
+    static class PunctuatedGenerator implements WatermarkGenerator<Integer> {
 
         private enum GenerationMode {
             ALL,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTest.java
@@ -211,6 +211,7 @@ public class SourceOperatorTest {
         context =
                 new SourceOperatorTestContext(
                         false,
+                        false,
                         WatermarkStrategy.<Integer>forMonotonousTimestamps()
                                 .withTimestampAssigner((element, recordTimestamp) -> element),
                         new CollectorOutput<>(outputStreamElements));

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTestContext.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorTestContext.java
@@ -75,15 +75,22 @@ public class SourceOperatorTestContext implements AutoCloseable {
 
     public SourceOperatorTestContext(boolean idle, WatermarkStrategy<Integer> watermarkStrategy)
             throws Exception {
-        this(idle, watermarkStrategy, new MockOutput<>(new ArrayList<>()));
+        this(idle, false, watermarkStrategy, new MockOutput<>(new ArrayList<>()));
     }
 
     public SourceOperatorTestContext(
             boolean idle,
+            boolean usePerSplitOutputs,
             WatermarkStrategy<Integer> watermarkStrategy,
             Output<StreamRecord<Integer>> output)
             throws Exception {
-        mockSourceReader = new MockSourceReader(idle, idle);
+        mockSourceReader =
+                new MockSourceReader(
+                        idle
+                                ? MockSourceReader.WaitingForSplits.WAIT_UNTIL_ALL_SPLITS_ASSIGNED
+                                : MockSourceReader.WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS,
+                        idle,
+                        usePerSplitOutputs);
         mockGateway = new MockOperatorEventGateway();
         timeService = new TestProcessingTimeService();
         operator =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorWatermarksTest.java
@@ -1,0 +1,97 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.streaming.api.operators.source.CollectingDataOutput;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.io.DataInputStatus;
+import org.apache.flink.streaming.util.MockOutput;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit test for {@link SourceOperator} watermark alignment. */
+@SuppressWarnings("serial")
+class SourceOperatorWatermarksTest {
+
+    @Nullable private SourceOperatorTestContext context;
+    @Nullable private SourceOperator<Integer, MockSourceSplit> operator;
+
+    @BeforeEach
+    void setup() throws Exception {
+        context =
+                new SourceOperatorTestContext(
+                        false,
+                        true,
+                        WatermarkStrategy.forGenerator(
+                                        ctx ->
+                                                new SourceOperatorAlignmentTest
+                                                        .PunctuatedGenerator())
+                                .withTimestampAssigner((r, t) -> r),
+                        new MockOutput<>(new ArrayList<>()));
+        operator = context.getOperator();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        context.close();
+        context = null;
+        operator = null;
+    }
+
+    @Test
+    void testPerPartitionWatermarksAfterRecovery() throws Exception {
+        List<MockSourceSplit> initialSplits = new ArrayList<>();
+        initialSplits.add(new MockSourceSplit(0).addRecord(1042).addRecord(1044));
+        initialSplits.add(new MockSourceSplit(1).addRecord(42).addRecord(44));
+        operator.initializeState(context.createStateContext(initialSplits));
+        operator.open();
+
+        CollectingDataOutput<Integer> actualOutput = new CollectingDataOutput<>();
+
+        // after emitting the first element from the first split, there can not be watermark
+        // emitted, as a watermark from the other split is still unknown.
+        assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.MORE_AVAILABLE);
+        assertNoWatermarks(actualOutput);
+
+        // after emitting two more elements (in this order: [1042, 1044, 42] but order doesn't
+        // matter for this test), three in total, watermark 42 can be finally emitted
+        assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.MORE_AVAILABLE);
+        assertThat(operator.emitNext(actualOutput)).isEqualTo(DataInputStatus.MORE_AVAILABLE);
+        assertWatermark(actualOutput, new Watermark(42));
+    }
+
+    private static void assertNoWatermarks(CollectingDataOutput<Integer> actualOutput) {
+        assertThat(actualOutput.getEvents()).noneMatch(element -> element instanceof Watermark);
+    }
+
+    private void assertWatermark(CollectingDataOutput<Integer> actualOutput, Watermark watermark) {
+        assertThat(actualOutput.getEvents()).containsOnlyOnce(watermark);
+    }
+}


### PR DESCRIPTION
This is a backport of https://github.com/apache/flink/pull/24794 to 1.19

## What is the purpose of the change

Properly initialize initial splits in WatermarkOutputMultiplexer
    
    Without this fix, initial splits were registered in the multiplexer only
    when first record from that split has been emitted. This was leading to
    incorrectly emitted watermarks, as resulting watermark was not properly
    combined from the initial splits, but only from the splits that have
    already emitted at least one record.


## Brief change log

Please check individual commit messages 

## Verifying this change

This bugfix is covered against future regressions by a new test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
