### PR TITLE
[FLINK-35379][Checkpoint] Fix incorrect checkpoint notification handling in file merging

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
@@ -102,6 +102,13 @@ public interface FileMergingSnapshotManager extends Closeable {
     void registerSubtaskForSharedStates(SubtaskKey subtaskKey);
 
     /**
+     * Unregister a subtask.
+     *
+     * @param subtaskKey the subtask key identifying a subtask.
+     */
+    void unregisterSubtask(SubtaskKey subtaskKey);
+
+    /**
      * Create a new {@link FileMergingCheckpointStateOutputStream}. According to the file merging
      * strategy, the streams returned by multiple calls to this function may share the same
      * underlying physical file, and each stream writes to a segment of the physical file.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/LogicalFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/LogicalFile.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.checkpoint.filemerging;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.StringBasedID;
 
 import javax.annotation.Nonnull;
@@ -40,10 +39,6 @@ public class LogicalFile {
 
         public LogicalFileId(String keyString) {
             super(keyString);
-        }
-
-        public Path getFilePath() {
-            return new Path(getKeyString());
         }
 
         public static LogicalFileId generateRandomId() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/SubtaskFileMergingManagerRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/SubtaskFileMergingManagerRestoreOperation.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filemerging.EmptySegmentFileStateHandle;
 import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 import org.apache.flink.util.Preconditions;
 
@@ -93,8 +94,12 @@ public class SubtaskFileMergingManagerRestoreOperation {
         Stream<SegmentFileStateHandle> segmentStateHandles =
                 Stream.of(keyedStateHandles, operatorStateHandles)
                         .flatMap(Function.identity())
-                        .filter(handle -> handle instanceof SegmentFileStateHandle)
+                        .filter(
+                                handle ->
+                                        (handle instanceof SegmentFileStateHandle)
+                                                && !(handle instanceof EmptySegmentFileStateHandle))
                         .map(handle -> (SegmentFileStateHandle) handle);
+        System.out.println("Restoring from checkpoint " + checkpointId);
         fileMergingSnapshotManager.restoreStateHandles(
                 checkpointId, subtaskKey, segmentStateHandles);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/SubtaskFileMergingManagerRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/SubtaskFileMergingManagerRestoreOperation.java
@@ -99,7 +99,6 @@ public class SubtaskFileMergingManagerRestoreOperation {
                                         (handle instanceof SegmentFileStateHandle)
                                                 && !(handle instanceof EmptySegmentFileStateHandle))
                         .map(handle -> (SegmentFileStateHandle) handle);
-        System.out.println("Restoring from checkpoint " + checkpointId);
         fileMergingSnapshotManager.restoreStateHandles(
                 checkpointId, subtaskKey, segmentStateHandles);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/SegmentFileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/SegmentFileStateHandle.java
@@ -106,8 +106,7 @@ public class SegmentFileStateHandle implements StreamStateHandle {
 
     @Override
     public PhysicalStateHandleID getStreamStateHandleID() {
-        return new PhysicalStateHandleID(
-                String.format("%s-%d-%d", filePath.toUri(), startPos, stateSize));
+        return new PhysicalStateHandleID(logicalFileId.getKeyString());
     }
 
     public long getStartPos() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageAccess.java
@@ -29,10 +29,12 @@ import org.apache.flink.runtime.state.CheckpointStreamFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /** An implementation of file merging checkpoint storage to file systems. */
-public class FsMergingCheckpointStorageAccess extends FsCheckpointStorageAccess {
+public class FsMergingCheckpointStorageAccess extends FsCheckpointStorageAccess
+        implements Closeable {
 
     /** FileMergingSnapshotManager manages files and meta information for checkpoints. */
     private final FileMergingSnapshotManager fileMergingSnapshotManager;
@@ -111,5 +113,11 @@ public class FsMergingCheckpointStorageAccess extends FsCheckpointStorageAccess 
                     fileMergingSnapshotManager,
                     checkpointId);
         }
+    }
+
+    /** This will be registered to resource closer of {@code StreamTask}. */
+    @Override
+    public void close() {
+        fileMergingSnapshotManager.unregisterSubtask(subtaskKey);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManagerTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.checkpoint.filemerging;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
-import org.apache.flink.runtime.state.filesystem.FileMergingCheckpointStateOutputStream;
+import org.apache.flink.util.function.BiFunctionWithException;
 
 import org.junit.jupiter.api.Test;
 
@@ -159,40 +159,76 @@ public class AcrossCheckpointFileMergingSnapshotManagerTest
                         (FileMergingSnapshotManagerBase)
                                 createFileMergingSnapshotManager(checkpointBaseDir);
                 CloseableRegistry closeableRegistry = new CloseableRegistry()) {
-            FileMergingCheckpointStateOutputStream cp1Stream =
-                    writeCheckpointAndGetStream(1, fmsm, closeableRegistry);
-            SegmentFileStateHandle cp1StateHandle = cp1Stream.closeAndGetHandle();
+            fmsm.registerSubtaskForSharedStates(subtaskKey1);
+            fmsm.registerSubtaskForSharedStates(subtaskKey2);
+            BiFunctionWithException<
+                            FileMergingSnapshotManager.SubtaskKey,
+                            Long,
+                            SegmentFileStateHandle,
+                            Exception>
+                    writer =
+                            ((subtaskKey, checkpointId) -> {
+                                return writeCheckpointAndGetStream(
+                                                subtaskKey,
+                                                checkpointId,
+                                                CheckpointedStateScope.SHARED,
+                                                fmsm,
+                                                closeableRegistry)
+                                        .closeAndGetHandle();
+                            });
+
+            SegmentFileStateHandle cp1StateHandle1 = writer.apply(subtaskKey1, 1L);
+            SegmentFileStateHandle cp1StateHandle2 = writer.apply(subtaskKey2, 1L);
             fmsm.notifyCheckpointComplete(subtaskKey1, 1);
-            assertFileInManagedDir(fmsm, cp1StateHandle);
-            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
-            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(1);
-            // complete checkpoint-2
-            FileMergingCheckpointStateOutputStream cp2Stream =
-                    writeCheckpointAndGetStream(2, fmsm, closeableRegistry);
-            SegmentFileStateHandle cp2StateHandle = cp2Stream.closeAndGetHandle();
-            fmsm.notifyCheckpointComplete(subtaskKey1, 2);
-            assertFileInManagedDir(fmsm, cp2StateHandle);
-            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertFileInManagedDir(fmsm, cp1StateHandle1);
+            assertFileInManagedDir(fmsm, cp1StateHandle2);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
             assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(2);
+
+            // complete checkpoint-2
+            SegmentFileStateHandle cp2StateHandle1 = writer.apply(subtaskKey1, 2L);
+            SegmentFileStateHandle cp2StateHandle2 = writer.apply(subtaskKey2, 2L);
+            fmsm.notifyCheckpointComplete(subtaskKey1, 2);
+            fmsm.notifyCheckpointComplete(subtaskKey2, 2);
+            assertFileInManagedDir(fmsm, cp2StateHandle1);
+            assertFileInManagedDir(fmsm, cp2StateHandle2);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(4);
+
+            assertThat(fmsm.isCheckpointDiscard(1)).isFalse();
 
             // subsume checkpoint-1
-            assertThat(fileExists(cp1StateHandle)).isTrue();
+            assertThat(fileExists(cp1StateHandle1)).isTrue();
+            assertThat(fileExists(cp1StateHandle2)).isTrue();
             fmsm.notifyCheckpointSubsumed(subtaskKey1, 1);
-            assertThat(fileExists(cp1StateHandle)).isTrue();
-            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
-            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(1);
+            assertThat(fileExists(cp1StateHandle1)).isTrue();
+            assertThat(fileExists(cp1StateHandle2)).isTrue();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(3);
+
+            assertThat(fmsm.isCheckpointDiscard(1)).isFalse();
+            fmsm.notifyCheckpointSubsumed(subtaskKey2, 1);
+            assertThat(fmsm.isCheckpointDiscard(1)).isTrue();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(2);
 
             // abort checkpoint-3
-            FileMergingCheckpointStateOutputStream cp3Stream =
-                    writeCheckpointAndGetStream(3, fmsm, closeableRegistry);
-            SegmentFileStateHandle cp3StateHandle = cp3Stream.closeAndGetHandle();
-            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
-            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(2);
-            assertFileInManagedDir(fmsm, cp3StateHandle);
+            SegmentFileStateHandle cp3StateHandle1 = writer.apply(subtaskKey1, 3L);
+            SegmentFileStateHandle cp3StateHandle2 = writer.apply(subtaskKey2, 3L);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(4);
+            assertFileInManagedDir(fmsm, cp3StateHandle1);
+            assertFileInManagedDir(fmsm, cp3StateHandle2);
             fmsm.notifyCheckpointAborted(subtaskKey1, 3);
-            assertThat(fileExists(cp3StateHandle)).isTrue();
-            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
-            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(1);
+            assertThat(fileExists(cp3StateHandle1)).isTrue();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(3);
+
+            assertThat(fmsm.isCheckpointDiscard(3)).isFalse();
+            fmsm.notifyCheckpointAborted(subtaskKey2, 3);
+            assertThat(fmsm.isCheckpointDiscard(3)).isTrue();
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(2);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
@@ -601,18 +601,36 @@ public abstract class FileMergingSnapshotManagerTestBase {
     FileMergingCheckpointStateOutputStream writeCheckpointAndGetStream(
             long checkpointId, FileMergingSnapshotManager fmsm, CloseableRegistry closeableRegistry)
             throws IOException {
-        return writeCheckpointAndGetStream(checkpointId, fmsm, closeableRegistry, 32);
+        return writeCheckpointAndGetStream(
+                subtaskKey1,
+                checkpointId,
+                CheckpointedStateScope.EXCLUSIVE,
+                fmsm,
+                closeableRegistry,
+                32);
     }
 
     FileMergingCheckpointStateOutputStream writeCheckpointAndGetStream(
+            SubtaskKey subtaskKey,
             long checkpointId,
+            CheckpointedStateScope scope,
+            FileMergingSnapshotManager fmsm,
+            CloseableRegistry closeableRegistry)
+            throws IOException {
+        return writeCheckpointAndGetStream(
+                subtaskKey, checkpointId, scope, fmsm, closeableRegistry, 32);
+    }
+
+    FileMergingCheckpointStateOutputStream writeCheckpointAndGetStream(
+            SubtaskKey subtaskKey,
+            long checkpointId,
+            CheckpointedStateScope scope,
             FileMergingSnapshotManager fmsm,
             CloseableRegistry closeableRegistry,
             int numBytes)
             throws IOException {
         FileMergingCheckpointStateOutputStream stream =
-                fmsm.createCheckpointStateOutputStream(
-                        subtaskKey1, checkpointId, CheckpointedStateScope.EXCLUSIVE);
+                fmsm.createCheckpointStateOutputStream(subtaskKey, checkpointId, scope);
         closeableRegistry.registerCloseable(stream);
         for (int i = 0; i < numBytes; i++) {
             stream.write(i);


### PR DESCRIPTION
## What is the purpose of the change

This PR fix several issues with file merging mechanism, see `Brief change log`.

## Brief change log

Fix following issues:
 - Checkpoint notification is not handled by the file merging manager.
 - File manager propagate the discard of one checkpoint incorrectly.
 - File manager cannot recognize the `PlaceholderStreamStateHandle`
 - Fail to filter `EmptySegmentFileStateHandle` out during recovery

## Verifying this change

UT modified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
