### PR TITLE
[FLINK-32088][checkpoint] Space control in file merging

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpoint_file_merging_section.html
+++ b/docs/layouts/shortcodes/generated/checkpoint_file_merging_section.html
@@ -32,5 +32,11 @@
             <td>Boolean</td>
             <td>Whether to use Blocking or Non-Blocking pool for merging physical files. A Non-Blocking pool will always provide usable physical file without blocking. It may create many physical files if poll file frequently. When poll a small file from a Blocking pool, it may be blocked until the file is returned.</td>
         </tr>
+        <tr>
+            <td><h5>state.checkpoints.file-merging.max-space-amplification</h5></td>
+            <td style="word-wrap: break-word;">2.0</td>
+            <td>Float</td>
+            <td>Space amplification stands for the magnification of the occupied space compared to the amount of valid data. The more space amplification is, the more waste of space will be. This configs a space amplification above which a re-uploading for physical files will be triggered to reclaim space. Any value below 1f means disabling the space control.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -141,6 +141,12 @@
             <td>Max size of a physical file for merged checkpoints.</td>
         </tr>
         <tr>
+            <td><h5>state.checkpoints.file-merging.max-space-amplification</h5></td>
+            <td style="word-wrap: break-word;">2.0</td>
+            <td>Float</td>
+            <td>Space amplification stands for the magnification of the occupied space compared to the amount of valid data. The more space amplification is, the more waste of space will be. This configs a space amplification above which a re-uploading for physical files will be triggered to reclaim space. Any value below 1f means disabling the space control.</td>
+        </tr>
+        <tr>
             <td><h5>state.checkpoints.file-merging.pool-blocking</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -434,10 +434,9 @@ public class CheckpointingOptions {
      * of valid data. The more space amplification is, the more waste of space will be. This configs
      * a space amplification above which a re-uploading for physical files will be triggered to
      * reclaim space.
-     *
-     * <p>TODO: remove '@Documentation.ExcludeFromDocumentation' after the feature is implemented.
      */
-    @Experimental @Documentation.ExcludeFromDocumentation
+    @Experimental
+    @Documentation.Section(value = Documentation.Sections.CHECKPOINT_FILE_MERGING, position = 6)
     public static final ConfigOption<Float> FILE_MERGING_MAX_SPACE_AMPLIFICATION =
             ConfigOptions.key("state.checkpoints.file-merging.max-space-amplification")
                     .floatType()
@@ -445,7 +444,8 @@ public class CheckpointingOptions {
                     .withDescription(
                             "Space amplification stands for the magnification of the occupied space compared to the amount of valid data. "
                                     + "The more space amplification is, the more waste of space will be. This configs a space amplification "
-                                    + "above which a re-uploading for physical files will be triggered to reclaim space.");
+                                    + "above which a re-uploading for physical files will be triggered to reclaim space. Any value below 1f "
+                                    + "means disabling the space control.");
 
     public static final ConfigOption<CheckpointingMode> CHECKPOINTING_CONSISTENCY_MODE =
             ConfigOptions.key("execution.checkpointing.mode")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/AcrossCheckpointFileMergingSnapshotManager.java
@@ -31,8 +31,12 @@ public class AcrossCheckpointFileMergingSnapshotManager extends FileMergingSnaps
     private final PhysicalFilePool filePool;
 
     public AcrossCheckpointFileMergingSnapshotManager(
-            String id, long maxFileSize, PhysicalFilePool.Type filePoolType, Executor ioExecutor) {
-        super(id, maxFileSize, filePoolType, ioExecutor);
+            String id,
+            long maxFileSize,
+            PhysicalFilePool.Type filePoolType,
+            float maxSpaceAmplification,
+            Executor ioExecutor) {
+        super(id, maxFileSize, filePoolType, maxSpaceAmplification, ioExecutor);
         filePool = createPhysicalPool();
     }
 
@@ -43,9 +47,6 @@ public class AcrossCheckpointFileMergingSnapshotManager extends FileMergingSnaps
             throws IOException {
         return filePool.pollFile(subtaskKey, scope);
     }
-
-    @Override
-    protected void discardCheckpoint(long checkpointId) {}
 
     @Override
     protected void returnPhysicalFileForNextReuse(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
@@ -171,6 +171,14 @@ public interface FileMergingSnapshotManager extends Closeable {
     void notifyCheckpointSubsumed(SubtaskKey subtaskKey, long checkpointId) throws Exception;
 
     /**
+     * Check whether previous state handles could further be reused considering the space
+     * amplification.
+     *
+     * @param stateHandle the handle to be reused.
+     */
+    boolean couldReusePreviousStateHandle(StreamStateHandle stateHandle);
+
+    /**
      * A callback method which is called when previous state handles are reused by following
      * checkpoint(s).
      *
@@ -302,7 +310,6 @@ public interface FileMergingSnapshotManager extends Closeable {
         }
 
         public void onLogicalFileCreate(long size) {
-            physicalFileSize.addAndGet(size);
             logicalFileSize.addAndGet(size);
             logicalFileCount.incrementAndGet();
         }
@@ -310,6 +317,10 @@ public interface FileMergingSnapshotManager extends Closeable {
         public void onLogicalFileDelete(long size) {
             logicalFileSize.addAndGet(-size);
             logicalFileCount.decrementAndGet();
+        }
+
+        public void onPhysicalFileUpdate(long size) {
+            physicalFileSize.addAndGet(size);
         }
 
         public void onPhysicalFileCreate() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBuilder.java
@@ -38,6 +38,9 @@ public class FileMergingSnapshotManagerBuilder {
     /** Type of physical file pool. */
     private PhysicalFilePool.Type filePoolType = PhysicalFilePool.Type.NON_BLOCKING;
 
+    /** The max space amplification that the manager should control. */
+    private float maxSpaceAmplification = Float.MAX_VALUE;
+
     @Nullable private Executor ioExecutor = null;
 
     /**
@@ -63,6 +66,17 @@ public class FileMergingSnapshotManagerBuilder {
         return this;
     }
 
+    public FileMergingSnapshotManagerBuilder setMaxSpaceAmplification(float amplification) {
+        if (amplification < 1) {
+            // only valid number counts. If not valid, disable space control by setting this to
+            // Float.MAX_VALUE.
+            this.maxSpaceAmplification = Float.MAX_VALUE;
+        } else {
+            this.maxSpaceAmplification = amplification;
+        }
+        return this;
+    }
+
     /**
      * Set the executor for io operation in manager. If null(default), all io operation will be
      * executed synchronously.
@@ -84,12 +98,14 @@ public class FileMergingSnapshotManagerBuilder {
                         id,
                         maxFileSize,
                         filePoolType,
+                        maxSpaceAmplification,
                         ioExecutor == null ? Runnable::run : ioExecutor);
             case MERGE_ACROSS_CHECKPOINT:
                 return new AcrossCheckpointFileMergingSnapshotManager(
                         id,
                         maxFileSize,
                         filePoolType,
+                        maxSpaceAmplification,
                         ioExecutor == null ? Runnable::run : ioExecutor);
             default:
                 throw new UnsupportedOperationException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/LogicalFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/LogicalFile.java
@@ -116,6 +116,7 @@ public class LogicalFile {
     public void discardWithCheckpointId(long checkpointId) throws IOException {
         if (!discarded && checkpointId >= lastUsedCheckpointID) {
             physicalFile.decRefCount();
+            physicalFile.decSize(length);
             discarded = true;
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManager.java
@@ -39,9 +39,13 @@ public class WithinCheckpointFileMergingSnapshotManager extends FileMergingSnaps
     private final Map<Long, PhysicalFilePool> writablePhysicalFilePool;
 
     public WithinCheckpointFileMergingSnapshotManager(
-            String id, long maxFileSize, PhysicalFilePool.Type filePoolType, Executor ioExecutor) {
+            String id,
+            long maxFileSize,
+            PhysicalFilePool.Type filePoolType,
+            float maxSpaceAmplification,
+            Executor ioExecutor) {
         // currently there is no file size limit For WITHIN_BOUNDARY mode
-        super(id, maxFileSize, filePoolType, ioExecutor);
+        super(id, maxFileSize, filePoolType, maxSpaceAmplification, ioExecutor);
         writablePhysicalFilePool = new HashMap<>();
     }
 
@@ -116,6 +120,7 @@ public class WithinCheckpointFileMergingSnapshotManager extends FileMergingSnaps
         if (filePool != null) {
             filePool.close();
         }
+        super.discardCheckpoint(checkpointId);
     }
 
     private PhysicalFilePool getOrCreateFilePool(long checkpointId) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
@@ -79,4 +79,16 @@ public interface CheckpointStreamFactory {
     default void reusePreviousStateHandle(Collection<? extends StreamStateHandle> previousHandle) {
         // Does nothing for normal stream factory
     }
+
+    /**
+     * A pre-check hook before the checkpoint writer want to reuse a state handle, if this returns
+     * false, it is not recommended for the writer to rewrite the state file considering the space
+     * amplification.
+     *
+     * @param stateHandle the handle to be reused.
+     * @return true if it can be reused.
+     */
+    default boolean couldReuseStateHandle(StreamStateHandle stateHandle) {
+        return true;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorFileMergingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorFileMergingManager.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import static org.apache.flink.configuration.CheckpointingOptions.FILE_MERGING_ACROSS_BOUNDARY;
 import static org.apache.flink.configuration.CheckpointingOptions.FILE_MERGING_ENABLED;
 import static org.apache.flink.configuration.CheckpointingOptions.FILE_MERGING_MAX_FILE_SIZE;
+import static org.apache.flink.configuration.CheckpointingOptions.FILE_MERGING_MAX_SPACE_AMPLIFICATION;
 import static org.apache.flink.configuration.CheckpointingOptions.FILE_MERGING_POOL_BLOCKING;
 
 /**
@@ -118,6 +119,13 @@ public class TaskExecutorFileMergingManager {
                                 .getOptional(FILE_MERGING_POOL_BLOCKING)
                                 .orElse(clusterConfiguration.get(FILE_MERGING_POOL_BLOCKING));
 
+                Float spaceAmplification =
+                        jobConfiguration
+                                .getOptional(FILE_MERGING_MAX_SPACE_AMPLIFICATION)
+                                .orElse(
+                                        clusterConfiguration.get(
+                                                FILE_MERGING_MAX_SPACE_AMPLIFICATION));
+
                 fileMergingSnapshotManagerAndRetainedExecutions =
                         Tuple2.of(
                                 new FileMergingSnapshotManagerBuilder(
@@ -127,6 +135,7 @@ public class TaskExecutorFileMergingManager {
                                                 usingBlockingPool
                                                         ? PhysicalFilePool.Type.BLOCKING
                                                         : PhysicalFilePool.Type.NON_BLOCKING)
+                                        .setMaxSpaceAmplification(spaceAmplification)
                                         .build(),
                                 new HashSet<>());
                 fileMergingSnapshotManagerByJobId.put(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocation.java
@@ -119,4 +119,9 @@ public class FsMergingCheckpointStorageLocation extends FsCheckpointStorageLocat
     public void reusePreviousStateHandle(Collection<? extends StreamStateHandle> previousHandle) {
         fileMergingSnapshotManager.reusePreviousStateHandle(checkpointId, previousHandle);
     }
+
+    @Override
+    public boolean couldReuseStateHandle(StreamStateHandle stateHandle) {
+        return fileMergingSnapshotManager.couldReusePreviousStateHandle(stateHandle);
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
@@ -344,7 +344,10 @@ public abstract class FileMergingSnapshotManagerTestBase {
         try (FileMergingSnapshotManagerBase fmsm =
                 (FileMergingSnapshotManagerBase)
                         createFileMergingSnapshotManager(
-                                checkpointBaseDir, 32, PhysicalFilePool.Type.BLOCKING)) {
+                                checkpointBaseDir,
+                                32,
+                                PhysicalFilePool.Type.BLOCKING,
+                                Float.MAX_VALUE)) {
             fmsm.registerSubtaskForSharedStates(subtaskKey1);
 
             // test reusing a physical file
@@ -563,11 +566,14 @@ public abstract class FileMergingSnapshotManagerTestBase {
     FileMergingSnapshotManager createFileMergingSnapshotManager(Path checkpointBaseDir)
             throws IOException {
         return createFileMergingSnapshotManager(
-                checkpointBaseDir, 32 * 1024 * 1024, PhysicalFilePool.Type.NON_BLOCKING);
+                checkpointBaseDir, 32 * 1024 * 1024, PhysicalFilePool.Type.NON_BLOCKING, 2f);
     }
 
     FileMergingSnapshotManager createFileMergingSnapshotManager(
-            Path checkpointBaseDir, long maxFileSize, PhysicalFilePool.Type filePoolType)
+            Path checkpointBaseDir,
+            long maxFileSize,
+            PhysicalFilePool.Type filePoolType,
+            float spaceAmplification)
             throws IOException {
         FileSystem fs = LocalFileSystem.getSharedInstance();
         Path sharedStateDir =
@@ -587,6 +593,7 @@ public abstract class FileMergingSnapshotManagerTestBase {
                 new FileMergingSnapshotManagerBuilder(tmId, getFileMergingType())
                         .setMaxFileSize(maxFileSize)
                         .setFilePoolType(filePoolType)
+                        .setMaxSpaceAmplification(spaceAmplification)
                         .build();
         fmsm.initFileSystem(
                 LocalFileSystem.getSharedInstance(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/WithinCheckpointFileMergingSnapshotManagerTest.java
@@ -238,4 +238,71 @@ public class WithinCheckpointFileMergingSnapshotManagerTest
             assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(3);
         }
     }
+
+    @Test
+    public void testSpaceControl() throws Exception {
+        try (FileMergingSnapshotManagerBase fmsm =
+                        (FileMergingSnapshotManagerBase)
+                                createFileMergingSnapshotManager(checkpointBaseDir);
+                CloseableRegistry closeableRegistry = new CloseableRegistry()) {
+
+            fmsm.registerSubtaskForSharedStates(subtaskKey1);
+
+            BiFunctionWithException<Long, Integer, SegmentFileStateHandle, Exception> writer =
+                    ((checkpointId, size) -> {
+                        return writeCheckpointAndGetStream(
+                                        subtaskKey1,
+                                        checkpointId,
+                                        CheckpointedStateScope.SHARED,
+                                        fmsm,
+                                        closeableRegistry,
+                                        size)
+                                .closeAndGetHandle();
+                    });
+            Integer eighthOfFile = 4 * 1024 * 1024;
+
+            // Doing checkpoint-1 with 6 files
+            SegmentFileStateHandle stateHandle1 = writer.apply(1L, eighthOfFile);
+            SegmentFileStateHandle stateHandle2 = writer.apply(1L, eighthOfFile);
+            SegmentFileStateHandle stateHandle3 = writer.apply(1L, eighthOfFile);
+            SegmentFileStateHandle stateHandle4 = writer.apply(1L, eighthOfFile);
+            SegmentFileStateHandle stateHandle5 = writer.apply(1L, eighthOfFile);
+            SegmentFileStateHandle stateHandle6 = writer.apply(1L, eighthOfFile);
+
+            fmsm.notifyCheckpointComplete(subtaskKey1, 1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(1);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(6);
+
+            // complete checkpoint-2 with 3 files written and 1 file reused from checkpoint 1
+            assertThat(fmsm.couldReusePreviousStateHandle(stateHandle1)).isTrue();
+            SegmentFileStateHandle stateHandle7 = writer.apply(2L, eighthOfFile);
+            SegmentFileStateHandle stateHandle8 = writer.apply(2L, eighthOfFile);
+            SegmentFileStateHandle stateHandle9 = writer.apply(2L, eighthOfFile);
+            fmsm.reusePreviousStateHandle(2, Collections.singletonList(stateHandle1));
+            fmsm.notifyCheckpointComplete(subtaskKey1, 2);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(9);
+
+            // subsume checkpoint-1
+            fmsm.notifyCheckpointSubsumed(subtaskKey1, 1);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(4);
+
+            // complete checkpoint-3 with 1 files reuse from checkpoint 1 and 2.
+            assertThat(fmsm.couldReusePreviousStateHandle(stateHandle1)).isFalse();
+            assertThat(fmsm.couldReusePreviousStateHandle(stateHandle7)).isTrue();
+            SegmentFileStateHandle stateHandle10 = writer.apply(3L, eighthOfFile);
+            SegmentFileStateHandle stateHandle11 = writer.apply(3L, eighthOfFile);
+            fmsm.reusePreviousStateHandle(3, Collections.singletonList(stateHandle7));
+
+            fmsm.notifyCheckpointComplete(subtaskKey1, 3);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(3);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(6);
+
+            // subsume checkpoint-2
+            fmsm.notifyCheckpointSubsumed(subtaskKey1, 2);
+            assertThat(fmsm.spaceStat.physicalFileCount.get()).isEqualTo(2);
+            assertThat(fmsm.spaceStat.logicalFileCount.get()).isEqualTo(3);
+        }
+    }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -416,7 +416,8 @@ public class RocksIncrementalSnapshotStrategy<K>
 
                 if (fileName.endsWith(SST_FILE_SUFFIX)) {
                     Optional<StreamStateHandle> uploaded = previousSnapshot.getUploaded(fileName);
-                    if (uploaded.isPresent()) {
+                    if (uploaded.isPresent()
+                            && checkpointStreamFactory.couldReuseStateHandle(uploaded.get())) {
                         sstFiles.add(HandleAndLocalPath.of(uploaded.get(), fileName));
                     } else {
                         sstFilePaths.add(filePath); // re-upload


### PR DESCRIPTION
## What is the purpose of the change

As we know, the checkpoint file merging will introduce space amplification. This PR introduce a space control in file merging, by rewriting old files and eliminate the empty slot on underlying files.

## Brief change log

 - Space accounting and flags in file merging manager and physical files.
 - Rewrite in RocksdbStateBackend

## Verifying this change

Added UTs for file merging manager.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
