### PR TITLE
[FLINK-35382][test] Disable snapshot-file-merging in ChangelogCompabilityITCase

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogCompatibilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogCompatibilityITCase.java
@@ -137,9 +137,9 @@ public class ChangelogCompatibilityITCase {
 
     private StreamExecutionEnvironment initEnvironment() {
         Configuration conf = new Configuration();
-        conf.set(
-                FILE_MERGING_ENABLED, false); // TODO: remove file merging setting after FLINK-32085
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        // TODO:remove file-merging setting after FLINK-32085 & FLINK-32081 are resolved.
+        conf.set(FILE_MERGING_ENABLED, false);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
         env.enableChangelogStateBackend(testCase.startWithChangelog);
         if (testCase.restoreSource == RestoreSource.CHECKPOINT) {
             env.enableCheckpointing(50);
@@ -182,7 +182,10 @@ public class ChangelogCompatibilityITCase {
     }
 
     private void restoreAndValidate(String location) {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        Configuration conf = new Configuration();
+        // TODO:remove file-merging setting after FLINK-32085 & FLINK-32081 are resolved.
+        conf.set(FILE_MERGING_ENABLED, false);
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment(conf);
         env.enableChangelogStateBackend(testCase.restoreWithChangelog);
         JobGraph jobGraph = addGraph(env);
         jobGraph.setSavepointRestoreSettings(forPath(location));


### PR DESCRIPTION

## What is the purpose of the change

This pull request disable snapshot-file-merging config in  ChangelogCompabilityITCase.


## Brief change log

  -  Disable the FILE_MERGING_ENABLED config in ChangelogCompabilityITCase


## Verifying this change


This change is already covered by existing tests (ChangelogCompabilityITCase).


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
