### PR TITLE
[FLINK-35403] Allow Skipping Invocation of Function Calls While Constant-folding

### DIFF
--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -263,7 +263,7 @@ function is not stateful (i.e. containing only transient and static fields).
 
 ### Evaluation Methods
 
-The base class provides a set of methods that can be overridden such as `open()`, `close()`, `isDeterministic()` or `canReduceExpression()`.
+The base class provides a set of methods that can be overridden such as `open()`, `close()`, `isDeterministic()` or `supportsConstantFolding()`.
 
 However, in addition to those declared methods, the main runtime logic that is applied to every incoming record must be implemented through specialized _evaluation methods_.
 
@@ -813,7 +813,7 @@ Note: `isDynamicFunction` is only applicable for system functions.
 ### Constant Expression Reduction
 
 User-defined functions can declare whether they allow for constant expression reduction by 
-overriding the method `canReduceExpression()`. Calls to functions with constant arguments can be 
+overriding the method `supportsConstantFolding()`. Calls to functions with constant arguments can be 
 reduced and simplified in some cases. An example could be the user-defined function call `PlusOne(10)` might just be simplified to `11` in an
 expression. This optimization happens at planning time, resulting in a plan only utilizing the
 reduced value. This generally is desirable, and therefore is enabled by default, though there are some
@@ -821,12 +821,12 @@ cases where it should be disabled.
 
 One is if the function call is not deterministic, which is covered in more detail in the 
 Determinism section above. Setting a function as non deterministic will have the effect of 
-preventing function call expression reduction, even if `canReduceExpression()` is true.
+preventing function call expression reduction, even if `supportsConstantFolding()` is true.
 
 A function call may also have some side effects, even if it always returns deterministic results. 
-This may mean that the correctness of the query within Flink may allow for reduction, but it may not
-be desired anyway. In this case, setting the method `canReduceExpression()` to return false also 
-has the effect of preventing expression reduction and ensuring invocation at runtime.
+This may mean that the correctness of the query within Flink may allow for constant expression reduction, but it may not
+be desired anyway. In this case, setting the method `supportsConstantFolding()` to return false also 
+has the effect of preventing constant expression reduction and ensuring invocation at runtime.
 
 ### Runtime Integration
 

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -263,7 +263,7 @@ function is not stateful (i.e. containing only transient and static fields).
 
 ### Evaluation Methods
 
-The base class provides a set of methods that can be overridden such as `open()`, `close()`, or `isDeterministic()`.
+The base class provides a set of methods that can be overridden such as `open()`, `close()`, `isDeterministic()` or `canReduceExpression()`.
 
 However, in addition to those declared methods, the main runtime logic that is applied to every incoming record must be implemented through specialized _evaluation methods_.
 
@@ -809,6 +809,24 @@ The following system temporal functions are dynamic, which will be pre-evaluated
 - LOCALTIMESTAMP
 
 Note: `isDynamicFunction` is only applicable for system functions.
+
+### Constant Expression Reduction
+
+User-defined functions can declare whether they allow for constant expression reduction by 
+overriding the method `canReduceExpression()`. Calls to functions with constant arguments can be 
+reduced and simplified in some cases. An example could be the user-defined function call `PlusOne(10)` might just be simplified to `11` in an
+expression. This optimization happens at planning time, resulting in a plan only utilizing the
+reduced value. This generally is desirable, and therefore is enabled by default, though there are some
+cases where it should be disabled.
+
+One is if the function call is not deterministic, which is covered in more detail in the 
+Determinism section above. Setting a function as non deterministic will have the effect of 
+preventing function call expression reduction, even if `canReduceExpression()` is true.
+
+A function call may also have some side effects, even if it always returns deterministic results. 
+This may mean that the correctness of the query within Flink may allow for reduction, but it may not
+be desired anyway. In this case, setting the method `canReduceExpression()` to return false also 
+has the effect of preventing expression reduction and ensuring invocation at runtime.
 
 ### Runtime Integration
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionDefinition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionDefinition.java
@@ -75,4 +75,14 @@ public interface FunctionDefinition {
     default boolean isDeterministic() {
         return true;
     }
+
+    /**
+     * If the Expression Reducer should be run during planning time on calls to this function. If
+     * not, the expression will be left as-is and the call will be made during runtime.
+     *
+     * @return Whether invocations can be reduced during planning time
+     */
+    default boolean canReduceExpression() {
+        return true;
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionDefinition.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionDefinition.java
@@ -77,12 +77,10 @@ public interface FunctionDefinition {
     }
 
     /**
-     * If the Expression Reducer should be run during planning time on calls to this function. If
-     * not, the expression will be left as-is and the call will be made during runtime.
-     *
-     * @return Whether invocations can be reduced during planning time
+     * If the constant-folding should be run during planning time on calls to this function. If not,
+     * the expression will be left as-is and the call will be made during runtime.
      */
-    default boolean canReduceExpression() {
+    default boolean supportsConstantFolding() {
         return true;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/ConstantFoldingUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/ConstantFoldingUtil.java
@@ -24,35 +24,35 @@ import org.apache.flink.table.planner.utils.ShortcutUtils;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
 
-/** Utility for deciding whether than expression can be reduced or not. */
-public class ReducerUtil {
+/** Utility for deciding whether than expression supports constant folding or not. */
+public class ConstantFoldingUtil {
 
     /**
-     * Checks whether it contains any function calls which don't want to be reduced.
+     * Checks whether it contains any function calls which don't support constant folding.
      *
      * @param node the RexNode to check
-     * @return true if it contains any non-reducible function calls in the specified node.
+     * @return true if it contains any unsupported function calls in the specified node.
      */
-    public static boolean canReduceExpression(RexNode node) {
-        return node.accept(new CanReduceExpressionVisitor());
+    public static boolean supportsConstantFolding(RexNode node) {
+        return node.accept(new CanConstantFoldExpressionVisitor());
     }
 
-    private static class CanReduceExpressionVisitor extends RexDefaultVisitor<Boolean> {
+    private static class CanConstantFoldExpressionVisitor extends RexDefaultVisitor<Boolean> {
 
         @Override
         public Boolean visitNode(RexNode rexNode) {
             return true;
         }
 
-        private boolean canReduceExpression(RexCall call) {
+        private boolean supportsConstantFolding(RexCall call) {
             FunctionDefinition definition = ShortcutUtils.unwrapFunctionDefinition(call);
-            return definition == null || definition.canReduceExpression();
+            return definition == null || definition.supportsConstantFolding();
         }
 
         @Override
         public Boolean visitCall(RexCall call) {
-            boolean canReduceExpression = canReduceExpression(call);
-            return canReduceExpression
+            boolean supportsConstantFolding = supportsConstantFolding(call);
+            return supportsConstantFolding
                     && (call.getOperands().stream().allMatch(node -> node.accept(this)));
         }
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/ReducerUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/ReducerUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils;
+
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+
+/** Utility for deciding whether than expression can be reduced or not. */
+public class ReducerUtil {
+
+    /**
+     * Checks whether it contains any function calls which don't want to be reduced.
+     *
+     * @param node the RexNode to check
+     * @return true if it contains any non-reducible function calls in the specified node.
+     */
+    public static boolean canReduceExpression(RexNode node) {
+        return node.accept(new CanReduceExpressionVisitor());
+    }
+
+    private static class CanReduceExpressionVisitor extends RexDefaultVisitor<Boolean> {
+
+        @Override
+        public Boolean visitNode(RexNode rexNode) {
+            return true;
+        }
+
+        private boolean canReduceExpression(RexCall call) {
+            FunctionDefinition definition = ShortcutUtils.unwrapFunctionDefinition(call);
+            return definition == null || definition.canReduceExpression();
+        }
+
+        @Override
+        public Boolean visitCall(RexCall call) {
+            boolean canReduceExpression = canReduceExpression(call);
+            return canReduceExpression
+                    && (call.getOperands().stream().allMatch(node -> node.accept(this)));
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.FunctionCodeGenerator.generateFunction
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable.{JSON_ARRAY, JSON_OBJECT}
-import org.apache.flink.table.planner.plan.utils.AsyncUtil
+import org.apache.flink.table.planner.plan.utils.{AsyncUtil, ReducerUtil}
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
 import org.apache.flink.table.planner.utils.Logging
@@ -66,9 +66,9 @@ class ExpressionReducer(
       constExprs: java.util.List[RexNode],
       reducedValues: java.util.List[RexNode]): Unit = {
 
-    val remoteUDFExprs = new ListBuffer[RexNode]()
+    val nonReducibleExprs = new ListBuffer[RexNode]()
 
-    val literals = skipAndValidateExprs(rexBuilder, constExprs, remoteUDFExprs)
+    val literals = skipAndValidateExprs(rexBuilder, constExprs, nonReducibleExprs)
 
     val literalTypes = literals.map(e => FlinkTypeFactory.toLogicalType(e.getType))
     val resultType = RowType.of(literalTypes: _*)
@@ -132,8 +132,8 @@ class ExpressionReducer(
     while (i < constExprs.size()) {
       val unreduced = constExprs.get(i)
       // use eq to compare reference
-      if (remoteUDFExprs.exists(_ eq unreduced)) {
-        // if contains async function then just insert the original expression.
+      if (nonReducibleExprs.exists(_ eq unreduced)) {
+        // if contains non reducible function calls then just insert the original expression.
         reducedValues.add(unreduced)
       } else
         unreduced match {
@@ -254,15 +254,17 @@ class ExpressionReducer(
   private def skipAndValidateExprs(
       rexBuilder: RexBuilder,
       constExprs: java.util.List[RexNode],
-      remoteUDFExprs: ListBuffer[RexNode]): List[RexNode] = {
+      nonReducibleExprs: ListBuffer[RexNode]): List[RexNode] = {
     constExprs.asScala
       .map(e => (e.getType.getSqlTypeName, e))
       .flatMap {
 
         // Skip expressions that contain python or async functions because it's quite expensive to
         // call async UDFs during optimization phase. They will be optimized during the runtime.
-        case (_, e) if containsPythonCall(e) || AsyncUtil.containsAsyncCall(e) =>
-          remoteUDFExprs += e
+        case (_, e)
+            if containsPythonCall(e) || AsyncUtil.containsAsyncCall(e) ||
+              !ReducerUtil.canReduceExpression(e) =>
+          nonReducibleExprs += e
           None
 
         // we don't support object literals yet, we skip those constant expressions

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.functions.{FunctionContext, UserDefinedFunction}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.FunctionCodeGenerator.generateFunction
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable.{JSON_ARRAY, JSON_OBJECT}
-import org.apache.flink.table.planner.plan.utils.{AsyncUtil, ReducerUtil}
+import org.apache.flink.table.planner.plan.utils.{AsyncUtil, ConstantFoldingUtil}
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
 import org.apache.flink.table.planner.utils.Logging
@@ -263,7 +263,7 @@ class ExpressionReducer(
         // call async UDFs during optimization phase. They will be optimized during the runtime.
         case (_, e)
             if containsPythonCall(e) || AsyncUtil.containsAsyncCall(e) ||
-              !ReducerUtil.canReduceExpression(e) =>
+              !ConstantFoldingUtil.supportsConstantFolding(e) =>
           nonReducibleExprs += e
           None
 

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.xml
@@ -102,4 +102,38 @@ Calc(select=[myUdf(+(1, 1)) AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testExpressionReductionWithNonReducibleUDF">
+	<Resource name="sql">
+		<![CDATA[SELECT MyUdf(1) FROM MyTable]]>
+	</Resource>
+	<Resource name="ast">
+		<![CDATA[
+LogicalProject(EXPR$0=[MyUdf(1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+	</Resource>
+	<Resource name="optimized rel plan">
+		<![CDATA[
+Calc(select=[MyUdf(1) AS EXPR$0])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testExpressionReductionWithNonReducibleMultipleUDF">
+	<Resource name="sql">
+		<![CDATA[SELECT MyUdf2(MyUdf1(1)), MyUdf1(MyUdf2(1)) FROM MyTable]]>
+	</Resource>
+	<Resource name="ast">
+		<![CDATA[
+LogicalProject(EXPR$0=[MyUdf2(MyUdf1(1))], EXPR$1=[MyUdf1(MyUdf2(1))])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+	</Resource>
+	<Resource name="optimized rel plan">
+		<![CDATA[
+Calc(select=[MyUdf2(MyUdf1(1)) AS EXPR$0, MyUdf1(MyUdf2(1)) AS EXPR$1])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -62,7 +62,7 @@ object FuncNotReducible extends ScalarFunction {
     index + 1
   }
 
-  override def canReduceExpression: Boolean = false
+  override def supportsConstantFolding: Boolean = false
 }
 
 @SerialVersionUID(1L)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -57,6 +57,15 @@ object Func1 extends ScalarFunction {
 }
 
 @SerialVersionUID(1L)
+object FuncNotReducible extends ScalarFunction {
+  def eval(index: Integer): Integer = {
+    index + 1
+  }
+
+  override def canReduceExpression: Boolean = false
+}
+
+@SerialVersionUID(1L)
 object Func3 extends ScalarFunction {
   def eval(index: Integer, str: String): String = {
     s"$index and $str"

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
@@ -23,6 +23,7 @@ import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
 import org.apache.flink.table.planner.expressions.utils.{Func1, FuncNotReducible, RichFunc1}
 import org.apache.flink.table.planner.utils.TableTestBase
+
 import org.junit.jupiter.api.Test
 
 /** Test for [[org.apache.flink.table.planner.codegen.ExpressionReducer]]. */

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
@@ -21,9 +21,8 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
-import org.apache.flink.table.planner.expressions.utils.{Func1, RichFunc1}
+import org.apache.flink.table.planner.expressions.utils.{Func1, FuncNotReducible, RichFunc1}
 import org.apache.flink.table.planner.utils.TableTestBase
-
 import org.junit.jupiter.api.Test
 
 /** Test for [[org.apache.flink.table.planner.codegen.ExpressionReducer]]. */
@@ -52,6 +51,19 @@ class ExpressionReductionRulesTest extends TableTestBase {
     // it will be executed during runtime though
     util.getTableEnv.getConfig.addJobParameter("fail-for-cached-file", "true")
     util.verifyRelPlan("SELECT myUdf(1 + 1) FROM MyTable")
+  }
+
+  @Test
+  def testExpressionReductionWithNonReducibleUDF(): Unit = {
+    util.addTemporarySystemFunction("MyUdf", FuncNotReducible)
+    util.verifyRelPlan("SELECT MyUdf(1) FROM MyTable")
+  }
+
+  @Test
+  def testExpressionReductionWithNonReducibleMultipleUDF(): Unit = {
+    util.addTemporarySystemFunction("MyUdf1", Func1)
+    util.addTemporarySystemFunction("MyUdf2", FuncNotReducible)
+    util.verifyRelPlan("SELECT MyUdf2(MyUdf1(1)), MyUdf1(MyUdf2(1)) FROM MyTable")
   }
 
   @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR adds a new method to `FunctionDefinition`, `supportsConstantFolding` which indicates of a function call should have constant expression reduction done during planning time.  For example, `AddOne(10)` could be reduced to `11` by invoking `AddOne` during planning time.  This is the default and current Flink functionality.  

This addition allows overriding the default behavior and returning false, which would keep the expression intact, to be invoked at runtime instead.

This functionality and motivation is covered in more detail in [FLIP 452](https://cwiki.apache.org/confluence/display/FLINK/FLIP-452%3A+Allow+Skipping+Invocation+of+Function+Calls+While+Constant-folding).


## Verifying this change

- Added new test cases to `ExpressionReductionRulesTest`.
  - These test that existing plans are unchanged
  - New tests show that disabling constant folding also keeps plans without reducing away the invocation

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
    - It shouldn't affect default behavior, which is to constant fold
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
