### PR TITLE
[hotfix][ForStStateBackend] Create new copy for each SerializedCompositeKeyBuilder in ForStStateBackend

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
@@ -113,15 +113,14 @@ public class ForStKeyedStateBackendBuilder<K>
         int keyGroupPrefixBytes =
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(
                         numberOfKeyGroups);
-        // it is important that we only create the key builder after the restore, and not
-        // before;
-        // restore operations may reconfigure the key serializer, so accessing the key
-        // serializer
+        // it is important that we only create the key builder after the restore, and not before;
+        // restore operations may reconfigure the key serializer, so accessing the key serializer
         // only now we can be certain that the key serializer used in the builder is final.
         Supplier<SerializedCompositeKeyBuilder<K>> serializedKeyBuilder =
                 () ->
                         new SerializedCompositeKeyBuilder<>(
-                                keySerializerProvider.currentSchemaSerializer(),
+                                // must create new copy for each SerializedCompositeKeyBuilder
+                                keySerializerProvider.currentSchemaSerializer().duplicate(),
                                 keyGroupPrefixBytes,
                                 KEY_SERIALIZER_BUFFER_START_SIZE);
         Supplier<DataOutputSerializer> valueSerializerView =


### PR DESCRIPTION
## What is the purpose of the change

This is a internal hotfix within development of ForStStateBackend (see: FLIP-427).

## Brief change log

  - As title, create new copy for each SerializedCompositeKeyBuilder in ForStStateBackend.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no