### PR TITLE
[FLINK-35400][checkpoint] Release FileMergingSnapshotManager if all tasks finished

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/FileMergingSnapshotManagerClosableWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/FileMergingSnapshotManagerClosableWrapper.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
+
+import javax.annotation.Nonnull;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/** A wrapper that wraps {@link FileMergingSnapshotManager} and a {@link Closeable}. */
+public class FileMergingSnapshotManagerClosableWrapper implements Closeable {
+
+    private final FileMergingSnapshotManager snapshotManager;
+
+    private final Closeable closeable;
+
+    private boolean closed = false;
+
+    private FileMergingSnapshotManagerClosableWrapper(
+            @Nonnull FileMergingSnapshotManager snapshotManager, @Nonnull Closeable closeable) {
+        this.snapshotManager = snapshotManager;
+        this.closeable = closeable;
+    }
+
+    public static FileMergingSnapshotManagerClosableWrapper of(
+            @Nonnull FileMergingSnapshotManager snapshotManager, @Nonnull Closeable closeable) {
+        return new FileMergingSnapshotManagerClosableWrapper(snapshotManager, closeable);
+    }
+
+    public FileMergingSnapshotManager get() {
+        return snapshotManager;
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        if (!closed) {
+            closed = true;
+            closeable.close();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskStateManagerImpl.java
@@ -79,11 +79,11 @@ public class TaskStateManagerImpl implements TaskStateManager {
     /** The local state store to which this manager reports local state snapshots. */
     private final TaskLocalStateStore localStateStore;
 
+    /** The file merging snapshot manager */
+    @Nullable private final FileMergingSnapshotManagerClosableWrapper fileMergingSnapshotManager;
+
     /** The changelog storage where the manager reads and writes the changelog */
     @Nullable private final StateChangelogStorage<?> stateChangelogStorage;
-
-    /** The file merging snapshot */
-    @Nullable private final FileMergingSnapshotManager fileMergingSnapshotManager;
 
     private final TaskExecutorStateChangelogStoragesManager changelogStoragesManager;
 
@@ -96,7 +96,7 @@ public class TaskStateManagerImpl implements TaskStateManager {
             @Nonnull JobID jobId,
             @Nonnull ExecutionAttemptID executionAttemptID,
             @Nonnull TaskLocalStateStore localStateStore,
-            @Nullable FileMergingSnapshotManager fileMergingSnapshotManager,
+            @Nullable FileMergingSnapshotManagerClosableWrapper fileMergingSnapshotManager,
             @Nullable StateChangelogStorage<?> stateChangelogStorage,
             @Nonnull TaskExecutorStateChangelogStoragesManager changelogStoragesManager,
             @Nullable JobManagerTaskRestore jobManagerTaskRestore,
@@ -120,7 +120,7 @@ public class TaskStateManagerImpl implements TaskStateManager {
             @Nonnull JobID jobId,
             @Nonnull ExecutionAttemptID executionAttemptID,
             @Nonnull TaskLocalStateStore localStateStore,
-            @Nullable FileMergingSnapshotManager fileMergingSnapshotManager,
+            @Nullable FileMergingSnapshotManagerClosableWrapper fileMergingSnapshotManager,
             @Nullable StateChangelogStorage<?> stateChangelogStorage,
             @Nonnull TaskExecutorStateChangelogStoragesManager changelogStoragesManager,
             @Nullable JobManagerTaskRestore jobManagerTaskRestore,
@@ -299,7 +299,7 @@ public class TaskStateManagerImpl implements TaskStateManager {
     @Nullable
     @Override
     public FileMergingSnapshotManager getFileMergingSnapshotManager() {
-        return fileMergingSnapshotManager;
+        return fileMergingSnapshotManager == null ? null : fileMergingSnapshotManager.get();
     }
 
     /** Tracking when local state can be confirmed and disposed. */
@@ -317,5 +317,8 @@ public class TaskStateManagerImpl implements TaskStateManager {
     @Override
     public void close() throws Exception {
         sequentialChannelStateReader.close();
+        if (fileMergingSnapshotManager != null) {
+            fileMergingSnapshotManager.close();
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, the `FileMergingSnapshotManager` is created for each job, only when the corresponding job released, the manager is released and disposed. For failover scenario, the tasks quit but job is still there, leading a reuse of `FileMergingSnapshotManager`, which violates the design of `FileMergingSnapshotManager`.


## Brief change log

 - Make `TaskExecutorFileMergingManager` record reference from `ExecutionAttemptID` to `FileMergingSnapshotManager`, and release the reference when task resources release. 

## Verifying this change

This change is already covered by modified existing tests, such as `TaskExecutorFileMergingManagerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
