### PR TITLE
[FLINK-35406] Use inner serializer when casting RAW type to BINARY or…

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
@@ -53,7 +53,7 @@ class RawToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
     // legacy behavior
     isNull$290 = isNull$289;
     if (!isNull$290) {
-        result$291 = result$289.toBytes(typeSerializer$292);
+        result$291 = result$289.toBytes(typeSerializer$292.getInnerSerializer());
         isNull$290 = result$291 == null;
     } else {
         result$291 = null;
@@ -62,7 +62,7 @@ class RawToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
     // new behavior
     isNull$290 = isNull$289;
     if (!isNull$290) {
-        byte[] deserializedByteArray$76 = result$289.toBytes(typeSerializer$292);
+        byte[] deserializedByteArray$76 = result$289.toBytes(typeSerializer$292.getInnerSerializer());
         if (deserializedByteArray$76.length <= 3) {
             result$291 = deserializedByteArray$76;
         } else {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToBinaryCastRule.java
@@ -92,14 +92,18 @@ class RawToBinaryCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
         if (context.legacyBehaviour()
                 || !(couldTrim(targetLength) || (couldPad(targetLogicalType, targetLength)))) {
             return new CastRuleUtils.CodeWriter()
-                    .assignStmt(returnVariable, methodCall(inputTerm, "toBytes", typeSerializer))
+                    .assignStmt(
+                            returnVariable,
+                            methodCall(
+                                    inputTerm, "toBytes", typeSerializer + ".getInnerSerializer()"))
                     .toString();
         } else {
             return new CastRuleUtils.CodeWriter()
                     .declStmt(
                             byte[].class,
                             deserializedByteArrayTerm,
-                            methodCall(inputTerm, "toBytes", typeSerializer))
+                            methodCall(
+                                    inputTerm, "toBytes", typeSerializer + ".getInnerSerializer()"))
                     .ifStmt(
                             arrayLength(deserializedByteArrayTerm) + " <= " + targetLength,
                             thenWriter -> {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToStringCastRule.java
@@ -45,7 +45,7 @@ class RawToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
 
     isNull$0 = _myInputIsNull;
     if (!isNull$0) {
-        java.lang.Object deserializedObj$0 = _myInput.toObject(typeSerializer$2);
+        java.lang.Object deserializedObj$0 = _myInput.toObject(typeSerializer$2.getInnerSerializer());
         if (deserializedObj$0 != null) {
             java.lang.String resultString$1;
             resultString$1 = deserializedObj$0.toString().toString();

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToStringCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/RawToStringCastRule.java
@@ -92,7 +92,7 @@ class RawToStringCastRule extends AbstractNullAwareCodeGeneratorCastRule<Object,
                 .declStmt(
                         Object.class,
                         deserializedObjTerm,
-                        methodCall(inputTerm, "toObject", typeSerializer))
+                        methodCall(inputTerm, "toObject", typeSerializer + ".getInnerSerializer()"))
                 .ifStmt(
                         deserializedObjTerm + " != null",
                         thenWriter ->

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -20,12 +20,12 @@ package org.apache.flink.table.planner.functions;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
-import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.InstantiationUtil;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -412,13 +412,11 @@ class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
     }
 
     public static byte[] serializeLocalDateTime(LocalDateTime localDateTime) {
-        DataOutputSerializer dos = new DataOutputSerializer(16);
-        LocalDateTimeSerializer serializer = new LocalDateTimeSerializer();
         try {
-            serializer.serialize(localDateTime, dos);
+            return InstantiationUtil.serializeToByteArray(
+                    LocalDateTimeSerializer.INSTANCE, localDateTime);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        return dos.getCopyOfBuffer();
     }
 }


### PR DESCRIPTION
… STRING in cast rules

## What is the purpose of the change

This pull request fix the wrong behaviour in casting RAW to BINARY or STRING. 
The generated code in RawToStringCastRule and RawToBinaryCastRule use 
BinaryRawValueData::toBytes and BinaryRawValueData::toObject to convert 
RawValueData(to java object or byte array), which should use inner serializer 
instead of RawValueDataSerializer.


## Brief change log

 - 049fbd2 fix the wrong behaviour and add tests.


## Verifying this change

This change is convered by new test cases in CastFunctionMiscITCase and CastFunctionMiscLegacyITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
