### PR TITLE
[FLINK-35410][state] Avoid sync waiting in coordinator thread of ForSt executor

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
@@ -57,7 +57,7 @@ public class ForStStateExecutorTest extends ForStDBOperationTestBase {
                     buildStateRequest(state, StateRequestType.VALUE_UPDATE, i, "test-" + i, i * 2));
         }
 
-        forStStateExecutor.executeBatchRequests(stateRequestContainer);
+        forStStateExecutor.executeBatchRequests(stateRequestContainer).get();
 
         List<StateRequest<?, ?, ?>> checkList = new ArrayList<>();
         stateRequestContainer = forStStateExecutor.createStateRequestContainer();
@@ -99,7 +99,7 @@ public class ForStStateExecutorTest extends ForStDBOperationTestBase {
             stateRequestContainer.offer(
                     buildStateRequest(state, StateRequestType.VALUE_UPDATE, i, null, i * 2));
         }
-        forStStateExecutor.executeBatchRequests(stateRequestContainer);
+        forStStateExecutor.executeBatchRequests(stateRequestContainer).get();
 
         // 5. Check that the deleted value is null :  keyRange [keyNum - 100, keyNum + 100)
         stateRequestContainer = forStStateExecutor.createStateRequestContainer();
@@ -111,7 +111,7 @@ public class ForStStateExecutorTest extends ForStDBOperationTestBase {
             stateRequestContainer.offer(getRequest);
             checkList.add(getRequest);
         }
-        forStStateExecutor.executeBatchRequests(stateRequestContainer);
+        forStStateExecutor.executeBatchRequests(stateRequestContainer).get();
         for (StateRequest<?, ?, ?> getRequest : checkList) {
             assertThat(getRequest.getRequestType()).isEqualTo(StateRequestType.VALUE_GET);
             assertThat(((TestStateFuture<String>) getRequest.getFuture()).getCompletedResult())


### PR DESCRIPTION
## What is the purpose of the change

Currently, the coordinator thread of ForSt executor will sync wait the state access result. This PR fixes that.

## Brief change log

 - remove the `FutureUtils.waitForAll` in `ForStStateExecutor`

## Verifying this change

This change is a trivial rework. The behavior of `ForStStateExecutor` is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
