### PR TITLE
[FLINK-35347][table] Introduce embedded scheduler and EmbeddedWorkflowScheduler plugin to support full refresh mode for materialized table

### DIFF
--- a/flink-table/flink-sql-gateway/pom.xml
+++ b/flink-table/flink-sql-gateway/pom.xml
@@ -64,6 +64,13 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz</artifactId>
+            <version>${quartz.version}</version>
+            <optional>${flink.markBundledAsOptional}</optional>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -153,8 +160,27 @@
                         <artifactSet>
                             <includes combine.children="append">
                                 <include>org.apache.flink:flink-sql-gateway-api</include>
+                                <include>org.quartz-scheduler:quartz</include>
                             </includes>
                         </artifactSet>
+                        <filters>
+                            <filter>
+                                <artifact>org.quartz-scheduler:quartz</artifact>
+                                <excludes>
+                                    <exclude>**/checkstyle.xml</exclude>
+                                </excludes>
+                            </filter>
+                        </filters>
+                        <relocations>
+                            <relocation>
+                                <pattern>org.quartz</pattern>
+                                <shadedPattern>org.apache.flink.table.shaded.org.quartz</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>org.terracotta.quartz</pattern>
+                                <shadedPattern>org.apache.flink.table.shaded.org.terracotta.quartz</shadedPattern>
+                            </relocation>
+                        </relocations>
                     </configuration>
                 </execution>
             </executions>

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
@@ -24,6 +24,10 @@ import org.apache.flink.runtime.rest.RestServerEndpoint;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.table.gateway.api.SqlGatewayService;
 import org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpoint;
+import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowHandler;
+import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.DeleteEmbeddedSchedulerWorkflowHandler;
+import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowHandler;
+import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.SuspendEmbeddedSchedulerWorkflowHandler;
 import org.apache.flink.table.gateway.rest.handler.operation.CancelOperationHandler;
 import org.apache.flink.table.gateway.rest.handler.operation.CloseOperationHandler;
 import org.apache.flink.table.gateway.rest.handler.operation.GetOperationStatusHandler;
@@ -37,6 +41,10 @@ import org.apache.flink.table.gateway.rest.handler.statement.ExecuteStatementHan
 import org.apache.flink.table.gateway.rest.handler.statement.FetchResultsHandler;
 import org.apache.flink.table.gateway.rest.handler.util.GetApiVersionHandler;
 import org.apache.flink.table.gateway.rest.handler.util.GetInfoHandler;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.DeleteEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.SuspendEmbeddedSchedulerWorkflowHeaders;
 import org.apache.flink.table.gateway.rest.header.operation.CancelOperationHeaders;
 import org.apache.flink.table.gateway.rest.header.operation.CloseOperationHeaders;
 import org.apache.flink.table.gateway.rest.header.operation.GetOperationStatusHeaders;
@@ -50,6 +58,7 @@ import org.apache.flink.table.gateway.rest.header.statement.ExecuteStatementHead
 import org.apache.flink.table.gateway.rest.header.statement.FetchResultsHeaders;
 import org.apache.flink.table.gateway.rest.header.util.GetApiVersionHeaders;
 import org.apache.flink.table.gateway.rest.header.util.GetInfoHeaders;
+import org.apache.flink.table.gateway.workflow.scheduler.EmbeddedQuartzScheduler;
 import org.apache.flink.util.ConfigurationException;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
@@ -63,11 +72,13 @@ import java.util.concurrent.CompletableFuture;
 public class SqlGatewayRestEndpoint extends RestServerEndpoint implements SqlGatewayEndpoint {
 
     public final SqlGatewayService service;
+    private final EmbeddedQuartzScheduler quartzScheduler;
 
     public SqlGatewayRestEndpoint(Configuration configuration, SqlGatewayService sqlGatewayService)
             throws IOException, ConfigurationException {
         super(configuration);
         service = sqlGatewayService;
+        quartzScheduler = new EmbeddedQuartzScheduler();
     }
 
     @Override
@@ -78,6 +89,7 @@ public class SqlGatewayRestEndpoint extends RestServerEndpoint implements SqlGat
         addOperationRelatedHandlers(handlers);
         addUtilRelatedHandlers(handlers);
         addStatementRelatedHandlers(handlers);
+        addEmbeddedSchedulerRelatedHandlers(handlers);
         return handlers;
     }
 
@@ -181,11 +193,57 @@ public class SqlGatewayRestEndpoint extends RestServerEndpoint implements SqlGat
                                 service, responseHeaders, FetchResultsHeaders.getInstanceV1())));
     }
 
+    private void addEmbeddedSchedulerRelatedHandlers(
+            List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers) {
+        // create workflow
+        CreateEmbeddedSchedulerWorkflowHandler createHandler =
+                new CreateEmbeddedSchedulerWorkflowHandler(
+                        service,
+                        quartzScheduler,
+                        responseHeaders,
+                        CreateEmbeddedSchedulerWorkflowHeaders.getInstance());
+        handlers.add(
+                Tuple2.of(CreateEmbeddedSchedulerWorkflowHeaders.getInstance(), createHandler));
+
+        // suspend workflow
+        SuspendEmbeddedSchedulerWorkflowHandler suspendHandler =
+                new SuspendEmbeddedSchedulerWorkflowHandler(
+                        service,
+                        quartzScheduler,
+                        responseHeaders,
+                        SuspendEmbeddedSchedulerWorkflowHeaders.getInstance());
+        handlers.add(
+                Tuple2.of(SuspendEmbeddedSchedulerWorkflowHeaders.getInstance(), suspendHandler));
+
+        // resume workflow
+        ResumeEmbeddedSchedulerWorkflowHandler resumeHandler =
+                new ResumeEmbeddedSchedulerWorkflowHandler(
+                        service,
+                        quartzScheduler,
+                        responseHeaders,
+                        ResumeEmbeddedSchedulerWorkflowHeaders.getInstance());
+        handlers.add(
+                Tuple2.of(ResumeEmbeddedSchedulerWorkflowHeaders.getInstance(), resumeHandler));
+
+        // delete workflow
+        DeleteEmbeddedSchedulerWorkflowHandler deleteHandler =
+                new DeleteEmbeddedSchedulerWorkflowHandler(
+                        service,
+                        quartzScheduler,
+                        responseHeaders,
+                        DeleteEmbeddedSchedulerWorkflowHeaders.getInstance());
+        handlers.add(
+                Tuple2.of(DeleteEmbeddedSchedulerWorkflowHeaders.getInstance(), deleteHandler));
+    }
+
     @Override
-    protected void startInternal() {}
+    protected void startInternal() {
+        quartzScheduler.start();
+    }
 
     @Override
     public void stop() throws Exception {
         super.close();
+        quartzScheduler.stop();
     }
 }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowResponseBody;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
+import org.apache.flink.table.gateway.workflow.WorkflowInfo;
+import org.apache.flink.table.gateway.workflow.scheduler.EmbeddedQuartzScheduler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Handler to create workflow in embedded scheduler. */
+public class CreateEmbeddedSchedulerWorkflowHandler
+        extends AbstractSqlGatewayRestHandler<
+                CreateEmbeddedSchedulerWorkflowRequestBody,
+                CreateEmbeddedSchedulerWorkflowResponseBody,
+                EmptyMessageParameters> {
+
+    private final EmbeddedQuartzScheduler quartzScheduler;
+
+    public CreateEmbeddedSchedulerWorkflowHandler(
+            SqlGatewayService service,
+            EmbeddedQuartzScheduler quartzScheduler,
+            Map<String, String> responseHeaders,
+            MessageHeaders<
+                            CreateEmbeddedSchedulerWorkflowRequestBody,
+                            CreateEmbeddedSchedulerWorkflowResponseBody,
+                            EmptyMessageParameters>
+                    messageHeaders) {
+        super(service, responseHeaders, messageHeaders);
+        this.quartzScheduler = quartzScheduler;
+    }
+
+    @Override
+    protected CompletableFuture<CreateEmbeddedSchedulerWorkflowResponseBody> handleRequest(
+            @Nullable SqlGatewayRestAPIVersion version,
+            @Nonnull HandlerRequest<CreateEmbeddedSchedulerWorkflowRequestBody> request)
+            throws RestHandlerException {
+        String materializedTableIdentifier =
+                request.getRequestBody().getMaterializedTableIdentifier();
+        String cronExpression = request.getRequestBody().getCronExpression();
+        Map<String, String> dynamicOptions = request.getRequestBody().getDynamicOptions();
+        Map<String, String> executionConfig = request.getRequestBody().getExecutionConfig();
+        String customScheduleTime = request.getRequestBody().getCustomScheduleTime();
+        String restEndpointURL = request.getRequestBody().getRestEndpointUrl();
+        WorkflowInfo workflowInfo =
+                new WorkflowInfo(
+                        materializedTableIdentifier,
+                        dynamicOptions == null ? Collections.emptyMap() : dynamicOptions,
+                        executionConfig == null ? Collections.emptyMap() : executionConfig,
+                        customScheduleTime,
+                        restEndpointURL);
+        try {
+            JobDetail jobDetail =
+                    quartzScheduler.createScheduleWorkflow(workflowInfo, cronExpression);
+            JobKey jobKey = jobDetail.getKey();
+            return CompletableFuture.completedFuture(
+                    new CreateEmbeddedSchedulerWorkflowResponseBody(
+                            jobKey.getName(), jobKey.getGroup()));
+        } catch (Exception e) {
+            throw new RestHandlerException(
+                    e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/DeleteEmbeddedSchedulerWorkflowHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/DeleteEmbeddedSchedulerWorkflowHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.EmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
+import org.apache.flink.table.gateway.workflow.scheduler.EmbeddedQuartzScheduler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Handler to delete workflow in embedded scheduler. */
+public class DeleteEmbeddedSchedulerWorkflowHandler
+        extends AbstractSqlGatewayRestHandler<
+                EmbeddedSchedulerWorkflowRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+
+    private final EmbeddedQuartzScheduler quartzScheduler;
+
+    public DeleteEmbeddedSchedulerWorkflowHandler(
+            SqlGatewayService service,
+            EmbeddedQuartzScheduler quartzScheduler,
+            Map<String, String> responseHeaders,
+            MessageHeaders<
+                            EmbeddedSchedulerWorkflowRequestBody,
+                            EmptyResponseBody,
+                            EmptyMessageParameters>
+                    messageHeaders) {
+        super(service, responseHeaders, messageHeaders);
+        this.quartzScheduler = quartzScheduler;
+    }
+
+    @Override
+    protected CompletableFuture<EmptyResponseBody> handleRequest(
+            @Nullable SqlGatewayRestAPIVersion version,
+            @Nonnull HandlerRequest<EmbeddedSchedulerWorkflowRequestBody> request)
+            throws RestHandlerException {
+        String workflowName = request.getRequestBody().getWorkflowName();
+        String workflowGroup = request.getRequestBody().getWorkflowGroup();
+        try {
+            quartzScheduler.deleteScheduleWorkflow(workflowName, workflowGroup);
+            return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
+        } catch (Exception e) {
+            throw new RestHandlerException(
+                    e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.EmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
+import org.apache.flink.table.gateway.workflow.scheduler.EmbeddedQuartzScheduler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Handler to resume workflow in embedded scheduler. */
+public class ResumeEmbeddedSchedulerWorkflowHandler
+        extends AbstractSqlGatewayRestHandler<
+                EmbeddedSchedulerWorkflowRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+
+    private final EmbeddedQuartzScheduler quartzScheduler;
+
+    public ResumeEmbeddedSchedulerWorkflowHandler(
+            SqlGatewayService service,
+            EmbeddedQuartzScheduler quartzScheduler,
+            Map<String, String> responseHeaders,
+            MessageHeaders<
+                            EmbeddedSchedulerWorkflowRequestBody,
+                            EmptyResponseBody,
+                            EmptyMessageParameters>
+                    messageHeaders) {
+        super(service, responseHeaders, messageHeaders);
+        this.quartzScheduler = quartzScheduler;
+    }
+
+    @Override
+    protected CompletableFuture<EmptyResponseBody> handleRequest(
+            @Nullable SqlGatewayRestAPIVersion version,
+            @Nonnull HandlerRequest<EmbeddedSchedulerWorkflowRequestBody> request)
+            throws RestHandlerException {
+        String workflowName = request.getRequestBody().getWorkflowName();
+        String workflowGroup = request.getRequestBody().getWorkflowGroup();
+        try {
+            quartzScheduler.resumeScheduleWorkflow(workflowName, workflowGroup);
+            return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
+        } catch (Exception e) {
+            throw new RestHandlerException(
+                    e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/SuspendEmbeddedSchedulerWorkflowHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/SuspendEmbeddedSchedulerWorkflowHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.EmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
+import org.apache.flink.table.gateway.workflow.scheduler.EmbeddedQuartzScheduler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Handler to suspend workflow in embedded scheduler. */
+public class SuspendEmbeddedSchedulerWorkflowHandler
+        extends AbstractSqlGatewayRestHandler<
+                EmbeddedSchedulerWorkflowRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+
+    private final EmbeddedQuartzScheduler quartzScheduler;
+
+    public SuspendEmbeddedSchedulerWorkflowHandler(
+            SqlGatewayService service,
+            EmbeddedQuartzScheduler quartzScheduler,
+            Map<String, String> responseHeaders,
+            MessageHeaders<
+                            EmbeddedSchedulerWorkflowRequestBody,
+                            EmptyResponseBody,
+                            EmptyMessageParameters>
+                    messageHeaders) {
+        super(service, responseHeaders, messageHeaders);
+        this.quartzScheduler = quartzScheduler;
+    }
+
+    @Override
+    protected CompletableFuture<EmptyResponseBody> handleRequest(
+            @Nullable SqlGatewayRestAPIVersion version,
+            @Nonnull HandlerRequest<EmbeddedSchedulerWorkflowRequestBody> request)
+            throws RestHandlerException {
+        String workflowName = request.getRequestBody().getWorkflowName();
+        String workflowGroup = request.getRequestBody().getWorkflowGroup();
+        try {
+            quartzScheduler.suspendScheduleWorkflow(workflowName, workflowGroup);
+            return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
+        } catch (Exception e) {
+            throw new RestHandlerException(
+                    e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/AbstractEmbeddedSchedulerWorkflowHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/AbstractEmbeddedSchedulerWorkflowHeaders.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.header.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
+import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.EmbeddedSchedulerWorkflowRequestBody;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion.V3;
+
+/** Abstract modify and delete workflow related message headers. */
+public abstract class AbstractEmbeddedSchedulerWorkflowHeaders
+        implements SqlGatewayMessageHeaders<
+                EmbeddedSchedulerWorkflowRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public Class<EmptyResponseBody> getResponseClass() {
+        return EmptyResponseBody.class;
+    }
+
+    @Override
+    public Class<EmbeddedSchedulerWorkflowRequestBody> getRequestClass() {
+        return EmbeddedSchedulerWorkflowRequestBody.class;
+    }
+
+    @Override
+    public EmptyMessageParameters getUnresolvedMessageParameters() {
+        return EmptyMessageParameters.getInstance();
+    }
+
+    @Override
+    public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
+        return Collections.singleton(V3);
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowHeaders.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.header.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
+import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowResponseBody;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion.V3;
+
+/** Message headers for create workflow in embedded scheduler. */
+public class CreateEmbeddedSchedulerWorkflowHeaders
+        implements SqlGatewayMessageHeaders<
+                CreateEmbeddedSchedulerWorkflowRequestBody,
+                CreateEmbeddedSchedulerWorkflowResponseBody,
+                EmptyMessageParameters> {
+
+    private static final CreateEmbeddedSchedulerWorkflowHeaders INSTANCE =
+            new CreateEmbeddedSchedulerWorkflowHeaders();
+
+    public static final String URL = "/workflow/embedded-scheduler/create";
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.POST;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public Class<CreateEmbeddedSchedulerWorkflowResponseBody> getResponseClass() {
+        return CreateEmbeddedSchedulerWorkflowResponseBody.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Create workflow";
+    }
+
+    @Override
+    public Class<CreateEmbeddedSchedulerWorkflowRequestBody> getRequestClass() {
+        return CreateEmbeddedSchedulerWorkflowRequestBody.class;
+    }
+
+    @Override
+    public EmptyMessageParameters getUnresolvedMessageParameters() {
+        return EmptyMessageParameters.getInstance();
+    }
+
+    @Override
+    public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
+        return Collections.singleton(V3);
+    }
+
+    public static CreateEmbeddedSchedulerWorkflowHeaders getInstance() {
+        return INSTANCE;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/DeleteEmbeddedSchedulerWorkflowHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/DeleteEmbeddedSchedulerWorkflowHeaders.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.header.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+
+/** Message headers for delete workflow in embedded scheduler. */
+public class DeleteEmbeddedSchedulerWorkflowHeaders
+        extends AbstractEmbeddedSchedulerWorkflowHeaders {
+
+    private static final DeleteEmbeddedSchedulerWorkflowHeaders INSTANCE =
+            new DeleteEmbeddedSchedulerWorkflowHeaders();
+
+    public static final String URL = "/workflow/embedded-scheduler/delete";
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.DELETE;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Delete workflow";
+    }
+
+    public static DeleteEmbeddedSchedulerWorkflowHeaders getInstance() {
+        return INSTANCE;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowHeaders.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.header.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+
+/** Message headers for resume workflow in embedded scheduler. */
+public class ResumeEmbeddedSchedulerWorkflowHeaders
+        extends AbstractEmbeddedSchedulerWorkflowHeaders {
+
+    private static final ResumeEmbeddedSchedulerWorkflowHeaders INSTANCE =
+            new ResumeEmbeddedSchedulerWorkflowHeaders();
+
+    public static final String URL = "/workflow/embedded-scheduler/resume";
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.POST;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Resume workflow";
+    }
+
+    public static ResumeEmbeddedSchedulerWorkflowHeaders getInstance() {
+        return INSTANCE;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/SuspendEmbeddedSchedulerWorkflowHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/SuspendEmbeddedSchedulerWorkflowHeaders.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.header.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+
+/** Message headers for suspend workflow in embedded scheduler. */
+public class SuspendEmbeddedSchedulerWorkflowHeaders
+        extends AbstractEmbeddedSchedulerWorkflowHeaders {
+
+    private static final SuspendEmbeddedSchedulerWorkflowHeaders INSTANCE =
+            new SuspendEmbeddedSchedulerWorkflowHeaders();
+
+    public static final String URL = "/workflow/embedded-scheduler/suspend";
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.POST;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Suspend workflow";
+    }
+
+    public static SuspendEmbeddedSchedulerWorkflowHeaders getInstance() {
+        return INSTANCE;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/session/ConfigureSessionHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/session/ConfigureSessionHeaders.java
@@ -29,8 +29,8 @@ import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 /** Message headers for configuring a session. */
 public class ConfigureSessionHeaders
@@ -87,7 +87,7 @@ public class ConfigureSessionHeaders
 
     @Override
     public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
-        return Collections.singleton(SqlGatewayRestAPIVersion.V2);
+        return Arrays.asList(SqlGatewayRestAPIVersion.V2, SqlGatewayRestAPIVersion.V3);
     }
 
     public static ConfigureSessionHeaders getInstance() {

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/statement/CompleteStatementHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/statement/CompleteStatementHeaders.java
@@ -29,8 +29,8 @@ import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 /** Message headers for completing a statement. */
 public class CompleteStatementHeaders
@@ -81,7 +81,7 @@ public class CompleteStatementHeaders
 
     @Override
     public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
-        return Collections.singleton(SqlGatewayRestAPIVersion.V2);
+        return Arrays.asList(SqlGatewayRestAPIVersion.V2, SqlGatewayRestAPIVersion.V3);
     }
 
     public static CompleteStatementHeaders getInstance() {

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowRequestBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowRequestBody.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+/** {@link RequestBody} for create workflow in embedded scheduler. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateEmbeddedSchedulerWorkflowRequestBody implements RequestBody {
+
+    private static final String FIELD_NAME_MATERIALIZED_TABLE = "materializedTableIdentifier";
+    private static final String FIELD_NAME_CRON_EXPRESSION = "cronExpression";
+    private static final String FIELD_NAME_DYNAMIC_OPTIONS = "dynamicOptions";
+    private static final String FIELD_NAME_EXECUTION_CONFIG = "executionConfig";
+    private static final String FIELD_NAME_SCHEDULE_TIME = "customScheduleTime";
+    private static final String FIELD_NAME_REST_ENDPOINT_URL = "restEndpointUrl";
+
+    @JsonProperty(FIELD_NAME_MATERIALIZED_TABLE)
+    private final String materializedTableIdentifier;
+
+    @JsonProperty(FIELD_NAME_CRON_EXPRESSION)
+    private final String cronExpression;
+
+    @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS)
+    @Nullable
+    private final Map<String, String> dynamicOptions;
+
+    @JsonProperty(FIELD_NAME_EXECUTION_CONFIG)
+    @Nullable
+    private final Map<String, String> executionConfig;
+
+    @JsonProperty(FIELD_NAME_SCHEDULE_TIME)
+    @Nullable
+    private final String customScheduleTime;
+
+    private final String restEndpointUrl;
+
+    @JsonCreator
+    public CreateEmbeddedSchedulerWorkflowRequestBody(
+            @JsonProperty(FIELD_NAME_MATERIALIZED_TABLE) String materializedTableIdentifier,
+            @JsonProperty(FIELD_NAME_CRON_EXPRESSION) String cronExpression,
+            @Nullable @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS) Map<String, String> dynamicOptions,
+            @Nullable @JsonProperty(FIELD_NAME_EXECUTION_CONFIG)
+                    Map<String, String> executionConfig,
+            @Nullable @JsonProperty(FIELD_NAME_SCHEDULE_TIME) String customScheduleTime,
+            @JsonProperty(FIELD_NAME_REST_ENDPOINT_URL) String restEndpointUrl) {
+        this.materializedTableIdentifier = materializedTableIdentifier;
+        this.cronExpression = cronExpression;
+        this.dynamicOptions = dynamicOptions;
+        this.executionConfig = executionConfig;
+        this.customScheduleTime = customScheduleTime;
+        this.restEndpointUrl = restEndpointUrl;
+    }
+
+    public String getMaterializedTableIdentifier() {
+        return materializedTableIdentifier;
+    }
+
+    @Nullable
+    public Map<String, String> getDynamicOptions() {
+        return dynamicOptions;
+    }
+
+    @Nullable
+    public Map<String, String> getExecutionConfig() {
+        return executionConfig;
+    }
+
+    @Nullable
+    public String getCustomScheduleTime() {
+        return customScheduleTime;
+    }
+
+    public String getCronExpression() {
+        return cronExpression;
+    }
+
+    public String getRestEndpointUrl() {
+        return restEndpointUrl;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowResponseBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowResponseBody.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+/** {@link ResponseBody} for create workflow in embedded scheduler. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateEmbeddedSchedulerWorkflowResponseBody implements ResponseBody {
+
+    private static final String FIELD_NAME_WORKFLOW_NAME = "workflowName";
+    private static final String FIELD_NAME_WORKFLOW_GROUP = "workflowGroup";
+
+    @JsonProperty(FIELD_NAME_WORKFLOW_NAME)
+    private final String workflowName;
+
+    @JsonProperty(FIELD_NAME_WORKFLOW_GROUP)
+    private final String workflowGroup;
+
+    public CreateEmbeddedSchedulerWorkflowResponseBody(
+            @JsonProperty(FIELD_NAME_WORKFLOW_NAME) String workflowName,
+            @JsonProperty(FIELD_NAME_WORKFLOW_GROUP) String workflowGroup) {
+        this.workflowName = workflowName;
+        this.workflowGroup = workflowGroup;
+    }
+
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    public String getWorkflowGroup() {
+        return workflowGroup;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/EmbeddedSchedulerWorkflowRequestBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/EmbeddedSchedulerWorkflowRequestBody.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+/** {@link RequestBody} for suspend, resume, delete workflow in embedded scheduler. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EmbeddedSchedulerWorkflowRequestBody implements RequestBody {
+
+    private static final String FIELD_NAME_WORKFLOW_NAME = "workflowName";
+    private static final String FIELD_NAME_WORKFLOW_GROUP = "workflowGroup";
+
+    @JsonProperty(FIELD_NAME_WORKFLOW_NAME)
+    private final String workflowName;
+
+    @JsonProperty(FIELD_NAME_WORKFLOW_GROUP)
+    private final String workflowGroup;
+
+    @JsonCreator
+    public EmbeddedSchedulerWorkflowRequestBody(
+            @JsonProperty(FIELD_NAME_WORKFLOW_NAME) String workflowName,
+            @JsonProperty(FIELD_NAME_WORKFLOW_GROUP) String workflowGroup) {
+        this.workflowName = workflowName;
+        this.workflowGroup = workflowGroup;
+    }
+
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    public String getWorkflowGroup() {
+        return workflowGroup;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/util/SqlGatewayRestAPIVersion.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/util/SqlGatewayRestAPIVersion.java
@@ -48,7 +48,10 @@ public enum SqlGatewayRestAPIVersion
 
     // V2 adds support for configuring Session and allows to serialize the RowData with PLAIN_TEXT
     // or JSON format.
-    V2(true, true);
+    V2(false, true),
+
+    // V3 introduces materialized table related APIs
+    V3(true, true);
 
     private final boolean isDefaultVersion;
 

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedRefreshHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedRefreshHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.refresh.RefreshHandler;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** A {@link RefreshHandler} instance for embedded workflow scheduler. */
+@PublicEvolving
+public class EmbeddedRefreshHandler implements RefreshHandler, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String workflowName;
+    private final String workflowGroup;
+
+    public EmbeddedRefreshHandler(String workflowName, String workflowGroup) {
+        this.workflowName = workflowName;
+        this.workflowGroup = workflowGroup;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format(
+                "{\n  workflowName: %s,\n  workflowGroup: %s\n}", workflowName, workflowGroup);
+    }
+
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    public String getWorkflowGroup() {
+        return workflowGroup;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EmbeddedRefreshHandler that = (EmbeddedRefreshHandler) o;
+        return Objects.equals(workflowName, that.workflowName)
+                && Objects.equals(workflowGroup, that.workflowGroup);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(workflowName, workflowGroup);
+    }
+
+    @Override
+    public String toString() {
+        return "EmbeddedRefreshHandler{"
+                + "workflowName='"
+                + workflowName
+                + '\''
+                + ", workflowGroup='"
+                + workflowGroup
+                + '\''
+                + '}';
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedRefreshHandlerSerializer.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedRefreshHandlerSerializer.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.refresh.RefreshHandlerSerializer;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+
+/** {@link RefreshHandlerSerializer} for {@link EmbeddedRefreshHandler}. */
+@PublicEvolving
+public class EmbeddedRefreshHandlerSerializer
+        implements RefreshHandlerSerializer<EmbeddedRefreshHandler> {
+
+    public static final EmbeddedRefreshHandlerSerializer INSTANCE =
+            new EmbeddedRefreshHandlerSerializer();
+
+    @Override
+    public byte[] serialize(EmbeddedRefreshHandler refreshHandler) throws IOException {
+        return InstantiationUtil.serializeObject(refreshHandler);
+    }
+
+    @Override
+    public EmbeddedRefreshHandler deserialize(byte[] serializedBytes, ClassLoader cl)
+            throws IOException, ClassNotFoundException {
+        return InstantiationUtil.deserializeObject(serializedBytes, cl);
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedWorkflowScheduler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedWorkflowScheduler.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.runtime.rest.RestClient;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.DeleteEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.SuspendEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowResponseBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.EmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.gateway.workflow.scheduler.EmbeddedQuartzScheduler;
+import org.apache.flink.table.workflow.CreatePeriodicRefreshWorkflow;
+import org.apache.flink.table.workflow.CreateRefreshWorkflow;
+import org.apache.flink.table.workflow.DeleteRefreshWorkflow;
+import org.apache.flink.table.workflow.ModifyRefreshWorkflow;
+import org.apache.flink.table.workflow.ResumeRefreshWorkflow;
+import org.apache.flink.table.workflow.SuspendRefreshWorkflow;
+import org.apache.flink.table.workflow.WorkflowException;
+import org.apache.flink.table.workflow.WorkflowScheduler;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A workflow scheduler plugin implementation for {@link EmbeddedQuartzScheduler}. It is used to
+ * create, modify refresh workflow for materialized table.
+ */
+@PublicEvolving
+public class EmbeddedWorkflowScheduler implements WorkflowScheduler<EmbeddedRefreshHandler> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmbeddedWorkflowScheduler.class);
+
+    private final Configuration configuration;
+    private final String restAddress;
+    private final int port;
+
+    private RestClient restClient;
+
+    public EmbeddedWorkflowScheduler(Configuration configuration) {
+        this.configuration = configuration;
+        this.restAddress = configuration.get(RestOptions.ADDRESS);
+        this.port = configuration.get(RestOptions.PORT);
+    }
+
+    @Override
+    public void open() throws WorkflowException {
+        try {
+            restClient = new RestClient(configuration, Executors.directExecutor());
+        } catch (Exception e) {
+            throw new WorkflowException(
+                    "Could not create RestClient to connect to embedded scheduler.", e);
+        }
+    }
+
+    @Override
+    public void close() throws WorkflowException {
+        restClient.closeAsync();
+    }
+
+    @Override
+    public EmbeddedRefreshHandlerSerializer getRefreshHandlerSerializer() {
+        return EmbeddedRefreshHandlerSerializer.INSTANCE;
+    }
+
+    @Override
+    public EmbeddedRefreshHandler createRefreshWorkflow(CreateRefreshWorkflow createRefreshWorkflow)
+            throws WorkflowException {
+        if (createRefreshWorkflow instanceof CreatePeriodicRefreshWorkflow) {
+            CreatePeriodicRefreshWorkflow periodicRefreshWorkflow =
+                    (CreatePeriodicRefreshWorkflow) createRefreshWorkflow;
+            ObjectIdentifier materializedTableIdentifier =
+                    periodicRefreshWorkflow.getMaterializedTableIdentifier();
+            CreateEmbeddedSchedulerWorkflowRequestBody requestBody =
+                    new CreateEmbeddedSchedulerWorkflowRequestBody(
+                            materializedTableIdentifier.asSerializableString(),
+                            periodicRefreshWorkflow.getCronExpression(),
+                            periodicRefreshWorkflow.getDynamicOptions(),
+                            periodicRefreshWorkflow.getExecutionConfig(),
+                            null,
+                            periodicRefreshWorkflow.getRestEndpointUrl());
+            CreateEmbeddedSchedulerWorkflowResponseBody responseBody;
+            try {
+                responseBody =
+                        restClient
+                                .sendRequest(
+                                        restAddress,
+                                        port,
+                                        CreateEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                                        EmptyMessageParameters.getInstance(),
+                                        requestBody)
+                                .get(30, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                LOG.error(
+                        "Failed to create periodic refresh workflow for materialized table {}.",
+                        materializedTableIdentifier,
+                        e);
+                throw new WorkflowException(
+                        String.format(
+                                "Failed to create periodic refresh workflow for materialized table %s.",
+                                materializedTableIdentifier),
+                        e);
+            }
+
+            return new EmbeddedRefreshHandler(
+                    responseBody.getWorkflowName(), responseBody.getWorkflowGroup());
+        } else {
+            LOG.error(
+                    "Unsupported create refresh workflow type {}.",
+                    createRefreshWorkflow.getClass().getSimpleName());
+            throw new WorkflowException(
+                    String.format(
+                            "Unsupported create refresh workflow type %s.",
+                            createRefreshWorkflow.getClass().getSimpleName()));
+        }
+    }
+
+    @Override
+    public void modifyRefreshWorkflow(
+            ModifyRefreshWorkflow<EmbeddedRefreshHandler> modifyRefreshWorkflow)
+            throws WorkflowException {
+        EmbeddedRefreshHandler embeddedRefreshHandler = modifyRefreshWorkflow.getRefreshHandler();
+        EmbeddedSchedulerWorkflowRequestBody requestBody =
+                new EmbeddedSchedulerWorkflowRequestBody(
+                        embeddedRefreshHandler.getWorkflowName(),
+                        embeddedRefreshHandler.getWorkflowGroup());
+        if (modifyRefreshWorkflow instanceof SuspendRefreshWorkflow) {
+            try {
+                restClient
+                        .sendRequest(
+                                restAddress,
+                                port,
+                                SuspendEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                                EmptyMessageParameters.getInstance(),
+                                requestBody)
+                        .get(30, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                LOG.error(
+                        "Failed to suspend refresh workflow {}.",
+                        embeddedRefreshHandler.asSummaryString(),
+                        e);
+                throw new WorkflowException(
+                        String.format(
+                                "Failed to suspend refresh workflow %s.",
+                                embeddedRefreshHandler.asSummaryString()),
+                        e);
+            }
+        } else if (modifyRefreshWorkflow instanceof ResumeRefreshWorkflow) {
+            try {
+                restClient
+                        .sendRequest(
+                                restAddress,
+                                port,
+                                ResumeEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                                EmptyMessageParameters.getInstance(),
+                                requestBody)
+                        .get(30, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                LOG.error(
+                        "Failed to resume refresh workflow {}.",
+                        embeddedRefreshHandler.asSummaryString(),
+                        e);
+                throw new WorkflowException(
+                        String.format(
+                                "Failed to resume refresh workflow %s.",
+                                embeddedRefreshHandler.asSummaryString()),
+                        e);
+            }
+        } else {
+            LOG.error(
+                    "Unsupported modify refresh workflow type {}.",
+                    modifyRefreshWorkflow.getClass().getSimpleName());
+            throw new WorkflowException(
+                    String.format(
+                            "Unsupported modify refresh workflow type %s.",
+                            modifyRefreshWorkflow.getClass().getSimpleName()));
+        }
+    }
+
+    @Override
+    public void deleteRefreshWorkflow(
+            DeleteRefreshWorkflow<EmbeddedRefreshHandler> deleteRefreshWorkflow)
+            throws WorkflowException {
+        EmbeddedRefreshHandler embeddedRefreshHandler = deleteRefreshWorkflow.getRefreshHandler();
+        EmbeddedSchedulerWorkflowRequestBody requestBody =
+                new EmbeddedSchedulerWorkflowRequestBody(
+                        embeddedRefreshHandler.getWorkflowName(),
+                        embeddedRefreshHandler.getWorkflowGroup());
+        try {
+            restClient
+                    .sendRequest(
+                            restAddress,
+                            port,
+                            DeleteEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                            EmptyMessageParameters.getInstance(),
+                            requestBody)
+                    .get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            LOG.error(
+                    "Failed to delete refresh workflow {}.",
+                    embeddedRefreshHandler.asSummaryString(),
+                    e);
+            throw new WorkflowException(
+                    String.format(
+                            "Failed to delete refresh workflow %s.",
+                            embeddedRefreshHandler.asSummaryString()),
+                    e);
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedWorkflowSchedulerFactory.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedWorkflowSchedulerFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.factories.WorkflowSchedulerFactory;
+import org.apache.flink.table.gateway.rest.SqlGatewayRestEndpointFactory;
+import org.apache.flink.table.workflow.WorkflowScheduler;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils.getEndpointConfig;
+import static org.apache.flink.table.gateway.rest.SqlGatewayRestEndpointFactory.rebuildRestEndpointOptions;
+
+/** The {@link WorkflowSchedulerFactory} to create the {@link EmbeddedWorkflowScheduler}. */
+@PublicEvolving
+public class EmbeddedWorkflowSchedulerFactory implements WorkflowSchedulerFactory {
+
+    public static final String IDENTIFIER = "embedded";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public WorkflowScheduler<?> createWorkflowScheduler(Context context) {
+        Map<String, String> flinkConfigMap = context.getConfiguration().toMap();
+        Configuration configuration = Configuration.fromMap(flinkConfigMap);
+        Map<String, String> restEndpointConfigMap =
+                getEndpointConfig(configuration, SqlGatewayRestEndpointFactory.IDENTIFIER);
+        // Use the SqlGateway rest endpoint config
+        Configuration restConfig =
+                rebuildRestEndpointOptions(restEndpointConfigMap, flinkConfigMap);
+        return new EmbeddedWorkflowScheduler(restConfig);
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/WorkflowInfo.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/WorkflowInfo.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The {@link WorkflowInfo} represents the required information of one materialized table background
+ * workflow. It is used by {@code EmbeddedSchedulerJob} when trigger the execution of workflow.
+ *
+ * <p>Note: All member variables need be able to be serialized as json string.
+ */
+public class WorkflowInfo {
+
+    private final String materializedTableIdentifier;
+
+    private final Map<String, String> dynamicOptions;
+    private final Map<String, String> executionConfig;
+
+    private final @Nullable String customSchedulerTime;
+
+    private final String restEndpointUrl;
+
+    @JsonCreator
+    public WorkflowInfo(
+            @JsonProperty("materializedTableIdentifier") String materializedTableIdentifier,
+            @JsonProperty("dynamicOptions") Map<String, String> dynamicOptions,
+            @JsonProperty("executionConfig") Map<String, String> executionConfig,
+            @JsonProperty("customSchedulerTime") @Nullable String customSchedulerTime,
+            @JsonProperty("restEndpointUrl") String restEndpointUrl) {
+        this.materializedTableIdentifier = materializedTableIdentifier;
+        this.dynamicOptions = dynamicOptions;
+        this.executionConfig = executionConfig;
+        this.customSchedulerTime = customSchedulerTime;
+        this.restEndpointUrl = restEndpointUrl;
+    }
+
+    public String getMaterializedTableIdentifier() {
+        return materializedTableIdentifier;
+    }
+
+    public Map<String, String> getDynamicOptions() {
+        return dynamicOptions;
+    }
+
+    public Map<String, String> getExecutionConfig() {
+        return executionConfig;
+    }
+
+    @Nullable
+    public String getCustomSchedulerTime() {
+        return customSchedulerTime;
+    }
+
+    public String getRestEndpointUrl() {
+        return restEndpointUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        WorkflowInfo that = (WorkflowInfo) o;
+        return Objects.equals(materializedTableIdentifier, that.materializedTableIdentifier)
+                && Objects.equals(dynamicOptions, that.dynamicOptions)
+                && Objects.equals(executionConfig, that.executionConfig)
+                && Objects.equals(customSchedulerTime, that.customSchedulerTime)
+                && Objects.equals(restEndpointUrl, that.restEndpointUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                materializedTableIdentifier,
+                dynamicOptions,
+                executionConfig,
+                customSchedulerTime,
+                restEndpointUrl);
+    }
+
+    @Override
+    public String toString() {
+        return "WorkflowInfo{"
+                + "materializedTableIdentifier='"
+                + materializedTableIdentifier
+                + '\''
+                + ", dynamicOptions="
+                + dynamicOptions
+                + ", executionConfig="
+                + executionConfig
+                + ", customSchedulerTime='"
+                + customSchedulerTime
+                + '\''
+                + ", restEndpointUrl='"
+                + restEndpointUrl
+                + '\''
+                + '}';
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/scheduler/EmbeddedQuartzScheduler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/scheduler/EmbeddedQuartzScheduler.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow.scheduler;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.gateway.SqlGateway;
+import org.apache.flink.table.gateway.workflow.WorkflowInfo;
+
+import org.quartz.CronTrigger;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.TriggerKey;
+import org.quartz.impl.StdSchedulerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.WORKFLOW_INFO;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.fromJson;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.getJobKey;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.initializeQuartzSchedulerConfig;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.toJson;
+import static org.quartz.CronScheduleBuilder.cronSchedule;
+import static org.quartz.TriggerBuilder.newTrigger;
+
+/**
+ * An embedded workflow scheduler based on quartz {@link Scheduler} that store all workflow in
+ * memory, it does not have high availability. This scheduler will be embedded in {@link SqlGateway}
+ * process to provide service by rest api.
+ *
+ * <p>This embedded scheduler is mainly used for testing scenarios and is not suitable for
+ * production environment.
+ */
+@Internal
+public class EmbeddedQuartzScheduler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmbeddedQuartzScheduler.class);
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private Scheduler quartzScheduler;
+
+    public void start() {
+        Properties properties = initializeQuartzSchedulerConfig();
+        try {
+            quartzScheduler = new StdSchedulerFactory(properties).getScheduler();
+            quartzScheduler.start();
+            LOG.info("Start quartz scheduler successfully.");
+        } catch (org.quartz.SchedulerException e) {
+            String msg =
+                    String.format("Failed to start quartz scheduler with config: %s.", properties);
+            LOG.error(msg);
+            throw new SchedulerException(msg, e);
+        }
+    }
+
+    public void stop() {
+        try {
+            quartzScheduler.shutdown();
+        } catch (org.quartz.SchedulerException e) {
+            LOG.error("Failed to shutdown quartz schedule.");
+            throw new SchedulerException("Failed to shutdown quartz scheduler.", e);
+        }
+    }
+
+    public JobDetail createScheduleWorkflow(WorkflowInfo workflowInfo, String cronExpression)
+            throws SchedulerException {
+        String materializedTableIdentifier = workflowInfo.getMaterializedTableIdentifier();
+        JobKey jobKey = getJobKey(materializedTableIdentifier);
+
+        lock.writeLock().lock();
+        try {
+            // check if the quartz schedule job is exists firstly.
+            if (quartzScheduler.checkExists(jobKey)) {
+                LOG.error(
+                        "Materialized table {} quartz schedule job already exist, job info: {}.",
+                        materializedTableIdentifier,
+                        jobKey);
+                throw new SchedulerException(
+                        String.format(
+                                "Materialized table %s quartz schedule job already exist, job info: %s.",
+                                materializedTableIdentifier, jobKey));
+            }
+
+            JobDetail jobDetail =
+                    JobBuilder.newJob(EmbeddedSchedulerJob.class).withIdentity(jobKey).build();
+            // put workflow info to job data map
+            jobDetail.getJobDataMap().put(WORKFLOW_INFO, toJson(workflowInfo));
+
+            TriggerKey triggerKey = TriggerKey.triggerKey(jobKey.getName(), jobKey.getGroup());
+            CronTrigger cronTrigger =
+                    newTrigger()
+                            .withIdentity(triggerKey)
+                            .withSchedule(
+                                    cronSchedule(cronExpression)
+                                            .withMisfireHandlingInstructionIgnoreMisfires())
+                            .forJob(jobDetail)
+                            .build();
+
+            // Create job in quartz scheduler with cron trigger
+            quartzScheduler.scheduleJob(jobDetail, cronTrigger);
+            LOG.info(
+                    "Create quartz schedule job for materialized table {} successfully, job info: {}, cron expression: {}.",
+                    materializedTableIdentifier,
+                    jobKey,
+                    cronExpression);
+
+            return jobDetail;
+        } catch (org.quartz.SchedulerException e) {
+            LOG.error(
+                    "Failed to create quartz schedule job for materialized table {}.",
+                    materializedTableIdentifier,
+                    e);
+            throw new SchedulerException(
+                    String.format(
+                            "Failed to create quartz schedule job for materialized table %s.",
+                            materializedTableIdentifier),
+                    e);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void suspendScheduleWorkflow(String workflowName, String workflowGroup)
+            throws SchedulerException {
+        JobKey jobKey = JobKey.jobKey(workflowName, workflowGroup);
+        lock.writeLock().lock();
+        try {
+            String errorMsg =
+                    String.format(
+                            "Failed to suspend a non-existent quartz schedule job: %s.", jobKey);
+            checkJobExists(jobKey, errorMsg);
+
+            quartzScheduler.pauseJob(jobKey);
+        } catch (org.quartz.SchedulerException e) {
+            LOG.error("Failed to suspend quartz schedule job: {}.", jobKey, e);
+            throw new SchedulerException(
+                    String.format("Failed to suspend quartz schedule job: %s.", jobKey), e);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void resumeScheduleWorkflow(String workflowName, String workflowGroup)
+            throws SchedulerException {
+        JobKey jobKey = JobKey.jobKey(workflowName, workflowGroup);
+        lock.writeLock().lock();
+        try {
+            String errorMsg =
+                    String.format(
+                            "Failed to resume a non-existent quartz schedule job: %s.", jobKey);
+            checkJobExists(jobKey, errorMsg);
+
+            quartzScheduler.resumeJob(jobKey);
+        } catch (org.quartz.SchedulerException e) {
+            LOG.error("Failed to resume quartz schedule job: {}.", jobKey, e);
+            throw new SchedulerException(
+                    String.format("Failed to resume quartz schedule job: %s.", jobKey), e);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    public void deleteScheduleWorkflow(String workflowName, String workflowGroup)
+            throws SchedulerException {
+        JobKey jobKey = JobKey.jobKey(workflowName, workflowGroup);
+        lock.writeLock().lock();
+        try {
+            String errorMsg =
+                    String.format(
+                            "Failed to delete a non-existent quartz schedule job: %s.", jobKey);
+            checkJobExists(jobKey, errorMsg);
+
+            quartzScheduler.deleteJob(jobKey);
+        } catch (org.quartz.SchedulerException e) {
+            LOG.error("Failed to delete quartz schedule job: {}.", jobKey, e);
+            throw new SchedulerException(
+                    String.format("Failed to delete quartz schedule job: %s.", jobKey), e);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void checkJobExists(JobKey jobKey, String errorMsg)
+            throws org.quartz.SchedulerException {
+        if (!quartzScheduler.checkExists(jobKey)) {
+            LOG.error(errorMsg);
+            throw new SchedulerException(errorMsg);
+        }
+    }
+
+    /** The {@link Job} implementation for embedded quartz scheduler. */
+    private class EmbeddedSchedulerJob implements Job {
+
+        @Override
+        public void execute(JobExecutionContext context) throws JobExecutionException {
+            JobDataMap dataMap = context.getJobDetail().getJobDataMap();
+            String workflowJsonStr = dataMap.getString(WORKFLOW_INFO);
+            WorkflowInfo workflowInfo = fromJson(workflowJsonStr, WorkflowInfo.class);
+            // TODO: implement the refresh operation for materialized table, see FLINK-35348
+            LOG.info("Execute refresh operation for workflow: {}.", workflowInfo);
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/scheduler/QuartzSchedulerUtils.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/scheduler/QuartzSchedulerUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow.scheduler;
+
+import org.apache.flink.util.jackson.JacksonMapperFactory;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.quartz.JobKey;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Properties;
+
+import static org.quartz.impl.StdSchedulerFactory.PROP_SCHED_INSTANCE_NAME;
+import static org.quartz.impl.StdSchedulerFactory.PROP_SCHED_RMI_EXPORT;
+import static org.quartz.impl.StdSchedulerFactory.PROP_SCHED_RMI_PROXY;
+import static org.quartz.impl.StdSchedulerFactory.PROP_THREAD_POOL_CLASS;
+import static org.quartz.impl.StdSchedulerFactory.PROP_THREAD_POOL_PREFIX;
+
+/** Utility class for quartz scheduler. */
+public class QuartzSchedulerUtils {
+
+    public static final String SCHEDULE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    public static final DateTimeFormatter DEFAULT_DATETIME_FORMATTER =
+            DateTimeFormatter.ofPattern(SCHEDULE_TIME_FORMAT);
+
+    public static final String QUARTZ_JOB_PREFIX = "quartz_job";
+    public static final String QUARTZ_JOB_GROUP = "default_group";
+    public static final String UNDERLINE = "_";
+    public static final String WORKFLOW_INFO = "workflowInfo";
+
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
+
+    /**
+     * This method is used for initializing the quartz scheduler config, the related options copy
+     * from quartz.properties, but we override the option {@code org.quartz.threadPool.threadCount}
+     * to 1 for minimizing the thread impact to SqlGateway.
+     */
+    public static Properties initializeQuartzSchedulerConfig() {
+        Properties properties = new Properties();
+        properties.setProperty(PROP_SCHED_INSTANCE_NAME, "FlinkQuartzScheduler");
+        properties.setProperty(PROP_THREAD_POOL_PREFIX, "FlinkQuartzSchedulerThreadPool");
+        properties.setProperty(PROP_SCHED_RMI_EXPORT, "false");
+        properties.setProperty(PROP_SCHED_RMI_PROXY, "false");
+        properties.setProperty(PROP_THREAD_POOL_CLASS, "org.quartz.simpl.SimpleThreadPool");
+        properties.setProperty("org.quartz.threadPool.threadCount", "1");
+        properties.setProperty("org.quartz.threadPool.threadPriority", "5");
+        properties.setProperty(
+                "org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread",
+                "true");
+        properties.setProperty(
+                "org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread",
+                "true");
+        properties.setProperty("org.quartz.jobStore.misfireThreshold", "60000");
+        properties.setProperty("org.quartz.jobStore.class", "org.quartz.simpl.RAMJobStore");
+
+        return properties;
+    }
+
+    public static JobKey getJobKey(String materializedTableIdentifier) {
+        String jobName = QUARTZ_JOB_PREFIX + UNDERLINE + materializedTableIdentifier;
+        return JobKey.jobKey(jobName, QUARTZ_JOB_GROUP);
+    }
+
+    public static <T> T fromJson(String json, Class<T> clazz) {
+        try {
+            return OBJECT_MAPPER.readValue(json, clazz);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    String.format(
+                            "Failed to deserialize JSON string to %s: %s.",
+                            clazz.getSimpleName(), e.getMessage()),
+                    e);
+        }
+    }
+
+    public static <T> String toJson(T t) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(t);
+        } catch (IOException e) {
+            throw new UncheckedIOException(
+                    String.format(
+                            "Failed to serialize instance of %s to JSON string: %s.",
+                            t.getClass().getSimpleName(), e.getMessage()),
+                    e);
+        }
+    }
+
+    public static String dateToString(Date date) {
+        return date2LocalDateTime(date).format(DEFAULT_DATETIME_FORMATTER);
+    }
+
+    /**
+     * Convert date to local datetime.
+     *
+     * @param date date
+     * @return local datetime
+     */
+    private static LocalDateTime date2LocalDateTime(Date date) {
+        return LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(date.getTime()), ZoneId.systemDefault());
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/scheduler/SchedulerException.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/scheduler/SchedulerException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow.scheduler;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.api.TableException;
+
+/** General exception for workflow scheduler related errors. */
+@PublicEvolving
+public class SchedulerException extends TableException {
+
+    public SchedulerException(String message) {
+        super(message);
+    }
+
+    public SchedulerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-sql-gateway/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,9 @@
+flink-sql-gateway
+Copyright 2014-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.quartz-scheduler:quartz:2.3.2

--- a/flink-table/flink-sql-gateway/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-sql-gateway/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.table.gateway.rest.SqlGatewayRestEndpointFactory
+org.apache.flink.table.gateway.workflow.EmbeddedWorkflowSchedulerFactory

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/RestAPIITCaseBase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/RestAPIITCaseBase.java
@@ -46,7 +46,7 @@ import static org.apache.flink.table.gateway.rest.util.TestingRestClient.getTest
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** The base class for Rest API IT test. */
-abstract class RestAPIITCaseBase {
+public abstract class RestAPIITCaseBase {
 
     @RegisterExtension
     @Order(1)
@@ -58,10 +58,10 @@ abstract class RestAPIITCaseBase {
             new SqlGatewayServiceExtension(MINI_CLUSTER::getClientConfiguration);
 
     @Nullable private static TestingRestClient restClient = null;
-    @Nullable private static String targetAddress = null;
+    @Nullable protected static String targetAddress = null;
     @Nullable private static SqlGatewayRestEndpoint sqlGatewayRestEndpoint = null;
 
-    private static int port = 0;
+    protected static int port = 0;
 
     @BeforeAll
     static void start() throws Exception {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/util/TestingSqlGatewayRestEndpoint.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/util/TestingSqlGatewayRestEndpoint.java
@@ -95,5 +95,7 @@ public class TestingSqlGatewayRestEndpoint extends SqlGatewayRestEndpoint {
     }
 
     @Override
-    protected void startInternal() {}
+    protected void startInternal() {
+        super.startInternal();
+    }
 }

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/EmbeddedRefreshHandlerTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/EmbeddedRefreshHandlerTest.java
@@ -16,25 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.workflow;
+package org.apache.flink.table.gateway.workflow;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.util.FlinkException;
+import org.junit.jupiter.api.Test;
 
-/**
- * A workflow-related operation exception to materialized table, including create, suspend, resume,
- * drop workflow operation, etc.
- */
-@PublicEvolving
-public class WorkflowException extends FlinkException {
+import static org.assertj.core.api.Assertions.assertThat;
 
-    private static final long serialVersionUID = 1L;
+/** Tests for {@link EmbeddedRefreshHandler} and {@link EmbeddedRefreshHandlerSerializer}. */
+public class EmbeddedRefreshHandlerTest {
 
-    public WorkflowException(String message) {
-        super(message);
-    }
+    @Test
+    void testSerDe() throws Exception {
+        EmbeddedRefreshHandler expected = new EmbeddedRefreshHandler("a", "b");
 
-    public WorkflowException(String message, Throwable cause) {
-        super(message, cause);
+        byte[] serBytes = EmbeddedRefreshHandlerSerializer.INSTANCE.serialize(expected);
+        EmbeddedRefreshHandler actual =
+                EmbeddedRefreshHandlerSerializer.INSTANCE.deserialize(
+                        serBytes, this.getClass().getClassLoader());
+
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/EmbeddedSchedulerRelatedITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/EmbeddedSchedulerRelatedITCase.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.util.RestClientException;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.factories.WorkflowSchedulerFactoryUtil;
+import org.apache.flink.table.gateway.rest.RestAPIITCaseBase;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.DeleteEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.SuspendEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowResponseBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.EmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.workflow.CreatePeriodicRefreshWorkflow;
+import org.apache.flink.table.workflow.CreateRefreshWorkflow;
+import org.apache.flink.table.workflow.DeleteRefreshWorkflow;
+import org.apache.flink.table.workflow.ModifyRefreshWorkflow;
+import org.apache.flink.table.workflow.ResumeRefreshWorkflow;
+import org.apache.flink.table.workflow.SuspendRefreshWorkflow;
+import org.apache.flink.table.workflow.WorkflowException;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
+import static org.apache.flink.table.factories.FactoryUtil.WORKFLOW_SCHEDULER_TYPE;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.QUARTZ_JOB_GROUP;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.QUARTZ_JOB_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test basic logic of handlers inherited from {@link AbstractSqlGatewayRestHandler} in embedded
+ * scheduler cases.
+ */
+public class EmbeddedSchedulerRelatedITCase extends RestAPIITCaseBase {
+
+    private static final EmbeddedSchedulerWorkflowRequestBody nonExistsWorkflow =
+            new EmbeddedSchedulerWorkflowRequestBody("non-exists", QUARTZ_JOB_GROUP);
+
+    private static final ObjectIdentifier materializedTableIdentifier =
+            ObjectIdentifier.of("cat", "db", "t1");
+    private static final String descriptionStatement =
+            String.format(
+                    "ALTER MATERIALIZED TABLE %s REFRESH",
+                    materializedTableIdentifier.asSerializableString());
+    private static final String cronExpression = "0 0/1 * * * ?";
+
+    private static final EmbeddedRefreshHandler nonExistsHandler =
+            new EmbeddedRefreshHandler("non-exits", QUARTZ_JOB_GROUP);
+
+    private CreateEmbeddedSchedulerWorkflowRequestBody createRequestBody;
+    private CreatePeriodicRefreshWorkflow createPeriodicWorkflow;
+
+    private EmbeddedWorkflowScheduler embeddedWorkflowScheduler;
+
+    @BeforeEach
+    void setup() throws Exception {
+        String gatewayRestEndpointURL = String.format("http://%s:%s", targetAddress, port);
+        createRequestBody =
+                new CreateEmbeddedSchedulerWorkflowRequestBody(
+                        materializedTableIdentifier.asSerializableString(),
+                        cronExpression,
+                        null,
+                        null,
+                        null,
+                        gatewayRestEndpointURL);
+        createPeriodicWorkflow =
+                new CreatePeriodicRefreshWorkflow(
+                        materializedTableIdentifier,
+                        descriptionStatement,
+                        cronExpression,
+                        null,
+                        null,
+                        gatewayRestEndpointURL);
+
+        Configuration configuration = new Configuration();
+        configuration.set(WORKFLOW_SCHEDULER_TYPE, "embedded");
+        configuration.setString("sql-gateway.endpoint.rest.address", targetAddress);
+        configuration.setString("sql-gateway.endpoint.rest.port", String.valueOf(port));
+
+        embeddedWorkflowScheduler =
+                (EmbeddedWorkflowScheduler)
+                        WorkflowSchedulerFactoryUtil.createWorkflowScheduler(
+                                configuration,
+                                EmbeddedSchedulerRelatedITCase.class.getClassLoader());
+        embeddedWorkflowScheduler.open();
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        embeddedWorkflowScheduler.close();
+    }
+
+    @Test
+    void testCreateWorkflow() throws Exception {
+        CreateEmbeddedSchedulerWorkflowResponseBody createResponse =
+                sendRequest(
+                                CreateEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                                EmptyMessageParameters.getInstance(),
+                                createRequestBody)
+                        .get(5, TimeUnit.SECONDS);
+
+        assertThat(createResponse.getWorkflowName())
+                .isEqualTo(
+                        QUARTZ_JOB_PREFIX
+                                + "_"
+                                + materializedTableIdentifier.asSerializableString());
+        assertThat(createResponse.getWorkflowGroup()).isEqualTo(QUARTZ_JOB_GROUP);
+
+        // create the workflow repeatedly
+        CompletableFuture<CreateEmbeddedSchedulerWorkflowResponseBody> repeatedCreateFuture =
+                sendRequest(
+                        CreateEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                        EmptyMessageParameters.getInstance(),
+                        createRequestBody);
+
+        assertThatFuture(repeatedCreateFuture)
+                .failsWithin(5, TimeUnit.SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RestClientException.class)
+                .withMessageContaining(
+                        "Materialized table `cat`.`db`.`t1` quartz schedule job already exist, job info: default_group.quartz_job_`cat`.`db`.`t1`.")
+                .satisfies(
+                        e ->
+                                assertThat(
+                                                ((RestClientException) e.getCause())
+                                                        .getHttpResponseStatus())
+                                        .isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR));
+
+        // delete the schedule job
+        EmbeddedSchedulerWorkflowRequestBody deleteRequestBody =
+                new EmbeddedSchedulerWorkflowRequestBody(
+                        createResponse.getWorkflowName(), createResponse.getWorkflowGroup());
+        CompletableFuture<EmptyResponseBody> deleteFuture =
+                sendRequest(
+                        DeleteEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                        EmptyMessageParameters.getInstance(),
+                        deleteRequestBody);
+        assertThatFuture(deleteFuture).succeedsWithin(5, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testSuspendNonExistsWorkflow() throws Exception {
+        CompletableFuture<EmptyResponseBody> suspendFuture =
+                sendRequest(
+                        SuspendEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                        EmptyMessageParameters.getInstance(),
+                        nonExistsWorkflow);
+
+        assertThatFuture(suspendFuture)
+                .failsWithin(5, TimeUnit.SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RestClientException.class)
+                .withMessageContaining(
+                        "Failed to suspend a non-existent quartz schedule job: default_group.non-exists")
+                .satisfies(
+                        e ->
+                                assertThat(
+                                                ((RestClientException) e.getCause())
+                                                        .getHttpResponseStatus())
+                                        .isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    void testResumeNonExistsWorkflow() throws Exception {
+        CompletableFuture<EmptyResponseBody> suspendFuture =
+                sendRequest(
+                        ResumeEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                        EmptyMessageParameters.getInstance(),
+                        nonExistsWorkflow);
+
+        assertThatFuture(suspendFuture)
+                .failsWithin(5, TimeUnit.SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RestClientException.class)
+                .withMessageContaining(
+                        "Failed to resume a non-existent quartz schedule job: default_group.non-exists")
+                .satisfies(
+                        e ->
+                                assertThat(
+                                                ((RestClientException) e.getCause())
+                                                        .getHttpResponseStatus())
+                                        .isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    void testDeleteNonExistsWorkflow() throws Exception {
+        CompletableFuture<EmptyResponseBody> suspendFuture =
+                sendRequest(
+                        DeleteEmbeddedSchedulerWorkflowHeaders.getInstance(),
+                        EmptyMessageParameters.getInstance(),
+                        nonExistsWorkflow);
+
+        assertThatFuture(suspendFuture)
+                .failsWithin(5, TimeUnit.SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(RestClientException.class)
+                .withMessageContaining(
+                        "Failed to delete a non-existent quartz schedule job: default_group.non-exists.")
+                .satisfies(
+                        e ->
+                                assertThat(
+                                                ((RestClientException) e.getCause())
+                                                        .getHttpResponseStatus())
+                                        .isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    void testCreateWorkflowByWorkflowSchedulerInterface() throws Exception {
+        // create workflow
+        EmbeddedRefreshHandler actual =
+                embeddedWorkflowScheduler.createRefreshWorkflow(createPeriodicWorkflow);
+
+        EmbeddedRefreshHandler expected =
+                new EmbeddedRefreshHandler(
+                        QUARTZ_JOB_PREFIX
+                                + "_"
+                                + materializedTableIdentifier.asSerializableString(),
+                        QUARTZ_JOB_GROUP);
+        assertThat(actual).isEqualTo(expected);
+
+        // create workflow repeatedly
+        assertThatThrownBy(
+                        () ->
+                                embeddedWorkflowScheduler.createRefreshWorkflow(
+                                        createPeriodicWorkflow))
+                .isInstanceOf(WorkflowException.class)
+                .hasMessage(
+                        "Failed to create periodic refresh workflow for materialized table `cat`.`db`.`t1`.");
+
+        // suspend, just to verify suspend function can work
+        SuspendRefreshWorkflow<EmbeddedRefreshHandler> suspendRefreshWorkflow =
+                new SuspendRefreshWorkflow<>(actual);
+        embeddedWorkflowScheduler.modifyRefreshWorkflow(suspendRefreshWorkflow);
+
+        // resume, just to verify suspend function can work
+        ResumeRefreshWorkflow<EmbeddedRefreshHandler> resumeRefreshWorkflow =
+                new ResumeRefreshWorkflow<>(actual);
+        embeddedWorkflowScheduler.modifyRefreshWorkflow(resumeRefreshWorkflow);
+
+        // delete, just to verify suspend function can work
+        DeleteRefreshWorkflow<EmbeddedRefreshHandler> deleteRefreshWorkflow =
+                new DeleteRefreshWorkflow<>(actual);
+        embeddedWorkflowScheduler.deleteRefreshWorkflow(deleteRefreshWorkflow);
+    }
+
+    @Test
+    void testCreateWorkflowWithUnsupportedTypeByWorkflowSchedulerInterface() {
+        assertThatThrownBy(
+                        () ->
+                                embeddedWorkflowScheduler.createRefreshWorkflow(
+                                        new UnsupportedCreateRefreshWorkflow()))
+                .isInstanceOf(WorkflowException.class)
+                .hasMessage(
+                        "Unsupported create refresh workflow type UnsupportedCreateRefreshWorkflow.");
+    }
+
+    @Test
+    void testModifyWorkflowWithUnsupportedTypeByWorkflowSchedulerInterface() {
+        assertThatThrownBy(
+                        () ->
+                                embeddedWorkflowScheduler.modifyRefreshWorkflow(
+                                        new UnsupportedModifyRefreshWorkflow()))
+                .isInstanceOf(WorkflowException.class)
+                .hasMessage(
+                        "Unsupported modify refresh workflow type UnsupportedModifyRefreshWorkflow.");
+    }
+
+    @Test
+    void testNonExistsWorkflowByWorkflowSchedulerInterface() {
+        // suspend case
+        assertThatThrownBy(
+                        () ->
+                                embeddedWorkflowScheduler.modifyRefreshWorkflow(
+                                        new SuspendRefreshWorkflow<>(nonExistsHandler)))
+                .isInstanceOf(WorkflowException.class)
+                .hasMessage(
+                        "Failed to suspend refresh workflow {\n"
+                                + "  workflowName: non-exits,\n"
+                                + "  workflowGroup: default_group\n"
+                                + "}.");
+
+        // resume case
+        assertThatThrownBy(
+                        () ->
+                                embeddedWorkflowScheduler.modifyRefreshWorkflow(
+                                        new ResumeRefreshWorkflow<>(nonExistsHandler)))
+                .isInstanceOf(WorkflowException.class)
+                .hasMessage(
+                        "Failed to resume refresh workflow {\n"
+                                + "  workflowName: non-exits,\n"
+                                + "  workflowGroup: default_group\n"
+                                + "}.");
+
+        // delete case
+        assertThatThrownBy(
+                        () ->
+                                embeddedWorkflowScheduler.deleteRefreshWorkflow(
+                                        new DeleteRefreshWorkflow<>(nonExistsHandler)))
+                .isInstanceOf(WorkflowException.class)
+                .hasMessage(
+                        "Failed to delete refresh workflow {\n"
+                                + "  workflowName: non-exits,\n"
+                                + "  workflowGroup: default_group\n"
+                                + "}.");
+    }
+
+    /** Just used for test. */
+    private static class UnsupportedCreateRefreshWorkflow implements CreateRefreshWorkflow {}
+
+    /** Just used for test. */
+    private static class UnsupportedModifyRefreshWorkflow
+            implements ModifyRefreshWorkflow<EmbeddedRefreshHandler> {
+
+        @Override
+        public EmbeddedRefreshHandler getRefreshHandler() {
+            return new EmbeddedRefreshHandler("a", "b");
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/QuartzSchedulerUtilsTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/QuartzSchedulerUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.workflow;
+
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils;
+
+import org.junit.jupiter.api.Test;
+import org.quartz.JobKey;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.QUARTZ_JOB_GROUP;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.QUARTZ_JOB_PREFIX;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.dateToString;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.fromJson;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.getJobKey;
+import static org.apache.flink.table.gateway.workflow.scheduler.QuartzSchedulerUtils.toJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link QuartzSchedulerUtils}. */
+public class QuartzSchedulerUtilsTest {
+
+    @Test
+    void testJsonSerDe() {
+        String identifier = ObjectIdentifier.of("a", "b", "c").asSerializableString();
+        Map<String, String> dynamicOptions = new HashMap<>();
+        dynamicOptions.put("k1", "v1");
+        dynamicOptions.put("k2", "v2");
+
+        Map<String, String> executionConfig = new HashMap<>();
+        executionConfig.put("k3", "v3");
+        executionConfig.put("k4", "v4");
+
+        String scheduleTime = "2023-04-04 20:00:00";
+        String url = "http://localhost:8083";
+        WorkflowInfo expected =
+                new WorkflowInfo(identifier, dynamicOptions, executionConfig, scheduleTime, url);
+
+        WorkflowInfo serde = fromJson(toJson(expected), WorkflowInfo.class);
+        assertThat(serde).isEqualTo(expected);
+    }
+
+    @Test
+    void testConvertDateToString() {
+        LocalDateTime localDateTime = LocalDateTime.of(2024, 5, 22, 12, 30, 15);
+        Date date = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        String actual = dateToString(date);
+
+        String expected = "2024-05-22 12:30:15";
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testGetJobKey() {
+        String materializedTableIdentifier = "`a`.`b`.`c`";
+        JobKey actual = getJobKey(materializedTableIdentifier);
+
+        assertThat(actual.getName())
+                .isEqualTo(QUARTZ_JOB_PREFIX + "_" + materializedTableIdentifier);
+        assertThat(actual.getGroup()).isEqualTo(QUARTZ_JOB_GROUP);
+    }
+}

--- a/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
@@ -1,0 +1,519 @@
+{
+  "calls" : [ {
+    "url" : "/api_versions",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:util:GetApiVersionResponseBody",
+      "properties" : {
+        "versions" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/info",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:util:GetInfoResponseBody",
+      "properties" : {
+        "productName" : {
+          "type" : "string"
+        },
+        "version" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:OpenSessionRequestBody",
+      "properties" : {
+        "sessionName" : {
+          "type" : "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:OpenSessionResponseBody",
+      "properties" : {
+        "sessionHandle" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle",
+    "method" : "DELETE",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:CloseSessionResponseBody",
+      "properties" : {
+        "status" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:GetSessionConfigResponseBody",
+      "properties" : {
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/complete-statement",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:statement:CompleteStatementRequestBody",
+      "properties" : {
+        "statement" : {
+          "type" : "string"
+        },
+        "position" : {
+          "type" : "integer"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:statement:CompleteStatementResponseBody",
+      "properties" : {
+        "candidates" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/configure-session",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:session:ConfigureSessionRequestBody",
+      "properties" : {
+        "statement" : {
+          "type" : "string"
+        },
+        "executionTimeout" : {
+          "type" : "integer"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
+    }
+  }, {
+    "url" : "/sessions/:session_handle/heartbeat",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
+    }
+  }, {
+    "url" : "/sessions/:session_handle/operations/:operation_handle/cancel",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      }, {
+        "key" : "operation_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:operation:OperationStatusResponseBody",
+      "properties" : {
+        "status" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/operations/:operation_handle/close",
+    "method" : "DELETE",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      }, {
+        "key" : "operation_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:operation:OperationStatusResponseBody",
+      "properties" : {
+        "status" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/operations/:operation_handle/result/:token",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      }, {
+        "key" : "operation_handle"
+      }, {
+        "key" : "token"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ {
+        "key" : "rowFormat",
+        "mandatory" : true
+      } ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "any"
+    }
+  }, {
+    "url" : "/sessions/:session_handle/operations/:operation_handle/status",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      }, {
+        "key" : "operation_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyRequestBody"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:operation:OperationStatusResponseBody",
+      "properties" : {
+        "status" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/sessions/:session_handle/statements",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:statement:ExecuteStatementRequestBody",
+      "properties" : {
+        "statement" : {
+          "type" : "string"
+        },
+        "executionTimeout" : {
+          "type" : "integer"
+        },
+        "executionConfig" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:statement:ExecuteStatementResponseBody",
+      "properties" : {
+        "operationHandle" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/workflow/embedded-scheduler/create",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:scheduler:CreateEmbeddedSchedulerWorkflowRequestBody",
+      "properties" : {
+        "materializedTableIdentifier" : {
+          "type" : "string"
+        },
+        "cronExpression" : {
+          "type" : "string"
+        },
+        "dynamicOptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "executionConfig" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "customScheduleTime" : {
+          "type" : "string"
+        },
+        "restEndpointUrl" : {
+          "type" : "string"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:scheduler:CreateEmbeddedSchedulerWorkflowResponseBody",
+      "properties" : {
+        "workflowName" : {
+          "type" : "string"
+        },
+        "workflowGroup" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
+    "url" : "/workflow/embedded-scheduler/delete",
+    "method" : "DELETE",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:scheduler:EmbeddedSchedulerWorkflowRequestBody",
+      "properties" : {
+        "workflowName" : {
+          "type" : "string"
+        },
+        "workflowGroup" : {
+          "type" : "string"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
+    }
+  }, {
+    "url" : "/workflow/embedded-scheduler/resume",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:scheduler:EmbeddedSchedulerWorkflowRequestBody",
+      "properties" : {
+        "workflowName" : {
+          "type" : "string"
+        },
+        "workflowGroup" : {
+          "type" : "string"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
+    }
+  }, {
+    "url" : "/workflow/embedded-scheduler/suspend",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:scheduler:EmbeddedSchedulerWorkflowRequestBody",
+      "properties" : {
+        "workflowName" : {
+          "type" : "string"
+        },
+        "workflowGroup" : {
+          "type" : "string"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
+    }
+  } ]
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/ContinuousRefreshHandler.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/refresh/ContinuousRefreshHandler.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 @Internal
 public class ContinuousRefreshHandler implements RefreshHandler, Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     // TODO: add clusterId for yarn and k8s resource manager
     private final String executionTarget;
     private final String jobId;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/CreatePeriodicRefreshWorkflow.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/CreatePeriodicRefreshWorkflow.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.workflow;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+/**
+ * {@link CreateRefreshWorkflow} provides the related information to create periodic refresh
+ * workflow of {@link CatalogMaterializedTable}.
+ */
+@PublicEvolving
+public class CreatePeriodicRefreshWorkflow implements CreateRefreshWorkflow {
+
+    private final ObjectIdentifier materializedTableIdentifier;
+    private final String descriptionStatement;
+    private final String cronExpression;
+    private final @Nullable Map<String, String> dynamicOptions;
+    private final @Nullable Map<String, String> executionConfig;
+
+    // The SQL Gateway rest endpoint url that used for execute refresh operation
+    private final String restEndpointUrl;
+
+    public CreatePeriodicRefreshWorkflow(
+            ObjectIdentifier materializedTableIdentifier,
+            String descriptionStatement,
+            String cronExpression,
+            Map<String, String> dynamicOptions,
+            Map<String, String> executionConfig,
+            String restEndpointUrl) {
+        this.materializedTableIdentifier = materializedTableIdentifier;
+        this.descriptionStatement = descriptionStatement;
+        this.cronExpression = cronExpression;
+        this.dynamicOptions = dynamicOptions;
+        this.executionConfig = executionConfig;
+        this.restEndpointUrl = restEndpointUrl;
+    }
+
+    public ObjectIdentifier getMaterializedTableIdentifier() {
+        return materializedTableIdentifier;
+    }
+
+    public String getDescriptionStatement() {
+        return descriptionStatement;
+    }
+
+    public String getCronExpression() {
+        return cronExpression;
+    }
+
+    @Nullable
+    public Map<String, String> getDynamicOptions() {
+        return dynamicOptions;
+    }
+
+    @Nullable
+    public Map<String, String> getExecutionConfig() {
+        return executionConfig;
+    }
+
+    public String getRestEndpointUrl() {
+        return restEndpointUrl;
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/ResumeRefreshWorkflow.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/ResumeRefreshWorkflow.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.workflow;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.refresh.RefreshHandler;
+
+/**
+ * {@link ModifyRefreshWorkflow} provides the related information to resume refresh workflow of
+ * {@link CatalogMaterializedTable}.
+ */
+@PublicEvolving
+public class ResumeRefreshWorkflow<T extends RefreshHandler> implements ModifyRefreshWorkflow<T> {
+
+    private final T refreshHandler;
+
+    public ResumeRefreshWorkflow(T refreshHandler) {
+        this.refreshHandler = refreshHandler;
+    }
+
+    @Override
+    public T getRefreshHandler() {
+        return refreshHandler;
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/SuspendRefreshWorkflow.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/SuspendRefreshWorkflow.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.workflow;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.refresh.RefreshHandler;
+
+/**
+ * {@link ModifyRefreshWorkflow} provides the related information to suspend refresh workflow of
+ * {@link CatalogMaterializedTable}.
+ */
+@PublicEvolving
+public class SuspendRefreshWorkflow<T extends RefreshHandler> implements ModifyRefreshWorkflow<T> {
+
+    private final T refreshHandler;
+
+    public SuspendRefreshWorkflow(T refreshHandler) {
+        this.refreshHandler = refreshHandler;
+    }
+
+    @Override
+    public T getRefreshHandler() {
+        return refreshHandler;
+    }
+}

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -85,5 +85,6 @@ under the License.
 		<janino.version>3.1.10</janino.version>
 		<jsonpath.version>2.7.0</jsonpath.version>
 		<guava.version>32.1.3-jre</guava.version>
+		<quartz.version>2.3.2</quartz.version>
 	</properties>
 </project>


### PR DESCRIPTION
## What is the purpose of the change

Introduce embedded scheduler and EmbeddedWorkflowScheduler plugin to support full refresh mode for materialized table.


## Brief change log

  - *Introduce RefreshWorkflow related implementation to support full refresh mode for materialized table*
  - *Introduce embedded scheduler to support full refresh mode for materialized table*
  - *Introduce EmbeddedWorkflowScheduler plugin based on embedded scheduler*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests in EmbeddedSchedulerRelatedITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
