### PR TITLE
chore: Update pekko version

### DIFF
--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -37,9 +37,9 @@ under the License.
 	</description>
 
 	<properties>
-		<pekko.version>1.0.1</pekko.version>
+		<pekko.version>1.1.0-M1</pekko.version>
 		<scala.binary.version>2.12</scala.binary.version>
-		<scala.version>2.12.16</scala.version>
+		<scala.version>2.12.19</scala.version>
 	</properties>
 
 	<dependencies>

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -6,18 +6,18 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.hierynomus:asn-one:0.5.0
+- com.hierynomus:asn-one:0.6.0
 - com.typesafe:config:1.4.2
 - com.typesafe:ssl-config-core_2.12:0.6.1
-- io.netty:netty:3.10.6.Final
-- org.agrona:agrona:1.15.1
-- org.apache.pekko:pekko-actor_2.12:1.0.1
-- org.apache.pekko:pekko-remote_2.12:1.0.1
-- org.apache.pekko:pekko-pki_2.12:1.0.1
-- org.apache.pekko:pekko-protobuf-v3_2.12:1.0.1
-- org.apache.pekko:pekko-slf4j_2.12:1.0.1
-- org.apache.pekko:pekko-stream_2.12:1.0.1
-- org.scala-lang:scala-library:2.12.16
+- io.netty:netty:4.1.109.Final
+- org.agrona:agrona:1.21.1
+- org.apache.pekko:pekko-actor_2.12:1.1.0-M1
+- org.apache.pekko:pekko-remote_2.12:1.1.0-M1
+- org.apache.pekko:pekko-pki_2.12:1.1.0-M1
+- org.apache.pekko:pekko-protobuf-v3_2.12:1.1.0-M1
+- org.apache.pekko:pekko-slf4j_2.12:1.1.0-M1
+- org.apache.pekko:pekko-stream_2.12:1.1.0-M1
+- org.scala-lang:scala-library:2.12.19
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 


### PR DESCRIPTION
Status: [DO NOT MERGE]
Open for testing

Motivation:
Test Pekko 1.1.0-M1

Modification:
The new pekko 1.1.0 is using Netty 4