### PR TITLE
[hotfix][rest] Add getter methods for SubtasksTimesInfo to get all values easily

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksTimesInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtasksTimesInfo.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.rest.handler.job.SubtasksTimesHandler;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -60,6 +61,26 @@ public class SubtasksTimesInfo implements ResponseBody {
         this.name = checkNotNull(name);
         this.now = now;
         this.subtasks = checkNotNull(subtasks);
+    }
+
+    @JsonIgnore
+    public String getId() {
+        return id;
+    }
+
+    @JsonIgnore
+    public String getName() {
+        return name;
+    }
+
+    @JsonIgnore
+    public long getNow() {
+        return now;
+    }
+
+    @JsonIgnore
+    public List<SubtaskTimeInfo> getSubtasks() {
+        return subtasks;
     }
 
     @Override
@@ -123,6 +144,31 @@ public class SubtasksTimesInfo implements ResponseBody {
             this.endpoint = checkNotNull(endpoint);
             this.duration = duration;
             this.timestamps = checkNotNull(timestamps);
+        }
+
+        @JsonIgnore
+        public int getSubtask() {
+            return subtask;
+        }
+
+        @JsonIgnore
+        public String getHost() {
+            return host;
+        }
+
+        @JsonIgnore
+        public String getEndpoint() {
+            return endpoint;
+        }
+
+        @JsonIgnore
+        public long getDuration() {
+            return duration;
+        }
+
+        @JsonIgnore
+        public Map<ExecutionState, Long> getTimestamps() {
+            return timestamps;
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

FLINK-34907 needs to get when all subtask are switched to RUNNING from `SubtasksTimesInfo` class, but `SubtasksTimesInfo` doesn't provide the getter method.


## Brief change log

- [hotfix][rest] Add getter methods for SubtasksTimesInfo to get all values easily


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  not documented
