### PR TITLE
[FLINK-34673][test] Fix SessionRelatedITCase#testTouchSession failure on GitHub Actions

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SessionRelatedITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SessionRelatedITCase.java
@@ -166,6 +166,7 @@ class SessionRelatedITCase extends RestAPIITCaseBase {
 
         long lastAccessTime = session.getLastAccessTime();
 
+        Thread.sleep(1); // ensure requests are not sent at the same time
         CompletableFuture<EmptyResponseBody> future =
                 sendRequest(
                         TriggerSessionHeartbeatHeaders.getInstance(),


### PR DESCRIPTION
## What is the purpose of the change
Fixes flaky test `SessionRelatedITCase#testTouchSession` by sending the `touch` request `1ms` later.

## Brief change log
Fixes flaky test `SessionRelatedITCase#testTouchSession`.