### PR TITLE
[FLINK-35434] Support pass exception in StateExecutor to runtime

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/state/CompletedStateFuture.java
+++ b/flink-core/src/main/java/org/apache/flink/core/state/CompletedStateFuture.java
@@ -70,6 +70,11 @@ public class CompletedStateFuture<T> implements InternalStateFuture<T> {
     }
 
     @Override
+    public void completeExceptionally(String message, Throwable ex) {
+        throw new UnsupportedOperationException("This state future has already been completed.");
+    }
+
+    @Override
     public void thenSyncAccept(ThrowingConsumer<? super T, ? extends Exception> action) {
         ThrowingConsumer.unchecked(action).accept(result);
     }

--- a/flink-core/src/main/java/org/apache/flink/core/state/InternalStateFuture.java
+++ b/flink-core/src/main/java/org/apache/flink/core/state/InternalStateFuture.java
@@ -32,6 +32,14 @@ public interface InternalStateFuture<T> extends StateFuture<T> {
     void complete(T result);
 
     /**
+     * Fail this future and pass the given exception to the runtime.
+     *
+     * @param message the description of this exception
+     * @param ex the exception
+     */
+    void completeExceptionally(String message, Throwable ex);
+
+    /**
      * Accept the action in the same thread with the one of complete (or current thread if it has
      * been completed).
      *

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBGetRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBGetRequest.java
@@ -59,6 +59,10 @@ public class ForStDBGetRequest<K, V> {
         future.complete(value);
     }
 
+    public void completeStateFutureExceptionally(String message, Throwable ex) {
+        future.completeExceptionally(message, ex);
+    }
+
     static <K, V> ForStDBGetRequest<K, V> of(
             K key, ForStInnerTable<K, V> table, InternalStateFuture<V> future) {
         return new ForStDBGetRequest<>(key, table, future);

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBPutRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBPutRequest.java
@@ -68,6 +68,10 @@ public class ForStDBPutRequest<K, V> {
         future.complete(null);
     }
 
+    public void completeStateFutureExceptionally(String message, Throwable ex) {
+        future.completeExceptionally(message, ex);
+    }
+
     /**
      * If the value of the ForStDBPutRequest is null, then the request will signify the deletion of
      * the data associated with that key.

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStWriteBatchOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStWriteBatchOperation.java
@@ -75,7 +75,13 @@ public class ForStWriteBatchOperation implements ForStDBOperation {
                             request.completeStateFuture();
                         }
                     } catch (Exception e) {
-                        throw new CompletionException("Error while adding data to ForStDB", e);
+                        String msg = "Error while write batch data to ForStDB.";
+                        for (ForStDBPutRequest<?, ?> request : batchRequest) {
+                            // fail every state request in this batch
+                            request.completeStateFutureExceptionally(msg, e);
+                        }
+                        // fail the whole batch operation
+                        throw new CompletionException(msg, e);
                     }
                 },
                 executor);

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
@@ -122,6 +122,11 @@ public class ForStDBOperationTestBase {
         }
 
         @Override
+        public void completeExceptionally(String message, Throwable ex) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
         public void thenSyncAccept(ThrowingConsumer<? super T, ? extends Exception> action) {
             throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
## What is the purpose of the change

As the title and [FLINK-35434](https://issues.apache.org/jira/browse/FLINK-35434) said, support pass exception in StateExecutor to runtime.


## Brief change log

  - *Add method InternalStateFuture#completeExceptionally()*
  - *ForStWriteBatchOperation and ForStGeneralMultiGetOperation will call this method when exception occurred.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

Please take a look @masteryhx, @Zakelly .
