### PR TITLE
[FLINK-35326][hive] add lineage integration for Hive connector

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
@@ -35,6 +35,8 @@ import org.apache.flink.connector.file.table.LimitableBulkFormat;
 import org.apache.flink.connectors.hive.read.HiveSourceSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.connector.source.DynamicFilteringEvent;
 import org.apache.flink.table.data.RowData;
@@ -60,7 +62,7 @@ import java.util.List;
  */
 @PublicEvolving
 public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit>
-        implements DynamicParallelismInference {
+        implements DynamicParallelismInference, LineageVertexProvider {
 
     private static final long serialVersionUID = 1L;
 
@@ -73,6 +75,7 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit>
     private final ContinuousPartitionFetcher<Partition, ?> fetcher;
     private final HiveTableSource.HiveContinuousPartitionFetcherContext<?> fetcherContext;
     private final ObjectPath tablePath;
+    private transient LineageVertex lineageVertex;
     private Long limit = null;
 
     HiveSource(
@@ -238,5 +241,14 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit>
                                                 0, partitions, jobConfWrapper.conf(), true)
                                         .size())
                 .limit(limit);
+    }
+
+    void setLineageVertex(LineageVertex lineageVertex) {
+        this.lineageVertex = lineageVertex;
+    }
+
+    @Override
+    public LineageVertex getLineageVertex() {
+        return lineageVertex;
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveSourceITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.connectors.hive;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -111,6 +112,10 @@ public class HiveSourceITCase {
                                         WatermarkStrategy.noWatermarks(),
                                         "HiveSource-tbl1")
                                 .executeAndCollect());
+        LineageVertex lineageVertex = hiveSource.getLineageVertex();
+        assertThat(lineageVertex.datasets()).hasSize(1);
+        assertThat(lineageVertex.datasets().get(0).name()).isEqualTo("default.tbl1");
+
         assertThat(results).hasSize(2);
         assertThat(results.get(0).getInt(0)).isEqualTo(1);
         assertThat(results.get(1).getInt(0)).isEqualTo(2);
@@ -156,6 +161,11 @@ public class HiveSourceITCase {
                                         WatermarkStrategy.noWatermarks(),
                                         "HiveSource-tbl2")
                                 .executeAndCollect());
+
+        lineageVertex = hiveSource.getLineageVertex();
+        assertThat(lineageVertex.datasets()).hasSize(1);
+        assertThat(lineageVertex.datasets().get(0).name()).isEqualTo("default.tbl2");
+
         assertThat(results).hasSize(1);
         assertThat(results.get(0).getInt(0)).isEqualTo(1);
         assertThat(results.get(0).getString(1).toString()).isEqualTo("a");
@@ -191,6 +201,11 @@ public class HiveSourceITCase {
                                         WatermarkStrategy.noWatermarks(),
                                         "HiveSource-tbl2")
                                 .executeAndCollect());
+
+        lineageVertex = hiveSource.getLineageVertex();
+        assertThat(lineageVertex.datasets()).hasSize(1);
+        assertThat(lineageVertex.datasets().get(0).name()).isEqualTo("default.tbl2");
+
         assertThat(results).hasSize(1);
         assertThat(results.get(0).getInt(0)).isEqualTo(3);
         assertThat(results.get(0).getString(1).toString()).isEqualTo("b");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageVertex.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultLineageVertex.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Default implementation for {@link LineageVertex}. */
+@Internal
+public class DefaultLineageVertex implements LineageVertex {
+    private List<LineageDataset> lineageDatasets;
+
+    public DefaultLineageVertex() {
+        this.lineageDatasets = new ArrayList<>();
+    }
+
+    public void addLineageDataset(LineageDataset lineageDataset) {
+        this.lineageDatasets.add(lineageDataset);
+    }
+
+    @Override
+    public List<LineageDataset> datasets() {
+        return lineageDatasets;
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultSourceLineageVertex.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/lineage/DefaultSourceLineageVertex.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.flink.streaming.api.lineage;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.Boundedness;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Default implementation for {@link SourceLineageVertex}. */
+@Internal
+public class DefaultSourceLineageVertex implements SourceLineageVertex {
+    private Boundedness boundedness;
+    private List<LineageDataset> lineageDatasets;
+
+    public DefaultSourceLineageVertex(Boundedness boundedness) {
+        this.lineageDatasets = new ArrayList<>();
+        this.boundedness = boundedness;
+    }
+
+    public void addDataset(LineageDataset lineageDataset) {
+        this.lineageDatasets.add(lineageDataset);
+    }
+
+    @Override
+    public List<LineageDataset> datasets() {
+        return this.lineageDatasets;
+    }
+
+    @Override
+    public Boundedness boundedness() {
+        return this.boundedness;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
Implement LineageVertexProvider Interface for Hive connectors, including HiveSource, FileSystemLookupFunction and HiveOutputformat. Given HiveInputFormat and HiveTableInputFormat is mainly used in HiveSource, skip them from adding lineage info.


## Brief change log
  - implement LineageVertexProvider in HiveSource, FileSystemLookupFunction and HiveOutputformat.


## Verifying this change

This change is already covered by existing tests with new verifications on lineage related info.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature?  (no)
  - If yes, how is the feature documented? (not applicable)

