### PR TITLE
[FLINK-35440][Table SQL / JDBC] feat(flink-connection): support isValid for tableau

### DIFF
--- a/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkConnection.java
+++ b/flink-table/flink-sql-jdbc-driver/src/main/java/org/apache/flink/table/jdbc/FlinkConnection.java
@@ -84,6 +84,13 @@ public class FlinkConnection extends BaseConnection {
     }
 
     // TODO We currently do not support this, but we can't throw a SQLException here because we want
+    // to support jdbc tools such as Tableau.
+    @Override
+    public boolean isValid(int timeout) throws SQLException {
+        return true;
+    }
+
+    // TODO We currently do not support this, but we can't throw a SQLException here because we want
     // to support jdbc tools such as beeline and sqlline.
     @Override
     public void setAutoCommit(boolean autoCommit) throws SQLException {}


### PR DESCRIPTION


## What is the purpose of the change

Allow Tableau to connect to flink sql via jdbc driver. Currently, tableau fails when FlinkConnection#isValid is called because it is not implemented. See the associated issue for a description of the exception.


## Brief change log

* isValid returns true always for FlinkConnection

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
