### PR TITLE
[hotfix][sqlgateway] Do not introduce new method in SqlGatewayEndpointFactory#Context

### DIFF
--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactory.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactory.java
@@ -51,14 +51,6 @@ public interface SqlGatewayEndpointFactory extends Factory {
         ReadableConfig getFlinkConfiguration();
 
         /**
-         * Get a map contains all flink configurations.
-         *
-         * @return The copy of flink configurations in the form of map, modifying this map will not
-         *     influence the original configuration object.
-         */
-        Map<String, String> getFlinkConfigurationOptions();
-
-        /**
          * Returns the options with which the endpoint is created. All options that are prefixed
          * with the endpoint identifier are included in the map.
          *

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactoryUtils.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/endpoint/SqlGatewayEndpointFactoryUtils.java
@@ -142,11 +142,6 @@ public class SqlGatewayEndpointFactoryUtils {
         }
 
         @Override
-        public Map<String, String> getFlinkConfigurationOptions() {
-            return flinkConfiguration.toMap();
-        }
-
-        @Override
         public Map<String, String> getEndpointOptions() {
             return endpointConfig;
         }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointFactory.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointFactory.java
@@ -49,7 +49,7 @@ public class SqlGatewayRestEndpointFactory implements SqlGatewayEndpointFactory 
         endpointFactoryHelper.validate();
         Configuration config =
                 rebuildRestEndpointOptions(
-                        context.getEndpointOptions(), context.getFlinkConfigurationOptions());
+                        context.getEndpointOptions(), context.getFlinkConfiguration().toMap());
         try {
             return new SqlGatewayRestEndpoint(config, context.getSqlGatewayService());
         } catch (Exception e) {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/util/SqlGatewayRestEndpointTestUtils.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/util/SqlGatewayRestEndpointTestUtils.java
@@ -41,7 +41,7 @@ public class SqlGatewayRestEndpointTestUtils {
                         null, flinkConf, getEndpointConfig(flinkConf, IDENTIFIER));
 
         return rebuildRestEndpointOptions(
-                context.getEndpointOptions(), context.getFlinkConfigurationOptions());
+                context.getEndpointOptions(), context.getFlinkConfiguration().toMap());
     }
 
     /** Create the configuration generated from config.yaml. */


### PR DESCRIPTION
## What is the purpose of the change

*Do not introduce new method in SqlGatewayEndpointFactory#Context as we have `toMap` method in `ReadableConfig` now.,*


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
