### PR TITLE
[FLINK-35446] Fix NPE when disabling checkpoint file merging but restore from merged files

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
@@ -684,10 +684,11 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
                                         fileHandle.getFilePath(),
                                         path -> {
                                             boolean managedByFileMergingManager =
-                                                    isManagedByFileMergingManager(
-                                                            path,
-                                                            subtaskKey,
-                                                            fileHandle.getScope());
+                                                    fileSystemInitiated
+                                                            && isManagedByFileMergingManager(
+                                                                    path,
+                                                                    subtaskKey,
+                                                                    fileHandle.getScope());
                                             if (managedByFileMergingManager) {
                                                 spaceStat.onPhysicalFileCreate();
                                             }


### PR DESCRIPTION
## What is the purpose of the change

See FLINK-35446. It seems the file merging is disabled, thus the `FileMergingSnapshotManagerBase#initFileSystem` is never called. And at this time if we restore from a checkpoint that files are already merged, the managed path is needed while it has not been initialized. This PR fix this.

## Brief change log

 - Skip using managed directory to claim management of files if it is not initialized, which means no management need to be claimed in this case.

## Verifying this change

This change is a trivial rework without any test coverage. But some github actions may fail like FLINK-35446.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
