### PR TITLE
 [FLINK-35348][table] Introduce refresh materialized table rest api

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -213,7 +213,7 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
     }
 
     /** Similar logic as for {@link TableConfig}. */
-    private void validateTimeZone(String zone) {
+    protected void validateTimeZone(String zone) {
         boolean isValid;
         try {
             // We enforce a zone string that is compatible with both java.util.TimeZone and

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/SqlGatewayService.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/SqlGatewayService.java
@@ -39,6 +39,8 @@ import org.apache.flink.table.gateway.api.session.SessionEnvironment;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.api.utils.SqlGatewayException;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -319,4 +321,30 @@ public interface SqlGatewayService {
      */
     List<String> completeStatement(SessionHandle sessionHandle, String statement, int position)
             throws SqlGatewayException;
+
+    // -------------------------------------------------------------------------------------------
+    // Materialized Table API
+    // -------------------------------------------------------------------------------------------
+
+    /**
+     * Trigger a refresh operation of specific materialized table.
+     *
+     * @param sessionHandle handle to identify the session.
+     * @param materializedTableIdentifier A fully qualified materialized table identifier:
+     *     'catalogName.databaseName.objectName', used for locating the materialized table in
+     *     catalog.
+     * @param isPeriodic Represents whether the workflow is refreshed periodically or one-time-only.
+     * @param scheduleTime The time point at which the scheduler triggers this refresh operation.
+     * @param staticPartitions The specific partitions for one-time-only refresh workflow.
+     * @param executionConfig The flink job config.
+     * @return handle to identify the operation.
+     */
+    OperationHandle refreshMaterializedTable(
+            SessionHandle sessionHandle,
+            String materializedTableIdentifier,
+            boolean isPeriodic,
+            @Nullable String scheduleTime,
+            Map<String, String> dynamicOptions,
+            Map<String, String> staticPartitions,
+            Map<String, String> executionConfig);
 }

--- a/flink-table/flink-sql-gateway-api/src/test/java/org/apache/flink/table/gateway/api/utils/MockedSqlGatewayService.java
+++ b/flink-table/flink-sql-gateway-api/src/test/java/org/apache/flink/table/gateway/api/utils/MockedSqlGatewayService.java
@@ -37,6 +37,8 @@ import org.apache.flink.table.gateway.api.results.TableInfo;
 import org.apache.flink.table.gateway.api.session.SessionEnvironment;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -184,6 +186,18 @@ public class MockedSqlGatewayService implements SqlGatewayService {
     public List<String> completeStatement(
             SessionHandle sessionHandle, String statement, int position)
             throws SqlGatewayException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OperationHandle refreshMaterializedTable(
+            SessionHandle sessionHandle,
+            String materializedTableIdentifier,
+            boolean isPeriodic,
+            @Nullable String scheduleTime,
+            Map<String, String> dynamicOptions,
+            Map<String, String> staticPartitions,
+            Map<String, String> executionConfig) {
         throw new UnsupportedOperationException();
     }
 

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.rest.RestServerEndpoint;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
 import org.apache.flink.table.gateway.api.SqlGatewayService;
 import org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpoint;
+import org.apache.flink.table.gateway.rest.handler.materializedtable.RefreshMaterializedTableHandler;
 import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowHandler;
 import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.DeleteEmbeddedSchedulerWorkflowHandler;
 import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowHandler;
@@ -41,6 +42,7 @@ import org.apache.flink.table.gateway.rest.handler.statement.ExecuteStatementHan
 import org.apache.flink.table.gateway.rest.handler.statement.FetchResultsHandler;
 import org.apache.flink.table.gateway.rest.handler.util.GetApiVersionHandler;
 import org.apache.flink.table.gateway.rest.handler.util.GetInfoHandler;
+import org.apache.flink.table.gateway.rest.header.materializedtable.RefreshMaterializedTableHeaders;
 import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowHeaders;
 import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.DeleteEmbeddedSchedulerWorkflowHeaders;
 import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowHeaders;
@@ -90,6 +92,7 @@ public class SqlGatewayRestEndpoint extends RestServerEndpoint implements SqlGat
         addUtilRelatedHandlers(handlers);
         addStatementRelatedHandlers(handlers);
         addEmbeddedSchedulerRelatedHandlers(handlers);
+        addMaterializedTableRelatedHandlers(handlers);
         return handlers;
     }
 
@@ -234,6 +237,18 @@ public class SqlGatewayRestEndpoint extends RestServerEndpoint implements SqlGat
                         DeleteEmbeddedSchedulerWorkflowHeaders.getInstance());
         handlers.add(
                 Tuple2.of(DeleteEmbeddedSchedulerWorkflowHeaders.getInstance(), deleteHandler));
+    }
+
+    private void addMaterializedTableRelatedHandlers(
+            List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers) {
+        // Refresh materialized table
+        RefreshMaterializedTableHandler refreshMaterializedTableHandler =
+                new RefreshMaterializedTableHandler(
+                        service, responseHeaders, RefreshMaterializedTableHeaders.getInstance());
+        handlers.add(
+                Tuple2.of(
+                        RefreshMaterializedTableHeaders.getInstance(),
+                        refreshMaterializedTableHandler));
     }
 
     @Override

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/RefreshMaterializedTableHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/RefreshMaterializedTableHandler.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.handler.materializedtable;
+
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.table.gateway.api.operation.OperationHandle;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.message.materializedtable.MaterializedTableIdentifierPathParameter;
+import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableParameters;
+import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableRequestBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableResponseBody;
+import org.apache.flink.table.gateway.rest.message.session.SessionHandleIdPathParameter;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Handler to execute materialized table refresh operation. */
+public class RefreshMaterializedTableHandler
+        extends AbstractSqlGatewayRestHandler<
+                RefreshMaterializedTableRequestBody,
+                RefreshMaterializedTableResponseBody,
+                RefreshMaterializedTableParameters> {
+
+    public RefreshMaterializedTableHandler(
+            SqlGatewayService service,
+            Map<String, String> responseHeaders,
+            MessageHeaders<
+                            RefreshMaterializedTableRequestBody,
+                            RefreshMaterializedTableResponseBody,
+                            RefreshMaterializedTableParameters>
+                    messageHeaders) {
+        super(service, responseHeaders, messageHeaders);
+    }
+
+    @Override
+    protected CompletableFuture<RefreshMaterializedTableResponseBody> handleRequest(
+            @Nullable SqlGatewayRestAPIVersion version,
+            @Nonnull HandlerRequest<RefreshMaterializedTableRequestBody> request)
+            throws RestHandlerException {
+        try {
+            SessionHandle sessionHandle =
+                    request.getPathParameter(SessionHandleIdPathParameter.class);
+            String materializedTableIdentifier =
+                    request.getPathParameter(MaterializedTableIdentifierPathParameter.class);
+            boolean isPeriodic = request.getRequestBody().isPeriodic();
+            String scheduleTime = request.getRequestBody().getScheduleTime();
+            Map<String, String> dynamicOptions = request.getRequestBody().getDynamicOptions();
+            Map<String, String> staticPartitions = request.getRequestBody().getStaticPartitions();
+            Map<String, String> executionConfig = request.getRequestBody().getExecutionConfig();
+            OperationHandle operationHandle =
+                    service.refreshMaterializedTable(
+                            sessionHandle,
+                            materializedTableIdentifier,
+                            isPeriodic,
+                            scheduleTime,
+                            dynamicOptions == null ? Collections.emptyMap() : dynamicOptions,
+                            staticPartitions == null ? Collections.emptyMap() : staticPartitions,
+                            executionConfig == null ? Collections.emptyMap() : executionConfig);
+
+            return CompletableFuture.completedFuture(
+                    new RefreshMaterializedTableResponseBody(
+                            operationHandle.getIdentifier().toString()));
+        } catch (Exception e) {
+            throw new RestHandlerException(
+                    e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/RefreshMaterializedTableHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/RefreshMaterializedTableHeaders.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.header.materializedtable;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
+import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
+import org.apache.flink.table.gateway.rest.message.materializedtable.MaterializedTableIdentifierPathParameter;
+import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableParameters;
+import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableRequestBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableResponseBody;
+import org.apache.flink.table.gateway.rest.message.session.SessionHandleIdPathParameter;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/** Message headers for executing a materialized table refresh operation. */
+public class RefreshMaterializedTableHeaders
+        implements SqlGatewayMessageHeaders<
+                RefreshMaterializedTableRequestBody,
+                RefreshMaterializedTableResponseBody,
+                RefreshMaterializedTableParameters> {
+
+    private static final RefreshMaterializedTableHeaders INSTANCE =
+            new RefreshMaterializedTableHeaders();
+
+    private static final String URL =
+            "/sessions/:"
+                    + SessionHandleIdPathParameter.KEY
+                    + "/materialized-tables/:"
+                    + MaterializedTableIdentifierPathParameter.KEY
+                    + "/refresh";
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.POST;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public Class<RefreshMaterializedTableResponseBody> getResponseClass() {
+        return RefreshMaterializedTableResponseBody.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Refresh materialized table";
+    }
+
+    @Override
+    public Class<RefreshMaterializedTableRequestBody> getRequestClass() {
+        return RefreshMaterializedTableRequestBody.class;
+    }
+
+    @Override
+    public RefreshMaterializedTableParameters getUnresolvedMessageParameters() {
+        return new RefreshMaterializedTableParameters();
+    }
+
+    @Override
+    public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
+        return Collections.singleton(SqlGatewayRestAPIVersion.V3);
+    }
+
+    public static RefreshMaterializedTableHeaders getInstance() {
+        return INSTANCE;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/MaterializedTableIdentifierPathParameter.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/MaterializedTableIdentifierPathParameter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.materializedtable;
+
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+
+/** {@link MessagePathParameter} that parses the materialized table identifier. */
+public class MaterializedTableIdentifierPathParameter extends MessagePathParameter<String> {
+
+    public static final String KEY = "identifier";
+
+    protected MaterializedTableIdentifierPathParameter() {
+        super(KEY);
+    }
+
+    @Override
+    protected String convertFromString(String value) {
+        return value;
+    }
+
+    @Override
+    protected String convertToString(String value) {
+        return value;
+    }
+
+    @Override
+    public String getDescription() {
+        return "The materialized table identifier.";
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/RefreshMaterializedTableParameters.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/RefreshMaterializedTableParameters.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.materializedtable;
+
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.rest.message.session.SessionHandleIdPathParameter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/** {@link MessageParameters} for execute materialized table refresh operation. */
+public class RefreshMaterializedTableParameters extends MessageParameters {
+
+    private final SessionHandleIdPathParameter sessionHandleIdPathParameter =
+            new SessionHandleIdPathParameter();
+
+    private final MaterializedTableIdentifierPathParameter identifierPathParameter =
+            new MaterializedTableIdentifierPathParameter();
+
+    public RefreshMaterializedTableParameters() {}
+
+    public RefreshMaterializedTableParameters(SessionHandle sessionHandle, String identifier) {
+        sessionHandleIdPathParameter.resolve(sessionHandle);
+        identifierPathParameter.resolve(identifier);
+    }
+
+    @Override
+    public Collection<MessagePathParameter<?>> getPathParameters() {
+        return Arrays.asList(sessionHandleIdPathParameter, identifierPathParameter);
+    }
+
+    @Override
+    public Collection<MessageQueryParameter<?>> getQueryParameters() {
+        return Collections.emptyList();
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/RefreshMaterializedTableRequestBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/RefreshMaterializedTableRequestBody.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.materializedtable;
+
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+/** {@link RequestBody} for executing materialized table refresh operation. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RefreshMaterializedTableRequestBody implements RequestBody {
+
+    private static final String FIELD_NAME_IS_PERIODIC = "isPeriodic";
+    private static final String FIELD_NAME_SCHEDULE_TIME = "scheduleTime";
+    private static final String FIELD_NAME_DYNAMIC_OPTIONS = "dynamicOptions";
+    private static final String FIELD_NAME_STATIC_PARTITIONS = "staticPartitions";
+    private static final String FIELD_NAME_EXECUTION_CONFIG = "executionConfig";
+
+    @JsonProperty(FIELD_NAME_IS_PERIODIC)
+    private final boolean isPeriodic;
+
+    @JsonProperty(FIELD_NAME_SCHEDULE_TIME)
+    @Nullable
+    private final String scheduleTime;
+
+    @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS)
+    @Nullable
+    private final Map<String, String> dynamicOptions;
+
+    @JsonProperty(FIELD_NAME_STATIC_PARTITIONS)
+    @Nullable
+    private final Map<String, String> staticPartitions;
+
+    @JsonProperty(FIELD_NAME_EXECUTION_CONFIG)
+    @Nullable
+    private final Map<String, String> executionConfig;
+
+    @JsonCreator
+    public RefreshMaterializedTableRequestBody(
+            @JsonProperty(FIELD_NAME_IS_PERIODIC) boolean isPeriodic,
+            @Nullable @JsonProperty(FIELD_NAME_SCHEDULE_TIME) String scheduleTime,
+            @Nullable @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS) Map<String, String> dynamicOptions,
+            @Nullable @JsonProperty(FIELD_NAME_STATIC_PARTITIONS)
+                    Map<String, String> staticPartitions,
+            @Nullable @JsonProperty(FIELD_NAME_EXECUTION_CONFIG)
+                    Map<String, String> executionConfig) {
+        this.isPeriodic = isPeriodic;
+        this.scheduleTime = scheduleTime;
+        this.dynamicOptions = dynamicOptions;
+        this.staticPartitions = staticPartitions;
+        this.executionConfig = executionConfig;
+    }
+
+    public boolean isPeriodic() {
+        return isPeriodic;
+    }
+
+    @Nullable
+    public String getScheduleTime() {
+        return scheduleTime;
+    }
+
+    @Nullable
+    public Map<String, String> getDynamicOptions() {
+        return dynamicOptions;
+    }
+
+    @Nullable
+    public Map<String, String> getStaticPartitions() {
+        return staticPartitions;
+    }
+
+    @Nullable
+    public Map<String, String> getExecutionConfig() {
+        return executionConfig;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/RefreshMaterializedTableResponseBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/RefreshMaterializedTableResponseBody.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.materializedtable;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+/** {@link ResponseBody} for executing a materialized table refresh operation. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RefreshMaterializedTableResponseBody implements ResponseBody {
+
+    private static final String FIELD_OPERATION_HANDLE = "operationHandle";
+
+    @JsonProperty(FIELD_OPERATION_HANDLE)
+    private final String operationHandle;
+
+    public RefreshMaterializedTableResponseBody(
+            @JsonProperty(FIELD_OPERATION_HANDLE) String operationHandle) {
+        this.operationHandle = operationHandle;
+    }
+
+    public String getOperationHandle() {
+        return operationHandle;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/SqlGatewayServiceImpl.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/SqlGatewayServiceImpl.java
@@ -46,6 +46,8 @@ import org.apache.flink.table.gateway.service.session.SessionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -296,6 +298,35 @@ public class SqlGatewayServiceImpl implements SqlGatewayService {
         } catch (Throwable t) {
             LOG.error("Failed to getTable.", t);
             throw new SqlGatewayException("Failed to getTable.", t);
+        }
+    }
+
+    @Override
+    public OperationHandle refreshMaterializedTable(
+            SessionHandle sessionHandle,
+            String materializedTableIdentifier,
+            boolean isPeriodic,
+            @Nullable String scheduleTime,
+            Map<String, String> dynamicOptions,
+            Map<String, String> staticPartitions,
+            Map<String, String> executionConfig) {
+        try {
+            return getSession(sessionHandle)
+                    .getOperationManager()
+                    .submitOperation(
+                            handle ->
+                                    getSession(sessionHandle)
+                                            .createExecutor(Configuration.fromMap(executionConfig))
+                                            .refreshMaterializedTable(
+                                                    handle,
+                                                    materializedTableIdentifier,
+                                                    isPeriodic,
+                                                    scheduleTime,
+                                                    staticPartitions,
+                                                    dynamicOptions));
+        } catch (Throwable t) {
+            LOG.error("Failed to refresh MaterializedTable.", t);
+            throw new SqlGatewayException("Failed to refresh MaterializedTable.", t);
         }
     }
 

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -107,6 +107,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Arrays;
@@ -530,6 +532,28 @@ public class OperationExecutor {
                                 tableConfig(),
                                 sessionContext.getSessionConf().get(RUNTIME_MODE) == STREAMING));
         return ResultFetcher.fromTableResult(handle, result, false);
+    }
+
+    public ResultFetcher refreshMaterializedTable(
+            OperationHandle handle,
+            String materializedTableIdentifier,
+            boolean isPeriodic,
+            @Nullable String scheduleTime,
+            Map<String, String> staticPartitions,
+            Map<String, String> dynamicOptions) {
+        TableEnvironmentInternal tEnv = getTableEnvironment();
+        UnresolvedIdentifier unresolvedIdentifier =
+                tEnv.getParser().parseIdentifier(materializedTableIdentifier);
+        ObjectIdentifier objectIdentifier =
+                tEnv.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+        return MaterializedTableManager.refreshMaterializedTable(
+                this,
+                handle,
+                objectIdentifier,
+                staticPartitions,
+                dynamicOptions,
+                isPeriodic,
+                scheduleTime);
     }
 
     private TableConfig tableConfig() {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractMaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractMaterializedTableStatementITCase.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.jobgraph.JobType;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.gateway.api.operation.OperationHandle;
+import org.apache.flink.table.gateway.api.results.TableInfo;
+import org.apache.flink.table.gateway.api.session.SessionEnvironment;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
+import org.apache.flink.table.gateway.api.utils.MockedEndpointVersion;
+import org.apache.flink.table.gateway.service.SqlGatewayServiceImpl;
+import org.apache.flink.table.gateway.service.utils.IgnoreExceptionHandler;
+import org.apache.flink.table.gateway.service.utils.SqlGatewayServiceExtension;
+import org.apache.flink.test.junit5.InjectClusterClient;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.catalog.CommonCatalogOptions.TABLE_CATALOG_STORE_KIND;
+import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.awaitOperationTermination;
+import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.fetchAllResults;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Base ITCase tests for materialized table. */
+public abstract class AbstractMaterializedTableStatementITCase {
+
+    private static final String FILE_CATALOG_STORE = "file_store";
+    private static final String TEST_CATALOG_PREFIX = "test_catalog";
+    protected static final String TEST_DEFAULT_DATABASE = "test_db";
+
+    private static final AtomicLong COUNTER = new AtomicLong(0);
+
+    @RegisterExtension
+    @Order(1)
+    static final MiniClusterExtension MINI_CLUSTER =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(2)
+                            .build());
+
+    @RegisterExtension
+    @Order(2)
+    protected static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
+            new SqlGatewayServiceExtension(MINI_CLUSTER::getClientConfiguration);
+
+    @RegisterExtension
+    @Order(3)
+    protected static final TestExecutorExtension<ExecutorService> EXECUTOR_EXTENSION =
+            new TestExecutorExtension<>(
+                    () ->
+                            Executors.newCachedThreadPool(
+                                    new ExecutorThreadFactory(
+                                            "SqlGatewayService Test Pool",
+                                            IgnoreExceptionHandler.INSTANCE)));
+
+    protected static SqlGatewayServiceImpl service;
+    private static SessionEnvironment defaultSessionEnvironment;
+    private static Path baseCatalogPath;
+
+    private String fileSystemCatalogPath;
+    protected String fileSystemCatalogName;
+
+    protected SessionHandle sessionHandle;
+
+    protected RestClusterClient<?> restClusterClient;
+
+    @BeforeAll
+    static void setUp(@TempDir Path temporaryFolder) throws Exception {
+        service = (SqlGatewayServiceImpl) SQL_GATEWAY_SERVICE_EXTENSION.getService();
+
+        // initialize file catalog store path
+        Path fileCatalogStore = temporaryFolder.resolve(FILE_CATALOG_STORE);
+        Files.createDirectory(fileCatalogStore);
+        Map<String, String> catalogStoreOptions = new HashMap<>();
+        catalogStoreOptions.put(TABLE_CATALOG_STORE_KIND.key(), "file");
+        catalogStoreOptions.put("table.catalog-store.file.path", fileCatalogStore.toString());
+
+        // initialize test-filesystem catalog base path
+        baseCatalogPath = temporaryFolder.resolve(TEST_CATALOG_PREFIX);
+        Files.createDirectory(baseCatalogPath);
+
+        defaultSessionEnvironment =
+                SessionEnvironment.newBuilder()
+                        .addSessionConfig(catalogStoreOptions)
+                        .setSessionEndpointVersion(MockedEndpointVersion.V1)
+                        .build();
+    }
+
+    @BeforeEach
+    void before(@InjectClusterClient RestClusterClient<?> injectClusterClient) throws Exception {
+        String randomStr = String.valueOf(COUNTER.incrementAndGet());
+        // initialize test-filesystem catalog path with random uuid
+        Path fileCatalogPath = baseCatalogPath.resolve(randomStr);
+        Files.createDirectory(fileCatalogPath);
+        Path dbPath = fileCatalogPath.resolve(TEST_DEFAULT_DATABASE);
+        Files.createDirectory(dbPath);
+
+        fileSystemCatalogPath = fileCatalogPath.toString();
+        fileSystemCatalogName = TEST_CATALOG_PREFIX + randomStr;
+        // initialize session handle, create test-filesystem catalog and register it to catalog
+        // store
+        sessionHandle = initializeSession();
+
+        // init rest cluster client
+        restClusterClient = injectClusterClient;
+    }
+
+    @AfterEach
+    void after() throws Exception {
+        Set<TableInfo> tableInfos =
+                service.listTables(
+                        sessionHandle,
+                        fileSystemCatalogName,
+                        TEST_DEFAULT_DATABASE,
+                        Collections.singleton(CatalogBaseTable.TableKind.TABLE));
+
+        // drop all materialized tables
+        for (TableInfo tableInfo : tableInfos) {
+            ResolvedCatalogBaseTable<?> resolvedTable =
+                    service.getTable(sessionHandle, tableInfo.getIdentifier());
+            if (CatalogBaseTable.TableKind.MATERIALIZED_TABLE == resolvedTable.getTableKind()) {
+                String dropTableDDL =
+                        String.format(
+                                "DROP MATERIALIZED TABLE %s",
+                                tableInfo.getIdentifier().asSerializableString());
+                OperationHandle dropTableHandle =
+                        service.executeStatement(
+                                sessionHandle, dropTableDDL, -1, new Configuration());
+                awaitOperationTermination(service, sessionHandle, dropTableHandle);
+            }
+        }
+    }
+
+    private SessionHandle initializeSession() {
+        SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
+        String catalogDDL =
+                String.format(
+                        "CREATE CATALOG %s\n"
+                                + "WITH (\n"
+                                + "  'type' = 'test-filesystem',\n"
+                                + "  'path' = '%s',\n"
+                                + "  'default-database' = '%s'\n"
+                                + "  )",
+                        fileSystemCatalogName, fileSystemCatalogPath, TEST_DEFAULT_DATABASE);
+        service.configureSession(sessionHandle, catalogDDL, -1);
+        service.configureSession(
+                sessionHandle, String.format("USE CATALOG %s", fileSystemCatalogName), -1);
+
+        // create source table
+        String dataGenSource =
+                "CREATE TABLE datagenSource (\n"
+                        + "  order_id BIGINT,\n"
+                        + "  order_number VARCHAR(20),\n"
+                        + "  user_id BIGINT,\n"
+                        + "  shop_id BIGINT,\n"
+                        + "  product_id BIGINT,\n"
+                        + "  status BIGINT,\n"
+                        + "  order_type BIGINT,\n"
+                        + "  order_created_at TIMESTAMP,\n"
+                        + "  payment_amount_cents BIGINT\n"
+                        + ")\n"
+                        + "WITH (\n"
+                        + "  'connector' = 'datagen',\n"
+                        + "  'rows-per-second' = '10'\n"
+                        + ")";
+        service.configureSession(sessionHandle, dataGenSource, -1);
+        return sessionHandle;
+    }
+
+    public void createAndVerifyCreateMaterializedTableWithData(
+            String materializedTableName,
+            String dataId,
+            List<Row> data,
+            Map<String, String> partitionFormatter)
+            throws Exception {
+        long timeout = Duration.ofSeconds(20).toMillis();
+        long pause = Duration.ofSeconds(2).toMillis();
+
+        String sourceDdl =
+                String.format(
+                        "CREATE TABLE IF NOT EXISTS my_source (\n"
+                                + "  order_id BIGINT,\n"
+                                + "  user_id BIGINT,\n"
+                                + "  shop_id BIGINT,\n"
+                                + "  order_created_at STRING\n"
+                                + ")\n"
+                                + "WITH (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'bounded' = 'true',\n"
+                                + "  'data-id' = '%s'\n"
+                                + ")",
+                        dataId);
+        OperationHandle sourceHandle =
+                service.executeStatement(sessionHandle, sourceDdl, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, sourceHandle);
+
+        String partitionFields =
+                partitionFormatter != null && !partitionFormatter.isEmpty()
+                        ? partitionFormatter.entrySet().stream()
+                                .map(
+                                        e ->
+                                                String.format(
+                                                        "'partition.fields.%s.date-formatter' = '%s'",
+                                                        e.getKey(), e.getValue()))
+                                .collect(Collectors.joining(",\n", "", ",\n"))
+                        : "\n";
+        String materializedTableDDL =
+                String.format(
+                        "CREATE MATERIALIZED TABLE %s"
+                                + " PARTITIONED BY (ds)\n"
+                                + " WITH(\n"
+                                + "    %s"
+                                + "   'format' = 'debezium-json'\n"
+                                + " )\n"
+                                + " FRESHNESS = INTERVAL '2' SECOND\n"
+                                + " AS SELECT \n"
+                                + "  user_id,\n"
+                                + "  shop_id,\n"
+                                + "  ds,\n"
+                                + "  COUNT(order_id) AS order_cnt\n"
+                                + " FROM (\n"
+                                + "    SELECT user_id, shop_id, order_created_at AS ds, order_id FROM my_source"
+                                + " ) AS tmp\n"
+                                + " GROUP BY (user_id, shop_id, ds)",
+                        materializedTableName, partitionFields);
+
+        OperationHandle materializedTableHandle =
+                service.executeStatement(
+                        sessionHandle, materializedTableDDL, -1, new Configuration());
+        awaitOperationTermination(service, sessionHandle, materializedTableHandle);
+
+        // verify data exists in materialized table
+        CommonTestUtils.waitUtil(
+                () ->
+                        fetchTableData(
+                                                sessionHandle,
+                                                String.format(
+                                                        "SELECT * FROM %s", materializedTableName))
+                                        .size()
+                                == data.size(),
+                Duration.ofMillis(timeout),
+                Duration.ofMillis(pause),
+                "Failed to verify the data in materialized table.");
+    }
+
+    public List<RowData> fetchTableData(SessionHandle sessionHandle, String query) {
+        OperationHandle queryHandle =
+                service.executeStatement(sessionHandle, query, -1, new Configuration());
+
+        return fetchAllResults(service, sessionHandle, queryHandle);
+    }
+
+    public void verifyRefreshJobCreated(
+            RestClusterClient<?> restClusterClient, String jobId, long startTime) throws Exception {
+        long timeout = Duration.ofSeconds(20).toMillis();
+        long pause = Duration.ofSeconds(2).toMillis();
+
+        // 1. verify a new job is created
+        Optional<JobStatusMessage> job =
+                restClusterClient.listJobs().get(timeout, TimeUnit.MILLISECONDS).stream()
+                        .filter(j -> j.getJobId().toString().equals(jobId))
+                        .findFirst();
+        assertThat(job).isPresent();
+        assertThat(job.get().getStartTime()).isGreaterThan(startTime);
+
+        // 2. verify the new job is a batch job
+        JobDetailsInfo jobDetailsInfo =
+                restClusterClient
+                        .getJobDetails(JobID.fromHexString(jobId))
+                        .get(timeout, TimeUnit.MILLISECONDS);
+        assertThat(jobDetailsInfo.getJobType()).isEqualTo(JobType.BATCH);
+
+        // 3. verify the new job is finished
+        CommonTestUtils.waitUtil(
+                () -> {
+                    try {
+                        return JobStatus.FINISHED.equals(
+                                restClusterClient
+                                        .getJobStatus(JobID.fromHexString(jobId))
+                                        .get(5, TimeUnit.SECONDS));
+                    } catch (Exception ignored) {
+                    }
+                    return false;
+                },
+                Duration.ofMillis(timeout),
+                Duration.ofMillis(pause),
+                "Failed to verify whether the job is finished.");
+    }
+}

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest;
+
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.gateway.AbstractMaterializedTableStatementITCase;
+import org.apache.flink.table.gateway.api.operation.OperationHandle;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.header.materializedtable.RefreshMaterializedTableHeaders;
+import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableParameters;
+import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableRequestBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableResponseBody;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestEndpointExtension;
+import org.apache.flink.table.gateway.rest.util.TestingRestClient;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.types.Row;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.flink.table.gateway.rest.util.TestingRestClient.getTestingRestClient;
+import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.fetchAllResults;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test basic logic of handlers inherited from {@link AbstractSqlGatewayRestHandler} in materialized
+ * table related cases.
+ */
+public class SqlGatewayRestEndpointMaterializedTableITCase
+        extends AbstractMaterializedTableStatementITCase {
+
+    private static TestingRestClient restClient;
+
+    @RegisterExtension
+    @Order(4)
+    private static final SqlGatewayRestEndpointExtension SQL_GATEWAY_REST_ENDPOINT_EXTENSION =
+            new SqlGatewayRestEndpointExtension(SQL_GATEWAY_SERVICE_EXTENSION::getService);
+
+    @BeforeAll
+    static void setup() throws Exception {
+        restClient = getTestingRestClient();
+    }
+
+    @Test
+    void testStaticPartitionRefreshMaterializedTableViaRestAPI() throws Exception {
+        List<Row> data = new ArrayList<>();
+        data.add(Row.of(1L, 1L, 1L, "2024-01-01"));
+        data.add(Row.of(2L, 2L, 2L, "2024-01-02"));
+        String dataId = TestValuesTableFactory.registerData(data);
+
+        createAndVerifyCreateMaterializedTableWithData(
+                "my_materialized_table", dataId, data, Collections.emptyMap());
+
+        RefreshMaterializedTableHeaders refreshMaterializedTableHeaders =
+                new RefreshMaterializedTableHeaders();
+
+        RefreshMaterializedTableParameters refreshMaterializedTableParameters =
+                new RefreshMaterializedTableParameters(
+                        sessionHandle,
+                        ObjectIdentifier.of(
+                                        fileSystemCatalogName,
+                                        TEST_DEFAULT_DATABASE,
+                                        "my_materialized_table")
+                                .asSerializableString());
+
+        Map<String, String> staticPartitions = new HashMap<>();
+        staticPartitions.put("ds", "2024-01-02");
+        RefreshMaterializedTableRequestBody refreshMaterializedTableRequestBody =
+                new RefreshMaterializedTableRequestBody(
+                        false,
+                        null,
+                        Collections.emptyMap(),
+                        staticPartitions,
+                        Collections.emptyMap());
+
+        long startTime = System.currentTimeMillis();
+        // refresh materialized table
+        RefreshMaterializedTableResponseBody response =
+                restClient
+                        .sendRequest(
+                                SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
+                                SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort(),
+                                refreshMaterializedTableHeaders,
+                                refreshMaterializedTableParameters,
+                                refreshMaterializedTableRequestBody)
+                        .get();
+
+        assertThat(response.getOperationHandle()).isNotNull();
+
+        // verify refresh job is created
+        String operationHandle = response.getOperationHandle();
+        List<RowData> results =
+                fetchAllResults(
+                        service,
+                        sessionHandle,
+                        new OperationHandle(UUID.fromString(operationHandle)));
+        String jobId = results.get(0).getString(0).toString();
+
+        verifyRefreshJobCreated(restClusterClient, jobId, startTime);
+    }
+
+    @Test
+    void testPeriodicRefreshMaterializedTableViaRestAPI() throws Exception {
+        List<Row> data = new ArrayList<>();
+        data.add(Row.of(1L, 1L, 1L, "2024-01-01"));
+        data.add(Row.of(2L, 2L, 2L, "2024-01-02"));
+        String dataId = TestValuesTableFactory.registerData(data);
+
+        createAndVerifyCreateMaterializedTableWithData(
+                "my_materialized_table",
+                dataId,
+                data,
+                Collections.singletonMap("ds", "yyyy-MM-dd"));
+
+        RefreshMaterializedTableHeaders refreshMaterializedTableHeaders =
+                new RefreshMaterializedTableHeaders();
+
+        RefreshMaterializedTableParameters refreshMaterializedTableParameters =
+                new RefreshMaterializedTableParameters(
+                        sessionHandle,
+                        ObjectIdentifier.of(
+                                        fileSystemCatalogName,
+                                        TEST_DEFAULT_DATABASE,
+                                        "my_materialized_table")
+                                .asSerializableString());
+
+        Map<String, String> staticPartitions = new HashMap<>();
+        RefreshMaterializedTableRequestBody refreshMaterializedTableRequestBody =
+                new RefreshMaterializedTableRequestBody(
+                        true,
+                        "2024-01-02 00:00:00",
+                        Collections.emptyMap(),
+                        staticPartitions,
+                        Collections.emptyMap());
+
+        long startTime = System.currentTimeMillis();
+        // refresh materialized table
+        RefreshMaterializedTableResponseBody response =
+                restClient
+                        .sendRequest(
+                                SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
+                                SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort(),
+                                refreshMaterializedTableHeaders,
+                                refreshMaterializedTableParameters,
+                                refreshMaterializedTableRequestBody)
+                        .get();
+
+        assertThat(response.getOperationHandle()).isNotNull();
+
+        // verify refresh job is created
+        String operationHandle = response.getOperationHandle();
+        List<RowData> results =
+                fetchAllResults(
+                        service,
+                        sessionHandle,
+                        new OperationHandle(UUID.fromString(operationHandle)));
+        String jobId = results.get(0).getString(0).toString();
+
+        verifyRefreshJobCreated(restClusterClient, jobId, startTime);
+    }
+}

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManagerTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManagerTest.java
@@ -18,39 +18,47 @@
 
 package org.apache.flink.table.gateway.service.materializedtable;
 
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link MaterializedTableManager}. */
 class MaterializedTableManagerTest {
 
     @Test
     void testGetManuallyRefreshStatement() {
-        String tableIdentifier = "my_materialized_table";
+        ObjectIdentifier tableIdentifier =
+                ObjectIdentifier.of("catalog", "database", "my_materialized_table");
         String query = "SELECT * FROM my_source_table";
         assertThat(
-                        MaterializedTableManager.getManuallyRefreshStatement(
-                                tableIdentifier, query, Collections.emptyMap()))
+                        MaterializedTableManager.getRefreshStatement(
+                                tableIdentifier,
+                                query,
+                                Collections.emptyMap(),
+                                Collections.emptyMap()))
                 .isEqualTo(
-                        "INSERT OVERWRITE my_materialized_table\n"
+                        "INSERT OVERWRITE `catalog`.`database`.`my_materialized_table`\n"
                                 + "  SELECT * FROM (SELECT * FROM my_source_table)");
 
         Map<String, String> partitionSpec = new LinkedHashMap<>();
         partitionSpec.put("k1", "v1");
         partitionSpec.put("k2", "v2");
         assertThat(
-                        MaterializedTableManager.getManuallyRefreshStatement(
-                                tableIdentifier, query, partitionSpec))
+                        MaterializedTableManager.getRefreshStatement(
+                                tableIdentifier, query, partitionSpec, Collections.emptyMap()))
                 .isEqualTo(
-                        "INSERT OVERWRITE my_materialized_table\n"
+                        "INSERT OVERWRITE `catalog`.`database`.`my_materialized_table`\n"
                                 + "  SELECT * FROM (SELECT * FROM my_source_table)\n"
                                 + "  WHERE k1 = 'v1' AND k2 = 'v2'");
     }
@@ -72,7 +80,7 @@ class MaterializedTableManagerTest {
     }
 
     @Test
-    void generateInsertStatementWithDynamicOptions() {
+    void testGenerateInsertStatementWithDynamicOptions() {
         ObjectIdentifier materializedTableIdentifier =
                 ObjectIdentifier.of("catalog", "database", "table");
         String definitionQuery = "SELECT * FROM source_table";
@@ -89,5 +97,58 @@ class MaterializedTableManagerTest {
                 MaterializedTableManager.getInsertStatement(
                         materializedTableIdentifier, definitionQuery, dynamicOptions);
         assertThat(actualStatement).isEqualTo(expectedStatement);
+    }
+
+    @Test
+    void testGetPeriodRefreshPartition() {
+        String schedulerTime = "2024-01-01 00:00:00";
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("partition.fields.day.date-formatter", "yyyy-MM-dd");
+        tableOptions.put("partition.fields.hour.date-formatter", "HH");
+
+        ObjectIdentifier objectIdentifier = ObjectIdentifier.of("catalog", "database", "table");
+
+        Map<String, String> actualRefreshPartition =
+                MaterializedTableManager.getPeriodRefreshPartition(
+                        schedulerTime, objectIdentifier, tableOptions, ZoneId.systemDefault());
+        Map<String, String> expectedRefreshPartition = new HashMap<>();
+        expectedRefreshPartition.put("day", "2024-01-01");
+        expectedRefreshPartition.put("hour", "00");
+
+        assertThat(actualRefreshPartition).isEqualTo(expectedRefreshPartition);
+    }
+
+    @Test
+    void testGetPeriodRefreshPartitionWithInvalidSchedulerTime() {
+        // scheduler time is null
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("partition.fields.day.date-formatter", "yyyy-MM-dd");
+        tableOptions.put("partition.fields.hour.date-formatter", "HH");
+
+        ObjectIdentifier objectIdentifier = ObjectIdentifier.of("catalog", "database", "table");
+
+        assertThatThrownBy(
+                        () ->
+                                MaterializedTableManager.getPeriodRefreshPartition(
+                                        null,
+                                        objectIdentifier,
+                                        tableOptions,
+                                        ZoneId.systemDefault()))
+                .isInstanceOf(ValidationException.class)
+                .hasMessage(
+                        "Scheduler time not properly set for periodic refresh of materialized table `catalog`.`database`.`table`.");
+
+        // scheduler time is invalid
+        String invalidSchedulerTime = "2024-01-01";
+        assertThatThrownBy(
+                        () ->
+                                MaterializedTableManager.getPeriodRefreshPartition(
+                                        invalidSchedulerTime,
+                                        objectIdentifier,
+                                        tableOptions,
+                                        ZoneId.systemDefault()))
+                .isInstanceOf(SqlExecutionException.class)
+                .hasMessage(
+                        "Failed to parse a valid partition value for the field 'day' in materialized table `catalog`.`database`.`table` using the scheduler time '2024-01-01' based on the date format 'yyyy-MM-dd HH:mm:ss'.");
     }
 }

--- a/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
@@ -231,6 +231,63 @@
       "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
     }
   }, {
+    "url" : "/sessions/:session_handle/materialized-tables/:identifier/refresh",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "session_handle"
+      }, {
+        "key" : "identifier"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:RefreshMaterializedTableRequestBody",
+      "properties" : {
+        "isPeriodic" : {
+          "type" : "boolean"
+        },
+        "scheduleTime" : {
+          "type" : "string"
+        },
+        "dynamicOptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "staticPartitions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "executionConfig" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
+        },
+        "periodic" : {
+          "type" : "boolean"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:RefreshMaterializedTableResponseBody",
+      "properties" : {
+        "operationHandle" : {
+          "type" : "string"
+        }
+      }
+    }
+  }, {
     "url" : "/sessions/:session_handle/operations/:operation_handle/cancel",
     "method" : "POST",
     "status-code" : "200 OK",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/MaterializedTableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/MaterializedTableConfigOptions.java
@@ -38,6 +38,8 @@ public class MaterializedTableConfigOptions {
     public static final String PARTITION_FIELDS = "partition.fields";
     public static final String DATE_FORMATTER = "date-formatter";
 
+    public static final String SCHEDULE_TIME_DATE_FORMATTER_DEFAULT = "yyyy-MM-dd HH:mm:ss";
+
     @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
     public static final ConfigOption<Duration> MATERIALIZED_TABLE_FRESHNESS_THRESHOLD =
             key("materialized-table.refresh-mode.freshness-threshold")

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/main/java/org/apache/flink/table/file/testutils/TestFileSystemTableFactory.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/main/java/org/apache/flink/table/file/testutils/TestFileSystemTableFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.file.testutils;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 import org.apache.flink.connector.file.table.FileSystemTableFactory;
 import org.apache.flink.connector.file.table.TestFileSystemTableSource;
 import org.apache.flink.connector.file.table.factories.BulkReaderFormatFactory;
@@ -30,6 +31,8 @@ import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.file.testutils.catalog.TestFileSystemCatalog;
 
 import java.util.Collections;
+
+import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.PARTITION_FIELDS;
 
 /** Test filesystem {@link Factory}. */
 @Internal
@@ -83,5 +86,18 @@ public class TestFileSystemTableFactory extends FileSystemTableFactory {
                     context.isTemporary());
         }
         return super.createDynamicTableSink(context);
+    }
+
+    @Override
+    protected void validate(FactoryUtil.TableFactoryHelper helper) {
+        // Except format options and partition fields options, some formats like parquet and orc can
+        // not list all supported options.
+        helper.validateExcept(
+                helper.getOptions().get(FactoryUtil.FORMAT) + ".", PARTITION_FIELDS + ".");
+
+        // validate time zone of watermark
+        validateTimeZone(
+                helper.getOptions()
+                        .get(FileSystemConnectorOptions.SINK_PARTITION_COMMIT_WATERMARK_TIME_ZONE));
     }
 }

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/TestFileSystemTableFactoryTest.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/TestFileSystemTableFactoryTest.java
@@ -55,6 +55,9 @@ public class TestFileSystemTableFactoryTest {
         // test ignore format options
         options.put("testcsv.my_option", "my_value");
 
+        // test ignore partition fields
+        options.put("partition.fields.f1.date-formatter", "yyyy-MM-dd");
+
         DynamicTableSource source = createTableSource(SCHEMA, options);
         assertThat(source).isInstanceOf(TestFileSystemTableSource.class);
 


### PR DESCRIPTION
## What is the purpose of the change

*Introduce refresh materialized table rest api*

## Brief change log

  - *test-filesystem support partition.fields option*
  - *Introduce refresh materialized table rest api*

## Verifying this change

* Add test case in MaterializedTableITCase to verify refresh materialzied table.
* Add test class SqlGatewayRestEndpointMaterializedTableITCase to verify refresh materialized table rest api.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Will be added in a separated pr.)
