### PR TITLE
[FLINK-35460][state] Adjust read size when ByteBuffer size is larger than file size for ForSt

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
@@ -28,6 +28,8 @@ import org.apache.flink.core.fs.Path;
 import java.io.IOException;
 import java.net.URI;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A {@link FileSystem} delegates some requests to file system loaded by Flink FileSystem mechanism.
  *
@@ -80,14 +82,18 @@ public class ForStFlinkFileSystem extends FileSystem {
 
     @Override
     public ByteBufferReadableFSDataInputStream open(Path path, int bufferSize) throws IOException {
+        FileStatus fileStatus = checkNotNull(getFileStatus(path));
         return new ByteBufferReadableFSDataInputStream(
-                () -> delegateFS.open(path, bufferSize), DEFAULT_INPUT_STREAM_CAPACITY);
+                () -> delegateFS.open(path, bufferSize),
+                DEFAULT_INPUT_STREAM_CAPACITY,
+                fileStatus.getLen());
     }
 
     @Override
     public ByteBufferReadableFSDataInputStream open(Path path) throws IOException {
+        FileStatus fileStatus = checkNotNull(getFileStatus(path));
         return new ByteBufferReadableFSDataInputStream(
-                () -> delegateFS.open(path), DEFAULT_INPUT_STREAM_CAPACITY);
+                () -> delegateFS.open(path), DEFAULT_INPUT_STREAM_CAPACITY, fileStatus.getLen());
     }
 
     @Override


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Adjust read size when ByteBuffer size is larger than file size to avoid bb.remaining() exceeding the file size limit.

## Brief change log

  - Adjust read size in ByteBufferReadableFSDataInputStream#readFully when ByteBuffer size is larger than file size

## Verifying this change

- Add case ForStFlinkFileSystemTest#testReadExceedingFileSize

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
