### PR TITLE
[FLINK-35427][json] Support fail-on-unknown-field config in json format

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/json.md
+++ b/docs/content.zh/docs/connectors/table/formats/json.md
@@ -85,7 +85,14 @@ Format 参数
       <td>可选</td>
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
-      <td>当解析字段缺失时，是跳过当前字段或行，还是抛出错误失败（默认为 false，即抛出错误失败）。</td>
+      <td>当解析字段缺失时，是跳过当前字段或行，还是抛出错误失败（默认为 false，即跳过当前字段或行）。</td>
+    </tr>
+    <tr>
+      <td><h5>json.fail-on-unknown-field</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>当解析到未知字段时，是跳过当前字段或行，还是抛出错误失败（默认为 false，即跳过当前字段或行）。</td>
     </tr>
     <tr>
       <td><h5>json.ignore-parse-errors</h5></td>

--- a/docs/content/docs/connectors/table/formats/json.md
+++ b/docs/content/docs/connectors/table/formats/json.md
@@ -93,6 +93,14 @@ Format Options
       <td>Whether to fail if a field is missing or not.</td>
     </tr>
     <tr>
+      <td><h5>json.fail-on-unknown-field</h5></td>
+      <td>optional</td>
+      <td>no</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Whether to fail if a field is unknown or not.</td>
+    </tr>
+    <tr>
       <td><h5>json.ignore-parse-errors</h5></td>
       <td>optional</td>
       <td>no</td>

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/AbstractJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/AbstractJsonDeserializationSchema.java
@@ -48,6 +48,9 @@ public abstract class AbstractJsonDeserializationSchema implements Deserializati
     /** Flag indicating whether to fail if a field is missing. */
     protected final boolean failOnMissingField;
 
+    /** Flag indicating whether to fail if a field is unknown. */
+    protected final boolean failOnUnknownField;
+
     /** Flag indicating whether to ignore invalid fields/rows (default: throw an exception). */
     protected final boolean ignoreParseErrors;
 
@@ -66,14 +69,20 @@ public abstract class AbstractJsonDeserializationSchema implements Deserializati
             RowType rowType,
             TypeInformation<RowData> resultTypeInfo,
             boolean failOnMissingField,
+            boolean failOnUnknownField,
             boolean ignoreParseErrors,
             TimestampFormat timestampFormat) {
         if (ignoreParseErrors && failOnMissingField) {
             throw new IllegalArgumentException(
                     "JSON format doesn't support failOnMissingField and ignoreParseErrors are both enabled.");
         }
+        if (ignoreParseErrors && failOnUnknownField) {
+            throw new IllegalArgumentException(
+                    "JSON format doesn't support failOnUnknownField and ignoreParseErrors are both enabled.");
+        }
         this.resultTypeInfo = checkNotNull(resultTypeInfo);
         this.failOnMissingField = failOnMissingField;
+        this.failOnUnknownField = failOnUnknownField;
         this.ignoreParseErrors = ignoreParseErrors;
         this.timestampFormat = timestampFormat;
         this.hasDecimalType = LogicalTypeChecks.hasNested(rowType, t -> t instanceof DecimalType);
@@ -111,6 +120,7 @@ public abstract class AbstractJsonDeserializationSchema implements Deserializati
         }
         AbstractJsonDeserializationSchema that = (AbstractJsonDeserializationSchema) o;
         return failOnMissingField == that.failOnMissingField
+                && failOnUnknownField == that.failOnUnknownField
                 && ignoreParseErrors == that.ignoreParseErrors
                 && resultTypeInfo.equals(that.resultTypeInfo)
                 && timestampFormat.equals(that.timestampFormat);
@@ -118,6 +128,11 @@ public abstract class AbstractJsonDeserializationSchema implements Deserializati
 
     @Override
     public int hashCode() {
-        return Objects.hash(failOnMissingField, ignoreParseErrors, resultTypeInfo, timestampFormat);
+        return Objects.hash(
+                failOnMissingField,
+                failOnUnknownField,
+                ignoreParseErrors,
+                resultTypeInfo,
+                timestampFormat);
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatFactory.java
@@ -48,6 +48,7 @@ import static org.apache.flink.formats.json.JsonFormatOptions.DECODE_JSON_PARSER
 import static org.apache.flink.formats.json.JsonFormatOptions.ENCODE_DECIMAL_AS_PLAIN_NUMBER;
 import static org.apache.flink.formats.json.JsonFormatOptions.ENCODE_IGNORE_NULL_FIELDS;
 import static org.apache.flink.formats.json.JsonFormatOptions.FAIL_ON_MISSING_FIELD;
+import static org.apache.flink.formats.json.JsonFormatOptions.FAIL_ON_UNKNOWN_FIELD;
 import static org.apache.flink.formats.json.JsonFormatOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.json.JsonFormatOptions.MAP_NULL_KEY_LITERAL;
 import static org.apache.flink.formats.json.JsonFormatOptions.MAP_NULL_KEY_MODE;
@@ -69,6 +70,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
         JsonFormatOptionsUtil.validateDecodingFormatOptions(formatOptions);
 
         final boolean failOnMissingField = formatOptions.get(FAIL_ON_MISSING_FIELD);
+        final boolean failOnUnknownField = formatOptions.get(FAIL_ON_UNKNOWN_FIELD);
         final boolean ignoreParseErrors = formatOptions.get(IGNORE_PARSE_ERRORS);
         final boolean jsonParserEnabled = formatOptions.get(DECODE_JSON_PARSER_ENABLED);
         TimestampFormat timestampOption = JsonFormatOptionsUtil.getTimestampFormat(formatOptions);
@@ -89,6 +91,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
                             rowType,
                             rowDataTypeInfo,
                             failOnMissingField,
+                            failOnUnknownField,
                             ignoreParseErrors,
                             timestampOption,
                             toProjectedNames(
@@ -98,6 +101,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
                             rowType,
                             rowDataTypeInfo,
                             failOnMissingField,
+                            failOnUnknownField,
                             ignoreParseErrors,
                             timestampOption);
                 }
@@ -185,6 +189,7 @@ public class JsonFormatFactory implements DeserializationFormatFactory, Serializ
     public Set<ConfigOption<?>> optionalOptions() {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(FAIL_ON_MISSING_FIELD);
+        options.add(FAIL_ON_UNKNOWN_FIELD);
         options.add(IGNORE_PARSE_ERRORS);
         options.add(TIMESTAMP_FORMAT);
         options.add(MAP_NULL_KEY_MODE);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptions.java
@@ -33,6 +33,13 @@ public class JsonFormatOptions {
                     .withDescription(
                             "Optional flag to specify whether to fail if a field is missing or not, false by default.");
 
+    public static final ConfigOption<Boolean> FAIL_ON_UNKNOWN_FIELD =
+            ConfigOptions.key("fail-on-unknown-field")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Optional flag to specify whether to fail if a field is unknown or not, false by default.");
+
     public static final ConfigOption<Boolean> IGNORE_PARSE_ERRORS =
             ConfigOptions.key("ignore-parse-errors")
                     .booleanType()

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptionsUtil.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonFormatOptionsUtil.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.formats.json.JsonFormatOptions.FAIL_ON_MISSING_FIELD;
+import static org.apache.flink.formats.json.JsonFormatOptions.FAIL_ON_UNKNOWN_FIELD;
 import static org.apache.flink.formats.json.JsonFormatOptions.IGNORE_PARSE_ERRORS;
 import static org.apache.flink.formats.json.JsonFormatOptions.MAP_NULL_KEY_MODE;
 import static org.apache.flink.formats.json.JsonFormatOptions.TIMESTAMP_FORMAT;
@@ -103,13 +104,19 @@ public class JsonFormatOptionsUtil {
     /** Validator for json decoding format. */
     public static void validateDecodingFormatOptions(ReadableConfig tableOptions) {
         boolean failOnMissingField = tableOptions.get(FAIL_ON_MISSING_FIELD);
+        boolean failOnUnknownField = tableOptions.get(FAIL_ON_UNKNOWN_FIELD);
         boolean ignoreParseErrors = tableOptions.get(IGNORE_PARSE_ERRORS);
         if (ignoreParseErrors && failOnMissingField) {
             throw new ValidationException(
-                    FAIL_ON_MISSING_FIELD.key()
-                            + " and "
-                            + IGNORE_PARSE_ERRORS.key()
-                            + " shouldn't both be true.");
+                    String.format(
+                            "%s and %s shouldn't both be true.",
+                            FAIL_ON_MISSING_FIELD.key(), IGNORE_PARSE_ERRORS.key()));
+        }
+        if (ignoreParseErrors && failOnUnknownField) {
+            throw new ValidationException(
+                    String.format(
+                            "%s and %s shouldn't both be true.",
+                            FAIL_ON_UNKNOWN_FIELD.key(), IGNORE_PARSE_ERRORS.key()));
         }
         validateTimestampFormat(tableOptions);
     }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonParserRowDataDeserializationSchema.java
@@ -52,22 +52,40 @@ public class JsonParserRowDataDeserializationSchema extends AbstractJsonDeserial
             RowType rowType,
             TypeInformation<RowData> resultTypeInfo,
             boolean failOnMissingField,
+            boolean failOnUnknownField,
             boolean ignoreParseErrors,
             TimestampFormat timestampFormat) {
-        this(rowType, resultTypeInfo, failOnMissingField, ignoreParseErrors, timestampFormat, null);
+        this(
+                rowType,
+                resultTypeInfo,
+                failOnMissingField,
+                failOnUnknownField,
+                ignoreParseErrors,
+                timestampFormat,
+                null);
     }
 
     public JsonParserRowDataDeserializationSchema(
             RowType rowType,
             TypeInformation<RowData> resultTypeInfo,
             boolean failOnMissingField,
+            boolean failOnUnknownField,
             boolean ignoreParseErrors,
             TimestampFormat timestampFormat,
             @Nullable String[][] projectedFields) {
-        super(rowType, resultTypeInfo, failOnMissingField, ignoreParseErrors, timestampFormat);
+        super(
+                rowType,
+                resultTypeInfo,
+                failOnMissingField,
+                failOnUnknownField,
+                ignoreParseErrors,
+                timestampFormat);
         this.runtimeConverter =
                 new JsonParserToRowDataConverters(
-                                failOnMissingField, ignoreParseErrors, timestampFormat)
+                                failOnMissingField,
+                                failOnUnknownField,
+                                ignoreParseErrors,
+                                timestampFormat)
                         .createConverter(projectedFields, checkNotNull(rowType));
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonRowDataDeserializationSchema.java
@@ -54,11 +54,22 @@ public class JsonRowDataDeserializationSchema extends AbstractJsonDeserializatio
             RowType rowType,
             TypeInformation<RowData> resultTypeInfo,
             boolean failOnMissingField,
+            boolean failOnUnknownField,
             boolean ignoreParseErrors,
             TimestampFormat timestampFormat) {
-        super(rowType, resultTypeInfo, failOnMissingField, ignoreParseErrors, timestampFormat);
+        super(
+                rowType,
+                resultTypeInfo,
+                failOnMissingField,
+                failOnUnknownField,
+                ignoreParseErrors,
+                timestampFormat);
         this.runtimeConverter =
-                new JsonToRowDataConverters(failOnMissingField, ignoreParseErrors, timestampFormat)
+                new JsonToRowDataConverters(
+                                failOnMissingField,
+                                failOnUnknownField,
+                                ignoreParseErrors,
+                                timestampFormat)
                         .createConverter(checkNotNull(rowType));
     }
 

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonSchemaException.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonSchemaException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json;
+
+/**
+ * Exception which refers to json field schema match errors in converters, only occurs when
+ * failOnMissingField or failOnUnknownField is set.
+ *
+ * <p>Inherit JsonParseException to make catch clauses compatible.
+ */
+public class JsonSchemaException extends JsonParseException {
+    private static final long serialVersionUID = 1L;
+
+    public JsonSchemaException(String message) {
+        super(message);
+    }
+
+    public JsonSchemaException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/canal/CanalJsonDeserializationSchema.java
@@ -116,7 +116,8 @@ public final class CanalJsonDeserializationSchema implements DeserializationSche
                         // info
                         producedTypeInfo,
                         false, // ignoreParseErrors already contains the functionality of
-                        // failOnMissingField
+                        // failOnMissingField and failOnUnknownField
+                        false,
                         ignoreParseErrors,
                         timestampFormat);
         this.hasMetadata = requestedMetadata.size() > 0;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/debezium/DebeziumJsonDeserializationSchema.java
@@ -104,7 +104,8 @@ public final class DebeziumJsonDeserializationSchema implements DeserializationS
                         // info
                         producedTypeInfo,
                         false, // ignoreParseErrors already contains the functionality of
-                        // failOnMissingField
+                        // failOnMissingField and failOnUnknownField
+                        false,
                         ignoreParseErrors,
                         timestampFormat);
         this.hasMetadata = requestedMetadata.size() > 0;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/maxwell/MaxwellJsonDeserializationSchema.java
@@ -96,7 +96,8 @@ public class MaxwellJsonDeserializationSchema implements DeserializationSchema<R
                         // info
                         producedTypeInfo,
                         // ignoreParseErrors already contains the functionality of
-                        // failOnMissingField
+                        // failOnMissingField and failOnUnknownField
+                        false,
                         false,
                         ignoreParseErrors,
                         timestampFormat);

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/ogg/OggJsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/ogg/OggJsonDeserializationSchema.java
@@ -95,7 +95,8 @@ public final class OggJsonDeserializationSchema implements DeserializationSchema
                         // info
                         producedTypeInfo,
                         false, // ignoreParseErrors already contains the functionality of
-                        // failOnMissingField
+                        // failOnMissingField and failOnUnknownField
+                        false,
                         ignoreParseErrors,
                         timestampFormat);
         this.hasMetadata = requestedMetadata.size() > 0;

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonFormatFactoryTest.java
@@ -69,6 +69,18 @@ class JsonFormatFactoryTest {
     }
 
     @Test
+    void testFailOnUnknownField() {
+        final Map<String, String> tableOptions =
+                getModifyOptions(options -> options.put("json.fail-on-unknown-field", "true"));
+
+        assertThatCreateRuntimeDecoder(tableOptions)
+                .satisfies(
+                        anyCauseMatches(
+                                ValidationException.class,
+                                "fail-on-unknown-field and ignore-parse-errors shouldn't both be true."));
+    }
+
+    @Test
     void testInvalidOptionForIgnoreParseErrors() {
         final Map<String, String> tableOptions =
                 getModifyOptions(options -> options.put("json.ignore-parse-errors", "abc"));
@@ -156,6 +168,7 @@ class JsonFormatFactoryTest {
                         PHYSICAL_TYPE,
                         InternalTypeInfo.of(PHYSICAL_TYPE),
                         false,
+                        false,
                         true,
                         TimestampFormat.ISO_8601);
 
@@ -223,6 +236,7 @@ class JsonFormatFactoryTest {
 
         options.put("format", JsonFormatFactory.IDENTIFIER);
         options.put("json.fail-on-missing-field", "false");
+        options.put("json.fail-on-unknown-field", "false");
         options.put("json.ignore-parse-errors", "true");
         options.put("json.timestamp-format.standard", "ISO-8601");
         options.put("json.map-null-key.mode", "LITERAL");

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonSerDeSchemaTest.java
@@ -40,7 +40,7 @@ class JsonSerDeSchemaTest {
     }
 
     @Test
-    void testSrialization() throws IOException {
+    void testSerialization() throws IOException {
         final byte[] serialized = SERIALIZATION_SCHEMA.serialize(new Event(34, "hello"));
         assertThat(serialized).isEqualTo(JSON.getBytes(StandardCharsets.UTF_8));
     }

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/utils/DeserializationSchemaMatcher.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/utils/DeserializationSchemaMatcher.java
@@ -44,14 +44,18 @@ import static org.apache.flink.util.InstantiationUtil.serializeObject;
  * Row expectedRow = ...
  * final JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(rowSchema);
  *
- * assertThat(jsonBytes, whenDeserializedWith(deserializationSchema)
- *     .matches(expectedRow));
+ * assertThat(
+ *     whenDeserializedWith(deserializationSchema)
+ *         .equalsTo(expectedRow)
+ *         .matches(jsonBytes))
+ *     .isTrue();
  * }</pre>
  *   <li>to check if an exception is thrown during serialization:
  *       <pre>{@code
- * assertThat(serializedJson,
+ * assertThat(
  *     whenDeserializedWith(deserializationSchema)
- *         .failsWithException(hasCause(instanceOf(IllegalStateException.class))));
+ *         .failsWithException(containsCause(new IllegalStateException(...))))
+ *     .isTrue();
  * }</pre>
  * </ul>
  */

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/utils/SerializationSchemaMatcher.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/utils/SerializationSchemaMatcher.java
@@ -44,13 +44,20 @@ import static org.apache.flink.util.InstantiationUtil.serializeObject;
  * final JsonRowSerializationSchema serializationSchema = new JsonRowSerializationSchema(rowSchema);
  * final JsonRowDeserializationSchema deserializationSchema = new JsonRowDeserializationSchema(rowSchema);
  *
- * assertThat(row, whenSerializedWith(serializationSchema)
- *     .andDeserializedWith(deserializationSchema)
- *     .matches(row));
+ * assertThat(
+ *     whenSerializedWith(serializationSchema)
+ *         .andDeserializedWith(deserializationSchema)
+ *         .equalsTo(row)
+ *         .matches(row))
+ *     .isTrue();
  * }</pre>
  *   <li>to check if an exception is thrown during serialization:
  *       <pre>{@code
- * assertThat(row, whenSerializedWith(serializationSchema).failsWithException(instanceOf(RuntimeException.class)));
+ * assertThat(
+ *     whenSerializedWith(serializationSchema)
+ *         .failsWithException(containsCause(new RuntimeException(...)))
+ *         .matches(row))
+ *     .isTrue();
  * }</pre>
  * </ul>
  */

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/ResultInfoDeserializer.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/serde/ResultInfoDeserializer.java
@@ -62,7 +62,7 @@ public class ResultInfoDeserializer extends StdDeserializer<ResultInfo> {
     }
 
     private static final JsonToRowDataConverters TO_ROW_DATA_CONVERTERS =
-            new JsonToRowDataConverters(false, false, TimestampFormat.ISO_8601);
+            new JsonToRowDataConverters(false, false, false, TimestampFormat.ISO_8601);
 
     @Override
     public ResultInfo deserialize(JsonParser jsonParser, DeserializationContext ctx)

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/formats/SchemaTestUtils.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/formats/SchemaTestUtils.java
@@ -20,6 +20,9 @@ package org.apache.flink.connector.testutils.formats;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 
+import static org.apache.flink.util.InstantiationUtil.deserializeObject;
+import static org.apache.flink.util.InstantiationUtil.serializeObject;
+
 /** Test utilities for schemas. */
 public class SchemaTestUtils {
 
@@ -30,6 +33,13 @@ public class SchemaTestUtils {
      * @throws RuntimeException if the schema throws an exception
      */
     public static void open(SerializationSchema<?> schema) {
+        try {
+            deserializeObject(
+                    serializeObject(schema), Thread.currentThread().getContextClassLoader());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
         try {
             schema.open(new DummyInitializationContext());
         } catch (Exception e) {
@@ -44,6 +54,13 @@ public class SchemaTestUtils {
      * @throws RuntimeException if the schema throws an exception
      */
     public static void open(DeserializationSchema<?> schema) {
+        try {
+            deserializeObject(
+                    serializeObject(schema), Thread.currentThread().getContextClassLoader());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
         try {
             schema.open(new DummyInitializationContext());
         } catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

As described in the issue FLINK-35427, this pull request trying to introduce a config in json format, so we can fail the flink job when the input schema evolves.

Copy from FLINK-35427:
In many cases, the consumer and producer of message queues come from different teams, or even different companies.
As a message consumer, sometimes it is difficult to subscribe updates on message's format, which may result in data loss.
We want to ensure the message format strictly matches the schema, if some field is missing or new field is added, it is better to fail the application so that we can notice and fix it quickly.
In this case, a fail-on-unknown-field config for JSON format could be very helpful, especially when works with fail-on-missing-field.

## Brief change log

- Add JsonFormatOptions.FAIL_ON_UNKNOWN_FIELD
- Add unknown field check code in converter classes
- Add JsonSchemaException, which extends JsonParseException
- Fix some test cases that were not working properly

## Verifying this change

This change added tests and can be verified as follows:
`JsonFormatFactoryTest#testFailOnUnknownField`
`JsonParserRowDataDeSerSchemaTest#testParsePartialJson`
`JsonRowDataSerDeSchemaTest#testDeserializationUnknownField`
`JsonRowDeserializationSchemaTest#testUnknownNode`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
