### PR TITLE
[FLINK-35425][table-common] Support convert freshness to cron expression in full refresh mode

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -235,8 +234,8 @@ class CatalogBaseTableResolutionTest {
 
         assertThat(resolvedCatalogMaterializedTable.getResolvedSchema())
                 .isEqualTo(RESOLVED_MATERIALIZED_TABLE_SCHEMA);
-        assertThat(resolvedCatalogMaterializedTable.getFreshness())
-                .isEqualTo(Duration.ofSeconds(30));
+        assertThat(resolvedCatalogMaterializedTable.getDefinitionFreshness())
+                .isEqualTo(IntervalFreshness.ofSecond("30"));
         assertThat(resolvedCatalogMaterializedTable.getDefinitionQuery())
                 .isEqualTo(DEFINITION_QUERY);
         assertThat(resolvedCatalogMaterializedTable.getLogicalRefreshMode())
@@ -424,7 +423,8 @@ class CatalogBaseTableResolutionTest {
         properties.put("schema.3.comment", "");
         properties.put("schema.primary-key.name", "primary_constraint");
         properties.put("schema.primary-key.columns", "id");
-        properties.put("freshness", "PT30S");
+        properties.put("freshness-interval", "30");
+        properties.put("freshness-unit", "SECOND");
         properties.put("logical-refresh-mode", "CONTINUOUS");
         properties.put("refresh-mode", "CONTINUOUS");
         properties.put("refresh-status", "INITIALIZING");
@@ -454,7 +454,7 @@ class CatalogBaseTableResolutionTest {
                 .partitionKeys(partitionKeys)
                 .options(Collections.emptyMap())
                 .definitionQuery(definitionQuery)
-                .freshness(Duration.ofSeconds(30))
+                .freshness(IntervalFreshness.ofSecond("30"))
                 .logicalRefreshMode(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC)
                 .refreshMode(CatalogMaterializedTable.RefreshMode.CONTINUOUS)
                 .refreshStatus(CatalogMaterializedTable.RefreshStatus.INITIALIZING)

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.flink.table.utils.IntervalFreshnessUtils.convertFreshnessToDuration;
+
 /**
  * Represents the unresolved metadata of a materialized table in a {@link Catalog}.
  *
@@ -113,9 +115,18 @@ public interface CatalogMaterializedTable extends CatalogBaseTable {
     String getDefinitionQuery();
 
     /**
-     * Get the freshness of materialized table which is used to determine the physical refresh mode.
+     * Get the definition freshness of materialized table which is used to determine the physical
+     * refresh mode.
      */
-    Duration getFreshness();
+    IntervalFreshness getDefinitionFreshness();
+
+    /**
+     * Get the {@link Duration} value of materialized table definition freshness, it is converted
+     * from {@link IntervalFreshness}.
+     */
+    default Duration getFreshness() {
+        return convertFreshnessToDuration(getDefinitionFreshness());
+    }
 
     /** Get the logical refresh mode of materialized table. */
     LogicalRefreshMode getLogicalRefreshMode();
@@ -185,7 +196,7 @@ public interface CatalogMaterializedTable extends CatalogBaseTable {
         private Map<String, String> options = Collections.emptyMap();
         private @Nullable Long snapshot;
         private String definitionQuery;
-        private Duration freshness;
+        private IntervalFreshness freshness;
         private LogicalRefreshMode logicalRefreshMode;
         private RefreshMode refreshMode;
         private RefreshStatus refreshStatus;
@@ -227,7 +238,7 @@ public interface CatalogMaterializedTable extends CatalogBaseTable {
             return this;
         }
 
-        public Builder freshness(Duration freshness) {
+        public Builder freshness(IntervalFreshness freshness) {
             this.freshness = Preconditions.checkNotNull(freshness, "Freshness must not be null.");
             return this;
         }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogMaterializedTable.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.api.Schema;
 
 import javax.annotation.Nullable;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +44,7 @@ public class DefaultCatalogMaterializedTable implements CatalogMaterializedTable
     private final @Nullable Long snapshot;
 
     private final String definitionQuery;
-    private final Duration freshness;
+    private final IntervalFreshness freshness;
     private final LogicalRefreshMode logicalRefreshMode;
     private final RefreshMode refreshMode;
     private final RefreshStatus refreshStatus;
@@ -59,7 +58,7 @@ public class DefaultCatalogMaterializedTable implements CatalogMaterializedTable
             Map<String, String> options,
             @Nullable Long snapshot,
             String definitionQuery,
-            Duration freshness,
+            IntervalFreshness freshness,
             LogicalRefreshMode logicalRefreshMode,
             RefreshMode refreshMode,
             RefreshStatus refreshStatus,
@@ -185,7 +184,7 @@ public class DefaultCatalogMaterializedTable implements CatalogMaterializedTable
     }
 
     @Override
-    public Duration getFreshness() {
+    public IntervalFreshness getDefinitionFreshness() {
         return freshness;
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/IntervalFreshness.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/IntervalFreshness.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.Objects;
+
+/**
+ * The {@link IntervalFreshness} represents freshness definition of {@link
+ * CatalogMaterializedTable}. It encapsulates the string interval value along with time unit,
+ * allowing for flexible representation of different freshness type. Moreover, it can provide
+ * detailed raw information for some specific operations.
+ */
+@PublicEvolving
+public class IntervalFreshness {
+
+    private final String interval;
+    private final TimeUnit timeUnit;
+
+    private IntervalFreshness(String interval, TimeUnit timeUnit) {
+        this.interval = interval;
+        this.timeUnit = timeUnit;
+    }
+
+    public static IntervalFreshness of(String interval, TimeUnit timeUnit) {
+        return new IntervalFreshness(interval, timeUnit);
+    }
+
+    public static IntervalFreshness ofSecond(String interval) {
+        return new IntervalFreshness(interval, TimeUnit.SECOND);
+    }
+
+    public static IntervalFreshness ofMinute(String interval) {
+        return new IntervalFreshness(interval, TimeUnit.MINUTE);
+    }
+
+    public static IntervalFreshness ofHour(String interval) {
+        return new IntervalFreshness(interval, TimeUnit.HOUR);
+    }
+
+    public static IntervalFreshness ofDay(String interval) {
+        return new IntervalFreshness(interval, TimeUnit.DAY);
+    }
+
+    public String getInterval() {
+        return interval;
+    }
+
+    public TimeUnit getTimeUnit() {
+        return timeUnit;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        IntervalFreshness that = (IntervalFreshness) o;
+        return Objects.equals(interval, that.interval) && timeUnit == that.timeUnit;
+    }
+
+    @Override
+    public String toString() {
+        return "INTERVAL '" + interval + "' " + timeUnit;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(interval, timeUnit);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // TimeUnit enums
+    // --------------------------------------------------------------------------------------------
+
+    /** An enumeration of time unit representing the unit of interval freshness. */
+    @PublicEvolving
+    public enum TimeUnit {
+        SECOND,
+        MINUTE,
+        HOUR,
+        DAY
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogMaterializedTable.java
@@ -23,7 +23,6 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -125,8 +124,8 @@ public class ResolvedCatalogMaterializedTable
     }
 
     @Override
-    public Duration getFreshness() {
-        return origin.getFreshness();
+    public IntervalFreshness getDefinitionFreshness() {
+        return origin.getDefinitionFreshness();
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/IntervalFreshnessUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/IntervalFreshnessUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.IntervalFreshness;
+
+import org.apache.commons.lang3.math.NumberUtils;
+
+import java.time.Duration;
+
+/** Utilities to {@link IntervalFreshness}. */
+@Internal
+public class IntervalFreshnessUtils {
+
+    private IntervalFreshnessUtils() {}
+
+    @VisibleForTesting
+    static void validateIntervalFreshness(IntervalFreshness intervalFreshness) {
+        if (!NumberUtils.isParsable(intervalFreshness.getInterval())) {
+            throw new ValidationException(
+                    String.format(
+                            "The interval freshness value '%s' is an illegal integer type value.",
+                            intervalFreshness.getInterval()));
+        }
+
+        if (!NumberUtils.isDigits(intervalFreshness.getInterval())) {
+            throw new ValidationException(
+                    "The freshness interval currently only supports integer type values.");
+        }
+    }
+
+    public static Duration convertFreshnessToDuration(IntervalFreshness intervalFreshness) {
+        // validate the freshness value firstly
+        validateIntervalFreshness(intervalFreshness);
+
+        long interval = Long.parseLong(intervalFreshness.getInterval());
+        switch (intervalFreshness.getTimeUnit()) {
+            case DAY:
+                return Duration.ofDays(interval);
+            case HOUR:
+                return Duration.ofHours(interval);
+            case MINUTE:
+                return Duration.ofMinutes(interval);
+            case SECOND:
+                return Duration.ofSeconds(interval);
+            default:
+                throw new ValidationException(
+                        String.format(
+                                "Unknown freshness time unit: %s.",
+                                intervalFreshness.getTimeUnit()));
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/IntervalFreshnessUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/IntervalFreshnessUtils.java
@@ -31,6 +31,15 @@ import java.time.Duration;
 @Internal
 public class IntervalFreshnessUtils {
 
+    private static final String SECOND_CRON_EXPRESSION_TEMPLATE = "0/%s * * * * ? *";
+    private static final String MINUTE_CRON_EXPRESSION_TEMPLATE = "0 0/%s * * * ? *";
+    private static final String HOUR_CRON_EXPRESSION_TEMPLATE = "0 0 0/%s * * ? *";
+    private static final String ONE_DAY_CRON_EXPRESSION_TEMPLATE = "0 0 0 * * ? *";
+
+    private static final long SECOND_CRON_UPPER_BOUND = 60;
+    private static final long MINUTE_CRON_UPPER_BOUND = 60;
+    private static final long HOUR_CRON_UPPER_BOUND = 24;
+
     private IntervalFreshnessUtils() {}
 
     @VisibleForTesting
@@ -68,5 +77,70 @@ public class IntervalFreshnessUtils {
                                 "Unknown freshness time unit: %s.",
                                 intervalFreshness.getTimeUnit()));
         }
+    }
+
+    /**
+     * This is an util method that is used to convert the freshness of materialized table to cron
+     * expression in full refresh mode. Since freshness and cron expression cannot be converted
+     * equivalently, there are currently only a limited patterns of freshness that can be converted
+     * to cron expression.
+     */
+    public static String convertFreshnessToCron(IntervalFreshness intervalFreshness) {
+        switch (intervalFreshness.getTimeUnit()) {
+            case SECOND:
+                return validateAndConvertCron(
+                        intervalFreshness,
+                        SECOND_CRON_UPPER_BOUND,
+                        SECOND_CRON_EXPRESSION_TEMPLATE);
+            case MINUTE:
+                return validateAndConvertCron(
+                        intervalFreshness,
+                        MINUTE_CRON_UPPER_BOUND,
+                        MINUTE_CRON_EXPRESSION_TEMPLATE);
+            case HOUR:
+                return validateAndConvertCron(
+                        intervalFreshness, HOUR_CRON_UPPER_BOUND, HOUR_CRON_EXPRESSION_TEMPLATE);
+            case DAY:
+                return validateAndConvertDayCron(intervalFreshness);
+            default:
+                throw new ValidationException(
+                        String.format(
+                                "Unknown freshness time unit: %s.",
+                                intervalFreshness.getTimeUnit()));
+        }
+    }
+
+    private static String validateAndConvertCron(
+            IntervalFreshness intervalFreshness, long cronUpperBound, String cronTemplate) {
+        long interval = Long.parseLong(intervalFreshness.getInterval());
+        IntervalFreshness.TimeUnit timeUnit = intervalFreshness.getTimeUnit();
+        // Freshness must be less than cronUpperBound for corresponding time unit when convert it
+        // to cron expression
+        if (interval >= cronUpperBound) {
+            throw new ValidationException(
+                    String.format(
+                            "In full refresh mode, freshness must be less than %s when the time unit is %s.",
+                            cronUpperBound, timeUnit));
+        }
+        // Freshness must be factors of cronUpperBound for corresponding time unit
+        if (cronUpperBound % interval != 0) {
+            throw new ValidationException(
+                    String.format(
+                            "In full refresh mode, only freshness that are factors of %s are currently supported when the time unit is %s.",
+                            cronUpperBound, timeUnit));
+        }
+
+        return String.format(cronTemplate, interval);
+    }
+
+    private static String validateAndConvertDayCron(IntervalFreshness intervalFreshness) {
+        // Since the number of days in each month is different, only one day of freshness is
+        // currently supported when the time unit is DAY
+        long interval = Long.parseLong(intervalFreshness.getInterval());
+        if (interval > 1) {
+            throw new ValidationException(
+                    "In full refresh mode, freshness must be 1 when the time unit is DAY.");
+        }
+        return ONE_DAY_CRON_EXPRESSION_TEMPLATE;
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/IntervalFreshnessUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/IntervalFreshnessUtilsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.IntervalFreshness;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.apache.flink.table.utils.IntervalFreshnessUtils.convertFreshnessToDuration;
+import static org.apache.flink.table.utils.IntervalFreshnessUtils.validateIntervalFreshness;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link IntervalFreshnessUtils}. */
+public class IntervalFreshnessUtilsTest {
+
+    @Test
+    void testIllegalIntervalFreshness() {
+        assertThatThrownBy(() -> validateIntervalFreshness(IntervalFreshness.ofMinute("2efedd")))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "The interval freshness value '2efedd' is an illegal integer type value.");
+
+        assertThatThrownBy(() -> validateIntervalFreshness(IntervalFreshness.ofMinute("2.5")))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "The freshness interval currently only supports integer type values.");
+    }
+
+    @Test
+    void testConvertFreshness() {
+        // verify second
+        Duration actualSecond = convertFreshnessToDuration(IntervalFreshness.ofSecond("20"));
+        assertThat(actualSecond).isEqualTo(Duration.ofSeconds(20));
+
+        // verify minute
+        Duration actualMinute = convertFreshnessToDuration(IntervalFreshness.ofMinute("3"));
+        assertThat(actualMinute).isEqualTo(Duration.ofMinutes(3));
+
+        // verify hour
+        Duration actualHour = convertFreshnessToDuration(IntervalFreshness.ofHour("3"));
+        assertThat(actualHour).isEqualTo(Duration.ofHours(3));
+
+        // verify day
+        Duration actualDay = convertFreshnessToDuration(IntervalFreshness.ofDay("3"));
+        assertThat(actualDay).isEqualTo(Duration.ofDays(3));
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateMaterializedTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateMaterializedTableConverter.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.MATERIALIZED_TABLE_FRESHNESS_THRESHOLD;
+import static org.apache.flink.table.utils.IntervalFreshnessUtils.convertFreshnessToCron;
 import static org.apache.flink.table.utils.IntervalFreshnessUtils.convertFreshnessToDuration;
 
 /** A converter for {@link SqlCreateMaterializedTable}. */
@@ -103,6 +104,11 @@ public class SqlCreateMaterializedTableConverter
                                 .get(MATERIALIZED_TABLE_FRESHNESS_THRESHOLD),
                         convertFreshnessToDuration(intervalFreshness),
                         logicalRefreshMode);
+        // If the refresh mode is full, validate whether the freshness can convert to cron
+        // expression in advance
+        if (CatalogMaterializedTable.RefreshMode.FULL == refreshMode) {
+            convertFreshnessToCron(intervalFreshness);
+        }
 
         // get query schema and definition query
         SqlNode validateQuery =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateMaterializedTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateMaterializedTableConverter.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.IntervalFreshness;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
@@ -40,7 +41,6 @@ import org.apache.flink.table.planner.utils.OperationConverterUtils;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.MATERIALIZED_TABLE_FRESHNESS_THRESHOLD;
+import static org.apache.flink.table.utils.IntervalFreshnessUtils.convertFreshnessToDuration;
 
 /** A converter for {@link SqlCreateMaterializedTable}. */
 public class SqlCreateMaterializedTableConverter
@@ -78,7 +79,7 @@ public class SqlCreateMaterializedTableConverter
                                         ((SqlTableOption) p).getValueString()));
 
         // get freshness
-        Duration freshness =
+        IntervalFreshness intervalFreshness =
                 MaterializedTableUtils.getMaterializedTableFreshness(
                         sqlCreateMaterializedTable.getFreshness());
 
@@ -100,7 +101,7 @@ public class SqlCreateMaterializedTableConverter
                         context.getTableConfig()
                                 .getRootConfiguration()
                                 .get(MATERIALIZED_TABLE_FRESHNESS_THRESHOLD),
-                        freshness,
+                        convertFreshnessToDuration(intervalFreshness),
                         logicalRefreshMode);
 
         // get query schema and definition query
@@ -139,7 +140,7 @@ public class SqlCreateMaterializedTableConverter
                         .partitionKeys(partitionKeys)
                         .options(options)
                         .definitionQuery(definitionQuery)
-                        .freshness(freshness)
+                        .freshness(intervalFreshness)
                         .logicalRefreshMode(logicalRefreshMode)
                         .refreshMode(refreshMode)
                         .refreshStatus(CatalogMaterializedTable.RefreshStatus.INITIALIZING)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.IntervalFreshness;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableRefreshOperation;
@@ -34,7 +35,6 @@ import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -85,7 +85,7 @@ public class SqlMaterializedTableNodeToOperationConverterTest
                         .comment("materialized table comment")
                         .options(options)
                         .partitionKeys(Arrays.asList("a", "d"))
-                        .freshness(Duration.ofSeconds(30))
+                        .freshness(IntervalFreshness.ofSecond("30"))
                         .logicalRefreshMode(CatalogMaterializedTable.LogicalRefreshMode.FULL)
                         .refreshMode(CatalogMaterializedTable.RefreshMode.FULL)
                         .refreshStatus(CatalogMaterializedTable.RefreshStatus.INITIALIZING)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -172,6 +172,15 @@ public class SqlMaterializedTableNodeToOperationConverterTest
                 .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.FULL);
         assertThat(materializedTable2.getRefreshMode())
                 .isEqualTo(CatalogMaterializedTable.RefreshMode.FULL);
+
+        final String sql3 =
+                "CREATE MATERIALIZED TABLE mtbl1\n"
+                        + "FRESHNESS = INTERVAL '40' MINUTE\n"
+                        + "AS SELECT * FROM t1";
+        assertThatThrownBy(() -> parse(sql3))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining(
+                        "In full refresh mode, only freshness that are factors of 60 are currently supported when the time unit is MINUTE.");
     }
 
     @Test

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogTest.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.IntervalFreshness;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
@@ -41,7 +42,6 @@ import org.apache.flink.table.refresh.RefreshHandler;
 
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -92,7 +92,7 @@ public class TestFileSystemCatalogTest extends TestFileSystemCatalogTestBase {
                     CREATE_RESOLVED_SCHEMA);
 
     private static final String DEFINITION_QUERY = "SELECT id, region, county FROM T";
-    private static final Duration FRESHNESS = Duration.ofMinutes(3);
+    private static final IntervalFreshness FRESHNESS = IntervalFreshness.ofMinute("3");
     private static final ResolvedCatalogMaterializedTable EXPECTED_CATALOG_MATERIALIZED_TABLE =
             new ResolvedCatalogMaterializedTable(
                     CatalogMaterializedTable.newBuilder()
@@ -235,7 +235,7 @@ public class TestFileSystemCatalogTest extends TestFileSystemCatalogTestBase {
         // validate definition query
         assertThat(actualMaterializedTable.getDefinitionQuery()).isEqualTo(DEFINITION_QUERY);
         // validate freshness
-        assertThat(actualMaterializedTable.getFreshness()).isEqualTo(FRESHNESS);
+        assertThat(actualMaterializedTable.getDefinitionFreshness()).isEqualTo(FRESHNESS);
         // validate logical refresh mode
         assertThat(actualMaterializedTable.getLogicalRefreshMode())
                 .isEqualTo(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC);


### PR DESCRIPTION
## What is the purpose of the change

Support convert freshness to cron expression in full refresh mode


## Brief change log

  - *Support convert freshness to cron expression in full refresh mode*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit tests in IntervalFreshnessUtilsTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( JavaDocs)
