### PR TITLE
[hotfix] Fix modification conflict between FLINK-35465 and FLINK-35359

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/JMFailoverITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/JMFailoverITCase.java
@@ -382,7 +382,7 @@ class JMFailoverITCase {
         NetUtils.Port jobManagerRpcPort = NetUtils.getAvailablePort();
         flinkConfiguration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
         flinkConfiguration.set(JobManagerOptions.PORT, jobManagerRpcPort.getPort());
-        flinkConfiguration.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
+        flinkConfiguration.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, Duration.ofMillis(5000L));
         flinkConfiguration.set(RestOptions.BIND_PORT, "0");
         flinkConfiguration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("1g"));
         flinkConfiguration.set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 0.4F);


### PR DESCRIPTION
## What is the purpose of the change

As title said, fix the compile error cause by modification conflict between FLINK-35465 and FLINK-35359.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:(no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature?  (no)
