### PR TITLE
[FLINK-35461][config] Improve Runtime Configuration for Flink 2.0

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -75,30 +75,6 @@
             <td>The minimum difference in percentage between the newly calculated buffer size and the old one to announce the new value. Can be used to avoid constant back and forth small adjustments.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
-            <td style="word-wrap: break-word;">2</td>
-            <td>Integer</td>
-            <td>Number of exclusive network buffers for each outgoing/incoming channel (subpartition/input channel) in the credit-based flow control model. For the outgoing channel(subpartition), this value is the effective exclusive buffers per channel. For the incoming channel(input channel), this value is the max number of exclusive buffers per channel, the number of effective exclusive network buffers per channel is dynamically calculated from taskmanager.network.memory.read-buffer.required-per-gate.max and the effective range is from 0 to the configured value. The minimum valid value for the option is 0. When the option is configured as 0, the exclusive network buffers used by downstream incoming channel will be 0, but for each upstream outgoing channel, max(1, configured value) will be used. In other words, we ensure that, for performance reasons, at least one buffer is used per outgoing channel regardless of the configuration.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>
-            <td style="word-wrap: break-word;">8</td>
-            <td>Integer</td>
-            <td>Number of floating network buffers for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the channels. The floating buffers can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. For the outgoing gate(result partition), this value is the effective floating buffers per gate. For the incoming gate(input gate), this value is a recommended number of floating buffers, the number of effective floating network buffers per gate is dynamically calculated from taskmanager.network.memory.read-buffer.required-per-gate.max and the range of effective floating buffers is from 0 to (parallelism - 1).</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.max-buffers-per-channel</h5></td>
-            <td style="word-wrap: break-word;">10</td>
-            <td>Integer</td>
-            <td>Number of max buffers that can be used for each channel. If a channel exceeds the number of max buffers, it will make the task become unavailable, cause the back pressure and block the data processing. This might speed up checkpoint alignment by preventing excessive growth of the buffered in-flight data in case of data skew and high number of configured floating buffers. This limit is not strictly guaranteed, and can be ignored by things like flatMap operators, records spanning multiple buffers or single timer producing large amount of data.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.max-overdraft-buffers-per-gate</h5></td>
-            <td style="word-wrap: break-word;">5</td>
-            <td>Integer</td>
-            <td>Number of max overdraft network buffers to use for each ResultPartition. The overdraft buffers will be used when the subtask cannot apply to the normal buffers  due to back pressure, while subtask is performing an action that can not be interrupted in the middle,  like serializing a large record, flatMap operator producing multiple records for one single input record or processing time timer producing large output. In situations like that system will allow subtask to request overdraft buffers, so that the subtask can finish such uninterruptible action, without blocking unaligned checkpoints for long period of time. Overdraft buffers are provided on best effort basis only if the system has some unused buffers available. Subtask that has used overdraft buffers won't be allowed to process any more records until the overdraft buffers are returned to the pool. It should be noted that this config option only takes effect for Pipelined Shuffle.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.memory.read-buffer.required-per-gate.max</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -15,12 +15,6 @@
             <td>Boolean flag indicating whether the shuffle data will be compressed for batch shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when compression ratio is high.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.blocking-shuffle.type</h5></td>
-            <td style="word-wrap: break-word;">"file"</td>
-            <td>String</td>
-            <td>The blocking shuffle type, either "mmap" or "file". The "auto" means selecting the property type automatically based on system memory architecture (64 bit for mmap and 32 bit for file). Note that the memory usage of mmap is not accounted by configured memory limits, but some resource frameworks like yarn would track this memory usage and kill the container once memory exceeding some threshold. Also note that this option is experimental and might be changed future.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.compression.codec</h5></td>
             <td style="word-wrap: break-word;">LZ4</td>
             <td><p>Enum</p></td>
@@ -217,12 +211,6 @@
             <td style="word-wrap: break-word;">512</td>
             <td>Integer</td>
             <td>Minimum number of network buffers required per blocking result partition for sort-shuffle. For production usage, it is suggested to increase this config value to at least 2048 (64M memory if the default 32K memory segment size is used) to improve the data compression ratio and reduce the small network packets. Usually, several hundreds of megabytes memory is enough for large scale batch jobs. Note: you may also need to increase the size of total network memory to avoid the 'insufficient number of network buffers' error if you are increasing this config value.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.sort-shuffle.min-parallelism</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>Parallelism threshold to switch between sort-based blocking shuffle and hash-based blocking shuffle, which means for batch jobs of smaller parallelism, hash-shuffle will be used and for batch jobs of larger or equal parallelism, sort-shuffle will be used. The value 1 means that sort-shuffle is the default option. Note: For production usage, you may also need to tune 'taskmanager.network.sort-shuffle.min-buffers' and 'taskmanager.memory.framework.off-heap.batch-shuffle.size' for better performance.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.tcp-connection.enable-reuse-across-jobs</h5></td>

--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -81,12 +81,6 @@
             <td>The Netty client connection timeout.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.netty.client.numThreads</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>The number of Netty client threads.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.netty.client.tcp.keepCount</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
@@ -103,36 +97,6 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>The time (in seconds) between individual keepalive probes. Note: This will not take effect when using netty transport type of nio with an older version of JDK 8, refer to https://bugs.openjdk.org/browse/JDK-8194298.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.num-arenas</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>The number of Netty arenas.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.sendReceiveBufferSize</h5></td>
-            <td style="word-wrap: break-word;">0</td>
-            <td>Integer</td>
-            <td>The Netty send and receive buffer size. This defaults to the system buffer size (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.server.backlog</h5></td>
-            <td style="word-wrap: break-word;">0</td>
-            <td>Integer</td>
-            <td>The netty server connection backlog.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.server.numThreads</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>The number of Netty server threads.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.transport</h5></td>
-            <td style="word-wrap: break-word;">"auto"</td>
-            <td>String</td>
-            <td>The Netty transport type, either "nio" or "epoll". The "auto" means selecting the property mode automatically based on the platform. Note that the "epoll" mode can get better performance, less GC and have more advanced features which are only available on modern Linux.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.partition-request-timeout</h5></td>

--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -33,12 +33,6 @@
             <td>The option is used to configure the base path of remote storage for hybrid shuffle. The shuffle data will be stored in remote storage when the disk space is not enough. Note: If the option is configured and taskmanager.network.hybrid-shuffle.enable-new-mode is false, this option will be ignored. If the option is not configured and taskmanager.network.hybrid-shuffle.enable-new-mode is true, the remote storage will be disabled.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>The maximum number of tpc connections between taskmanagers for data communication.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.memory.buffer-debloat.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -9,16 +9,10 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>taskmanager.network.batch-shuffle.compression.enabled</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Boolean flag indicating whether the shuffle data will be compressed for batch shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when compression ratio is high.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.compression.codec</h5></td>
             <td style="word-wrap: break-word;">LZ4</td>
             <td><p>Enum</p></td>
-            <td>The codec to be used when compressing shuffle data, only "LZ4", "LZO" and "ZSTD" are supported now. Through tpc-ds test of these three algorithms, the results show that "LZ4" algorithm has the highest compression and decompression speed, but the compression ratio is the lowest. "ZSTD" has the highest compression ratio, but the compression and decompression speed is the slowest, and LZO is between the two. Also note that this option is experimental and might be changed in the future.<br /><br />Possible values:<ul><li>"LZ4"</li><li>"LZO"</li><li>"ZSTD"</li></ul></td>
+            <td>The codec to be used when compressing shuffle data. If it is "NONE", compression is disable. If it is not "NONE", only "LZ4", "LZO" and "ZSTD" are supported now. Through tpc-ds test of these three algorithms, the results show that "LZ4" algorithm has the highest compression and decompression speed, but the compression ratio is the lowest. "ZSTD" has the highest compression ratio, but the compression and decompression speed is the slowest, and LZO is between the two. Also note that this option is experimental and might be changed in the future.<br /><br />Possible values:<ul><li>"NONE"</li><li>"LZ4"</li><li>"LZO"</li><li>"ZSTD"</li></ul></td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.detailed-metrics</h5></td>

--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -27,34 +27,16 @@
             <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.hybrid-shuffle.enable-new-mode</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>The option is used to enable the new mode of hybrid shuffle, which has resolved existing issues in the legacy mode. First, the new mode uses less required network memory. Second, the new mode can store shuffle data in remote storage when the disk space is not enough, which could avoid insufficient disk space errors and is only supported when taskmanager.network.hybrid-shuffle.remote.path is configured. The new mode is currently in an experimental phase. It can be set to false to fallback to the legacy mode  if something unexpected. Once the new mode reaches a stable state, the legacy mode as well as the option will be removed.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.hybrid-shuffle.memory-decoupling.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>The option is used to make the memory that is used by hybrid shuffle decoupled from the complexity of the job topology and the number of tasks on the task manager. It significantly reduces the chance of the "Insufficient number of network buffers" exception, while the workloads may suffer performance reduction silently.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.hybrid-shuffle.num-retained-in-memory-regions-max</h5></td>
-            <td style="word-wrap: break-word;">1048576</td>
-            <td>Long</td>
-            <td>Controls the max number of hybrid retained regions in memory. Note: This option will be ignored if taskmanager.network.hybrid-shuffle.enable-new-mode is set true. </td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.hybrid-shuffle.remote.path</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>The option is used to configure the base path of remote storage for hybrid shuffle. The shuffle data will be stored in remote storage when the disk space is not enough. Note: If the option is configured and taskmanager.network.hybrid-shuffle.enable-new-mode is false, this option will be ignored. If the option is not configured and taskmanager.network.hybrid-shuffle.enable-new-mode is true, the remote storage will be disabled.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.hybrid-shuffle.spill-index-region-group-size</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>Integer</td>
-            <td>Controls the region group size(in bytes) of hybrid spilled file data index. Note: This option will be ignored if taskmanager.network.hybrid-shuffle.enable-new-mode is set true.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>

--- a/docs/layouts/shortcodes/generated/cluster_configuration.html
+++ b/docs/layouts/shortcodes/generated/cluster_configuration.html
@@ -69,12 +69,6 @@
             <td>Defines whether cluster will handle any uncaught exceptions by just logging them (LOG mode), or by failing job (FAIL mode)<br /><br />Possible values:<ul><li>"LOG"</li><li>"FAIL"</li></ul></td>
         </tr>
         <tr>
-            <td><h5>fine-grained.shuffle-mode.all-blocking</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to convert all PIPELINE edges to BLOCKING when apply fine-grained resource management in batch jobs.</td>
-        </tr>
-        <tr>
             <td><h5>process.jobmanager.working-dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -75,12 +75,6 @@
             <td>Controls the maximum number of execution attempts of each operator that can execute concurrently, including the original one and speculative ones.</td>
         </tr>
         <tr>
-            <td><h5>fine-grained.shuffle-mode.all-blocking</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to convert all PIPELINE edges to BLOCKING when apply fine-grained resource management in batch jobs.</td>
-        </tr>
-        <tr>
             <td><h5>job-event.store.write-buffer.flush-interval</h5></td>
             <td style="word-wrap: break-word;">1 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -69,12 +69,6 @@
             <td>The Netty client connection timeout.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.netty.client.numThreads</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>The number of Netty client threads.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.netty.client.tcp.keepCount</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
@@ -91,36 +85,6 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
             <td>The time (in seconds) between individual keepalive probes. Note: This will not take effect when using netty transport type of nio with an older version of JDK 8, refer to https://bugs.openjdk.org/browse/JDK-8194298.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.num-arenas</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>The number of Netty arenas.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.sendReceiveBufferSize</h5></td>
-            <td style="word-wrap: break-word;">0</td>
-            <td>Integer</td>
-            <td>The Netty send and receive buffer size. This defaults to the system buffer size (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.server.backlog</h5></td>
-            <td style="word-wrap: break-word;">0</td>
-            <td>Integer</td>
-            <td>The netty server connection backlog.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.server.numThreads</h5></td>
-            <td style="word-wrap: break-word;">-1</td>
-            <td>Integer</td>
-            <td>The number of Netty server threads.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.netty.transport</h5></td>
-            <td style="word-wrap: break-word;">"auto"</td>
-            <td>String</td>
-            <td>The Netty transport type, either "nio" or "epoll". The "auto" means selecting the property mode automatically based on the platform. Note that the "epoll" mode can get better performance, less GC and have more advanced features which are only available on modern Linux.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.partition-request-timeout</h5></td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -33,12 +33,6 @@
             <td>Boolean flag indicating whether the shuffle data will be compressed for batch shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when compression ratio is high.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.blocking-shuffle.type</h5></td>
-            <td style="word-wrap: break-word;">"file"</td>
-            <td>String</td>
-            <td>The blocking shuffle type, either "mmap" or "file". The "auto" means selecting the property type automatically based on system memory architecture (64 bit for mmap and 32 bit for file). Note that the memory usage of mmap is not accounted by configured memory limits, but some resource frameworks like yarn would track this memory usage and kill the container once memory exceeding some threshold. Also note that this option is experimental and might be changed future.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.compression.codec</h5></td>
             <td style="word-wrap: break-word;">LZ4</td>
             <td><p>Enum</p></td>
@@ -205,12 +199,6 @@
             <td style="word-wrap: break-word;">512</td>
             <td>Integer</td>
             <td>Minimum number of network buffers required per blocking result partition for sort-shuffle. For production usage, it is suggested to increase this config value to at least 2048 (64M memory if the default 32K memory segment size is used) to improve the data compression ratio and reduce the small network packets. Usually, several hundreds of megabytes memory is enough for large scale batch jobs. Note: you may also need to increase the size of total network memory to avoid the 'insufficient number of network buffers' error if you are increasing this config value.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.sort-shuffle.min-parallelism</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>Parallelism threshold to switch between sort-based blocking shuffle and hash-based blocking shuffle, which means for batch jobs of smaller parallelism, hash-shuffle will be used and for batch jobs of larger or equal parallelism, sort-shuffle will be used. The value 1 means that sort-shuffle is the default option. Note: For production usage, you may also need to tune 'taskmanager.network.sort-shuffle.min-buffers' and 'taskmanager.memory.framework.off-heap.batch-shuffle.size' for better performance.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.tcp-connection.enable-reuse-across-jobs</h5></td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -51,12 +51,6 @@
             <td>The option is used to configure the base path of remote storage for hybrid shuffle. The shuffle data will be stored in remote storage when the disk space is not enough. Note: If the option is configured and taskmanager.network.hybrid-shuffle.enable-new-mode is false, this option will be ignored. If the option is not configured and taskmanager.network.hybrid-shuffle.enable-new-mode is true, the remote storage will be disabled.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>The maximum number of tpc connections between taskmanagers for data communication.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.memory.read-buffer.required-per-gate.max</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -45,34 +45,16 @@
             <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.hybrid-shuffle.enable-new-mode</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>The option is used to enable the new mode of hybrid shuffle, which has resolved existing issues in the legacy mode. First, the new mode uses less required network memory. Second, the new mode can store shuffle data in remote storage when the disk space is not enough, which could avoid insufficient disk space errors and is only supported when taskmanager.network.hybrid-shuffle.remote.path is configured. The new mode is currently in an experimental phase. It can be set to false to fallback to the legacy mode  if something unexpected. Once the new mode reaches a stable state, the legacy mode as well as the option will be removed.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.hybrid-shuffle.memory-decoupling.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>The option is used to make the memory that is used by hybrid shuffle decoupled from the complexity of the job topology and the number of tasks on the task manager. It significantly reduces the chance of the "Insufficient number of network buffers" exception, while the workloads may suffer performance reduction silently.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.hybrid-shuffle.num-retained-in-memory-regions-max</h5></td>
-            <td style="word-wrap: break-word;">1048576</td>
-            <td>Long</td>
-            <td>Controls the max number of hybrid retained regions in memory. Note: This option will be ignored if taskmanager.network.hybrid-shuffle.enable-new-mode is set true. </td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.hybrid-shuffle.remote.path</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>The option is used to configure the base path of remote storage for hybrid shuffle. The shuffle data will be stored in remote storage when the disk space is not enough. Note: If the option is configured and taskmanager.network.hybrid-shuffle.enable-new-mode is false, this option will be ignored. If the option is not configured and taskmanager.network.hybrid-shuffle.enable-new-mode is true, the remote storage will be disabled.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.hybrid-shuffle.spill-index-region-group-size</h5></td>
-            <td style="word-wrap: break-word;">1024</td>
-            <td>Integer</td>
-            <td>Controls the region group size(in bytes) of hybrid spilled file data index. Note: This option will be ignored if taskmanager.network.hybrid-shuffle.enable-new-mode is set true.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -27,16 +27,10 @@
             <td>Enable SSL support for the taskmanager data transport. This is applicable only when the global flag for internal SSL (security.ssl.internal.enabled) is set to true</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.batch-shuffle.compression.enabled</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Boolean flag indicating whether the shuffle data will be compressed for batch shuffle mode. Note that data is compressed per buffer and compression can incur extra CPU overhead, so it is more effective for IO bounded scenario when compression ratio is high.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.compression.codec</h5></td>
             <td style="word-wrap: break-word;">LZ4</td>
             <td><p>Enum</p></td>
-            <td>The codec to be used when compressing shuffle data, only "LZ4", "LZO" and "ZSTD" are supported now. Through tpc-ds test of these three algorithms, the results show that "LZ4" algorithm has the highest compression and decompression speed, but the compression ratio is the lowest. "ZSTD" has the highest compression ratio, but the compression and decompression speed is the slowest, and LZO is between the two. Also note that this option is experimental and might be changed in the future.<br /><br />Possible values:<ul><li>"LZ4"</li><li>"LZO"</li><li>"ZSTD"</li></ul></td>
+            <td>The codec to be used when compressing shuffle data. If it is "NONE", compression is disable. If it is not "NONE", only "LZ4", "LZO" and "ZSTD" are supported now. Through tpc-ds test of these three algorithms, the results show that "LZ4" algorithm has the highest compression and decompression speed, but the compression ratio is the lowest. "ZSTD" has the highest compression ratio, but the compression and decompression speed is the slowest, and LZO is between the two. Also note that this option is experimental and might be changed in the future.<br /><br />Possible values:<ul><li>"NONE"</li><li>"LZ4"</li><li>"LZO"</li><li>"ZSTD"</li></ul></td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.detailed-metrics</h5></td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -63,30 +63,6 @@
             <td>The maximum number of tpc connections between taskmanagers for data communication.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
-            <td style="word-wrap: break-word;">2</td>
-            <td>Integer</td>
-            <td>Number of exclusive network buffers for each outgoing/incoming channel (subpartition/input channel) in the credit-based flow control model. For the outgoing channel(subpartition), this value is the effective exclusive buffers per channel. For the incoming channel(input channel), this value is the max number of exclusive buffers per channel, the number of effective exclusive network buffers per channel is dynamically calculated from taskmanager.network.memory.read-buffer.required-per-gate.max and the effective range is from 0 to the configured value. The minimum valid value for the option is 0. When the option is configured as 0, the exclusive network buffers used by downstream incoming channel will be 0, but for each upstream outgoing channel, max(1, configured value) will be used. In other words, we ensure that, for performance reasons, at least one buffer is used per outgoing channel regardless of the configuration.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>
-            <td style="word-wrap: break-word;">8</td>
-            <td>Integer</td>
-            <td>Number of floating network buffers for each outgoing/incoming gate (result partition/input gate). In credit-based flow control mode, this indicates how many floating credits are shared among all the channels. The floating buffers can help relieve back-pressure caused by unbalanced data distribution among the subpartitions. For the outgoing gate(result partition), this value is the effective floating buffers per gate. For the incoming gate(input gate), this value is a recommended number of floating buffers, the number of effective floating network buffers per gate is dynamically calculated from taskmanager.network.memory.read-buffer.required-per-gate.max and the range of effective floating buffers is from 0 to (parallelism - 1).</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.max-buffers-per-channel</h5></td>
-            <td style="word-wrap: break-word;">10</td>
-            <td>Integer</td>
-            <td>Number of max buffers that can be used for each channel. If a channel exceeds the number of max buffers, it will make the task become unavailable, cause the back pressure and block the data processing. This might speed up checkpoint alignment by preventing excessive growth of the buffered in-flight data in case of data skew and high number of configured floating buffers. This limit is not strictly guaranteed, and can be ignored by things like flatMap operators, records spanning multiple buffers or single timer producing large amount of data.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.network.memory.max-overdraft-buffers-per-gate</h5></td>
-            <td style="word-wrap: break-word;">5</td>
-            <td>Integer</td>
-            <td>Number of max overdraft network buffers to use for each ResultPartition. The overdraft buffers will be used when the subtask cannot apply to the normal buffers  due to back pressure, while subtask is performing an action that can not be interrupted in the middle,  like serializing a large record, flatMap operator producing multiple records for one single input record or processing time timer producing large output. In situations like that system will allow subtask to request overdraft buffers, so that the subtask can finish such uninterruptible action, without blocking unaligned checkpoints for long period of time. Overdraft buffers are provided on best effort basis only if the system has some unused buffers available. Subtask that has used overdraft buffers won't be allowed to process any more records until the overdraft buffers are returned to the pool. It should be noted that this config option only takes effect for Pipelined Shuffle.</td>
-        </tr>
-        <tr>
             <td><h5>taskmanager.network.memory.read-buffer.required-per-gate.max</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -141,7 +141,10 @@ public class ClusterOptions {
                     .withDescription(
                             "The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.");
 
-    @Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
+    /**
+     * @deprecated The option is unnecessary. It is deprecated in 1.20 and will be removed in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<Boolean> FINE_GRAINED_SHUFFLE_MODE_ALL_BLOCKING =
             ConfigOptions.key("fine-grained.shuffle-mode.all-blocking")
                     .booleanType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -341,8 +341,14 @@ public class NettyShuffleEnvironmentOptions {
                                     // this raw value must be changed correspondingly
                                     "taskmanager.memory.framework.off-heap.batch-shuffle.size"));
 
-    /** Region group size of hybrid spilled file data index. */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * Region group size of hybrid spilled file data index.
+     *
+     * @deprecated The option is only used in the legacy hybrid shuffle mode. It is deprecated in
+     *     1.20 and will be totally removed in 2.0, as the legacy hybrid shuffle mode will be
+     *     removed in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<Integer> HYBRID_SHUFFLE_SPILLED_INDEX_REGION_GROUP_SIZE =
             key("taskmanager.network.hybrid-shuffle.spill-index-region-group-size")
                     .intType()
@@ -355,8 +361,14 @@ public class NettyShuffleEnvironmentOptions {
                                     + HYBRID_SHUFFLE_NEW_MODE_OPTION_NAME
                                     + " is set true.");
 
-    /** Max number of hybrid retained regions in memory. */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * Max number of hybrid retained regions in memory.
+     *
+     * @deprecated The option is only used in the legacy hybrid shuffle mode. It is deprecated in
+     *     1.20 and will be totally removed in 2.0, as the legacy hybrid shuffle mode will be
+     *     removed in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<Long> HYBRID_SHUFFLE_NUM_RETAINED_IN_MEMORY_REGIONS_MAX =
             key("taskmanager.network.hybrid-shuffle.num-retained-in-memory-regions-max")
                     .longType()
@@ -413,9 +425,13 @@ public class NettyShuffleEnvironmentOptions {
                                     + "tasks have occupied all the buffers and the downstream tasks are waiting for the exclusive buffers. The timeout breaks"
                                     + "the tie by failing the request of exclusive buffers and ask users to increase the number of total buffers.");
 
-    /** The option to enable the new mode of hybrid shuffle. */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
-    @Experimental
+    /**
+     * The option to enable the new mode of hybrid shuffle.
+     *
+     * @deprecated This option is deprecated in 1.20 and will be totally removed in 2.0, as the
+     *     legacy hybrid shuffle mode will be removed in 2.0.
+     */
+    @Deprecated @Experimental
     public static final ConfigOption<Boolean> NETWORK_HYBRID_SHUFFLE_ENABLE_NEW_MODE =
             ConfigOptions.key(HYBRID_SHUFFLE_NEW_MODE_OPTION_NAME)
                     .booleanType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -198,8 +198,13 @@ public class NettyShuffleEnvironmentOptions {
                     .defaultValue("1gb")
                     .withDescription("Maximum memory size for network buffers.");
 
-    /** The maximum number of tpc connections between taskmanagers for data communication. */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * The maximum number of tpc connections between taskmanagers for data communication.
+     *
+     * @deprecated The option is unnecessary. It is deprecated in 1.20 and will be removed and
+     *     hard-coded to 1 in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<Integer> MAX_NUM_TCP_CONNECTIONS =
             key("taskmanager.network.max-num-tcp-connections")
                     .intType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -90,8 +90,12 @@ public class NettyShuffleEnvironmentOptions {
      *
      * <p>Note: Data is compressed per buffer and compression can incur extra CPU overhead so it is
      * more effective for IO bounded scenario when data compression ratio is high.
+     *
+     * @deprecated This option is deprecated in 1.20 and will be removed in 2.0. Please set the
+     *     {@link NettyShuffleEnvironmentOptions#SHUFFLE_COMPRESSION_CODEC} to NONE to disable the
+     *     compression.
      */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    @Deprecated
     public static final ConfigOption<Boolean> BATCH_SHUFFLE_COMPRESSION_ENABLED =
             key("taskmanager.network.batch-shuffle.compression.enabled")
                     .booleanType()
@@ -106,13 +110,13 @@ public class NettyShuffleEnvironmentOptions {
 
     /** The codec to be used when compressing shuffle data. */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
-    @Experimental
     public static final ConfigOption<CompressionCodec> SHUFFLE_COMPRESSION_CODEC =
             key("taskmanager.network.compression.codec")
                     .enumType(CompressionCodec.class)
                     .defaultValue(CompressionCodec.LZ4)
                     .withDescription(
-                            "The codec to be used when compressing shuffle data, only \"LZ4\", \"LZO\" "
+                            "The codec to be used when compressing shuffle data. If it is \"NONE\", "
+                                    + "compression is disable. If it is not \"NONE\", only \"LZ4\", \"LZO\" "
                                     + "and \"ZSTD\" are supported now. Through tpc-ds test of these "
                                     + "three algorithms, the results show that \"LZ4\" algorithm has "
                                     + "the highest compression and decompression speed, but the "
@@ -123,6 +127,7 @@ public class NettyShuffleEnvironmentOptions {
 
     /** Supported compression codec. */
     public enum CompressionCodec {
+        NONE,
         LZ4,
         LZO,
         ZSTD

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -316,8 +316,11 @@ public class NettyShuffleEnvironmentOptions {
     /**
      * Parallelism threshold to switch between sort-based blocking shuffle and hash-based blocking
      * shuffle.
+     *
+     * @deprecated The hash-based blocking shuffle is deprecated in 1.20 and will be totally removed
+     *     in 2.0.
      */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    @Deprecated
     public static final ConfigOption<Integer> NETWORK_SORT_SHUFFLE_MIN_PARALLELISM =
             key("taskmanager.network.sort-shuffle.min-parallelism")
                     .intType()
@@ -455,7 +458,11 @@ public class NettyShuffleEnvironmentOptions {
                                     + "the \"Insufficient number of network buffers\" exception, while the workloads may suffer performance "
                                     + "reduction silently.");
 
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * @deprecated The hash-based blocking shuffle is deprecated in 1.20 and will be totally removed
+     *     in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<String> NETWORK_BLOCKING_SHUFFLE_TYPE =
             key("taskmanager.network.blocking-shuffle.type")
                     .stringType()

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -240,8 +240,11 @@ public class NettyShuffleEnvironmentOptions {
      * upstream outgoing channel, max(1, configured value) will be used. In other words we ensure
      * that, for performance reasons, at least one buffer is used per outgoing channel regardless of
      * the configuration.
+     *
+     * @deprecated This option is deprecated in 1.20 and will be removed in 2.0 to simplify the
+     *     configuration of network buffers.
      */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    @Deprecated
     public static final ConfigOption<Integer> NETWORK_BUFFERS_PER_CHANNEL =
             key("taskmanager.network.memory.buffers-per-channel")
                     .intType()
@@ -270,8 +273,11 @@ public class NettyShuffleEnvironmentOptions {
     /**
      * Number of floating network buffers for each outgoing/incoming gate (result partition/input
      * gate).
+     *
+     * @deprecated This option is deprecated in 1.20 and will be removed in 2.0 to simplify the
+     *     configuration of network buffers.
      */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    @Deprecated
     public static final ConfigOption<Integer> NETWORK_EXTRA_BUFFERS_PER_GATE =
             key("taskmanager.network.memory.floating-buffers-per-gate")
                     .intType()
@@ -379,8 +385,13 @@ public class NettyShuffleEnvironmentOptions {
                                     + HYBRID_SHUFFLE_NEW_MODE_OPTION_NAME
                                     + " is set true. ");
 
-    /** Number of max buffers can be used for each output subpartition. */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * Number of max buffers can be used for each output subpartition.
+     *
+     * @deprecated This option is deprecated in 1.20 and will be removed in 2.0 to simplify the
+     *     configuration of network buffers.
+     */
+    @Deprecated
     public static final ConfigOption<Integer> NETWORK_MAX_BUFFERS_PER_CHANNEL =
             key("taskmanager.network.memory.max-buffers-per-channel")
                     .intType()
@@ -393,8 +404,13 @@ public class NettyShuffleEnvironmentOptions {
                                     + " and can be ignored by things like flatMap operators, records spanning multiple buffers or single timer"
                                     + " producing large amount of data.");
 
-    /** Number of max overdraft network buffers to use for each ResultPartition. */
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * Number of max overdraft network buffers to use for each ResultPartition.
+     *
+     * @deprecated This option is deprecated in 1.20 and will be removed in 2.0 to simplify the
+     *     configuration of network buffers.
+     */
+    @Deprecated
     public static final ConfigOption<Integer> NETWORK_MAX_OVERDRAFT_BUFFERS_PER_GATE =
             key("taskmanager.network.memory.max-overdraft-buffers-per-gate")
                     .intType()
@@ -412,15 +428,35 @@ public class NettyShuffleEnvironmentOptions {
                                     + " process any more records until the overdraft buffers are returned to the pool."
                                     + " It should be noted that this config option only takes effect for Pipelined Shuffle.");
 
-    /** The timeout for requesting exclusive buffers for each channel. */
-    @Documentation.ExcludeFromDocumentation(
-            "This option is purely implementation related, and may be removed as the implementation changes.")
+    /**
+     * The timeout for requesting exclusive buffers for each channel.
+     *
+     * @deprecated This option is deprecated in 1.20 and will be removed in 2.0 to simplify the
+     *     configuration of network buffers. Please use {@link
+     *     NettyShuffleEnvironmentOptions#NETWORK_BUFFERS_REQUEST_TIMEOUT} instead.
+     */
+    @Deprecated
     public static final ConfigOption<Long> NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS =
             key("taskmanager.network.memory.exclusive-buffers-request-timeout-ms")
                     .longType()
                     .defaultValue(30000L)
                     .withDescription(
                             "The timeout for requesting exclusive buffers for each channel. Since the number of maximum buffers and "
+                                    + "the number of required buffers is not the same for local buffer pools, there may be deadlock cases that the upstream"
+                                    + "tasks have occupied all the buffers and the downstream tasks are waiting for the exclusive buffers. The timeout breaks"
+                                    + "the tie by failing the request of exclusive buffers and ask users to increase the number of total buffers.");
+
+    /** The timeout for requesting buffers for each channel. */
+    @Documentation.ExcludeFromDocumentation(
+            "This option is purely implementation related, and may be removed as the implementation changes.")
+    public static final ConfigOption<Duration> NETWORK_BUFFERS_REQUEST_TIMEOUT =
+            key("taskmanager.network.memory.buffers-request-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(30000L))
+                    .withDeprecatedKeys(
+                            "taskmanager.network.memory.exclusive-buffers-request-timeout-ms")
+                    .withDescription(
+                            "The timeout for requesting buffers for each channel. Since the number of maximum buffers and "
                                     + "the number of required buffers is not the same for local buffer pools, there may be deadlock cases that the upstream"
                                     + "tasks have occupied all the buffers and the downstream tasks are waiting for the exclusive buffers. The timeout breaks"
                                     + "the tie by failing the request of exclusive buffers and ask users to increase the number of total buffers.");

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -560,7 +560,11 @@ public class NettyShuffleEnvironmentOptions {
     //  Netty Options
     // ------------------------------------------------------------------------
 
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * @deprecated It is not recommended to use the option. It is deprecated in 1.20 and will be
+     *     totally removed in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<Integer> NUM_ARENAS =
             key("taskmanager.network.netty.num-arenas")
                     .intType()
@@ -568,7 +572,11 @@ public class NettyShuffleEnvironmentOptions {
                     .withDeprecatedKeys("taskmanager.net.num-arenas")
                     .withDescription("The number of Netty arenas.");
 
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * @deprecated It is not recommended to use the option. It is deprecated in 1.20 and will be
+     *     totally removed in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<Integer> NUM_THREADS_SERVER =
             key("taskmanager.network.netty.server.numThreads")
                     .intType()
@@ -576,7 +584,11 @@ public class NettyShuffleEnvironmentOptions {
                     .withDeprecatedKeys("taskmanager.net.server.numThreads")
                     .withDescription("The number of Netty server threads.");
 
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * @deprecated It is not recommended to use the option. It is deprecated in 1.20 and will be
+     *     totally removed in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<Integer> NUM_THREADS_CLIENT =
             key("taskmanager.network.netty.client.numThreads")
                     .intType()
@@ -584,7 +596,11 @@ public class NettyShuffleEnvironmentOptions {
                     .withDeprecatedKeys("taskmanager.net.client.numThreads")
                     .withDescription("The number of Netty client threads.");
 
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * @deprecated It is not recommended to use the option. It is deprecated in 1.20 and will be
+     *     totally removed in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<Integer> CONNECT_BACKLOG =
             key("taskmanager.network.netty.server.backlog")
                     .intType()
@@ -610,7 +626,11 @@ public class NettyShuffleEnvironmentOptions {
                             "The number of retry attempts for network communication."
                                     + " Currently it's only used for establishing input/output channel connections");
 
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * @deprecated It is not recommended to use the option. It is deprecated in 1.20 and will be
+     *     totally removed in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<Integer> SEND_RECEIVE_BUFFER_SIZE =
             key("taskmanager.network.netty.sendReceiveBufferSize")
                     .intType()
@@ -620,7 +640,11 @@ public class NettyShuffleEnvironmentOptions {
                             "The Netty send and receive buffer size. This defaults to the system buffer size"
                                     + " (cat /proc/sys/net/ipv4/tcp_[rw]mem) and is 4 MiB in modern Linux.");
 
-    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    /**
+     * @deprecated It is not recommended to use the option. It is deprecated in 1.20 and will be
+     *     totally removed in 2.0.
+     */
+    @Deprecated
     public static final ConfigOption<String> TRANSPORT_TYPE =
             key("taskmanager.network.netty.transport")
                     .stringType()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -261,8 +261,7 @@ public class NetworkBufferPool
                                             + " or you may increase the timeout which is %dms by setting the key '%s'.",
                                     getConfigDescription(),
                                     requestSegmentsTimeout.toMillis(),
-                                    NettyShuffleEnvironmentOptions
-                                            .NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS
+                                    NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_REQUEST_TIMEOUT
                                             .key()));
                 }
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -368,10 +368,7 @@ public class NettyShuffleEnvironmentConfiguration {
         Collections.shuffle(shuffleDirs);
 
         Duration requestSegmentsTimeout =
-                Duration.ofMillis(
-                        configuration.get(
-                                NettyShuffleEnvironmentOptions
-                                        .NETWORK_EXCLUSIVE_BUFFERS_REQUEST_TIMEOUT_MILLISECONDS));
+                configuration.get(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_REQUEST_TIMEOUT);
 
         BoundedBlockingSubpartitionType blockingSubpartitionType =
                 getBlockingSubpartitionType(configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -373,10 +373,25 @@ public class NettyShuffleEnvironmentConfiguration {
         BoundedBlockingSubpartitionType blockingSubpartitionType =
                 getBlockingSubpartitionType(configuration);
 
-        boolean batchShuffleCompressionEnabled =
-                configuration.get(NettyShuffleEnvironmentOptions.BATCH_SHUFFLE_COMPRESSION_ENABLED);
         CompressionCodec compressionCodec =
                 configuration.get(NettyShuffleEnvironmentOptions.SHUFFLE_COMPRESSION_CODEC);
+
+        boolean batchShuffleCompressionEnabled;
+        if (compressionCodec == CompressionCodec.NONE) {
+            batchShuffleCompressionEnabled = false;
+        } else {
+            batchShuffleCompressionEnabled =
+                    configuration.get(
+                            NettyShuffleEnvironmentOptions.BATCH_SHUFFLE_COMPRESSION_ENABLED);
+
+            if (!batchShuffleCompressionEnabled) {
+                LOG.warn(
+                        "Deprecated configuration key {} is used to disable the compression. "
+                                + "Please set the {} to \"None\" to disable the compression.",
+                        NettyShuffleEnvironmentOptions.BATCH_SHUFFLE_COMPRESSION_ENABLED.key(),
+                        NettyShuffleEnvironmentOptions.SHUFFLE_COMPRESSION_CODEC.key());
+            }
+        }
 
         int maxNumConnections =
                 Math.max(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPipelineOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamPipelineOptions.java
@@ -30,7 +30,10 @@ import org.apache.flink.streaming.api.TimeCharacteristic;
 /**
  * The {@link ConfigOption configuration options} for job execution. Those are stream specific
  * options. See also {@link org.apache.flink.configuration.PipelineOptions}.
+ *
+ * @deprecated This option class is deprecated in 1.20 and will be removed in 2.0.
  */
+@Deprecated
 @PublicEvolving
 public class StreamPipelineOptions {
 


### PR DESCRIPTION

## What is the purpose of the change

As Flink moves toward 2.0, we have revisited all runtime configurations and identified several improvements to enhance user-friendliness and maintainability. We want to refine the runtime configuration.


## Brief change log

- Deprecate options related to hash-based blocking shuffle
- Deprecate options related to legacy hybrid shuffle
- Deprecate or update options of floating/exclusive buffer
- Deprecate or update options of shuffle compression
- Deprecate netty options that are not recommended to be used
- Deprecate taskmanager.network.max-num-tcp-connections
- Deprecate the unnecessary option fine-grained.shuffle-mode.all-blocking
- Deprecate StreamPipelineOptions that only contains deprecated option


## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
