### PR TITLE
[hotfix][statebackend/forst] Normalize ForSt option names and working dir

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -20,6 +20,7 @@ package org.apache.flink.state.forst;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.asyncprocessing.StateExecutor;
@@ -43,7 +44,6 @@ import javax.annotation.concurrent.GuardedBy;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
@@ -231,7 +231,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
     }
 
     @VisibleForTesting
-    URI getRemoteBasePath() {
+    Path getRemoteBasePath() {
         return optionsContainer.getRemoteBasePath();
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
@@ -32,7 +32,7 @@ public class ForStOptions {
 
     /** The local directory (on the TaskManager) where ForSt puts some meta files. */
     public static final ConfigOption<String> LOCAL_DIRECTORIES =
-            ConfigOptions.key("state.backend.forst.localdir")
+            ConfigOptions.key("state.backend.forst.local-dir")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
@@ -47,7 +47,7 @@ public class ForStOptions {
 
     /** The remote directory where ForSt puts its SST files. */
     public static final ConfigOption<String> REMOTE_DIRECTORY =
-            ConfigOptions.key("state.backend.forst.remotedir")
+            ConfigOptions.key("state.backend.forst.remote-dir")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.util.function.ThrowingRunnable;
 
@@ -43,7 +44,6 @@ import org.rocksdb.WriteOptions;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -303,18 +303,18 @@ public class ForStResourceContainerTest {
     @Test
     public void testDirectoryResources() throws Exception {
         File localBasePath = TMP_FOLDER.newFolder();
-        URI remoteBasePath = TMP_FOLDER.newFolder().toURI();
+        Path remoteBasePath = new Path(TMP_FOLDER.newFolder().getPath());
         try (final ForStResourceContainer optionsContainer =
                 new ForStResourceContainer(
                         new Configuration(), null, null, localBasePath, remoteBasePath, false)) {
             optionsContainer.prepareDirectories();
             assertTrue(localBasePath.exists());
-            assertTrue(new File(remoteBasePath).exists());
+            assertTrue(new File(remoteBasePath.getPath()).exists());
             assertTrue(optionsContainer.getDbOptions().getEnv() instanceof FlinkEnv);
 
             optionsContainer.clearDirectories();
             assertFalse(localBasePath.exists());
-            assertFalse(new File(remoteBasePath).exists());
+            assertFalse(new File(remoteBasePath.getPath()).exists());
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

As title said, normalize ForSt option names and working dir.


## Brief change log

  - rename option "state.backend.forst.localdir" to "state.backend.forst.local-dir"
  - rename option "state.backend.forst.remotedir" to "state.backend.forst.remote-dir"
  - fix the forst backend working dir mistake


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

Please help review this change @masteryhx , thanks.