### PR TITLE
[FLINK-26808] Limit FileUploadHandler to multipart routes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/MultipartRoutes.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/MultipartRoutes.java
@@ -1,0 +1,84 @@
+package org.apache.flink.runtime.rest.handler.router;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A utility for {@link org.apache.flink.runtime.rest.FileUploadHandler} to determine whether it
+ * should accept a request.
+ */
+public class MultipartRoutes {
+
+    private final List<PathPattern> postRoutes;
+    private final List<PathPattern> fileUploadRoutes;
+
+    private MultipartRoutes(List<PathPattern> postRoutes, List<PathPattern> fileUploadRoutes) {
+        this.postRoutes = new ArrayList<>(postRoutes);
+        this.fileUploadRoutes = new ArrayList<>(fileUploadRoutes);
+    }
+
+    /**
+     * Returns <code>true</code> if the handler at the provided <code>requestUri</code> endpoint
+     * accepts POST requests.
+     *
+     * @param requestUri URI for the request
+     */
+    public boolean isPostRoute(String requestUri) {
+        return checkRoutes(requestUri, postRoutes);
+    }
+
+    /**
+     * Returns <code>true</code> if the handler at the provided <code>requestUri</code> endpoint
+     * accepts file uploads.
+     *
+     * @param requestUri URI for the request
+     */
+    public boolean isFileUploadRoute(String requestUri) {
+        return checkRoutes(requestUri, fileUploadRoutes);
+    }
+
+    @Override
+    public String toString() {
+        return "MultipartRoutes{"
+                + "postRoutes="
+                + postRoutes
+                + ", fileUploadRoutes="
+                + fileUploadRoutes
+                + '}';
+    }
+
+    private boolean checkRoutes(String requestUri, List<PathPattern> routes) {
+        String[] pathTokens = Router.decodePathTokens(requestUri);
+        Map<String, String> params = new HashMap<>();
+        for (PathPattern route : routes) {
+            if (route.match(pathTokens, params)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static class Builder {
+
+        private final List<PathPattern> postRoutes = new ArrayList<>();
+        private final List<PathPattern> fileUploadRoutes = new ArrayList<>();
+
+        public Builder() {}
+
+        public MultipartRoutes.Builder addPostRoute(String pattern) {
+            postRoutes.add(new PathPattern(pattern));
+            return this;
+        }
+
+        public MultipartRoutes.Builder addFileUploadRoute(String pattern) {
+            fileUploadRoutes.add(new PathPattern(pattern));
+            return this;
+        }
+
+        public MultipartRoutes build() {
+            return new MultipartRoutes(postRoutes, fileUploadRoutes);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/MultipartRoutes.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/MultipartRoutes.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.runtime.rest.handler.router;
 
 import java.util.ArrayList;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/PathPattern.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/PathPattern.java
@@ -93,6 +93,11 @@ final class PathPattern {
         return tokens;
     }
 
+    @Override
+    public String toString() {
+        return pattern;
+    }
+
     // --------------------------------------------------------------------------
     // Instances of this class can be conveniently used as Map keys.
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/Router.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/router/Router.java
@@ -235,7 +235,7 @@ public class Router<T> {
 
     // --------------------------------------------------------------------------
 
-    private String[] decodePathTokens(String uri) {
+    static String[] decodePathTokens(String uri) {
         // Need to split the original URI (instead of QueryStringDecoder#path) then decode the
         // tokens (components),
         // otherwise /test1/123%2F456 will not match /test1/:p1

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/router/MultipartRoutesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/router/MultipartRoutesTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.runtime.rest.handler.router;
 
 import org.junit.jupiter.api.Test;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/router/MultipartRoutesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/router/MultipartRoutesTest.java
@@ -1,0 +1,34 @@
+package org.apache.flink.runtime.rest.handler.router;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MultipartRoutesTest {
+
+    @Test
+    public void testRoutePatternMatching() {
+        MultipartRoutes.Builder builder = new MultipartRoutes.Builder();
+        builder.addPostRoute("/jobs");
+        builder.addPostRoute("/jobs/:jobid/stop");
+        builder.addPostRoute("/jobs/:jobid/savepoints/:savepointid/delete");
+
+        builder.addFileUploadRoute("/jobs");
+        builder.addFileUploadRoute("/jobs/:jobid/stop");
+        builder.addFileUploadRoute("/jobs/:jobid/savepoints/:savepointid/delete");
+
+        MultipartRoutes routes = builder.build();
+
+        assertThat(routes.isPostRoute("/jobs")).isTrue();
+        assertThat(routes.isPostRoute("/jobs?q1=p1&q2=p2")).isTrue();
+        assertThat(routes.isPostRoute("/jobs/abc")).isFalse();
+        assertThat(routes.isPostRoute("/jobs/abc/stop")).isTrue();
+        assertThat(routes.isPostRoute("/jobs/abc/savepoints/def/delete")).isTrue();
+
+        assertThat(routes.isFileUploadRoute("/jobs")).isTrue();
+        assertThat(routes.isFileUploadRoute("/jobs?q1=p1&q2=p2")).isTrue();
+        assertThat(routes.isFileUploadRoute("/jobs/abc")).isFalse();
+        assertThat(routes.isFileUploadRoute("/jobs/abc/stop")).isTrue();
+        assertThat(routes.isFileUploadRoute("/jobs/abc/savepoints/def/delete")).isTrue();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this change is to limit multipart requests to POST endpoints and file upload endpoint. Prior to this change, any request could be a multipart request (and upload a file).

With this change, the behavior of `FileUploadHandler` will be as follows:
1. Only accept a multipart request if the endpoint handler accepts POST requests.
2. Only accept a file upload if the endpoint handler accept file uploads.

Note that there multipart requests can mix file uploads with regular requests.

## Brief change log

  - Add `MultipartRoutes` in the `*.router` package for re-use of existing path patterns utilities.
  - Factor out `RestServerEndpoint#getHandlerUrls(RestHandlerSpecification)` in order to ensure that we have a consistent way of getting the registered endpoint URLs.
  - Add `MultipartRoutes` to `FileUploadHandler` and populate from handler list in `RestServerEndpoint`.
  - Validate that all multipart requests go to a POST endpoint.
  - Validate that file uploads go to a endpoint that accepts file uploads.

## Verifying this change

This change is already covered by existing tests, such as `RestServerEndpointITCase` and `FileUploadHandlerITCase`. I made minor additions to these tests.

I manually verified that I can submit jobs via `bin/flink run` and `curl` both when web sumission is enabled and disabled.

The following gets logged in DEBUG on startup:

When web submission enabled:

```
DEBUG org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint   [] - Using MultipartRoutes{postRoutes=[v1/jars/upload, jars/upload, v1/jars/:jarid/plan, jars/:jarid/plan, v1/jars/:jarid/run, jars/:jarid/run, v1/jobs, jobs, v1/jobs/:jobid/checkpoints, jobs/:jobid/checkpoints, v1/jobs/:jobid/coordinators/:operatorid, jobs/:jobid/coordinators/:operatorid, v1/jobs/:jobid/savepoints, jobs/:jobid/savepoints, v1/jobs/:jobid/stop, jobs/:jobid/stop, v1/savepoint-disposal, savepoint-disposal], fileUploadRoutes=[v1/jars/upload, jars/upload, v1/jobs, jobs]} for FileUploadHandler
```

When web submission disabled:

```
DEBUG org.apache.flink.runtime.dispatcher.DispatcherRestEndpoint   [] - Using MultipartRoutes{postRoutes=[v1/jobs, jobs, v1/jobs/:jobid/checkpoints, jobs/:jobid/checkpoints, v1/jobs/:jobid/coordinators/:operatorid, jobs/:jobid/coordinators/:operatorid, v1/jobs/:jobid/savepoints, jobs/:jobid/savepoints, v1/jobs/:jobid/stop, jobs/:jobid/stop, v1/savepoint-disposal, savepoint-disposal], fileUploadRoutes=[v1/jobs, jobs]} for FileUploadHandler
```

When trying to upload a JAR with web submission disabled:

```
$ curl -X POST -H "Expect:" -F "jarfile=@examples/streaming/StateMachineExample.jar" http://localhost:8081/jars/upload
{"errors":["POST request not allowed"]}
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: yes (REST API for job and JAR submission)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
