### PR TITLE
[FLINK-35199][table] Support the execution of create materialized table in full refresh mode

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SingleSessionManager.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/SingleSessionManager.java
@@ -96,6 +96,7 @@ public class SingleSessionManager implements SessionManager {
                                 sessionHandle,
                                 environment,
                                 operationExecutorService));
+        session.open();
         return session;
     }
 

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.gateway.rest;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.rest.RestServerEndpoint;
@@ -81,6 +82,11 @@ public class SqlGatewayRestEndpoint extends RestServerEndpoint implements SqlGat
         super(configuration);
         service = sqlGatewayService;
         quartzScheduler = new EmbeddedQuartzScheduler();
+    }
+
+    @VisibleForTesting
+    public EmbeddedQuartzScheduler getQuartzScheduler() {
+        return quartzScheduler;
     }
 
     @Override

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowHandler.java
@@ -72,14 +72,15 @@ public class CreateEmbeddedSchedulerWorkflowHandler
         String materializedTableIdentifier =
                 request.getRequestBody().getMaterializedTableIdentifier();
         String cronExpression = request.getRequestBody().getCronExpression();
-        Map<String, String> dynamicOptions = request.getRequestBody().getDynamicOptions();
+        Map<String, String> initConfig = request.getRequestBody().getInitConfig();
         Map<String, String> executionConfig = request.getRequestBody().getExecutionConfig();
         String customScheduleTime = request.getRequestBody().getCustomScheduleTime();
         String restEndpointURL = request.getRequestBody().getRestEndpointUrl();
         WorkflowInfo workflowInfo =
                 new WorkflowInfo(
                         materializedTableIdentifier,
-                        dynamicOptions == null ? Collections.emptyMap() : dynamicOptions,
+                        Collections.emptyMap(),
+                        initConfig == null ? Collections.emptyMap() : initConfig,
                         executionConfig == null ? Collections.emptyMap() : executionConfig,
                         customScheduleTime,
                         restEndpointURL);

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowRequestBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/CreateEmbeddedSchedulerWorkflowRequestBody.java
@@ -34,7 +34,7 @@ public class CreateEmbeddedSchedulerWorkflowRequestBody implements RequestBody {
 
     private static final String FIELD_NAME_MATERIALIZED_TABLE = "materializedTableIdentifier";
     private static final String FIELD_NAME_CRON_EXPRESSION = "cronExpression";
-    private static final String FIELD_NAME_DYNAMIC_OPTIONS = "dynamicOptions";
+    private static final String FIELD_NAME_INIT_CONFIG = "initConfig";
     private static final String FIELD_NAME_EXECUTION_CONFIG = "executionConfig";
     private static final String FIELD_NAME_SCHEDULE_TIME = "customScheduleTime";
     private static final String FIELD_NAME_REST_ENDPOINT_URL = "restEndpointUrl";
@@ -45,9 +45,8 @@ public class CreateEmbeddedSchedulerWorkflowRequestBody implements RequestBody {
     @JsonProperty(FIELD_NAME_CRON_EXPRESSION)
     private final String cronExpression;
 
-    @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS)
-    @Nullable
-    private final Map<String, String> dynamicOptions;
+    @JsonProperty(FIELD_NAME_INIT_CONFIG)
+    private final Map<String, String> initConfig;
 
     @JsonProperty(FIELD_NAME_EXECUTION_CONFIG)
     @Nullable
@@ -63,14 +62,14 @@ public class CreateEmbeddedSchedulerWorkflowRequestBody implements RequestBody {
     public CreateEmbeddedSchedulerWorkflowRequestBody(
             @JsonProperty(FIELD_NAME_MATERIALIZED_TABLE) String materializedTableIdentifier,
             @JsonProperty(FIELD_NAME_CRON_EXPRESSION) String cronExpression,
-            @Nullable @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS) Map<String, String> dynamicOptions,
+            @Nullable @JsonProperty(FIELD_NAME_INIT_CONFIG) Map<String, String> initConfig,
             @Nullable @JsonProperty(FIELD_NAME_EXECUTION_CONFIG)
                     Map<String, String> executionConfig,
             @Nullable @JsonProperty(FIELD_NAME_SCHEDULE_TIME) String customScheduleTime,
             @JsonProperty(FIELD_NAME_REST_ENDPOINT_URL) String restEndpointUrl) {
         this.materializedTableIdentifier = materializedTableIdentifier;
         this.cronExpression = cronExpression;
-        this.dynamicOptions = dynamicOptions;
+        this.initConfig = initConfig;
         this.executionConfig = executionConfig;
         this.customScheduleTime = customScheduleTime;
         this.restEndpointUrl = restEndpointUrl;
@@ -81,8 +80,8 @@ public class CreateEmbeddedSchedulerWorkflowRequestBody implements RequestBody {
     }
 
     @Nullable
-    public Map<String, String> getDynamicOptions() {
-        return dynamicOptions;
+    public Map<String, String> getInitConfig() {
+        return initConfig;
     }
 
     @Nullable

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
@@ -30,8 +31,11 @@ import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.WorkflowSchedulerFactoryUtil;
 import org.apache.flink.table.gateway.api.operation.OperationHandle;
 import org.apache.flink.table.gateway.api.results.ResultSet;
+import org.apache.flink.table.gateway.rest.SqlGatewayRestEndpointFactory;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestOptions;
 import org.apache.flink.table.gateway.service.operation.OperationExecutor;
 import org.apache.flink.table.gateway.service.result.ResultFetcher;
 import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
@@ -46,7 +50,12 @@ import org.apache.flink.table.operations.materializedtable.DropMaterializedTable
 import org.apache.flink.table.operations.materializedtable.MaterializedTableOperation;
 import org.apache.flink.table.refresh.ContinuousRefreshHandler;
 import org.apache.flink.table.refresh.ContinuousRefreshHandlerSerializer;
+import org.apache.flink.table.refresh.RefreshHandler;
+import org.apache.flink.table.refresh.RefreshHandlerSerializer;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.workflow.CreatePeriodicRefreshWorkflow;
+import org.apache.flink.table.workflow.CreateRefreshWorkflow;
+import org.apache.flink.table.workflow.WorkflowScheduler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +63,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.net.URLClassLoader;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,7 +89,10 @@ import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.P
 import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.SCHEDULE_TIME_DATE_FORMATTER_DEFAULT;
 import static org.apache.flink.table.api.internal.TableResultInternal.TABLE_RESULT_OK;
 import static org.apache.flink.table.catalog.CatalogBaseTable.TableKind.MATERIALIZED_TABLE;
+import static org.apache.flink.table.factories.WorkflowSchedulerFactoryUtil.WORKFLOW_SCHEDULER_PREFIX;
+import static org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils.getEndpointConfig;
 import static org.apache.flink.table.utils.DateTimeUtils.formatTimestampString;
+import static org.apache.flink.table.utils.IntervalFreshnessUtils.convertFreshnessToCron;
 
 /** Manager is responsible for execute the {@link MaterializedTableOperation}. */
 @Internal
@@ -87,7 +100,46 @@ public class MaterializedTableManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(MaterializedTableManager.class);
 
-    public static ResultFetcher callMaterializedTableOperation(
+    private final URLClassLoader userCodeClassLoader;
+
+    private final @Nullable WorkflowScheduler<? extends RefreshHandler> workflowScheduler;
+
+    private final String restEndpointUrl;
+
+    public MaterializedTableManager(
+            Configuration configuration, URLClassLoader userCodeClassLoader) {
+        this.userCodeClassLoader = userCodeClassLoader;
+        this.restEndpointUrl = buildRestEndpointUrl(configuration);
+        this.workflowScheduler = buildWorkflowScheduler(configuration, userCodeClassLoader);
+    }
+
+    private String buildRestEndpointUrl(Configuration configuration) {
+        Map<String, String> restEndpointConfigMap =
+                getEndpointConfig(configuration, SqlGatewayRestEndpointFactory.IDENTIFIER);
+        String address = restEndpointConfigMap.get(SqlGatewayRestOptions.ADDRESS.key());
+        String port = restEndpointConfigMap.get(SqlGatewayRestOptions.PORT.key());
+        return String.format("http://%s:%s", address, port);
+    }
+
+    private WorkflowScheduler<? extends RefreshHandler> buildWorkflowScheduler(
+            Configuration configuration, URLClassLoader userCodeClassLoader) {
+        return WorkflowSchedulerFactoryUtil.createWorkflowScheduler(
+                configuration, userCodeClassLoader);
+    }
+
+    public void open() throws Exception {
+        if (workflowScheduler != null) {
+            workflowScheduler.open();
+        }
+    }
+
+    public void close() throws Exception {
+        if (workflowScheduler != null) {
+            workflowScheduler.close();
+        }
+    }
+
+    public ResultFetcher callMaterializedTableOperation(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             MaterializedTableOperation op,
@@ -114,7 +166,7 @@ public class MaterializedTableManager {
                         "Unsupported Operation %s for materialized table.", op.asSummaryString()));
     }
 
-    private static ResultFetcher callCreateMaterializedTableOperation(
+    private ResultFetcher callCreateMaterializedTableOperation(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             CreateMaterializedTableOperation createMaterializedTableOperation) {
@@ -124,15 +176,15 @@ public class MaterializedTableManager {
             createMaterializedInContinuousMode(
                     operationExecutor, handle, createMaterializedTableOperation);
         } else {
-            throw new SqlExecutionException(
-                    "Only support create materialized table in continuous refresh mode currently.");
+            createMaterializedInFullMode(
+                    operationExecutor, handle, createMaterializedTableOperation);
         }
         // Just return ok for unify different refresh job info of continuous and full mode, user
         // should get the refresh job info via desc table.
         return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
     }
 
-    private static void createMaterializedInContinuousMode(
+    private void createMaterializedInContinuousMode(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             CreateMaterializedTableOperation createMaterializedTableOperation) {
@@ -165,7 +217,67 @@ public class MaterializedTableManager {
         }
     }
 
-    private static ResultFetcher callAlterMaterializedTableSuspend(
+    private void createMaterializedInFullMode(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            CreateMaterializedTableOperation createMaterializedTableOperation) {
+        if (workflowScheduler == null) {
+            throw new SqlExecutionException(
+                    "The workflow scheduler must be configured when creating materialized table in full refresh mode.");
+        }
+        // create materialized table first
+        operationExecutor.callExecutableOperation(handle, createMaterializedTableOperation);
+
+        ObjectIdentifier materializedTableIdentifier =
+                createMaterializedTableOperation.getTableIdentifier();
+        CatalogMaterializedTable catalogMaterializedTable =
+                createMaterializedTableOperation.getCatalogMaterializedTable();
+
+        // convert duration to cron expression
+        String cronExpression =
+                convertFreshnessToCron(catalogMaterializedTable.getDefinitionFreshness());
+        // create full refresh job
+        CreateRefreshWorkflow createRefreshWorkflow =
+                new CreatePeriodicRefreshWorkflow(
+                        materializedTableIdentifier,
+                        catalogMaterializedTable.getDefinitionQuery(),
+                        cronExpression,
+                        getSessionInitializationConf(operationExecutor),
+                        Collections.emptyMap(),
+                        restEndpointUrl);
+
+        try {
+            RefreshHandler refreshHandler =
+                    workflowScheduler.createRefreshWorkflow(createRefreshWorkflow);
+            RefreshHandlerSerializer refreshHandlerSerializer =
+                    workflowScheduler.getRefreshHandlerSerializer();
+            byte[] serializedRefreshHandler = refreshHandlerSerializer.serialize(refreshHandler);
+
+            updateRefreshHandler(
+                    operationExecutor,
+                    handle,
+                    materializedTableIdentifier,
+                    catalogMaterializedTable,
+                    refreshHandler.asSummaryString(),
+                    serializedRefreshHandler);
+        } catch (Exception e) {
+            // drop materialized table while create refresh workflow occur exception. Thus, weak
+            // atomicity is guaranteed
+            LOG.warn(
+                    "Create refresh workflow occur exception, drop materialized table {}.",
+                    materializedTableIdentifier,
+                    e);
+            operationExecutor.callExecutableOperation(
+                    handle, new DropMaterializedTableOperation(materializedTableIdentifier, true));
+            throw new SqlExecutionException(
+                    String.format(
+                            "Failed to create refresh workflow for materialized table %s.",
+                            materializedTableIdentifier),
+                    e);
+        }
+    }
+
+    private ResultFetcher callAlterMaterializedTableSuspend(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             AlterMaterializedTableSuspendOperation op) {
@@ -179,9 +291,7 @@ public class MaterializedTableManager {
         }
 
         ContinuousRefreshHandler refreshHandler =
-                deserializeContinuousHandler(
-                        materializedTable.getSerializedRefreshHandler(),
-                        operationExecutor.getSessionContext().getUserClassloader());
+                deserializeContinuousHandler(materializedTable.getSerializedRefreshHandler());
 
         String savepointPath =
                 stopJobWithSavepoint(operationExecutor, handle, refreshHandler.getJobId());
@@ -209,7 +319,7 @@ public class MaterializedTableManager {
         return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
     }
 
-    private static ResultFetcher callAlterMaterializedTableResume(
+    private ResultFetcher callAlterMaterializedTableResume(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             AlterMaterializedTableResumeOperation op) {
@@ -225,8 +335,7 @@ public class MaterializedTableManager {
 
         ContinuousRefreshHandler continuousRefreshHandler =
                 deserializeContinuousHandler(
-                        catalogMaterializedTable.getSerializedRefreshHandler(),
-                        operationExecutor.getSessionContext().getUserClassloader());
+                        catalogMaterializedTable.getSerializedRefreshHandler());
         Optional<String> restorePath = continuousRefreshHandler.getRestorePath();
         executeContinuousRefreshJob(
                 operationExecutor,
@@ -239,7 +348,7 @@ public class MaterializedTableManager {
         return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
     }
 
-    private static void executeContinuousRefreshJob(
+    private void executeContinuousRefreshJob(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             CatalogMaterializedTable catalogMaterializedTable,
@@ -278,25 +387,13 @@ public class MaterializedTableManager {
                     new ContinuousRefreshHandler(executeTarget, jobId);
             byte[] serializedBytes = serializeContinuousHandler(continuousRefreshHandler);
 
-            // update RefreshHandler to Catalog
-            CatalogMaterializedTable updatedMaterializedTable =
-                    catalogMaterializedTable.copy(
-                            CatalogMaterializedTable.RefreshStatus.ACTIVATED,
-                            continuousRefreshHandler.asSummaryString(),
-                            serializedBytes);
-            List<TableChange> tableChanges = new ArrayList<>();
-            tableChanges.add(
-                    TableChange.modifyRefreshStatus(
-                            CatalogMaterializedTable.RefreshStatus.ACTIVATED));
-            tableChanges.add(
-                    TableChange.modifyRefreshHandler(
-                            continuousRefreshHandler.asSummaryString(), serializedBytes));
-
-            AlterMaterializedTableChangeOperation alterMaterializedTableChangeOperation =
-                    new AlterMaterializedTableChangeOperation(
-                            materializedTableIdentifier, tableChanges, updatedMaterializedTable);
-            operationExecutor.callExecutableOperation(
-                    handle, alterMaterializedTableChangeOperation);
+            updateRefreshHandler(
+                    operationExecutor,
+                    handle,
+                    materializedTableIdentifier,
+                    catalogMaterializedTable,
+                    continuousRefreshHandler.asSummaryString(),
+                    serializedBytes);
         } catch (Exception e) {
             // drop materialized table while submit flink streaming job occur exception. Thus, weak
             // atomicity is guaranteed
@@ -315,7 +412,7 @@ public class MaterializedTableManager {
         }
     }
 
-    private static ResultFetcher callAlterMaterializedTableRefreshOperation(
+    private ResultFetcher callAlterMaterializedTableRefreshOperation(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             AlterMaterializedTableRefreshOperation alterMaterializedTableRefreshOperation) {
@@ -335,7 +432,7 @@ public class MaterializedTableManager {
                 null);
     }
 
-    public static ResultFetcher refreshMaterializedTable(
+    public ResultFetcher refreshMaterializedTable(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             ObjectIdentifier materializedTableIdentifier,
@@ -440,7 +537,7 @@ public class MaterializedTableManager {
         return refreshPartitions;
     }
 
-    private static void validatePartitionSpec(
+    private void validatePartitionSpec(
             Map<String, String> partitionSpec, ResolvedCatalogMaterializedTable table) {
         ResolvedSchema schema = table.getResolvedSchema();
         Set<String> allPartitionKeys = new HashSet<>(table.getPartitionKeys());
@@ -510,7 +607,7 @@ public class MaterializedTableManager {
         return insertStatement.toString();
     }
 
-    private static ResultFetcher callDropMaterializedTableOperation(
+    private ResultFetcher callDropMaterializedTableOperation(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             DropMaterializedTableOperation dropMaterializedTableOperation) {
@@ -536,9 +633,7 @@ public class MaterializedTableManager {
         if (CatalogMaterializedTable.RefreshStatus.ACTIVATED
                 == materializedTable.getRefreshStatus()) {
             ContinuousRefreshHandler refreshHandler =
-                    deserializeContinuousHandler(
-                            materializedTable.getSerializedRefreshHandler(),
-                            operationExecutor.getSessionContext().getUserClassloader());
+                    deserializeContinuousHandler(materializedTable.getSerializedRefreshHandler());
             // get job running status
             JobStatus jobStatus = getJobStatus(operationExecutor, handle, refreshHandler);
             if (!jobStatus.isTerminalState()) {
@@ -578,6 +673,40 @@ public class MaterializedTableManager {
         operationExecutor.callExecutableOperation(handle, dropMaterializedTableOperation);
 
         return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
+    }
+
+    /**
+     * Retrieves the session configuration for initializing the periodic refresh job. The function
+     * filters out default context configurations and removes unnecessary configurations such as
+     * resources download directory and workflow scheduler related configurations.
+     *
+     * @param operationExecutor The OperationExecutor instance used to access the session context.
+     * @return A Map containing the session configurations for initializing session for executing
+     *     the periodic refresh job.
+     */
+    private Map<String, String> getSessionInitializationConf(OperationExecutor operationExecutor) {
+        Map<String, String> sessionConf =
+                operationExecutor.getSessionContext().getSessionConf().toMap();
+
+        // we only keep the session conf that is not in the default context or the conf value is
+        // different from the default context.
+        Map<String, String> defaultContextConf =
+                operationExecutor.getSessionContext().getDefaultContext().getFlinkConfig().toMap();
+        sessionConf
+                .entrySet()
+                .removeIf(
+                        entry -> {
+                            String key = entry.getKey();
+                            String value = entry.getValue();
+                            return defaultContextConf.containsKey(key)
+                                    && defaultContextConf.get(key).equals(value);
+                        });
+
+        // remove useless conf
+        sessionConf.remove(TableConfigOptions.RESOURCES_DOWNLOAD_DIR.key());
+        sessionConf.keySet().removeIf(key -> key.startsWith(WORKFLOW_SCHEDULER_PREFIX));
+
+        return sessionConf;
     }
 
     private static JobStatus getJobStatus(
@@ -620,18 +749,17 @@ public class MaterializedTableManager {
         return results.get(0).getString(0).toString();
     }
 
-    private static ContinuousRefreshHandler deserializeContinuousHandler(
-            byte[] serializedRefreshHandler, ClassLoader classLoader) {
+    private ContinuousRefreshHandler deserializeContinuousHandler(byte[] serializedRefreshHandler) {
         try {
             return ContinuousRefreshHandlerSerializer.INSTANCE.deserialize(
-                    serializedRefreshHandler, classLoader);
+                    serializedRefreshHandler, userCodeClassLoader);
         } catch (IOException | ClassNotFoundException e) {
             throw new SqlExecutionException(
                     "Deserialize ContinuousRefreshHandler occur exception.", e);
         }
     }
 
-    private static byte[] serializeContinuousHandler(ContinuousRefreshHandler refreshHandler) {
+    private byte[] serializeContinuousHandler(ContinuousRefreshHandler refreshHandler) {
         try {
             return ContinuousRefreshHandlerSerializer.INSTANCE.serialize(refreshHandler);
         } catch (IOException e) {
@@ -640,10 +768,15 @@ public class MaterializedTableManager {
         }
     }
 
-    private static ResolvedCatalogMaterializedTable getCatalogMaterializedTable(
+    private ResolvedCatalogMaterializedTable getCatalogMaterializedTable(
             OperationExecutor operationExecutor, ObjectIdentifier tableIdentifier) {
         ResolvedCatalogBaseTable<?> resolvedCatalogBaseTable =
-                operationExecutor.getTable(tableIdentifier);
+                operationExecutor
+                        .getSessionContext()
+                        .getSessionState()
+                        .catalogManager
+                        .getTableOrError(tableIdentifier)
+                        .getResolvedTable();
         if (MATERIALIZED_TABLE != resolvedCatalogBaseTable.getTableKind()) {
             throw new ValidationException(
                     String.format(
@@ -652,6 +785,31 @@ public class MaterializedTableManager {
         }
 
         return (ResolvedCatalogMaterializedTable) resolvedCatalogBaseTable;
+    }
+
+    private void updateRefreshHandler(
+            OperationExecutor operationExecutor,
+            OperationHandle operationHandle,
+            ObjectIdentifier materializedTableIdentifier,
+            CatalogMaterializedTable catalogMaterializedTable,
+            String refreshHandlerSummary,
+            byte[] serializedRefreshHandler) {
+        CatalogMaterializedTable updatedMaterializedTable =
+                catalogMaterializedTable.copy(
+                        CatalogMaterializedTable.RefreshStatus.ACTIVATED,
+                        refreshHandlerSummary,
+                        serializedRefreshHandler);
+        List<TableChange> tableChanges = new ArrayList<>();
+        tableChanges.add(
+                TableChange.modifyRefreshStatus(CatalogMaterializedTable.RefreshStatus.ACTIVATED));
+        tableChanges.add(
+                TableChange.modifyRefreshHandler(refreshHandlerSummary, serializedRefreshHandler));
+        AlterMaterializedTableChangeOperation alterMaterializedTableChangeOperation =
+                new AlterMaterializedTableChangeOperation(
+                        materializedTableIdentifier, tableChanges, updatedMaterializedTable);
+        // update RefreshHandler to Catalog
+        operationExecutor.callExecutableOperation(
+                operationHandle, alterMaterializedTableChangeOperation);
     }
 
     /** Generate insert statement for materialized table. */

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -65,7 +65,6 @@ import org.apache.flink.table.gateway.api.results.FunctionInfo;
 import org.apache.flink.table.gateway.api.results.TableInfo;
 import org.apache.flink.table.gateway.environment.SqlGatewayStreamExecutionEnvironment;
 import org.apache.flink.table.gateway.service.context.SessionContext;
-import org.apache.flink.table.gateway.service.materializedtable.MaterializedTableManager;
 import org.apache.flink.table.gateway.service.result.ResultFetcher;
 import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
 import org.apache.flink.table.module.ModuleManager;
@@ -514,8 +513,11 @@ public class OperationExecutor {
                 || op instanceof ShowFunctionsOperation) {
             return callExecutableOperation(handle, (ExecutableOperation) op);
         } else if (op instanceof MaterializedTableOperation) {
-            return MaterializedTableManager.callMaterializedTableOperation(
-                    this, handle, (MaterializedTableOperation) op, statement);
+            return sessionContext
+                    .getSessionState()
+                    .materializedTableManager
+                    .callMaterializedTableOperation(
+                            this, handle, (MaterializedTableOperation) op, statement);
         } else {
             return callOperation(tableEnv, handle, op);
         }
@@ -546,14 +548,17 @@ public class OperationExecutor {
                 tEnv.getParser().parseIdentifier(materializedTableIdentifier);
         ObjectIdentifier objectIdentifier =
                 tEnv.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
-        return MaterializedTableManager.refreshMaterializedTable(
-                this,
-                handle,
-                objectIdentifier,
-                staticPartitions,
-                dynamicOptions,
-                isPeriodic,
-                scheduleTime);
+        return sessionContext
+                .getSessionState()
+                .materializedTableManager
+                .refreshMaterializedTable(
+                        this,
+                        handle,
+                        objectIdentifier,
+                        staticPartitions,
+                        dynamicOptions,
+                        isPeriodic,
+                        scheduleTime);
     }
 
     private TableConfig tableConfig() {

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/Session.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/Session.java
@@ -82,6 +82,10 @@ public class Session implements Closeable {
         return sessionContext.getPlanCacheManager();
     }
 
+    public void open() {
+        sessionContext.open();
+    }
+
     @Override
     public void close() {
         sessionContext.close();

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/SessionManagerImpl.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/SessionManagerImpl.java
@@ -155,6 +155,7 @@ public class SessionManagerImpl implements SessionManager {
                         defaultContext, sessionId, environment, operationExecutorService);
 
         session = new Session(sessionContext);
+        session.open();
         sessions.put(sessionId, session);
 
         LOG.info(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedWorkflowScheduler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/EmbeddedWorkflowScheduler.java
@@ -100,7 +100,7 @@ public class EmbeddedWorkflowScheduler implements WorkflowScheduler<EmbeddedRefr
                     new CreateEmbeddedSchedulerWorkflowRequestBody(
                             materializedTableIdentifier.asSerializableString(),
                             periodicRefreshWorkflow.getCronExpression(),
-                            periodicRefreshWorkflow.getDynamicOptions(),
+                            periodicRefreshWorkflow.getInitConfig(),
                             periodicRefreshWorkflow.getExecutionConfig(),
                             null,
                             periodicRefreshWorkflow.getRestEndpointUrl());

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/WorkflowInfo.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/WorkflowInfo.java
@@ -37,6 +37,7 @@ public class WorkflowInfo {
     private final String materializedTableIdentifier;
 
     private final Map<String, String> dynamicOptions;
+    private final Map<String, String> initConfig;
     private final Map<String, String> executionConfig;
 
     private final @Nullable String customSchedulerTime;
@@ -47,11 +48,13 @@ public class WorkflowInfo {
     public WorkflowInfo(
             @JsonProperty("materializedTableIdentifier") String materializedTableIdentifier,
             @JsonProperty("dynamicOptions") Map<String, String> dynamicOptions,
+            @JsonProperty("initConfig") Map<String, String> initConfig,
             @JsonProperty("executionConfig") Map<String, String> executionConfig,
             @JsonProperty("customSchedulerTime") @Nullable String customSchedulerTime,
             @JsonProperty("restEndpointUrl") String restEndpointUrl) {
         this.materializedTableIdentifier = materializedTableIdentifier;
         this.dynamicOptions = dynamicOptions;
+        this.initConfig = initConfig;
         this.executionConfig = executionConfig;
         this.customSchedulerTime = customSchedulerTime;
         this.restEndpointUrl = restEndpointUrl;
@@ -63,6 +66,10 @@ public class WorkflowInfo {
 
     public Map<String, String> getDynamicOptions() {
         return dynamicOptions;
+    }
+
+    public Map<String, String> getInitConfig() {
+        return initConfig;
     }
 
     public Map<String, String> getExecutionConfig() {
@@ -88,7 +95,7 @@ public class WorkflowInfo {
         }
         WorkflowInfo that = (WorkflowInfo) o;
         return Objects.equals(materializedTableIdentifier, that.materializedTableIdentifier)
-                && Objects.equals(dynamicOptions, that.dynamicOptions)
+                && Objects.equals(initConfig, that.initConfig)
                 && Objects.equals(executionConfig, that.executionConfig)
                 && Objects.equals(customSchedulerTime, that.customSchedulerTime)
                 && Objects.equals(restEndpointUrl, that.restEndpointUrl);
@@ -99,6 +106,7 @@ public class WorkflowInfo {
         return Objects.hash(
                 materializedTableIdentifier,
                 dynamicOptions,
+                initConfig,
                 executionConfig,
                 customSchedulerTime,
                 restEndpointUrl);
@@ -112,6 +120,8 @@ public class WorkflowInfo {
                 + '\''
                 + ", dynamicOptions="
                 + dynamicOptions
+                + ", initConfig="
+                + initConfig
                 + ", executionConfig="
                 + executionConfig
                 + ", customSchedulerTime='"

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
@@ -27,15 +27,12 @@ import org.apache.flink.table.gateway.rest.header.materializedtable.RefreshMater
 import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableParameters;
 import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableRequestBody;
 import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableResponseBody;
-import org.apache.flink.table.gateway.rest.util.SqlGatewayRestEndpointExtension;
 import org.apache.flink.table.gateway.rest.util.TestingRestClient;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -56,11 +53,6 @@ public class SqlGatewayRestEndpointMaterializedTableITCase
         extends AbstractMaterializedTableStatementITCase {
 
     private static TestingRestClient restClient;
-
-    @RegisterExtension
-    @Order(4)
-    private static final SqlGatewayRestEndpointExtension SQL_GATEWAY_REST_ENDPOINT_EXTENSION =
-            new SqlGatewayRestEndpointExtension(SQL_GATEWAY_SERVICE_EXTENSION::getService);
 
     @BeforeAll
     static void setup() throws Exception {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/util/SqlGatewayRestEndpointExtension.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/util/SqlGatewayRestEndpointExtension.java
@@ -61,6 +61,10 @@ public class SqlGatewayRestEndpointExtension implements BeforeAllCallback, After
         return sqlGatewayService;
     }
 
+    public SqlGatewayRestEndpoint getSqlGatewayRestEndpoint() {
+        return sqlGatewayRestEndpoint;
+    }
+
     public SqlGatewayRestEndpointExtension(Supplier<SqlGatewayService> serviceSupplier) {
         this(serviceSupplier, (conf) -> {});
     }

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/QuartzSchedulerUtilsTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/QuartzSchedulerUtilsTest.java
@@ -48,14 +48,19 @@ public class QuartzSchedulerUtilsTest {
         dynamicOptions.put("k1", "v1");
         dynamicOptions.put("k2", "v2");
 
+        Map<String, String> initConfig = new HashMap<>();
+        initConfig.put("k3", "v4");
+        initConfig.put("k4", "v5");
+
         Map<String, String> executionConfig = new HashMap<>();
-        executionConfig.put("k3", "v3");
-        executionConfig.put("k4", "v4");
+        executionConfig.put("k5", "v5");
+        executionConfig.put("k6", "v6");
 
         String scheduleTime = "2023-04-04 20:00:00";
         String url = "http://localhost:8083";
         WorkflowInfo expected =
-                new WorkflowInfo(identifier, dynamicOptions, executionConfig, scheduleTime, url);
+                new WorkflowInfo(
+                        identifier, dynamicOptions, initConfig, executionConfig, scheduleTime, url);
 
         WorkflowInfo serde = fromJson(toJson(expected), WorkflowInfo.class);
         assertThat(serde).isEqualTo(expected);

--- a/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
@@ -459,7 +459,7 @@
         "cronExpression" : {
           "type" : "string"
         },
-        "dynamicOptions" : {
+        "initConfig" : {
           "type" : "object",
           "additionalProperties" : {
             "type" : "string"

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/CreatePeriodicRefreshWorkflow.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/CreatePeriodicRefreshWorkflow.java
@@ -36,7 +36,7 @@ public class CreatePeriodicRefreshWorkflow implements CreateRefreshWorkflow {
     private final ObjectIdentifier materializedTableIdentifier;
     private final String descriptionStatement;
     private final String cronExpression;
-    private final @Nullable Map<String, String> dynamicOptions;
+    private final @Nullable Map<String, String> initConfig;
     private final @Nullable Map<String, String> executionConfig;
 
     // The SQL Gateway rest endpoint url that used for execute refresh operation
@@ -46,13 +46,13 @@ public class CreatePeriodicRefreshWorkflow implements CreateRefreshWorkflow {
             ObjectIdentifier materializedTableIdentifier,
             String descriptionStatement,
             String cronExpression,
-            Map<String, String> dynamicOptions,
+            Map<String, String> initConfig,
             Map<String, String> executionConfig,
             String restEndpointUrl) {
         this.materializedTableIdentifier = materializedTableIdentifier;
         this.descriptionStatement = descriptionStatement;
         this.cronExpression = cronExpression;
-        this.dynamicOptions = dynamicOptions;
+        this.initConfig = initConfig;
         this.executionConfig = executionConfig;
         this.restEndpointUrl = restEndpointUrl;
     }
@@ -70,8 +70,8 @@ public class CreatePeriodicRefreshWorkflow implements CreateRefreshWorkflow {
     }
 
     @Nullable
-    public Map<String, String> getDynamicOptions() {
-        return dynamicOptions;
+    public Map<String, String> getInitConfig() {
+        return initConfig;
     }
 
     @Nullable


### PR DESCRIPTION
## What is the purpose of the change

*Support the execution of create materialized table in full refresh mode*


## Brief change log
  - *Support the execution of create materialized table in full refresh mode*


## Verifying this change
- *Add test testCreateMaterializedTableInFullMode in MaterializedTableStatementITCase *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Will be added in a separated pr.)
