### PR TITLE
[FLINK-15753][web] Displaying non-numeric metrics in Web UI dashboard

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/components/job-chart/job-chart.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/components/job-chart/job-chart.component.html
@@ -38,8 +38,8 @@
     </div>
   </div>
   <div class="content">
-    <div [hidden]="displayMode === 'numeric'" #chart></div>
-    <div class="numeric" [hidden]="displayMode === 'chart'">
+    <div [hidden]="displayMode === 'literal'" #chart></div>
+    <div class="literal" [hidden]="displayMode === 'chart'">
       {{ latestValue | humanizeChartNumeric: title }}
     </div>
     <div class="type-switch">
@@ -53,10 +53,10 @@
         </button>
         <button
           nz-button
-          [nzType]="displayMode === 'numeric' ? 'primary' : 'default'"
-          (click)="setMode('numeric')"
+          [nzType]="displayMode === 'literal' ? 'primary' : 'default'"
+          (click)="setMode('literal')"
         >
-          Numeric
+          Literal
         </button>
       </nz-button-group>
     </div>

--- a/flink-runtime-web/web-dashboard/src/app/components/job-chart/job-chart.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/components/job-chart/job-chart.component.less
@@ -62,7 +62,7 @@
 .content {
   padding: 12px;
 
-  .numeric {
+  .literal {
     font-size: 32px;
     line-height: 150px;
     text-align: center;

--- a/flink-runtime-web/web-dashboard/src/app/components/job-chart/job-chart.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/job-chart/job-chart.component.ts
@@ -52,10 +52,10 @@ export class JobChartComponent implements AfterViewInit, OnDestroy {
   @Output() closed = new EventEmitter();
   @ViewChild('chart', { static: true }) chart: ElementRef;
   size = 'small';
-  displayMode: 'chart' | 'numeric' = 'chart';
+  displayMode: 'chart' | 'literal' = 'chart';
   chartInstance: Chart;
-  data: Array<{ time: number; value: number; type: string }> = [];
-  latestValue: number;
+  data: Array<{ time: number; value: number | string; type: string }> = [];
+  latestValue: number | string;
   destroy$ = new Subject<void>();
 
   @HostBinding('class.big')
@@ -63,9 +63,9 @@ export class JobChartComponent implements AfterViewInit, OnDestroy {
     return this.size === 'big';
   }
 
-  refresh(res: { timestamp: number; values: { [id: string]: number } }): void {
+  refresh(res: { timestamp: number; values: { [id: string]: number | string } }): void {
     this.latestValue = res.values[this.title];
-    if (this.displayMode === 'numeric') {
+    if (this.displayMode === 'literal') {
       this.cdr.detectChanges();
     }
     this.data.push({
@@ -82,7 +82,7 @@ export class JobChartComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  setMode(mode: 'chart' | 'numeric'): void {
+  setMode(mode: 'chart' | 'literal'): void {
     this.displayMode = mode;
     this.cdr.detectChanges();
   }

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-metrics.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-metrics.ts
@@ -22,7 +22,7 @@ export interface JobMetric {
 }
 
 export interface MetricMap {
-  [p: string]: number;
+  [p: string]: number | string;
 }
 
 export interface AggregateValueMap {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job-manager/metrics/job-manager-metrics.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job-manager/metrics/job-manager-metrics.component.ts
@@ -53,7 +53,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
   standalone: true
 })
 export class JobManagerMetricsComponent implements OnInit, OnDestroy {
-  public metrics: { [id: string]: number } = {};
+  public metrics: { [id: string]: number | string } = {};
   public jmConfig: { [id: string]: string } = {};
   public listOfGCName: string[] = [];
   public listOfGCMetric: Array<{ name: string; count: number | null; time: number | null }> = [];
@@ -122,8 +122,8 @@ export class JobManagerMetricsComponent implements OnInit, OnDestroy {
           ).map(name => {
             return {
               name,
-              count: this.metrics[`Status.JVM.GarbageCollector.${name}.Count`],
-              time: this.metrics[`Status.JVM.GarbageCollector.${name}.Time`]
+              count: +this.metrics[`Status.JVM.GarbageCollector.${name}.Count`],
+              time: +this.metrics[`Status.JVM.GarbageCollector.${name}.Time`]
             };
           });
           this.cdr.markForCheck();

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/dataskew/data-skew.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/dataskew/data-skew.component.ts
@@ -68,7 +68,7 @@ export class DataSkewComponent implements OnInit, OnDestroy {
             this.metricsService
               .loadAggregatedMetrics(this.jobDetail.jid, v.id, ['numRecordsIn'], 'skew')
               .subscribe(metricMap => {
-                const skew = Number.isNaN(+metricMap['numRecordsIn']) ? 0 : Math.round(metricMap['numRecordsIn']);
+                const skew = Number.isNaN(+metricMap['numRecordsIn']) ? 0 : Math.round(+metricMap['numRecordsIn']);
                 result.push({ vertexName: v.name, skewPct: skew });
                 result.sort((a, b) => (a.skewPct > b.skewPct ? -1 : 1));
                 this.isLoading = false;

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/metrics/task-manager-metrics.component.ts
@@ -54,7 +54,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 })
 export class TaskManagerMetricsComponent implements OnInit, OnDestroy {
   public taskManagerDetail?: TaskManagerDetail;
-  public metrics: { [id: string]: number } = {};
+  public metrics: { [id: string]: number | string } = {};
 
   private readonly destroy$ = new Subject<void>();
 

--- a/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
@@ -67,7 +67,7 @@ export class MetricsService {
         map(arr => {
           const result: MetricMap = {};
           arr.forEach(item => {
-            result[item.id] = parseInt(item.value, 10);
+            result[item.id] = Number.isNaN(parseInt(item.value, 10)) ? item.value : parseInt(item.value, 10);
           });
           return {
             timestamp: Date.now(),


### PR DESCRIPTION
## What is the purpose of the change

Currently, Flink allows creating gauge metrics with various types [[1]](https://nightlies.apache.org/flink/flink-docs-master/docs/ops/metrics/#gauge). However Web UI doesn't support showing any types other than numerics and always displays `NaN`, which isn't very helpful. This change lets dashboard displays raw metric value when converting to numbers isn't applicable.

## Brief change log

  - Adds raw value display as fallback when receiving non-numeric metric values
  - Changes "Chart / Numeric" label to "Chart / Literal" because not all metrics are of number type

## Verifying this change

This change is a trivial work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
