### PR TITLE
[FLINK-35475][runtime] Introduce isInternalSorterSupport to OperatorAttributes

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributes.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributes.java
@@ -30,9 +30,11 @@ public class OperatorAttributes implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final boolean outputOnlyAfterEndOfStream;
+    private final boolean internalSorterSupported;
 
-    OperatorAttributes(boolean outputOnlyAfterEndOfStream) {
+    OperatorAttributes(boolean outputOnlyAfterEndOfStream, boolean internalSorterSupported) {
         this.outputOnlyAfterEndOfStream = outputOnlyAfterEndOfStream;
+        this.internalSorterSupported = internalSorterSupported;
     }
 
     /**
@@ -48,5 +50,13 @@ public class OperatorAttributes implements Serializable {
      */
     public boolean isOutputOnlyAfterEndOfStream() {
         return outputOnlyAfterEndOfStream;
+    }
+
+    /**
+     * Returns true iff the operator uses an internal sorter to sort inputs by key. When it is true,
+     * the input records will not to be sorted externally before being fed into this operator.
+     */
+    public boolean isInternalSorterSupported() {
+        return internalSorterSupported;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributesBuilder.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorAttributesBuilder.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.Experimental;
 @Experimental
 public class OperatorAttributesBuilder {
     private boolean outputOnlyAfterEndOfStream = false;
+    private boolean internalSorterSupported = false;
 
     /**
      * Set to true if and only if the operator only emits records after all its inputs have ended.
@@ -34,7 +35,12 @@ public class OperatorAttributesBuilder {
         return this;
     }
 
+    public OperatorAttributesBuilder setInternalSorterSupported(boolean internalSorterSupported) {
+        this.internalSorterSupported = internalSorterSupported;
+        return this;
+    }
+
     public OperatorAttributes build() {
-        return new OperatorAttributes(outputOnlyAfterEndOfStream);
+        return new OperatorAttributes(outputOnlyAfterEndOfStream, internalSorterSupported);
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/KeyedSortPartitionOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/KeyedSortPartitionOperator.java
@@ -250,7 +250,10 @@ public class KeyedSortPartitionOperator<INPUT, KEY> extends AbstractStreamOperat
 
     @Override
     public OperatorAttributes getOperatorAttributes() {
-        return new OperatorAttributesBuilder().setOutputOnlyAfterEndOfStream(true).build();
+        return new OperatorAttributesBuilder()
+                .setOutputOnlyAfterEndOfStream(true)
+                .setInternalSorterSupported(true)
+                .build();
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
@@ -94,4 +94,8 @@ public abstract class AbstractMultipleInputTransformation<OUT> extends PhysicalT
     public boolean isOutputOnlyAfterEndOfStream() {
         return operatorFactory.getOperatorAttributes().isOutputOnlyAfterEndOfStream();
     }
+
+    public boolean isInternalSorterSupported() {
+        return operatorFactory.getOperatorAttributes().isInternalSorterSupported();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -188,4 +188,8 @@ public class OneInputTransformation<IN, OUT> extends PhysicalTransformation<OUT>
     public boolean isOutputOnlyAfterEndOfStream() {
         return operatorFactory.getOperatorAttributes().isOutputOnlyAfterEndOfStream();
     }
+
+    public boolean isInternalSorterSupported() {
+        return operatorFactory.getOperatorAttributes().isInternalSorterSupported();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
@@ -235,4 +235,8 @@ public class TwoInputTransformation<IN1, IN2, OUT> extends PhysicalTransformatio
     public boolean isOutputOnlyAfterEndOfStream() {
         return operatorFactory.getOperatorAttributes().isOutputOnlyAfterEndOfStream();
     }
+
+    public boolean isInternalSorterSupported() {
+        return operatorFactory.getOperatorAttributes().isInternalSorterSupported();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
@@ -132,7 +132,8 @@ public class MultiInputTransformationTranslator<OUT>
 
     private void maybeApplyBatchExecutionSettings(
             final AbstractMultipleInputTransformation<OUT> transformation, final Context context) {
-        if (transformation instanceof KeyedMultipleInputTransformation) {
+        if (transformation instanceof KeyedMultipleInputTransformation
+                && !transformation.isInternalSorterSupported()) {
             KeyedMultipleInputTransformation<OUT> keyedTransformation =
                     (KeyedMultipleInputTransformation<OUT>) transformation;
             List<Transformation<?>> inputs = transformation.getInputs();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
@@ -22,9 +22,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.TransformationTranslator;
-import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
-import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
-import org.apache.flink.streaming.api.operators.sortpartition.KeyedSortPartitionOperator;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 
 import java.util.Collection;
@@ -80,16 +77,7 @@ public final class OneInputTransformationTranslator<IN, OUT>
     private void maybeApplyBatchExecutionSettings(
             final OneInputTransformation<IN, OUT> transformation, final Context context) {
         KeySelector<IN, ?> keySelector = transformation.getStateKeySelector();
-        if (keySelector != null) {
-            // KeyedSortPartitionOperator doesn't need sorted input because it sorts data
-            // internally.
-            StreamOperatorFactory<OUT> operatorFactory = transformation.getOperatorFactory();
-            if (operatorFactory instanceof SimpleOperatorFactory
-                    && operatorFactory.getStreamOperatorClass(
-                                    Thread.currentThread().getContextClassLoader())
-                            == KeyedSortPartitionOperator.class) {
-                return;
-            }
+        if (keySelector != null && !transformation.isInternalSorterSupported()) {
             BatchExecutionUtils.applyBatchExecutionSettings(
                     transformation.getId(), context, StreamConfig.InputRequirement.SORTED);
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/TwoInputTransformationTranslator.java
@@ -89,8 +89,9 @@ public class TwoInputTransformationTranslator<IN1, IN2, OUT>
                         ? StreamConfig.InputRequirement.SORTED
                         : StreamConfig.InputRequirement.PASS_THROUGH;
 
-        if (input1Requirement == StreamConfig.InputRequirement.SORTED
-                || input2Requirement == StreamConfig.InputRequirement.SORTED) {
+        if ((input1Requirement == StreamConfig.InputRequirement.SORTED
+                        || input2Requirement == StreamConfig.InputRequirement.SORTED)
+                && !transformation.isInternalSorterSupported()) {
             BatchExecutionUtils.applyBatchExecutionSettings(
                     transformation.getId(), context, input1Requirement, input2Requirement);
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorWithOperatorAttributesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorWithOperatorAttributesTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.co.CoProcessFunction;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
+import org.apache.flink.streaming.api.operators.OperatorAttributes;
+import org.apache.flink.streaming.api.operators.OperatorAttributesBuilder;
+import org.apache.flink.streaming.api.operators.StreamMap;
+import org.apache.flink.streaming.api.operators.co.CoProcessOperator;
+import org.apache.flink.util.Collector;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link StreamingJobGraphGenerator} with internal sorter. */
+public class StreamingJobGraphGeneratorWithOperatorAttributesTest {
+    @Test
+    void testOutputOnlyAfterEndOfStream() {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(new Configuration());
+
+        final DataStream<Integer> source = env.fromData(1, 2, 3).name("source");
+        source.keyBy(x -> x)
+                .transform(
+                        "transform",
+                        Types.INT,
+                        new StreamOperatorWithConfigurableOperatorAttributes<>(
+                                x -> x,
+                                new OperatorAttributesBuilder()
+                                        .setOutputOnlyAfterEndOfStream(true)
+                                        .build()))
+                .map(x -> x)
+                .sinkTo(new DiscardingSink<>())
+                .disableChaining()
+                .name("sink");
+
+        final StreamGraph streamGraph = env.getStreamGraph(false);
+        Map<String, StreamNode> nodeMap = new HashMap<>();
+        for (StreamNode node : streamGraph.getStreamNodes()) {
+            nodeMap.put(node.getOperatorName(), node);
+        }
+        assertThat(nodeMap).hasSize(4);
+        assertThat(nodeMap.get("Source: source").isOutputOnlyAfterEndOfStream()).isFalse();
+        assertThat(nodeMap.get("transform").isOutputOnlyAfterEndOfStream()).isTrue();
+        assertThat(nodeMap.get("Map").isOutputOnlyAfterEndOfStream()).isFalse();
+        assertThat(nodeMap.get("sink: Writer").isOutputOnlyAfterEndOfStream()).isFalse();
+        assertManagedMemoryWeightsSize(nodeMap.get("Source: source"), 0);
+        assertManagedMemoryWeightsSize(nodeMap.get("transform"), 1);
+        assertManagedMemoryWeightsSize(nodeMap.get("Map"), 0);
+        assertManagedMemoryWeightsSize(nodeMap.get("sink: Writer"), 0);
+
+        JobGraph jobGraph = StreamingJobGraphGenerator.createJobGraph(streamGraph);
+        Map<String, JobVertex> vertexMap = new HashMap<>();
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            vertexMap.put(vertex.getName(), vertex);
+        }
+        assertThat(vertexMap).hasSize(3);
+        assertHasOutputPartitionType(
+                vertexMap.get("Source: source"), ResultPartitionType.PIPELINED_BOUNDED);
+        assertHasOutputPartitionType(
+                vertexMap.get("transform -> Map"), ResultPartitionType.BLOCKING);
+        assertThat(vertexMap.get("Source: source").isAnyOutputBlocking()).isFalse();
+        assertThat(vertexMap.get("transform -> Map").isAnyOutputBlocking()).isTrue();
+        assertThat(vertexMap.get("sink: Writer").isAnyOutputBlocking()).isFalse();
+
+        env.disableOperatorChaining();
+        jobGraph = StreamingJobGraphGenerator.createJobGraph(env.getStreamGraph(false));
+        vertexMap = new HashMap<>();
+        for (JobVertex vertex : jobGraph.getVertices()) {
+            vertexMap.put(vertex.getName(), vertex);
+        }
+        assertThat(vertexMap).hasSize(4);
+        assertHasOutputPartitionType(
+                vertexMap.get("Source: source"), ResultPartitionType.PIPELINED_BOUNDED);
+        assertHasOutputPartitionType(vertexMap.get("transform"), ResultPartitionType.BLOCKING);
+        assertHasOutputPartitionType(vertexMap.get("Map"), ResultPartitionType.PIPELINED_BOUNDED);
+        assertThat(vertexMap.get("Source: source").isAnyOutputBlocking()).isFalse();
+        assertThat(vertexMap.get("transform").isAnyOutputBlocking()).isTrue();
+        assertThat(vertexMap.get("Map").isAnyOutputBlocking()).isFalse();
+        assertThat(vertexMap.get("sink: Writer").isAnyOutputBlocking()).isFalse();
+    }
+
+    @Test
+    void testApplyBatchExecutionSettingsOnTwoInputOperator() {
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(new Configuration());
+
+        final DataStream<Integer> source1 = env.fromData(1, 2, 3).name("source1");
+        final DataStream<Integer> source2 = env.fromData(1, 2, 3).name("source2");
+        source1.keyBy(x -> x)
+                .connect(source2.keyBy(x -> x))
+                .transform(
+                        "transform",
+                        Types.INT,
+                        new TwoInputStreamOperatorWithConfigurableOperatorAttributes<>(
+                                new OperatorAttributesBuilder()
+                                        .setOutputOnlyAfterEndOfStream(true)
+                                        .build()))
+                .sinkTo(new DiscardingSink<>())
+                .name("sink");
+
+        final StreamGraph streamGraph = env.getStreamGraph(false);
+        Map<String, StreamNode> nodeMap = new HashMap<>();
+        for (StreamNode node : streamGraph.getStreamNodes()) {
+            nodeMap.put(node.getOperatorName(), node);
+        }
+        assertThat(nodeMap).hasSize(4);
+        assertManagedMemoryWeightsSize(nodeMap.get("Source: source1"), 0);
+        assertManagedMemoryWeightsSize(nodeMap.get("Source: source2"), 0);
+        assertManagedMemoryWeightsSize(nodeMap.get("transform"), 1);
+        assertManagedMemoryWeightsSize(nodeMap.get("sink: Writer"), 0);
+    }
+
+    private static void assertManagedMemoryWeightsSize(StreamNode node, int weightSize) {
+        assertThat(node.getManagedMemoryOperatorScopeUseCaseWeights()).hasSize(weightSize);
+    }
+
+    private static class StreamOperatorWithConfigurableOperatorAttributes<IN, OUT>
+            extends StreamMap<IN, OUT> {
+        private final OperatorAttributes attributes;
+
+        public StreamOperatorWithConfigurableOperatorAttributes(
+                MapFunction<IN, OUT> mapper, OperatorAttributes attributes) {
+            super(mapper);
+            this.attributes = attributes;
+        }
+
+        @Override
+        public OperatorAttributes getOperatorAttributes() {
+            return attributes;
+        }
+    }
+
+    private static class TwoInputStreamOperatorWithConfigurableOperatorAttributes<IN1, IN2, OUT>
+            extends CoProcessOperator<IN1, IN2, OUT> {
+        private final OperatorAttributes attributes;
+
+        public TwoInputStreamOperatorWithConfigurableOperatorAttributes(
+                OperatorAttributes attributes) {
+            super(new NoOpCoProcessFunction<>());
+            this.attributes = attributes;
+        }
+
+        @Override
+        public OperatorAttributes getOperatorAttributes() {
+            return attributes;
+        }
+    }
+
+    private static class NoOpCoProcessFunction<IN1, IN2, OUT>
+            extends CoProcessFunction<IN1, IN2, OUT> {
+        @Override
+        public void processElement1(
+                IN1 value, CoProcessFunction<IN1, IN2, OUT>.Context ctx, Collector<OUT> out) {}
+
+        @Override
+        public void processElement2(
+                IN2 value, CoProcessFunction<IN1, IN2, OUT>.Context ctx, Collector<OUT> out) {}
+    }
+
+    private void assertHasOutputPartitionType(
+            JobVertex jobVertex, ResultPartitionType partitionType) {
+        assertThat(jobVertex.getProducedDataSets().get(0).getResultType()).isEqualTo(partitionType);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce isInternalSorterSupport to OperatorAttributes to notify Flink whether the operator will sort the data internally in batch mode or during backlog.


## Brief change log

- Introduce isInternalSorterSupport to OperatorAttributes.
- Update transformation translator to check the isInternalSorterSupport


## Verifying this change

This change added tests and can be verified as follows:

- org.apache.flink.streaming.api.graph.StreamingJobGraphGeneratorWithOperatorAttributesTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
