### PR TITLE
 [FLINK-35200][table] Support the execution of suspend, resume materialized table in full refresh mode

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowHandler.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.table.gateway.api.SqlGatewayService;
 import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
-import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.EmbeddedSchedulerWorkflowRequestBody;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowRequestBody;
 import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
 import org.apache.flink.table.gateway.workflow.scheduler.EmbeddedQuartzScheduler;
 
@@ -34,13 +34,16 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /** Handler to resume workflow in embedded scheduler. */
 public class ResumeEmbeddedSchedulerWorkflowHandler
         extends AbstractSqlGatewayRestHandler<
-                EmbeddedSchedulerWorkflowRequestBody, EmptyResponseBody, EmptyMessageParameters> {
+                ResumeEmbeddedSchedulerWorkflowRequestBody,
+                EmptyResponseBody,
+                EmptyMessageParameters> {
 
     private final EmbeddedQuartzScheduler quartzScheduler;
 
@@ -49,7 +52,7 @@ public class ResumeEmbeddedSchedulerWorkflowHandler
             EmbeddedQuartzScheduler quartzScheduler,
             Map<String, String> responseHeaders,
             MessageHeaders<
-                            EmbeddedSchedulerWorkflowRequestBody,
+                            ResumeEmbeddedSchedulerWorkflowRequestBody,
                             EmptyResponseBody,
                             EmptyMessageParameters>
                     messageHeaders) {
@@ -60,12 +63,16 @@ public class ResumeEmbeddedSchedulerWorkflowHandler
     @Override
     protected CompletableFuture<EmptyResponseBody> handleRequest(
             @Nullable SqlGatewayRestAPIVersion version,
-            @Nonnull HandlerRequest<EmbeddedSchedulerWorkflowRequestBody> request)
+            @Nonnull HandlerRequest<ResumeEmbeddedSchedulerWorkflowRequestBody> request)
             throws RestHandlerException {
         String workflowName = request.getRequestBody().getWorkflowName();
         String workflowGroup = request.getRequestBody().getWorkflowGroup();
+        Map<String, String> dynamicOptions = request.getRequestBody().getDynamicOptions();
         try {
-            quartzScheduler.resumeScheduleWorkflow(workflowName, workflowGroup);
+            quartzScheduler.resumeScheduleWorkflow(
+                    workflowName,
+                    workflowGroup,
+                    dynamicOptions == null ? Collections.emptyMap() : dynamicOptions);
             return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
         } catch (Exception e) {
             throw new RestHandlerException(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowHeaders.java
@@ -19,10 +19,25 @@
 package org.apache.flink.table.gateway.rest.header.materializedtable.scheduler;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
+import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowRequestBody;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion.V3;
 
 /** Message headers for resume workflow in embedded scheduler. */
 public class ResumeEmbeddedSchedulerWorkflowHeaders
-        extends AbstractEmbeddedSchedulerWorkflowHeaders {
+        implements SqlGatewayMessageHeaders<
+                ResumeEmbeddedSchedulerWorkflowRequestBody,
+                EmptyResponseBody,
+                EmptyMessageParameters> {
 
     private static final ResumeEmbeddedSchedulerWorkflowHeaders INSTANCE =
             new ResumeEmbeddedSchedulerWorkflowHeaders();
@@ -46,5 +61,30 @@ public class ResumeEmbeddedSchedulerWorkflowHeaders
 
     public static ResumeEmbeddedSchedulerWorkflowHeaders getInstance() {
         return INSTANCE;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public Class<EmptyResponseBody> getResponseClass() {
+        return EmptyResponseBody.class;
+    }
+
+    @Override
+    public Class<ResumeEmbeddedSchedulerWorkflowRequestBody> getRequestClass() {
+        return ResumeEmbeddedSchedulerWorkflowRequestBody.class;
+    }
+
+    @Override
+    public EmptyMessageParameters getUnresolvedMessageParameters() {
+        return EmptyMessageParameters.getInstance();
+    }
+
+    @Override
+    public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
+        return Collections.singleton(V3);
     }
 }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowRequestBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/ResumeEmbeddedSchedulerWorkflowRequestBody.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+/** {@link RequestBody} for resume workflow in embedded scheduler. */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResumeEmbeddedSchedulerWorkflowRequestBody implements RequestBody {
+
+    private static final String FIELD_NAME_WORKFLOW_NAME = "workflowName";
+    private static final String FIELD_NAME_WORKFLOW_GROUP = "workflowGroup";
+    private static final String FIELD_NAME_DYNAMIC_OPTIONS = "dynamicOptions";
+
+    @JsonProperty(FIELD_NAME_WORKFLOW_NAME)
+    private final String workflowName;
+
+    @JsonProperty(FIELD_NAME_WORKFLOW_GROUP)
+    private final String workflowGroup;
+
+    @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS)
+    @Nullable
+    private final Map<String, String> dynamicOptions;
+
+    @JsonCreator
+    public ResumeEmbeddedSchedulerWorkflowRequestBody(
+            @JsonProperty(FIELD_NAME_WORKFLOW_NAME) String workflowName,
+            @JsonProperty(FIELD_NAME_WORKFLOW_GROUP) String workflowGroup,
+            @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS) Map<String, String> dynamicOptions) {
+        this.workflowName = workflowName;
+        this.workflowGroup = workflowGroup;
+        this.dynamicOptions = dynamicOptions;
+    }
+
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    public String getWorkflowGroup() {
+        return workflowGroup;
+    }
+
+    @Nullable
+    public Map<String, String> getDynamicOptions() {
+        return dynamicOptions;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -23,15 +23,20 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
 import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.factories.WorkflowSchedulerFactoryUtil;
 import org.apache.flink.table.gateway.api.operation.OperationHandle;
 import org.apache.flink.table.gateway.api.results.ResultSet;
@@ -94,6 +99,8 @@ import static org.apache.flink.table.api.internal.TableResultInternal.TABLE_RESU
 import static org.apache.flink.table.catalog.CatalogBaseTable.TableKind.MATERIALIZED_TABLE;
 import static org.apache.flink.table.factories.WorkflowSchedulerFactoryUtil.WORKFLOW_SCHEDULER_PREFIX;
 import static org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpointFactoryUtils.getEndpointConfig;
+import static org.apache.flink.table.gateway.service.utils.Constants.CLUSTER_INFO;
+import static org.apache.flink.table.gateway.service.utils.Constants.JOB_ID;
 import static org.apache.flink.table.utils.DateTimeUtils.formatTimestampString;
 import static org.apache.flink.table.utils.IntervalFreshnessUtils.convertFreshnessToCron;
 
@@ -598,7 +605,29 @@ public class MaterializedTableManager {
                     "Begin to manually refreshing the materialization table {}, statement: {}",
                     materializedTableIdentifier,
                     insertStatement);
-            return operationExecutor.executeStatement(handle, customConfig, insertStatement);
+            ResultFetcher resultFetcher =
+                    operationExecutor.executeStatement(handle, customConfig, insertStatement);
+
+            List<RowData> results = fetchAllResults(resultFetcher);
+            String jobId = results.get(0).getString(0).toString();
+            String executeTarget =
+                    operationExecutor.getSessionContext().getSessionConf().get(TARGET);
+            Map<StringData, StringData> clusterInfo = new HashMap<>();
+            clusterInfo.put(
+                    StringData.fromString(TARGET.key()), StringData.fromString(executeTarget));
+            // TODO get clusterId
+
+            return ResultFetcher.fromResults(
+                    handle,
+                    ResolvedSchema.of(
+                            Column.physical(JOB_ID, DataTypes.STRING()),
+                            Column.physical(
+                                    CLUSTER_INFO,
+                                    DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()))),
+                    Collections.singletonList(
+                            GenericRowData.of(
+                                    StringData.fromString(jobId),
+                                    new GenericMapData(clusterInfo))));
         } catch (Exception e) {
             // log and throw exception
             LOG.error(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/utils/Constants.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/utils/Constants.java
@@ -29,4 +29,5 @@ public class Constants {
     public static final String SET_VALUE = "value";
     public static final String COMPLETION_CANDIDATES = "candidates";
     public static final String SAVEPOINT_PATH = "savepoint path";
+    public static final String CLUSTER_INFO = "cluster info";
 }

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.gateway.rest;
 
+import org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshMode;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.gateway.AbstractMaterializedTableStatementITCase;
@@ -28,7 +29,6 @@ import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMate
 import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableRequestBody;
 import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableResponseBody;
 import org.apache.flink.table.gateway.rest.util.TestingRestClient;
-import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -64,10 +64,9 @@ public class SqlGatewayRestEndpointMaterializedTableITCase
         List<Row> data = new ArrayList<>();
         data.add(Row.of(1L, 1L, 1L, "2024-01-01"));
         data.add(Row.of(2L, 2L, 2L, "2024-01-02"));
-        String dataId = TestValuesTableFactory.registerData(data);
 
         createAndVerifyCreateMaterializedTableWithData(
-                "my_materialized_table", dataId, data, Collections.emptyMap());
+                "my_materialized_table", data, Collections.emptyMap(), RefreshMode.CONTINUOUS);
 
         RefreshMaterializedTableHeaders refreshMaterializedTableHeaders =
                 new RefreshMaterializedTableHeaders();
@@ -122,13 +121,12 @@ public class SqlGatewayRestEndpointMaterializedTableITCase
         List<Row> data = new ArrayList<>();
         data.add(Row.of(1L, 1L, 1L, "2024-01-01"));
         data.add(Row.of(2L, 2L, 2L, "2024-01-02"));
-        String dataId = TestValuesTableFactory.registerData(data);
 
         createAndVerifyCreateMaterializedTableWithData(
                 "my_materialized_table",
-                dataId,
                 data,
-                Collections.singletonMap("ds", "yyyy-MM-dd"));
+                Collections.singletonMap("ds", "yyyy-MM-dd"),
+                RefreshMode.CONTINUOUS);
 
         RefreshMaterializedTableHeaders refreshMaterializedTableHeaders =
                 new RefreshMaterializedTableHeaders();

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
@@ -18,31 +18,42 @@
 
 package org.apache.flink.table.gateway.rest;
 
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.table.catalog.CatalogMaterializedTable.RefreshMode;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.gateway.AbstractMaterializedTableStatementITCase;
 import org.apache.flink.table.gateway.api.operation.OperationHandle;
+import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
 import org.apache.flink.table.gateway.rest.header.materializedtable.RefreshMaterializedTableHeaders;
+import org.apache.flink.table.gateway.rest.header.statement.FetchResultsHeaders;
 import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableParameters;
 import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableRequestBody;
 import org.apache.flink.table.gateway.rest.message.materializedtable.RefreshMaterializedTableResponseBody;
+import org.apache.flink.table.gateway.rest.message.statement.FetchResultsMessageParameters;
+import org.apache.flink.table.gateway.rest.message.statement.FetchResultsResponseBody;
+import org.apache.flink.table.gateway.rest.util.RowFormat;
 import org.apache.flink.table.gateway.rest.util.TestingRestClient;
 import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
+import static org.apache.flink.configuration.DeploymentOptions.TARGET;
 import static org.apache.flink.table.gateway.rest.util.TestingRestClient.getTestingRestClient;
-import static org.apache.flink.table.gateway.service.utils.SqlGatewayServiceTestUtil.fetchAllResults;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -105,15 +116,30 @@ public class SqlGatewayRestEndpointMaterializedTableITCase
         assertThat(response.getOperationHandle()).isNotNull();
 
         // verify refresh job is created
-        String operationHandle = response.getOperationHandle();
-        List<RowData> results =
-                fetchAllResults(
-                        service,
-                        sessionHandle,
-                        new OperationHandle(UUID.fromString(operationHandle)));
-        String jobId = results.get(0).getString(0).toString();
+        OperationHandle operationHandle =
+                new OperationHandle(UUID.fromString(response.getOperationHandle()));
 
+        CommonTestUtils.waitUtil(
+                () ->
+                        SQL_GATEWAY_SERVICE_EXTENSION
+                                .getService()
+                                .getOperationInfo(sessionHandle, operationHandle)
+                                .getStatus()
+                                .isTerminalStatus(),
+                Duration.ofSeconds(100),
+                "Failed to wait operation finish.");
+
+        // fetch all results
+        FetchResultsResponseBody fetchResultsResponseBody =
+                fetchResults(sessionHandle, operationHandle, 0L);
+        List<RowData> results = fetchResultsResponseBody.getResults().getData();
+
+        String jobId = results.get(0).getString(0).toString();
         verifyRefreshJobCreated(restClusterClient, jobId, startTime);
+
+        GenericMapData clusterInfo = ((GenericMapData) results.get(0).getMap(1));
+        assertThat(clusterInfo.get(StringData.fromString(TARGET.key())))
+                .isEqualTo(StringData.fromString("remote"));
     }
 
     @Test
@@ -164,14 +190,45 @@ public class SqlGatewayRestEndpointMaterializedTableITCase
         assertThat(response.getOperationHandle()).isNotNull();
 
         // verify refresh job is created
-        String operationHandle = response.getOperationHandle();
-        List<RowData> results =
-                fetchAllResults(
-                        service,
-                        sessionHandle,
-                        new OperationHandle(UUID.fromString(operationHandle)));
-        String jobId = results.get(0).getString(0).toString();
+        OperationHandle operationHandle =
+                new OperationHandle(UUID.fromString(response.getOperationHandle()));
 
+        CommonTestUtils.waitUtil(
+                () ->
+                        SQL_GATEWAY_SERVICE_EXTENSION
+                                .getService()
+                                .getOperationInfo(sessionHandle, operationHandle)
+                                .getStatus()
+                                .isTerminalStatus(),
+                Duration.ofSeconds(100),
+                "Failed to wait operation finish.");
+
+        // fetch all results
+        FetchResultsResponseBody fetchResultsResponseBody =
+                fetchResults(sessionHandle, operationHandle, 0L);
+        List<RowData> results = fetchResultsResponseBody.getResults().getData();
+
+        String jobId = results.get(0).getString(0).toString();
         verifyRefreshJobCreated(restClusterClient, jobId, startTime);
+
+        GenericMapData clusterInfo = ((GenericMapData) results.get(0).getMap(1));
+        assertThat(clusterInfo.get(StringData.fromString(TARGET.key())))
+                .isEqualTo(StringData.fromString("remote"));
+    }
+
+    FetchResultsResponseBody fetchResults(
+            SessionHandle sessionHandle, OperationHandle operationHandle, Long token)
+            throws Exception {
+        FetchResultsMessageParameters fetchResultsMessageParameters =
+                new FetchResultsMessageParameters(
+                        sessionHandle, operationHandle, token, RowFormat.JSON);
+        CompletableFuture<FetchResultsResponseBody> response =
+                restClient.sendRequest(
+                        SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetAddress(),
+                        SQL_GATEWAY_REST_ENDPOINT_EXTENSION.getTargetPort(),
+                        FetchResultsHeaders.getDefaultInstance(),
+                        fetchResultsMessageParameters,
+                        EmptyRequestBody.getInstance());
+        return response.get();
     }
 }

--- a/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
@@ -531,13 +531,19 @@
     },
     "request" : {
       "type" : "object",
-      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:scheduler:EmbeddedSchedulerWorkflowRequestBody",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:scheduler:ResumeEmbeddedSchedulerWorkflowRequestBody",
       "properties" : {
         "workflowName" : {
           "type" : "string"
         },
         "workflowGroup" : {
           "type" : "string"
+        },
+        "dynamicOptions" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "string"
+          }
         }
       }
     },

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/ResumeRefreshWorkflow.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/ResumeRefreshWorkflow.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.refresh.RefreshHandler;
 
+import java.util.Map;
+
 /**
  * {@link ModifyRefreshWorkflow} provides the related information to resume refresh workflow of
  * {@link CatalogMaterializedTable}.
@@ -31,8 +33,15 @@ public class ResumeRefreshWorkflow<T extends RefreshHandler> implements ModifyRe
 
     private final T refreshHandler;
 
-    public ResumeRefreshWorkflow(T refreshHandler) {
+    private final Map<String, String> dynamicOptions;
+
+    public ResumeRefreshWorkflow(T refreshHandler, Map<String, String> dynamicOptions) {
         this.refreshHandler = refreshHandler;
+        this.dynamicOptions = dynamicOptions;
+    }
+
+    public Map<String, String> getDynamicOptions() {
+        return dynamicOptions;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

*Support the execution of suspend, resume materialized table in full refresh mode*


## Brief change log

* Add dynamic options for ResumeRefreshWorkflow interface.
*  Support the execution of suspend, resume materialized table in full refresh mode 


## Verifying this change

* Add test case testAlterMaterializedSuspendAndResumeInFullMode in MaterializedTableStatementITCase to verify the suspend and resume operation for materialized table in full mode.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (will be added in another pr)
