### PR TITLE
[FLINK-35510][statebackend] Implement basic incremental checkpoint fo…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.InternalCheckpointListener;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.asyncprocessing.StateExecutor;
@@ -35,7 +36,11 @@ import java.io.Closeable;
  * in batch.
  */
 @Internal
-public interface AsyncKeyedStateBackend extends Disposable, Closeable {
+public interface AsyncKeyedStateBackend
+        extends Snapshotable<SnapshotResult<KeyedStateHandle>>,
+                InternalCheckpointListener,
+                Disposable,
+                Closeable {
 
     /**
      * Initializes with some contexts.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/RegisteredStateMetaInfoBase.java
@@ -65,6 +65,9 @@ public abstract class RegisteredStateMetaInfoBase {
                 return new RegisteredBroadcastStateBackendMetaInfo<>(snapshot);
             case PRIORITY_QUEUE:
                 return new RegisteredPriorityQueueStateBackendMetaInfo<>(snapshot);
+            case KEY_VALUE_V2:
+                return new org.apache.flink.runtime.state.v2
+                        .RegisteredKeyValueStateBackendMetaInfo<>(snapshot);
             default:
                 throw new IllegalArgumentException(
                         "Unknown backend state type: " + backendStateType);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshot.java
@@ -41,7 +41,10 @@ public class StateMetaInfoSnapshot {
         KEY_VALUE(0),
         OPERATOR(1),
         BROADCAST(2),
-        PRIORITY_QUEUE(3);
+        PRIORITY_QUEUE(3),
+
+        KEY_VALUE_V2(10),
+        ;
         private final byte code;
 
         BackendStateType(int code) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/RegisteredKeyValueStateBackendMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/RegisteredKeyValueStateBackendMetaInfo.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
+import org.apache.flink.runtime.state.StateSerializerProvider;
+import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Compound meta information for a registered state in a keyed state backend. This combines all
+ * serializers and the state name.
+ *
+ * @param <S> Type of state value
+ */
+public class RegisteredKeyValueStateBackendMetaInfo<S> extends RegisteredStateMetaInfoBase {
+
+    @Nonnull private final StateDescriptor.Type stateType;
+    @Nonnull private final StateSerializerProvider<S> stateSerializerProvider;
+    @Nonnull private StateSnapshotTransformFactory<S> stateSnapshotTransformFactory;
+
+    public RegisteredKeyValueStateBackendMetaInfo(
+            @Nonnull String name,
+            @Nonnull StateDescriptor.Type stateType,
+            @Nonnull TypeSerializer<S> stateSerializer) {
+
+        this(
+                name,
+                stateType,
+                StateSerializerProvider.fromNewRegisteredSerializer(stateSerializer),
+                StateSnapshotTransformFactory.noTransform());
+    }
+
+    public RegisteredKeyValueStateBackendMetaInfo(
+            @Nonnull String name,
+            @Nonnull StateDescriptor.Type stateType,
+            @Nonnull TypeSerializer<S> stateSerializer,
+            @Nonnull StateSnapshotTransformFactory<S> stateSnapshotTransformFactory) {
+
+        this(
+                name,
+                stateType,
+                StateSerializerProvider.fromNewRegisteredSerializer(stateSerializer),
+                stateSnapshotTransformFactory);
+    }
+
+    @SuppressWarnings("unchecked")
+    public RegisteredKeyValueStateBackendMetaInfo(@Nonnull StateMetaInfoSnapshot snapshot) {
+        this(
+                snapshot.getName(),
+                StateDescriptor.Type.valueOf(
+                        snapshot.getOption(
+                                StateMetaInfoSnapshot.CommonOptionsKeys.KEYED_STATE_TYPE)),
+                StateSerializerProvider.fromPreviousSerializerSnapshot(
+                        (TypeSerializerSnapshot<S>)
+                                Preconditions.checkNotNull(
+                                        snapshot.getTypeSerializerSnapshot(
+                                                StateMetaInfoSnapshot.CommonSerializerKeys
+                                                        .VALUE_SERIALIZER))),
+                StateSnapshotTransformFactory.noTransform());
+
+        Preconditions.checkState(
+                StateMetaInfoSnapshot.BackendStateType.KEY_VALUE_V2
+                        == snapshot.getBackendStateType());
+    }
+
+    private RegisteredKeyValueStateBackendMetaInfo(
+            @Nonnull String name,
+            @Nonnull StateDescriptor.Type stateType,
+            @Nonnull StateSerializerProvider<S> stateSerializerProvider,
+            @Nonnull StateSnapshotTransformFactory<S> stateSnapshotTransformFactory) {
+
+        super(name);
+        this.stateType = stateType;
+        this.stateSerializerProvider = stateSerializerProvider;
+        this.stateSnapshotTransformFactory = stateSnapshotTransformFactory;
+    }
+
+    @Nonnull
+    public StateDescriptor.Type getStateType() {
+        return stateType;
+    }
+
+    @Nonnull
+    public TypeSerializer<S> getStateSerializer() {
+        return stateSerializerProvider.currentSchemaSerializer();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RegisteredKeyValueStateBackendMetaInfo<?> that =
+                (RegisteredKeyValueStateBackendMetaInfo<?>) o;
+
+        if (!stateType.equals(that.stateType)) {
+            return false;
+        }
+
+        if (!getName().equals(that.getName())) {
+            return false;
+        }
+
+        return getStateSerializer().equals(that.getStateSerializer());
+    }
+
+    @Override
+    public String toString() {
+        return "RegisteredKeyedBackendStateMetaInfo{"
+                + "stateType="
+                + stateType
+                + ", name='"
+                + name
+                + '\''
+                + ", stateSerializer="
+                + getStateSerializer()
+                + '}';
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getName().hashCode();
+        result = 31 * result + getStateType().hashCode();
+        result = 31 * result + getStateSerializer().hashCode();
+        return result;
+    }
+
+    @Nonnull
+    @Override
+    public StateMetaInfoSnapshot snapshot() {
+        return computeSnapshot();
+    }
+
+    @Nonnull
+    @Override
+    public RegisteredKeyValueStateBackendMetaInfo<S> withSerializerUpgradesAllowed() {
+        return new RegisteredKeyValueStateBackendMetaInfo<>(snapshot());
+    }
+
+    @Nonnull
+    private StateMetaInfoSnapshot computeSnapshot() {
+        Map<String, String> optionsMap =
+                Collections.singletonMap(
+                        StateMetaInfoSnapshot.CommonOptionsKeys.KEYED_STATE_TYPE.toString(),
+                        stateType.toString());
+
+        Map<String, TypeSerializer<?>> serializerMap = CollectionUtil.newHashMapWithExpectedSize(1);
+        Map<String, TypeSerializerSnapshot<?>> serializerConfigSnapshotsMap =
+                CollectionUtil.newHashMapWithExpectedSize(1);
+
+        String valueSerializerKey =
+                StateMetaInfoSnapshot.CommonSerializerKeys.VALUE_SERIALIZER.toString();
+        TypeSerializer<S> stateSerializer = getStateSerializer();
+
+        serializerMap.put(valueSerializerKey, stateSerializer.duplicate());
+        serializerConfigSnapshotsMap.put(
+                valueSerializerKey, stateSerializer.snapshotConfiguration());
+
+        return new StateMetaInfoSnapshot(
+                name,
+                StateMetaInfoSnapshot.BackendStateType.KEY_VALUE_V2,
+                optionsMap,
+                serializerConfigSnapshotsMap,
+                serializerMap);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -277,6 +277,15 @@ public class StreamOperatorStateHandler {
                             keyedStateBackend.snapshot(
                                     checkpointId, timestamp, factory, checkpointOptions));
                 }
+
+            } else if (null != asyncKeyedStateBackend) {
+                if (isCanonicalSavepoint(checkpointOptions.getCheckpointType())) {
+                    throw new UnsupportedOperationException("Not supported yet.");
+                } else {
+                    snapshotInProgress.setKeyedStateManagedFuture(
+                            asyncKeyedStateBackend.snapshot(
+                                    checkpointId, timestamp, factory, checkpointOptions));
+                }
             }
         } catch (Exception snapshotException) {
             try {
@@ -331,11 +340,19 @@ public class StreamOperatorStateHandler {
         if (keyedStateBackend instanceof CheckpointListener) {
             ((CheckpointListener) keyedStateBackend).notifyCheckpointComplete(checkpointId);
         }
+
+        if (asyncKeyedStateBackend != null) {
+            asyncKeyedStateBackend.notifyCheckpointComplete(checkpointId);
+        }
     }
 
     public void notifyCheckpointAborted(long checkpointId) throws Exception {
         if (keyedStateBackend instanceof CheckpointListener) {
             ((CheckpointListener) keyedStateBackend).notifyCheckpointAborted(checkpointId);
+        }
+
+        if (asyncKeyedStateBackend != null) {
+            asyncKeyedStateBackend.notifyCheckpointAborted(checkpointId);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -210,7 +210,10 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
                                 managedMemoryFraction,
                                 statsCollector,
                                 StateBackend::createKeyedStateBackend);
-                asyncKeyedStateBackend = new AsyncKeyedStateBackendAdaptor<>(keyedStatedBackend);
+                if (keyedStatedBackend != null) {
+                    asyncKeyedStateBackend =
+                            new AsyncKeyedStateBackendAdaptor<>(keyedStatedBackend);
+                }
             }
 
             // -------------- Operator State Backend --------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -152,6 +152,27 @@ public class StateBackendTestUtils {
         public void close() {
             // do nothing
         }
+
+        @Override
+        public void notifyCheckpointSubsumed(long checkpointId) throws Exception {
+            // do nothing
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) throws Exception {
+            // do nothing
+        }
+
+        @Override
+        public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+                long checkpointId,
+                long timestamp,
+                CheckpointStreamFactory streamFactory,
+                CheckpointOptions checkpointOptions)
+                throws Exception {
+            // do nothing
+            return null;
+        }
     }
 
     /** Wrapper of state backend which supports apply the snapshot result. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotEnumConstantsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/metainfo/StateMetaInfoSnapshotEnumConstantsTest.java
@@ -29,13 +29,15 @@ class StateMetaInfoSnapshotEnumConstantsTest {
 
     @Test
     void testFixedBackendStateTypeEnumConstants() {
-        assertThat(StateMetaInfoSnapshot.BackendStateType.values()).hasSize(4);
+        assertThat(StateMetaInfoSnapshot.BackendStateType.values()).hasSize(5);
         assertThat(StateMetaInfoSnapshot.BackendStateType.KEY_VALUE.ordinal()).isZero();
         assertThat(StateMetaInfoSnapshot.BackendStateType.OPERATOR.ordinal()).isOne();
         assertThat(StateMetaInfoSnapshot.BackendStateType.BROADCAST.ordinal()).isEqualTo(2);
         assertThat(StateMetaInfoSnapshot.BackendStateType.PRIORITY_QUEUE.ordinal()).isEqualTo(3);
         assertThat(StateMetaInfoSnapshot.BackendStateType.KEY_VALUE.toString())
                 .isEqualTo("KEY_VALUE");
+        assertThat(StateMetaInfoSnapshot.BackendStateType.KEY_VALUE_V2.toString())
+                .isEqualTo("KEY_VALUE_V2");
         assertThat(StateMetaInfoSnapshot.BackendStateType.OPERATOR.toString())
                 .isEqualTo("OPERATOR");
         assertThat(StateMetaInfoSnapshot.BackendStateType.BROADCAST.toString())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AsyncKeyedStateBackendAdaptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AsyncKeyedStateBackendAdaptorTest.java
@@ -23,11 +23,17 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
 import org.apache.flink.runtime.state.Keyed;
-import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.KeyedStateFunction;
+import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.SavepointResources;
+import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
@@ -39,6 +45,7 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
+import java.util.concurrent.RunnableFuture;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +55,7 @@ public class AsyncKeyedStateBackendAdaptorTest {
 
     @Test
     public void testAdapt() throws Exception {
-        KeyedStateBackend<Integer> keyedStateBackend = new TestKeyedStateBackend();
+        CheckpointableKeyedStateBackend<Integer> keyedStateBackend = new TestKeyedStateBackend();
         AsyncKeyedStateBackendAdaptor<Integer> adaptor =
                 new AsyncKeyedStateBackendAdaptor<>(keyedStateBackend);
         StateDescriptor<Integer> descriptor =
@@ -107,7 +114,7 @@ public class AsyncKeyedStateBackendAdaptorTest {
         }
     }
 
-    static class TestKeyedStateBackend implements KeyedStateBackend<Integer> {
+    static class TestKeyedStateBackend implements CheckpointableKeyedStateBackend<Integer> {
 
         @Override
         public void setCurrentKey(Integer newKey) {}
@@ -193,6 +200,33 @@ public class AsyncKeyedStateBackendAdaptorTest {
                         @Nonnull String stateName,
                         @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
             return null;
+        }
+
+        @Override
+        public KeyGroupRange getKeyGroupRange() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Nonnull
+        @Override
+        public SavepointResources<Integer> savepoint() throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() throws IOException {
+            // nothing to do
+        }
+
+        @Nonnull
+        @Override
+        public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+                long checkpointId,
+                long timestamp,
+                @Nonnull CheckpointStreamFactory streamFactory,
+                @Nonnull CheckpointOptions checkpointOptions)
+                throws Exception {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalKeyedStateTestBase.java
@@ -26,10 +26,14 @@ import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackend;
 
 import org.junit.jupiter.api.AfterEach;
@@ -43,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -122,6 +127,27 @@ public class InternalKeyedStateTestBase {
         public <K> AsyncKeyedStateBackend createAsyncKeyedStateBackend(
                 KeyedStateBackendParameters<K> parameters) {
             return new AsyncKeyedStateBackend() {
+                @Nonnull
+                @Override
+                public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+                        long checkpointId,
+                        long timestamp,
+                        @Nonnull CheckpointStreamFactory streamFactory,
+                        @Nonnull CheckpointOptions checkpointOptions)
+                        throws Exception {
+                    throw new UnsupportedOperationException("Not support yet");
+                }
+
+                @Override
+                public void notifyCheckpointComplete(long checkpointId) throws Exception {
+                    throw new UnsupportedOperationException("Not support yet");
+                }
+
+                @Override
+                public void notifyCheckpointSubsumed(long checkpointId) throws Exception {
+                    throw new UnsupportedOperationException("Not support yet");
+                }
+
                 @Override
                 public void close() throws IOException {}
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -20,17 +20,26 @@ package org.apache.flink.state.forst;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.asyncprocessing.StateExecutor;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.SnapshotStrategyRunner;
 import org.apache.flink.runtime.state.v2.ListStateDescriptor;
 import org.apache.flink.runtime.state.v2.ReducingStateDescriptor;
+import org.apache.flink.runtime.state.v2.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.v2.StateDescriptor;
 import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
+import org.apache.flink.state.forst.snapshot.ForStSnapshotStrategyBase;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
@@ -47,9 +56,14 @@ import javax.annotation.concurrent.GuardedBy;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.RunnableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import static org.apache.flink.runtime.state.SnapshotExecutionType.ASYNCHRONOUS;
 
 /**
  * A KeyedStateBackend that stores its state in {@code ForSt}. This state backend can store very
@@ -74,6 +88,8 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
     /** Supplier to create DataInputDeserializer to deserialize value. */
     private final Supplier<DataInputDeserializer> valueDeserializerView;
 
+    private final UUID backendUID;
+
     /** The container of ForSt options. */
     private final ForStResourceContainer optionsContainer;
 
@@ -88,6 +104,14 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
      */
     private final ColumnFamilyHandle defaultColumnFamily;
 
+    private final ForStSnapshotStrategyBase<K, ?> snapshotStrategy;
+
+    /**
+     * Registry for all opened streams, so they can be closed if the task using this backend is
+     * closed.
+     */
+    private final CloseableRegistry cancelStreamRegistry;
+
     /** The native metrics monitor. */
     private final ForStNativeMetricMonitor nativeMetricMonitor;
 
@@ -99,6 +123,13 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
 
     /** Handler to handle state request. */
     private StateRequestHandler stateRequestHandler;
+
+    /**
+     * Information about the k/v states, maintained in the order as we create them. This is used to
+     * retrieve the column family that is used for a state and also for sanity checks when
+     * restoring.
+     */
+    private final LinkedHashMap<String, ForStKvStateInfo> kvStateInformation;
 
     /** Lock guarding the {@code managedStateExecutors} and {@code disposed}. */
     private final Object lock = new Object();
@@ -115,6 +146,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
     private boolean disposed = false;
 
     public ForStKeyedStateBackend(
+            UUID backendUID,
             ForStResourceContainer optionsContainer,
             int keyGroupPrefixBytes,
             TypeSerializer<K> keySerializer,
@@ -122,9 +154,13 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
             Supplier<DataOutputSerializer> valueSerializerView,
             Supplier<DataInputDeserializer> valueDeserializerView,
             RocksDB db,
+            LinkedHashMap<String, ForStKvStateInfo> kvStateInformation,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             ColumnFamilyHandle defaultColumnFamilyHandle,
+            ForStSnapshotStrategyBase<K, ?> snapshotStrategy,
+            CloseableRegistry cancelStreamRegistry,
             ForStNativeMetricMonitor nativeMetricMonitor) {
+        this.backendUID = backendUID;
         this.optionsContainer = Preconditions.checkNotNull(optionsContainer);
         this.keyGroupPrefixBytes = keyGroupPrefixBytes;
         this.keySerializer = keySerializer;
@@ -132,8 +168,11 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
         this.valueSerializerView = valueSerializerView;
         this.valueDeserializerView = valueDeserializerView;
         this.db = db;
+        this.kvStateInformation = kvStateInformation;
         this.columnFamilyOptionsFactory = columnFamilyOptionsFactory;
         this.defaultColumnFamily = defaultColumnFamilyHandle;
+        this.snapshotStrategy = snapshotStrategy;
+        this.cancelStreamRegistry = cancelStreamRegistry;
         this.nativeMetricMonitor = nativeMetricMonitor;
         this.managedStateExecutors = new HashSet<>(1);
     }
@@ -158,6 +197,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
                         stateDesc.getStateId(), db, columnFamilyOptionsFactory);
         switch (stateDesc.getType()) {
             case VALUE:
+                registerKvStateInformation(stateDesc, columnFamilyHandle);
                 return (S)
                         new ForStValueState<>(
                                 stateRequestHandler,
@@ -169,6 +209,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
                                 valueSerializerView,
                                 valueDeserializerView);
             case LIST:
+                registerKvStateInformation(stateDesc, columnFamilyHandle);
                 return (S)
                         new ForStListState<>(
                                 stateRequestHandler,
@@ -209,6 +250,18 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
         }
     }
 
+    private <SV> void registerKvStateInformation(
+            @Nonnull StateDescriptor<SV> stateDesc, ColumnFamilyHandle columnFamilyHandle) {
+        kvStateInformation.put(
+                stateDesc.getStateId(),
+                new ForStKvStateInfo(
+                        columnFamilyHandle,
+                        new RegisteredKeyValueStateBackendMetaInfo<>(
+                                stateDesc.getStateId(),
+                                stateDesc.getType(),
+                                stateDesc.getSerializer())));
+    }
+
     @Override
     @Nonnull
     public StateExecutor createStateExecutor() {
@@ -223,6 +276,42 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
             managedStateExecutors.add(stateExecutor);
             return stateExecutor;
         }
+    }
+
+    @Nonnull
+    @Override
+    public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
+            long checkpointId,
+            long timestamp,
+            @Nonnull CheckpointStreamFactory streamFactory,
+            @Nonnull CheckpointOptions checkpointOptions)
+            throws Exception {
+
+        return new SnapshotStrategyRunner<>(
+                        snapshotStrategy.getDescription(),
+                        snapshotStrategy,
+                        cancelStreamRegistry,
+                        ASYNCHRONOUS)
+                .snapshot(checkpointId, timestamp, streamFactory, checkpointOptions);
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        if (snapshotStrategy != null) {
+            snapshotStrategy.notifyCheckpointComplete(checkpointId);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        if (snapshotStrategy != null) {
+            snapshotStrategy.notifyCheckpointAborted(checkpointId);
+        }
+    }
+
+    @Override
+    public void notifyCheckpointSubsumed(long checkpointId) throws Exception {
+        LOG.info("Backend:{} checkpoint: {} subsumed.", backendUID, checkpointId);
     }
 
     /** Should only be called by one thread, and only after all accesses to the DB happened. */
@@ -271,6 +360,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
 
             IOUtils.closeQuietly(optionsContainer);
         }
+        IOUtils.closeQuietly(snapshotStrategy);
         this.disposed = true;
     }
 
@@ -294,6 +384,23 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
             for (StateExecutor executor : managedStateExecutors) {
                 executor.shutdown();
             }
+        }
+    }
+
+    /** ForSt specific information about the k/v states. */
+    public static class ForStKvStateInfo implements AutoCloseable {
+        public final ColumnFamilyHandle columnFamilyHandle;
+        public final RegisteredStateMetaInfoBase metaInfo;
+
+        public ForStKvStateInfo(
+                ColumnFamilyHandle columnFamilyHandle, RegisteredStateMetaInfoBase metaInfo) {
+            this.columnFamilyHandle = columnFamilyHandle;
+            this.metaInfo = metaInfo;
+        }
+
+        @Override
+        public void close() throws Exception {
+            this.columnFamilyHandle.close();
         }
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -197,7 +197,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
                         stateDesc.getStateId(), db, columnFamilyOptionsFactory);
         switch (stateDesc.getType()) {
             case VALUE:
-                registerKvStateInformation(stateDesc, columnFamilyHandle);
+                registerKvStateInformation(stateDesc, namespaceSerializer, columnFamilyHandle);
                 return (S)
                         new ForStValueState<>(
                                 stateRequestHandler,
@@ -209,7 +209,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
                                 valueSerializerView,
                                 valueDeserializerView);
             case LIST:
-                registerKvStateInformation(stateDesc, columnFamilyHandle);
+                registerKvStateInformation(stateDesc, namespaceSerializer, columnFamilyHandle);
                 return (S)
                         new ForStListState<>(
                                 stateRequestHandler,
@@ -250,8 +250,10 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
         }
     }
 
-    private <SV> void registerKvStateInformation(
-            @Nonnull StateDescriptor<SV> stateDesc, ColumnFamilyHandle columnFamilyHandle) {
+    private <N, SV> void registerKvStateInformation(
+            @Nonnull StateDescriptor<SV> stateDesc,
+            TypeSerializer<N> namespaceSerializer,
+            ColumnFamilyHandle columnFamilyHandle) {
         kvStateInformation.put(
                 stateDesc.getStateId(),
                 new ForStKvStateInfo(
@@ -259,6 +261,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
                         new RegisteredKeyValueStateBackendMetaInfo<>(
                                 stateDesc.getStateId(),
                                 stateDesc.getType(),
+                                namespaceSerializer,
                                 stateDesc.getSerializer())));
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -195,9 +195,11 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
         ColumnFamilyHandle columnFamilyHandle =
                 ForStOperationUtils.createColumnFamilyHandle(
                         stateDesc.getStateId(), db, columnFamilyOptionsFactory);
+
+        registerKvStateInformation(stateDesc, namespaceSerializer, columnFamilyHandle);
+
         switch (stateDesc.getType()) {
             case VALUE:
-                registerKvStateInformation(stateDesc, namespaceSerializer, columnFamilyHandle);
                 return (S)
                         new ForStValueState<>(
                                 stateRequestHandler,
@@ -209,7 +211,6 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
                                 valueSerializerView,
                                 valueDeserializerView);
             case LIST:
-                registerKvStateInformation(stateDesc, namespaceSerializer, columnFamilyHandle);
                 return (S)
                         new ForStListState<>(
                                 stateRequestHandler,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
@@ -19,11 +19,14 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.BackendBuildingException;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
 import org.apache.flink.runtime.state.StateBackendBuilder;
@@ -31,9 +34,12 @@ import org.apache.flink.runtime.state.StateSerializerProvider;
 import org.apache.flink.state.forst.restore.ForStNoneRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStRestoreResult;
+import org.apache.flink.state.forst.snapshot.ForStIncrementalSnapshotStrategy;
+import org.apache.flink.state.forst.snapshot.ForStSnapshotStrategyBase;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.ResourceGuard;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
@@ -41,10 +47,15 @@ import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -66,6 +77,7 @@ public class ForStKeyedStateBackendBuilder<K>
     private final StateSerializerProvider<K> keySerializerProvider;
 
     private final int numberOfKeyGroups;
+    private final KeyGroupRange keyGroupRange;
 
     private final Collection<KeyedStateHandle> restoreStateHandles;
 
@@ -77,6 +89,9 @@ public class ForStKeyedStateBackendBuilder<K>
 
     private final MetricGroup metricGroup;
 
+    /** True if incremental checkpointing is enabled. */
+    private boolean enableIncrementalCheckpointing;
+
     /** ForSt property-based and statistics-based native metrics options. */
     private ForStNativeMetricOptions nativeMetricOptions;
 
@@ -85,6 +100,7 @@ public class ForStKeyedStateBackendBuilder<K>
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             TypeSerializer<K> keySerializer,
             int numberOfKeyGroups,
+            KeyGroupRange keyGroupRange,
             MetricGroup metricGroup,
             @Nonnull Collection<KeyedStateHandle> stateHandles) {
         this.optionsContainer = optionsContainer;
@@ -92,9 +108,16 @@ public class ForStKeyedStateBackendBuilder<K>
         this.keySerializerProvider =
                 StateSerializerProvider.fromNewRegisteredSerializer(keySerializer);
         this.numberOfKeyGroups = numberOfKeyGroups;
+        this.keyGroupRange = keyGroupRange;
         this.metricGroup = metricGroup;
         this.restoreStateHandles = stateHandles;
         this.nativeMetricOptions = new ForStNativeMetricOptions();
+    }
+
+    ForStKeyedStateBackendBuilder<K> setEnableIncrementalCheckpointing(
+            boolean enableIncrementalCheckpointing) {
+        this.enableIncrementalCheckpointing = enableIncrementalCheckpointing;
+        return this;
     }
 
     ForStKeyedStateBackendBuilder<K> setNativeMetricOptions(
@@ -107,12 +130,22 @@ public class ForStKeyedStateBackendBuilder<K>
     public ForStKeyedStateBackend<K> build() throws BackendBuildingException {
         ColumnFamilyHandle defaultColumnFamilyHandle = null;
         ForStNativeMetricMonitor nativeMetricMonitor = null;
+
+        CloseableRegistry cancelStreamRegistryForBackend = new CloseableRegistry();
+
+        LinkedHashMap<String, ForStKeyedStateBackend.ForStKvStateInfo> kvStateInformation =
+                new LinkedHashMap<>();
+
         RocksDB db = null;
         ForStRestoreOperation restoreOperation = null;
         // Number of bytes required to prefix the key groups.
         int keyGroupPrefixBytes =
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(
                         numberOfKeyGroups);
+
+        ResourceGuard forstResourceGuard = new ResourceGuard();
+        ForStSnapshotStrategyBase<K, ?> snapshotStrategy = null;
+
         // it is important that we only create the key builder after the restore, and not before;
         // restore operations may reconfigure the key serializer, so accessing the key serializer
         // only now we can be certain that the key serializer used in the builder is final.
@@ -127,6 +160,8 @@ public class ForStKeyedStateBackendBuilder<K>
                 () -> new DataOutputSerializer(VALUE_SERIALIZER_BUFFER_START_SIZE);
         Supplier<DataInputDeserializer> valueDeserializerView = DataInputDeserializer::new;
 
+        UUID backendUID = UUID.randomUUID();
+
         try {
             optionsContainer.prepareDirectories();
             restoreOperation = getForStRestoreOperation();
@@ -135,10 +170,26 @@ public class ForStKeyedStateBackendBuilder<K>
             defaultColumnFamilyHandle = restoreResult.getDefaultColumnFamilyHandle();
             nativeMetricMonitor = restoreResult.getNativeMetricMonitor();
 
-            // TODO: Support to init snapshot strategy
+            // TODO: init materializedSstFiles and lastCompletedCheckpointId when implement restore
+            SortedMap<Long, Collection<IncrementalKeyedStateHandle.HandleAndLocalPath>>
+                    materializedSstFiles = new TreeMap<>();
+            long lastCompletedCheckpointId = -1L;
+
+            snapshotStrategy =
+                    initializeSnapshotStrategy(
+                            db,
+                            forstResourceGuard,
+                            keySerializerProvider.currentSchemaSerializer(),
+                            kvStateInformation,
+                            keyGroupRange,
+                            keyGroupPrefixBytes,
+                            backendUID,
+                            materializedSstFiles,
+                            lastCompletedCheckpointId);
 
         } catch (Throwable e) {
             // Do clean up
+            IOUtils.closeQuietly(cancelStreamRegistryForBackend);
             IOUtils.closeQuietly(defaultColumnFamilyHandle);
             IOUtils.closeQuietly(nativeMetricMonitor);
             IOUtils.closeQuietly(db);
@@ -154,6 +205,7 @@ public class ForStKeyedStateBackendBuilder<K>
                         ex);
             }
             IOUtils.closeQuietly(optionsContainer);
+            IOUtils.closeQuietly(snapshotStrategy);
             // Log and rethrow
             if (e instanceof BackendBuildingException) {
                 throw (BackendBuildingException) e;
@@ -168,6 +220,7 @@ public class ForStKeyedStateBackendBuilder<K>
                 optionsContainer.getLocalBasePath(),
                 optionsContainer.getRemoteBasePath());
         return new ForStKeyedStateBackend<>(
+                backendUID,
                 this.optionsContainer,
                 keyGroupPrefixBytes,
                 this.keySerializerProvider.currentSchemaSerializer(),
@@ -175,8 +228,11 @@ public class ForStKeyedStateBackendBuilder<K>
                 valueSerializerView,
                 valueDeserializerView,
                 db,
+                kvStateInformation,
                 columnFamilyOptionsFactory,
                 defaultColumnFamilyHandle,
+                snapshotStrategy,
+                cancelStreamRegistryForBackend,
                 nativeMetricMonitor);
     }
 
@@ -202,5 +258,47 @@ public class ForStKeyedStateBackendBuilder<K>
         }
         // TODO: Support Restoring
         throw new UnsupportedOperationException("Not support restoring yet for ForStStateBackend");
+    }
+
+    private ForStSnapshotStrategyBase<K, ?> initializeSnapshotStrategy(
+            @Nonnull RocksDB db,
+            @Nonnull ResourceGuard forstResourceGuard,
+            @Nonnull TypeSerializer<K> keySerializer,
+            @Nonnull
+                    LinkedHashMap<String, ForStKeyedStateBackend.ForStKvStateInfo>
+                            kvStateInformation,
+            @Nonnull KeyGroupRange keyGroupRange,
+            @Nonnegative int keyGroupPrefixBytes,
+            @Nonnull UUID backendUID,
+            @Nonnull
+                    SortedMap<Long, Collection<IncrementalKeyedStateHandle.HandleAndLocalPath>>
+                            uploadedStateHandles,
+            long lastCompletedCheckpointId) {
+
+        ForStSnapshotStrategyBase<K, ?> snapshotStrategy;
+
+        ForStStateDataTransfer stateTransfer =
+                new ForStStateDataTransfer(ForStStateDataTransfer.DEFAULT_THREAD_NUM);
+
+        if (enableIncrementalCheckpointing) {
+            snapshotStrategy =
+                    new ForStIncrementalSnapshotStrategy<>(
+                            db,
+                            forstResourceGuard,
+                            optionsContainer,
+                            keySerializer,
+                            kvStateInformation,
+                            keyGroupRange,
+                            keyGroupPrefixBytes,
+                            backendUID,
+                            uploadedStateHandles,
+                            stateTransfer,
+                            lastCompletedCheckpointId);
+
+        } else {
+            // TODO: 2024/5/29 wangfeifan -
+            throw new UnsupportedOperationException("Not implemented yet for ForStStateBackend");
+        }
+        return snapshotStrategy;
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
@@ -296,7 +296,6 @@ public class ForStKeyedStateBackendBuilder<K>
                             lastCompletedCheckpointId);
 
         } else {
-            // TODO: 2024/5/29 wangfeifan -
             throw new UnsupportedOperationException("Not implemented yet for ForStStateBackend");
         }
         return snapshotStrategy;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
@@ -268,6 +268,14 @@ public final class ForStResourceContainer implements AutoCloseable {
         return remoteForStPath;
     }
 
+    public Path getDbPath() {
+        if (remoteForStPath != null) {
+            return remoteForStPath;
+        } else {
+            return Path.fromLocalFile(localForStPath);
+        }
+    }
+
     /**
      * Prepare local and remote directories.
      *

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
@@ -335,8 +335,11 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
                                 stateName -> resourceContainer.getColumnOptions(),
                                 parameters.getKeySerializer(),
                                 parameters.getNumberOfKeyGroups(),
+                                parameters.getKeyGroupRange(),
                                 parameters.getMetricGroup(),
                                 parameters.getStateHandles())
+                        // TODO: remove after support more snapshot strategy
+                        .setEnableIncrementalCheckpointing(true)
                         .setNativeMetricOptions(
                                 resourceContainer.getMemoryWatcherOptions(nativeMetricOptions));
         return builder.build();

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateDataTransfer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateDataTransfer.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.state.forst.fs.ForStFlinkFileSystem;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
@@ -54,7 +55,14 @@ public class ForStStateDataTransfer implements Closeable {
 
     protected final ExecutorService executorService;
 
+    private final ForStFlinkFileSystem forStFs;
+
     public ForStStateDataTransfer(int threadNum) {
+        this(threadNum, null);
+    }
+
+    public ForStStateDataTransfer(int threadNum, ForStFlinkFileSystem forStFs) {
+        this.forStFs = forStFs;
         if (threadNum > 1) {
             executorService =
                     Executors.newFixedThreadPool(
@@ -170,7 +178,7 @@ public class ForStStateDataTransfer implements Closeable {
         try {
             final byte[] buffer = new byte[READ_BUFFER_SIZE];
 
-            FileSystem sourceFilesystem = filePath.getFileSystem();
+            FileSystem sourceFilesystem = forStFs == null ? filePath.getFileSystem() : forStFs;
             inputStream = sourceFilesystem.open(filePath, READ_BUFFER_SIZE);
             closeableRegistry.registerCloseable(inputStream);
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateDataTransfer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateDataTransfer.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.CheckpointStateOutputStream;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
+import org.apache.flink.runtime.state.StateUtil;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.apache.flink.util.function.CheckedSupplier;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.concurrent.Executors.newDirectExecutorService;
+
+/** Data transfer util class for {@link ForStKeyedStateBackend}. */
+public class ForStStateDataTransfer implements Closeable {
+    private static final int READ_BUFFER_SIZE = 64 * 1024;
+
+    // TODO: Add ConfigOption replace this field after ForSt checkpoint implementation stable
+    public static final int DEFAULT_THREAD_NUM = 4;
+
+    protected final ExecutorService executorService;
+
+    public ForStStateDataTransfer(int threadNum) {
+        if (threadNum > 1) {
+            executorService =
+                    Executors.newFixedThreadPool(
+                            threadNum, new ExecutorThreadFactory("Flink-ForStStateDataTransfer"));
+        } else {
+            executorService = newDirectExecutorService();
+        }
+    }
+
+    /**
+     * Transfer a single file to checkpoint filesystem.
+     *
+     * @param transferBytes Bytes will be transfer from the head of the file. If < 0, the whole file
+     *     will be transferred.
+     */
+    public HandleAndLocalPath transferFileToCheckpointFs(
+            Path file,
+            long transferBytes,
+            CheckpointStreamFactory checkpointStreamFactory,
+            CheckpointedStateScope stateScope,
+            CloseableRegistry snapshotCloseableRegistry,
+            CloseableRegistry tmpResourcesRegistry)
+            throws Exception {
+
+        try {
+            return createTransferFuture(
+                            file,
+                            transferBytes,
+                            checkpointStreamFactory,
+                            stateScope,
+                            snapshotCloseableRegistry,
+                            tmpResourcesRegistry)
+                    .get();
+        } catch (ExecutionException e) {
+            throw convertExecutionException(e);
+        }
+    }
+
+    /** Transfer a batch of files to checkpoint filesystem. */
+    public List<HandleAndLocalPath> transferFilesToCheckpointFs(
+            List<Path> files,
+            CheckpointStreamFactory checkpointStreamFactory,
+            CheckpointedStateScope stateScope,
+            CloseableRegistry closeableRegistry,
+            CloseableRegistry tmpResourcesRegistry)
+            throws Exception {
+
+        List<CompletableFuture<HandleAndLocalPath>> futures =
+                files.stream()
+                        .map(
+                                file ->
+                                        createTransferFuture(
+                                                file,
+                                                -1,
+                                                checkpointStreamFactory,
+                                                stateScope,
+                                                closeableRegistry,
+                                                tmpResourcesRegistry))
+                        .collect(Collectors.toList());
+
+        try {
+            List<HandleAndLocalPath> handles = new ArrayList<>(files.size());
+
+            for (CompletableFuture<HandleAndLocalPath> future : futures) {
+                handles.add(future.get());
+            }
+
+            return handles;
+        } catch (ExecutionException e) {
+            throw convertExecutionException(e);
+        }
+    }
+
+    private CompletableFuture<HandleAndLocalPath> createTransferFuture(
+            Path file,
+            long transferBytes,
+            CheckpointStreamFactory checkpointStreamFactory,
+            CheckpointedStateScope stateScope,
+            CloseableRegistry closeableRegistry,
+            CloseableRegistry tmpResourcesRegistry) {
+        return CompletableFuture.supplyAsync(
+                CheckedSupplier.unchecked(
+                        () ->
+                                transferFile(
+                                        file,
+                                        transferBytes,
+                                        checkpointStreamFactory,
+                                        stateScope,
+                                        closeableRegistry,
+                                        tmpResourcesRegistry)),
+                executorService);
+    }
+
+    private HandleAndLocalPath transferFile(
+            Path filePath,
+            long transferBytes,
+            CheckpointStreamFactory checkpointStreamFactory,
+            CheckpointedStateScope stateScope,
+            CloseableRegistry closeableRegistry,
+            CloseableRegistry tmpResourcesRegistry)
+            throws IOException {
+
+        if (transferBytes < 0) {
+            // Means transfer whole file to checkpoint storage.
+            transferBytes = Long.MAX_VALUE;
+
+            // TODO: Optimizing transfer with fast duplicate
+        }
+
+        InputStream inputStream = null;
+        CheckpointStateOutputStream outputStream = null;
+
+        try {
+            final byte[] buffer = new byte[READ_BUFFER_SIZE];
+
+            FileSystem sourceFilesystem = filePath.getFileSystem();
+            inputStream = sourceFilesystem.open(filePath, READ_BUFFER_SIZE);
+            closeableRegistry.registerCloseable(inputStream);
+
+            outputStream = checkpointStreamFactory.createCheckpointStateOutputStream(stateScope);
+            closeableRegistry.registerCloseable(outputStream);
+
+            while (transferBytes >= 0) {
+                int numBytes = inputStream.read(buffer);
+
+                if (numBytes == -1) {
+                    break;
+                }
+
+                int writeBytes = numBytes < transferBytes ? numBytes : (int) transferBytes;
+                outputStream.write(buffer, 0, writeBytes);
+
+                transferBytes -= writeBytes;
+            }
+
+            final StreamStateHandle result;
+            if (closeableRegistry.unregisterCloseable(outputStream)) {
+                result = outputStream.closeAndGetHandle();
+                outputStream = null;
+            } else {
+                result = null;
+            }
+            tmpResourcesRegistry.registerCloseable(
+                    () -> StateUtil.discardStateObjectQuietly(result));
+
+            return HandleAndLocalPath.of(result, filePath.getName());
+
+        } finally {
+
+            if (closeableRegistry.unregisterCloseable(inputStream)) {
+                IOUtils.closeQuietly(inputStream);
+            }
+
+            if (closeableRegistry.unregisterCloseable(outputStream)) {
+                IOUtils.closeQuietly(outputStream);
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        executorService.shutdownNow();
+    }
+
+    private Exception convertExecutionException(ExecutionException e) {
+        Throwable throwable = ExceptionUtils.stripExecutionException(e);
+        throwable = ExceptionUtils.stripException(throwable, RuntimeException.class);
+        if (throwable instanceof IOException) {
+            return (IOException) throwable;
+        } else {
+            return new FlinkRuntimeException("Failed to transfer data.", e);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateDataTransfer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateDataTransfer.java
@@ -177,7 +177,7 @@ public class ForStStateDataTransfer implements Closeable {
             outputStream = checkpointStreamFactory.createCheckpointStateOutputStream(stateScope);
             closeableRegistry.registerCloseable(outputStream);
 
-            while (maxTransferBytes >= 0) {
+            while (maxTransferBytes > 0) {
                 int maxReadBytes = (int) Math.min(maxTransferBytes, READ_BUFFER_SIZE);
                 int readBytes = inputStream.read(buffer, 0, maxReadBytes);
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
@@ -1,0 +1,435 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.snapshot;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.checkpoint.SnapshotType;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.state.forst.ForStKeyedStateBackend.ForStKvStateInfo;
+import org.apache.flink.state.forst.ForStResourceContainer;
+import org.apache.flink.state.forst.ForStStateDataTransfer;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.ResourceGuard;
+
+import org.rocksdb.RocksDB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.UUID;
+
+import static org.apache.flink.state.forst.snapshot.ForStSnapshotUtil.MANIFEST_FILE_PREFIX;
+import static org.apache.flink.state.forst.snapshot.ForStSnapshotUtil.SST_FILE_SUFFIX;
+
+/**
+ * Snapshot strategy for {@link org.apache.flink.state.forst.ForStKeyedStateBackend} that is based
+ * on disableFileDeletions()+getLiveFiles() of ForSt and creates incremental snapshots.
+ *
+ * @param <K> type of the backend keys.
+ */
+public class ForStIncrementalSnapshotStrategy<K>
+        extends ForStSnapshotStrategyBase<
+                K, ForStSnapshotStrategyBase.ForStNativeSnapshotResources> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(ForStIncrementalSnapshotStrategy.class);
+
+    private static final String DESCRIPTION = "Asynchronous incremental ForSt snapshot";
+
+    /**
+     * Stores the {@link StreamStateHandle} and corresponding local path of uploaded SST files that
+     * build the incremental history. Once the checkpoint is confirmed by JM, they can be reused for
+     * incremental checkpoint.
+     */
+    @Nonnull private final SortedMap<Long, Collection<HandleAndLocalPath>> uploadedSstFiles;
+
+    /** The identifier of the last completed checkpoint. */
+    private long lastCompletedCheckpointId;
+
+    /** The help class used to upload state files. */
+    private final ForStStateDataTransfer stateTransfer;
+
+    public ForStIncrementalSnapshotStrategy(
+            @Nonnull RocksDB db,
+            @Nonnull ResourceGuard forstResourceGuard,
+            @Nonnull ForStResourceContainer resourceContainer,
+            @Nonnull TypeSerializer<K> keySerializer,
+            @Nonnull LinkedHashMap<String, ForStKvStateInfo> kvStateInformation,
+            @Nonnull KeyGroupRange keyGroupRange,
+            @Nonnegative int keyGroupPrefixBytes,
+            @Nonnull UUID backendUID,
+            @Nonnull SortedMap<Long, Collection<HandleAndLocalPath>> uploadedStateHandles,
+            @Nonnull ForStStateDataTransfer stateTransfer,
+            long lastCompletedCheckpointId) {
+
+        super(
+                DESCRIPTION,
+                db,
+                forstResourceGuard,
+                resourceContainer,
+                keySerializer,
+                kvStateInformation,
+                keyGroupRange,
+                keyGroupPrefixBytes,
+                backendUID);
+
+        this.uploadedSstFiles = new TreeMap<>(uploadedStateHandles);
+        this.stateTransfer = stateTransfer;
+        this.lastCompletedCheckpointId = lastCompletedCheckpointId;
+    }
+
+    @Override
+    public SnapshotResultSupplier<KeyedStateHandle> asyncSnapshot(
+            ForStNativeSnapshotResources snapshotResources,
+            long checkpointId,
+            long timestamp,
+            @Nonnull CheckpointStreamFactory checkpointStreamFactory,
+            @Nonnull CheckpointOptions checkpointOptions) {
+
+        if (snapshotResources.stateMetaInfoSnapshots.isEmpty()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "Asynchronous ForSt snapshot performed on empty keyed state at {}. Returning null.",
+                        timestamp);
+            }
+            return registry -> SnapshotResult.empty();
+        }
+
+        final CheckpointType.SharingFilesStrategy sharingFilesStrategy =
+                checkpointOptions.getCheckpointType().getSharingFilesStrategy();
+
+        switch (sharingFilesStrategy) {
+            case FORWARD_BACKWARD:
+                // incremental checkpoint, use origin PreviousSnapshot
+                break;
+            case FORWARD:
+            case NO_SHARING:
+                // full checkpoint, use empty PreviousSnapshot
+                snapshotResources.setPreviousSnapshot(EMPTY_PREVIOUS_SNAPSHOT);
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported sharing files strategy: " + sharingFilesStrategy);
+        }
+
+        return new ForStIncrementalSnapshotOperation(
+                checkpointId, snapshotResources, checkpointStreamFactory, sharingFilesStrategy);
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long completedCheckpointId) {
+        synchronized (uploadedSstFiles) {
+            LOG.info("Backend:{} checkpoint:{} complete.", backendUID, completedCheckpointId);
+
+            // FLINK-23949: materializedSstFiles.keySet().contains(completedCheckpointId) make sure
+            // the notified checkpointId is not a savepoint, otherwise next checkpoint will
+            // degenerate into a full checkpoint
+            if (completedCheckpointId > lastCompletedCheckpointId
+                    && uploadedSstFiles.containsKey(completedCheckpointId)) {
+                uploadedSstFiles
+                        .keySet()
+                        .removeIf(checkpointId -> checkpointId < completedCheckpointId);
+                lastCompletedCheckpointId = completedCheckpointId;
+            }
+        }
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long abortedCheckpointId) {
+        synchronized (uploadedSstFiles) {
+            LOG.info("Backend:{} checkpoint:{} aborted.", backendUID, abortedCheckpointId);
+            uploadedSstFiles.keySet().remove(abortedCheckpointId);
+        }
+    }
+
+    @Override
+    public void close() {
+        stateTransfer.close();
+    }
+
+    @Override
+    protected PreviousSnapshot snapshotMetaData(
+            long checkpointId, @Nonnull List<StateMetaInfoSnapshot> stateMetaInfoSnapshots) {
+
+        final long lastCompletedCheckpoint;
+        final Collection<HandleAndLocalPath> confirmedSstFiles;
+
+        // use the last completed checkpoint as the comparison base.
+        synchronized (uploadedSstFiles) {
+            lastCompletedCheckpoint = lastCompletedCheckpointId;
+            confirmedSstFiles = uploadedSstFiles.get(lastCompletedCheckpoint);
+            LOG.trace(
+                    "Use confirmed SST files for checkpoint {}: {}",
+                    checkpointId,
+                    confirmedSstFiles);
+        }
+        LOG.trace(
+                "Taking incremental snapshot for checkpoint {}. Snapshot is based on last completed checkpoint {} "
+                        + "assuming the following (shared) confirmed files as base: {}.",
+                checkpointId,
+                lastCompletedCheckpoint,
+                confirmedSstFiles);
+
+        // snapshot meta data to save
+        for (Map.Entry<String, ForStKvStateInfo> stateMetaInfoEntry :
+                kvStateInformation.entrySet()) {
+            stateMetaInfoSnapshots.add(stateMetaInfoEntry.getValue().metaInfo.snapshot());
+        }
+        return new PreviousSnapshot(confirmedSstFiles);
+    }
+
+    /** Encapsulates the process to perform an incremental snapshot of a ForStKeyedStateBackend. */
+    private final class ForStIncrementalSnapshotOperation extends ForStSnapshotOperation {
+
+        @Nonnull private final SnapshotType.SharingFilesStrategy sharingFilesStrategy;
+
+        private ForStIncrementalSnapshotOperation(
+                long checkpointId,
+                @Nonnull ForStNativeSnapshotResources snapshotResources,
+                @Nonnull CheckpointStreamFactory checkpointStreamFactory,
+                @Nonnull SnapshotType.SharingFilesStrategy sharingFilesStrategy) {
+
+            super(checkpointId, snapshotResources, checkpointStreamFactory);
+            this.sharingFilesStrategy = sharingFilesStrategy;
+        }
+
+        @Override
+        public SnapshotResult<KeyedStateHandle> get(CloseableRegistry snapshotCloseableRegistry)
+                throws Exception {
+
+            boolean completed = false;
+
+            final List<StreamStateHandle> reusedHandle = new ArrayList<>();
+
+            try {
+
+                // Handle to the meta data file
+                SnapshotResult<StreamStateHandle> metaStateHandle =
+                        materializeMetaData(
+                                snapshotCloseableRegistry,
+                                tmpResourcesRegistry,
+                                snapshotResources.stateMetaInfoSnapshots,
+                                checkpointId,
+                                checkpointStreamFactory);
+
+                final List<HandleAndLocalPath> sstFiles = new ArrayList<>();
+                final List<HandleAndLocalPath> miscFiles = new ArrayList<>();
+
+                long checkpointedSize = metaStateHandle.getStateSize();
+                checkpointedSize +=
+                        transferSnapshotFiles(
+                                sstFiles,
+                                miscFiles,
+                                snapshotCloseableRegistry,
+                                tmpResourcesRegistry,
+                                reusedHandle);
+
+                final IncrementalRemoteKeyedStateHandle jmIncrementalKeyedStateHandle =
+                        new IncrementalRemoteKeyedStateHandle(
+                                backendUID,
+                                keyGroupRange,
+                                checkpointId,
+                                sstFiles,
+                                miscFiles,
+                                metaStateHandle.getJobManagerOwnedSnapshot(),
+                                checkpointedSize);
+
+                completed = true;
+
+                return SnapshotResult.of(jmIncrementalKeyedStateHandle);
+            } finally {
+                snapshotResources.release();
+
+                if (!completed) {
+                    try {
+                        tmpResourcesRegistry.close();
+                    } catch (Exception e) {
+                        LOG.warn("Could not properly clean tmp resources.", e);
+                    }
+
+                } else {
+                    // Report the reuse of state handle to stream factory, which is essential for
+                    // file merging mechanism.
+                    checkpointStreamFactory.reusePreviousStateHandle(reusedHandle);
+                }
+            }
+        }
+
+        /**
+         * Transfer files to checkpoint filesystem and return total uploaded size.
+         *
+         * @param sstHandles Empty container, all sst files which should be including in checkpoint
+         *     will be put in it.
+         * @param metaHandles Empty container, all meta files (include manifest file) which should
+         *     be including in checkpoint will be put in it.
+         * @return Total bytes transfer to checkpoint filesystem.
+         */
+        private long transferSnapshotFiles(
+                @Nonnull List<HandleAndLocalPath> sstHandles,
+                @Nonnull List<HandleAndLocalPath> metaHandles,
+                @Nonnull CloseableRegistry snapshotCloseableRegistry,
+                @Nonnull CloseableRegistry tmpResourcesRegistry,
+                @Nonnull List<StreamStateHandle> reusedHandle)
+                throws Exception {
+
+            Preconditions.checkNotNull(
+                    snapshotResources.liveFiles, "liveFiles were not properly created.");
+
+            if (snapshotResources.liveFiles.isEmpty()) {
+                return 0;
+            }
+
+            Tuple4<List<HandleAndLocalPath>, List<Path>, List<Path>, Path> classifiedFiles =
+                    classifyFiles();
+
+            sstHandles.addAll(classifiedFiles.f0);
+            // Collect the reuse of state handle.
+            sstHandles.stream().map(HandleAndLocalPath::getHandle).forEach(reusedHandle::add);
+
+            final CheckpointedStateScope stateScope =
+                    sharingFilesStrategy == SnapshotType.SharingFilesStrategy.NO_SHARING
+                            ? CheckpointedStateScope.EXCLUSIVE
+                            : CheckpointedStateScope.SHARED;
+
+            long transferBytes = 0;
+
+            List<HandleAndLocalPath> sstFilesTransferResult =
+                    stateTransfer.transferFilesToCheckpointFs(
+                            classifiedFiles.f1,
+                            checkpointStreamFactory,
+                            stateScope,
+                            snapshotCloseableRegistry,
+                            tmpResourcesRegistry);
+
+            sstHandles.addAll(sstFilesTransferResult);
+            transferBytes +=
+                    sstFilesTransferResult.stream()
+                            .mapToLong(HandleAndLocalPath::getStateSize)
+                            .sum();
+
+            List<HandleAndLocalPath> miscFilesTransferResult =
+                    stateTransfer.transferFilesToCheckpointFs(
+                            classifiedFiles.f2,
+                            checkpointStreamFactory,
+                            stateScope,
+                            snapshotCloseableRegistry,
+                            tmpResourcesRegistry);
+            metaHandles.addAll(miscFilesTransferResult);
+            transferBytes +=
+                    miscFilesTransferResult.stream()
+                            .mapToLong(HandleAndLocalPath::getStateSize)
+                            .sum();
+
+            HandleAndLocalPath manifestFileTransferResult =
+                    stateTransfer.transferFileToCheckpointFs(
+                            classifiedFiles.f3,
+                            snapshotResources.manifestFileSize,
+                            checkpointStreamFactory,
+                            stateScope,
+                            snapshotCloseableRegistry,
+                            tmpResourcesRegistry);
+            metaHandles.add(manifestFileTransferResult);
+            transferBytes += manifestFileTransferResult.getStateSize();
+
+            recordReusableHandles(sstHandles);
+
+            return transferBytes;
+        }
+
+        private void recordReusableHandles(List<HandleAndLocalPath> sstHandles) {
+            synchronized (uploadedSstFiles) {
+                switch (sharingFilesStrategy) {
+                    case FORWARD_BACKWARD:
+                    case FORWARD:
+                        uploadedSstFiles.put(
+                                checkpointId, Collections.unmodifiableList(sstHandles));
+                        break;
+                    case NO_SHARING:
+                        break;
+                    default:
+                        // This is just a safety precaution. It is checked before creating the
+                        // ForStIncrementalSnapshotOperation
+                        throw new IllegalArgumentException(
+                                "Unsupported sharing files strategy: " + sharingFilesStrategy);
+                }
+            }
+        }
+
+        private Tuple4<List<HandleAndLocalPath>, List<Path>, List<Path>, Path> classifyFiles() {
+            int totalFileNum = snapshotResources.liveFiles.size();
+
+            List<HandleAndLocalPath> transferredSstHandles = new ArrayList<>(totalFileNum);
+
+            List<Path> toTransferSstFiles = new ArrayList<>(totalFileNum);
+            List<Path> toTransferMiscFiles = new ArrayList<>(totalFileNum);
+            Path toTransferManifestFile = null;
+
+            for (Path filePath : snapshotResources.liveFiles) {
+                final String fileName = filePath.getName();
+
+                if (fileName.startsWith(MANIFEST_FILE_PREFIX)) {
+                    Preconditions.checkState(
+                            toTransferManifestFile == null,
+                            String.format("Backend:%s should only one manifest file.", backendUID));
+                    toTransferManifestFile = filePath;
+                } else if (fileName.endsWith(SST_FILE_SUFFIX)) {
+                    Optional<StreamStateHandle> uploaded =
+                            snapshotResources.previousSnapshot.getUploaded(fileName);
+                    if (uploaded.isPresent()) {
+                        transferredSstHandles.add(HandleAndLocalPath.of(uploaded.get(), fileName));
+                    } else {
+                        toTransferSstFiles.add(filePath); // re-transfer
+                    }
+                } else {
+                    toTransferMiscFiles.add(filePath);
+                }
+            }
+
+            return Tuple4.of(
+                    transferredSstHandles,
+                    toTransferSstFiles,
+                    toTransferMiscFiles,
+                    toTransferManifestFile);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
@@ -58,6 +58,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
 
+import static org.apache.flink.state.forst.snapshot.ForStSnapshotUtil.CURRENT_FILE_NAME;
 import static org.apache.flink.state.forst.snapshot.ForStSnapshotUtil.MANIFEST_FILE_PREFIX;
 import static org.apache.flink.state.forst.snapshot.ForStSnapshotUtil.SST_FILE_SUFFIX;
 
@@ -370,6 +371,19 @@ public class ForStIncrementalSnapshotStrategy<K>
                             tmpResourcesRegistry);
             metaHandles.add(manifestFileTransferResult);
             transferBytes += manifestFileTransferResult.getStateSize();
+
+            // To prevent the content of the current file change, the manifest file name is directly
+            // used to rewrite the current file during the checkpoint asynchronous phase.
+            HandleAndLocalPath currentFileWriteResult =
+                    stateTransfer.writeFileToCheckpointFs(
+                            CURRENT_FILE_NAME,
+                            snapshotResources.manifestFileName,
+                            checkpointStreamFactory,
+                            stateScope,
+                            snapshotCloseableRegistry,
+                            tmpResourcesRegistry);
+            metaHandles.add(currentFileWriteResult);
+            transferBytes += currentFileWriteResult.getStateSize();
 
             recordReusableHandles(sstHandles);
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
@@ -415,7 +415,8 @@ public class ForStIncrementalSnapshotStrategy<K>
                 } else if (fileName.endsWith(SST_FILE_SUFFIX)) {
                     Optional<StreamStateHandle> uploaded =
                             snapshotResources.previousSnapshot.getUploaded(fileName);
-                    if (uploaded.isPresent()) {
+                    if (uploaded.isPresent()
+                            && checkpointStreamFactory.couldReuseStateHandle(uploaded.get())) {
                         transferredSstHandles.add(HandleAndLocalPath.of(uploaded.get(), fileName));
                     } else {
                         toTransferSstFiles.add(filePath); // re-transfer

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
@@ -59,7 +59,6 @@ import java.util.TreeMap;
 import java.util.UUID;
 
 import static org.apache.flink.state.forst.snapshot.ForStSnapshotUtil.CURRENT_FILE_NAME;
-import static org.apache.flink.state.forst.snapshot.ForStSnapshotUtil.MANIFEST_FILE_PREFIX;
 import static org.apache.flink.state.forst.snapshot.ForStSnapshotUtil.SST_FILE_SUFFIX;
 
 /**
@@ -422,9 +421,6 @@ public class ForStIncrementalSnapshotStrategy<K>
                 final String fileName = filePath.getName();
 
                 if (fileName.equals(snapshotResources.manifestFileName)) {
-                    Preconditions.checkState(
-                            toTransferManifestFile == null,
-                            String.format("Backend:%s should only one manifest file.", backendUID));
                     toTransferManifestFile = filePath;
                 } else if (fileName.endsWith(SST_FILE_SUFFIX)) {
                     Optional<StreamStateHandle> uploaded =

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
@@ -421,7 +421,7 @@ public class ForStIncrementalSnapshotStrategy<K>
             for (Path filePath : snapshotResources.liveFiles) {
                 final String fileName = filePath.getName();
 
-                if (fileName.startsWith(MANIFEST_FILE_PREFIX)) {
+                if (fileName.equals(snapshotResources.manifestFileName)) {
                     Preconditions.checkState(
                             toTransferManifestFile == null,
                             String.format("Backend:%s should only one manifest file.", backendUID));

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
@@ -360,6 +360,8 @@ public class ForStIncrementalSnapshotStrategy<K>
                             .mapToLong(HandleAndLocalPath::getStateSize)
                             .sum();
 
+            // TODO: The FLINK-35927 will change the storage of manifest/current files, so this part
+            // should be change accordingly after that.
             HandleAndLocalPath manifestFileTransferResult =
                     stateTransfer.transferFileToCheckpointFs(
                             classifiedFiles.f3,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
@@ -360,8 +360,6 @@ public class ForStIncrementalSnapshotStrategy<K>
                             .mapToLong(HandleAndLocalPath::getStateSize)
                             .sum();
 
-            // TODO: The FLINK-35927 will change the storage of manifest/current files, so this part
-            // should be change accordingly after that.
             HandleAndLocalPath manifestFileTransferResult =
                     stateTransfer.transferFileToCheckpointFs(
                             classifiedFiles.f3,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
@@ -300,7 +300,7 @@ public abstract class ForStSnapshotStrategyBase<K, R extends SnapshotResources>
         @Override
         public void release() {
             // make sure only release once
-            if (!released.getAndSet(true)) {
+            if (released.compareAndSet(false, true)) {
                 releaser.run();
             }
         }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.snapshot;
+
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointStreamWithResultProvider;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
+import org.apache.flink.runtime.state.SnapshotResources;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.SnapshotStrategy;
+import org.apache.flink.runtime.state.StateUtil;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.state.forst.ForStKeyedStateBackend.ForStKvStateInfo;
+import org.apache.flink.state.forst.ForStResourceContainer;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.ResourceGuard;
+
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnegative;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract base class for {@link SnapshotStrategy} implementations for ForSt state backend.
+ *
+ * @param <K> type of the backend keys.
+ */
+public abstract class ForStSnapshotStrategyBase<K, R extends SnapshotResources>
+        implements CheckpointListener,
+                SnapshotStrategy<
+                        KeyedStateHandle, ForStSnapshotStrategyBase.ForStNativeSnapshotResources>,
+                AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForStSnapshotStrategyBase.class);
+
+    @Nonnull private final String description;
+
+    /** ForSt instance from the backend. */
+    @Nonnull protected final RocksDB db;
+
+    /** Resource guard for the ForSt instance. */
+    @Nonnull protected final ResourceGuard resourceGuard;
+
+    @Nonnull protected final ForStResourceContainer resourceContainer;
+
+    /** The key serializer of the backend. */
+    @Nonnull protected final TypeSerializer<K> keySerializer;
+
+    /** Key/Value state meta info from the backend. */
+    @Nonnull protected final LinkedHashMap<String, ForStKvStateInfo> kvStateInformation;
+
+    /** The key-group range for the task. */
+    @Nonnull protected final KeyGroupRange keyGroupRange;
+
+    /** Number of bytes in the key-group prefix. */
+    @Nonnegative protected final int keyGroupPrefixBytes;
+
+    /** The state handle ids of all sst files materialized in snapshots for previous checkpoints. */
+    @Nonnull protected final UUID backendUID;
+
+    public ForStSnapshotStrategyBase(
+            @Nonnull String description,
+            @Nonnull RocksDB db,
+            @Nonnull ResourceGuard resourceGuard,
+            @Nonnull ForStResourceContainer resourceContainer,
+            @Nonnull TypeSerializer<K> keySerializer,
+            @Nonnull LinkedHashMap<String, ForStKvStateInfo> kvStateInformation,
+            @Nonnull KeyGroupRange keyGroupRange,
+            @Nonnegative int keyGroupPrefixBytes,
+            @Nonnull UUID backendUID) {
+        this.db = db;
+        this.resourceGuard = resourceGuard;
+        this.resourceContainer = resourceContainer;
+        this.keySerializer = keySerializer;
+        this.kvStateInformation = kvStateInformation;
+        this.keyGroupRange = keyGroupRange;
+        this.keyGroupPrefixBytes = keyGroupPrefixBytes;
+        this.description = description;
+        this.backendUID = backendUID;
+    }
+
+    @Nonnull
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public ForStNativeSnapshotResources syncPrepareResources(long checkpointId) throws Exception {
+
+        final List<StateMetaInfoSnapshot> stateMetaInfoSnapshots =
+                new ArrayList<>(kvStateInformation.size());
+        final PreviousSnapshot previousSnapshot =
+                snapshotMetaData(checkpointId, stateMetaInfoSnapshots);
+
+        // Disable file deletion for file transformation. ForSt will decide whether to allow file
+        // deletion based on the number of calls to disableFileDeletions() and
+        // enableFileDeletions(), so disableFileDeletions() should be call only once.
+        db.disableFileDeletions();
+
+        // get live files with flush memtable
+        RocksDB.LiveFiles liveFiles = db.getLiveFiles(true);
+        List<Path> liveFilesPath =
+                liveFiles.files.stream()
+                        .map(file -> new Path(resourceContainer.getDbPath(), file))
+                        .collect(Collectors.toList());
+
+        logLiveFiles(checkpointId, liveFiles.manifestFileSize, liveFilesPath);
+
+        return new ForStNativeSnapshotResources(
+                stateMetaInfoSnapshots,
+                liveFiles.manifestFileSize,
+                liveFilesPath,
+                previousSnapshot,
+                () -> {
+                    try {
+                        db.enableFileDeletions(false);
+                        LOG.info(
+                                "Release one file deletion lock with ForStNativeSnapshotResources, backendUID:{}, checkpointId:{}.",
+                                backendUID,
+                                checkpointId);
+                    } catch (RocksDBException e) {
+                        LOG.error(
+                                "Enable file deletion failed, backendUID:{}, checkpointId:{}.",
+                                backendUID,
+                                checkpointId,
+                                e);
+                        // TODO: 2024/5/28 wangfeifan - Add more robust exception handling
+                    }
+                });
+    }
+
+    private void logLiveFiles(long checkpointId, long manifestFileSize, List<Path> liveFilesPath) {
+        StringBuilder sb =
+                new StringBuilder("    manifestFileSize:").append(manifestFileSize).append("\n");
+        liveFilesPath.forEach(e -> sb.append("    file : ").append(e).append("\n"));
+        LOG.trace("Backend:{} live files for checkpoint:{} : \n{}", backendUID, checkpointId, sb);
+    }
+
+    protected abstract PreviousSnapshot snapshotMetaData(
+            long checkpointId, @Nonnull List<StateMetaInfoSnapshot> stateMetaInfoSnapshots);
+
+    @Nonnull
+    protected SnapshotResult<StreamStateHandle> materializeMetaData(
+            @Nonnull CloseableRegistry snapshotCloseableRegistry,
+            @Nonnull CloseableRegistry tmpResourcesRegistry,
+            @Nonnull List<StateMetaInfoSnapshot> stateMetaInfoSnapshots,
+            long checkpointId,
+            @Nonnull CheckpointStreamFactory checkpointStreamFactory)
+            throws Exception {
+
+        CheckpointStreamWithResultProvider streamWithResultProvider =
+                CheckpointStreamWithResultProvider.createSimpleStream(
+                        CheckpointedStateScope.EXCLUSIVE, checkpointStreamFactory);
+
+        snapshotCloseableRegistry.registerCloseable(streamWithResultProvider);
+
+        try {
+            // no need for compression scheme support because sst-files are already compressed
+            KeyedBackendSerializationProxy<K> serializationProxy =
+                    new KeyedBackendSerializationProxy<>(
+                            keySerializer, stateMetaInfoSnapshots, false);
+
+            DataOutputView out =
+                    new DataOutputViewStreamWrapper(
+                            streamWithResultProvider.getCheckpointOutputStream());
+
+            serializationProxy.write(out);
+
+            if (snapshotCloseableRegistry.unregisterCloseable(streamWithResultProvider)) {
+                SnapshotResult<StreamStateHandle> result =
+                        streamWithResultProvider.closeAndFinalizeCheckpointStreamResult();
+
+                streamWithResultProvider = null;
+                tmpResourcesRegistry.registerCloseable(
+                        () -> StateUtil.discardStateObjectQuietly(result));
+
+                // Sanity checks - they should never fail
+                Preconditions.checkNotNull(
+                        result,
+                        String.format(
+                                "Backend:%s, checkpoint:%s, Metadata was not properly created.",
+                                backendUID, checkpointId));
+                Preconditions.checkNotNull(
+                        result.getJobManagerOwnedSnapshot(),
+                        String.format(
+                                "Backend:%s, checkpoint:%s, Metadata for job manager was not properly created.",
+                                backendUID, checkpointId));
+
+                return result;
+            } else {
+                throw new IOException("Stream already closed and cannot return a handle.");
+            }
+        } finally {
+            if (snapshotCloseableRegistry.unregisterCloseable(streamWithResultProvider)) {
+                IOUtils.closeQuietly(streamWithResultProvider);
+            }
+        }
+    }
+
+    @Override
+    public abstract void close();
+
+    /** Common operation in native ForSt snapshot result supplier. */
+    protected abstract class ForStSnapshotOperation
+            implements SnapshotResultSupplier<KeyedStateHandle> {
+
+        protected final long checkpointId;
+        @Nonnull protected final ForStNativeSnapshotResources snapshotResources;
+        @Nonnull protected final CheckpointStreamFactory checkpointStreamFactory;
+        @Nonnull protected final CloseableRegistry tmpResourcesRegistry;
+
+        protected ForStSnapshotOperation(
+                long checkpointId,
+                @Nonnull ForStNativeSnapshotResources snapshotResources,
+                @Nonnull CheckpointStreamFactory checkpointStreamFactory) {
+            this.checkpointId = checkpointId;
+            this.snapshotResources = snapshotResources;
+            this.checkpointStreamFactory = checkpointStreamFactory;
+            this.tmpResourcesRegistry = new CloseableRegistry();
+        }
+    }
+
+    /** A {@link SnapshotResources} for native ForSt snapshot. */
+    protected static class ForStNativeSnapshotResources implements SnapshotResources {
+
+        @Nonnull protected final List<StateMetaInfoSnapshot> stateMetaInfoSnapshots;
+        protected final long manifestFileSize;
+        @Nonnull protected final List<Path> liveFiles;
+        @Nonnull protected PreviousSnapshot previousSnapshot;
+        @Nonnull protected final Runnable releaser;
+
+        private final AtomicBoolean released;
+
+        public ForStNativeSnapshotResources(
+                @Nonnull List<StateMetaInfoSnapshot> stateMetaInfoSnapshots,
+                long manifestFileSize,
+                @Nonnull List<Path> liveFiles,
+                @Nonnull PreviousSnapshot previousSnapshot,
+                @Nonnull Runnable releaser) {
+            this.stateMetaInfoSnapshots = stateMetaInfoSnapshots;
+            this.manifestFileSize = manifestFileSize;
+            this.liveFiles = liveFiles;
+            this.previousSnapshot = previousSnapshot;
+            this.releaser = releaser;
+            this.released = new AtomicBoolean(false);
+        }
+
+        public void setPreviousSnapshot(@Nonnull PreviousSnapshot previousSnapshot) {
+            this.previousSnapshot = previousSnapshot;
+        }
+
+        @Override
+        public void release() {
+            // make sure only release once
+            if (!released.getAndSet(true)) {
+                releaser.run();
+            }
+        }
+    }
+
+    protected static final PreviousSnapshot EMPTY_PREVIOUS_SNAPSHOT =
+            new PreviousSnapshot(Collections.emptyList());
+
+    /** Previous snapshot with uploaded sst files. */
+    protected static class PreviousSnapshot {
+
+        @Nonnull private final Map<String, StreamStateHandle> confirmedSstFiles;
+
+        protected PreviousSnapshot(@Nullable Collection<HandleAndLocalPath> confirmedSstFiles) {
+            this.confirmedSstFiles =
+                    confirmedSstFiles != null
+                            ? confirmedSstFiles.stream()
+                                    .collect(
+                                            Collectors.toMap(
+                                                    HandleAndLocalPath::getLocalPath,
+                                                    HandleAndLocalPath::getHandle))
+                            : Collections.emptyMap();
+        }
+
+        protected Optional<StreamStateHandle> getUploaded(String filename) {
+            if (confirmedSstFiles.containsKey(filename)) {
+                StreamStateHandle handle = confirmedSstFiles.get(filename);
+                // We introduce a placeholder state handle to reduce network transfer overhead,
+                // it will be replaced by the original handle from the shared state registry
+                // (created from a previous checkpoint).
+                return Optional.of(
+                        new PlaceholderStreamStateHandle(
+                                handle.getStreamStateHandleID(),
+                                handle.getStateSize(),
+                                FileMergingSnapshotManager.isFileMergingHandle(handle)));
+            } else {
+                // Don't use any uploaded but not confirmed handles because they might be deleted
+                // (by TM) if the previous checkpoint failed. See FLINK-25395
+                return Optional.empty();
+            }
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
@@ -176,10 +176,12 @@ public abstract class ForStSnapshotStrategyBase<K, R extends SnapshotResources>
     }
 
     private void logLiveFiles(long checkpointId, long manifestFileSize, List<Path> liveFilesPath) {
-        StringBuilder sb =
-                new StringBuilder("    manifestFileSize:").append(manifestFileSize).append("\n");
-        liveFilesPath.forEach(e -> sb.append("    file : ").append(e).append("\n"));
-        LOG.trace("Backend:{} live files for checkpoint:{} : \n{}", backendUID, checkpointId, sb);
+        if (LOG.isDebugEnabled()) {
+            StringBuilder sb =
+                    new StringBuilder("    manifestFileSize:").append(manifestFileSize).append("\n");
+            liveFilesPath.forEach(e -> sb.append("    file : ").append(e).append("\n"));
+            LOG.debug("Backend:{} live files for checkpoint:{} : \n{}", backendUID, checkpointId, sb);
+        }
     }
 
     protected abstract PreviousSnapshot snapshotMetaData(

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
@@ -178,9 +178,12 @@ public abstract class ForStSnapshotStrategyBase<K, R extends SnapshotResources>
     private void logLiveFiles(long checkpointId, long manifestFileSize, List<Path> liveFilesPath) {
         if (LOG.isDebugEnabled()) {
             StringBuilder sb =
-                    new StringBuilder("    manifestFileSize:").append(manifestFileSize).append("\n");
+                    new StringBuilder("    manifestFileSize:")
+                            .append(manifestFileSize)
+                            .append("\n");
             liveFilesPath.forEach(e -> sb.append("    file : ").append(e).append("\n"));
-            LOG.debug("Backend:{} live files for checkpoint:{} : \n{}", backendUID, checkpointId, sb);
+            LOG.debug(
+                    "Backend:{} live files for checkpoint:{} : \n{}", backendUID, checkpointId, sb);
         }
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotUtil.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.snapshot;
+
+/**
+ * Utility methods and constants around ForSt creating and restoring snapshots for {@link
+ * org.apache.flink.state.forst.ForStStateBackend}.
+ */
+public class ForStSnapshotUtil {
+
+    public static final String SST_FILE_SUFFIX = ".sst";
+    public static final String MANIFEST_FILE_PREFIX = "MANIFEST-";
+
+    private ForStSnapshotUtil() {
+        throw new AssertionError();
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotUtil.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotUtil.java
@@ -26,6 +26,7 @@ public class ForStSnapshotUtil {
 
     public static final String SST_FILE_SUFFIX = ".sst";
     public static final String MANIFEST_FILE_PREFIX = "MANIFEST-";
+    public static final String CURRENT_FILE_NAME = "CURRENT";
 
     private ForStSnapshotUtil() {
         throw new AssertionError();

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateDataTransferTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateDataTransferTest.java
@@ -1,0 +1,422 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.CheckpointStateOutputStream;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
+import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test class for {@link ForStStateDataTransfer}. */
+class ForStStateDataTransferTest extends TestLogger {
+
+    @TempDir private java.nio.file.Path temporaryFolder;
+
+    /** Test that the exception arose in the thread pool will rethrow to the main thread. */
+    @Test
+    void testMultiThreadTransferThreadPoolExceptionRethrow() throws IOException {
+        SpecifiedException expectedException =
+                new SpecifiedException("throw exception while multi thread transfer states.");
+
+        CheckpointStateOutputStream outputStream =
+                createFailingCheckpointStateOutputStream(expectedException);
+        CheckpointStreamFactory checkpointStreamFactory =
+                new CheckpointStreamFactory() {
+                    @Override
+                    public CheckpointStateOutputStream createCheckpointStateOutputStream(
+                            CheckpointedStateScope scope) {
+                        return outputStream;
+                    }
+
+                    @Override
+                    public boolean canFastDuplicate(
+                            StreamStateHandle stateHandle, CheckpointedStateScope scope) {
+                        return false;
+                    }
+
+                    @Override
+                    public List<StreamStateHandle> duplicate(
+                            List<StreamStateHandle> stateHandles, CheckpointedStateScope scope) {
+                        return null;
+                    }
+                };
+
+        File file = TempDirUtils.newFile(temporaryFolder, String.valueOf(UUID.randomUUID()));
+        generateRandomFileContent(file.getPath(), 20);
+
+        List<Path> filePaths = new ArrayList<>(1);
+        filePaths.add(Path.fromLocalFile(file));
+        try (ForStStateDataTransfer stateTransfer = new ForStStateDataTransfer(5)) {
+            assertThatThrownBy(
+                            () ->
+                                    stateTransfer.transferFilesToCheckpointFs(
+                                            filePaths,
+                                            checkpointStreamFactory,
+                                            CheckpointedStateScope.SHARED,
+                                            new CloseableRegistry(),
+                                            new CloseableRegistry()))
+                    .isEqualTo(expectedException);
+        }
+    }
+
+    @Test
+    void testTransferredSstCanBeCleanedUp() throws Exception {
+        SpecifiedException expectedException =
+                new SpecifiedException("throw exception while multi thread transfer states.");
+
+        File checkpointPrivateFolder = TempDirUtils.newFolder(temporaryFolder, "private");
+        Path checkpointPrivateDirectory = Path.fromLocalFile(checkpointPrivateFolder);
+
+        File checkpointSharedFolder = TempDirUtils.newFolder(temporaryFolder, "shared");
+        Path checkpointSharedDirectory = Path.fromLocalFile(checkpointSharedFolder);
+
+        FileSystem fileSystem = checkpointPrivateDirectory.getFileSystem();
+
+        int sstFileCount = 6;
+        int fileStateSizeThreshold = 1024;
+        int writeBufferSize = 4096;
+        CheckpointStreamFactory checkpointStreamFactory =
+                new FsCheckpointStreamFactory(
+                        fileSystem,
+                        checkpointPrivateDirectory,
+                        checkpointSharedDirectory,
+                        fileStateSizeThreshold,
+                        writeBufferSize);
+
+        String localFolder = "local";
+        TempDirUtils.newFolder(temporaryFolder, localFolder);
+
+        List<Path> filePaths =
+                generateRandomSstFiles(localFolder, sstFileCount, fileStateSizeThreshold);
+        CloseableRegistry tmpResourcesRegistry = new CloseableRegistry();
+        try (ForStStateDataTransfer stateTransfer = new ForStStateDataTransfer(1)) {
+            stateTransfer.transferFilesToCheckpointFs(
+                    filePaths,
+                    checkpointStreamFactory,
+                    CheckpointedStateScope.SHARED,
+                    new CloseableRegistry(),
+                    tmpResourcesRegistry);
+
+            assertThatThrownBy(
+                            () ->
+                                    stateTransfer.transferFilesToCheckpointFs(
+                                            filePaths,
+                                            new LastFailingCheckpointStateOutputStreamFactory(
+                                                    checkpointStreamFactory,
+                                                    sstFileCount,
+                                                    expectedException),
+                                            CheckpointedStateScope.SHARED,
+                                            new CloseableRegistry(),
+                                            tmpResourcesRegistry))
+                    .isEqualTo(expectedException);
+            assertThat(checkpointPrivateFolder.list()).isEmpty();
+            assertThat(checkpointSharedFolder.list()).isNotEmpty();
+
+            tmpResourcesRegistry.close();
+            // Check whether the temporary file before the exception can be cleaned up
+            assertThat(checkpointPrivateFolder.list()).isEmpty();
+            assertThat(checkpointSharedFolder.list()).isEmpty();
+
+            Path first = filePaths.stream().findFirst().get();
+            assertThatThrownBy(
+                            () ->
+                                    stateTransfer.transferFilesToCheckpointFs(
+                                            Collections.singletonList(first),
+                                            checkpointStreamFactory,
+                                            CheckpointedStateScope.SHARED,
+                                            new CloseableRegistry(),
+                                            tmpResourcesRegistry))
+                    .as("Cannot register Closeable, registry is already closed. Closing argument.")
+                    .isInstanceOf(IOException.class);
+
+            // Check whether the temporary file after the exception can be cleaned up.
+            assertThat(checkpointPrivateFolder.list()).isEmpty();
+            assertThat(checkpointSharedFolder.list()).isEmpty();
+        }
+    }
+
+    /** Test that transfer file head part correctly. */
+    @Test
+    void testTransferHeadPartCorrectly() throws Exception {
+        File checkpointPrivateFolder = TempDirUtils.newFolder(temporaryFolder, "private");
+        Path checkpointPrivateDirectory = Path.fromLocalFile(checkpointPrivateFolder);
+
+        File checkpointSharedFolder = TempDirUtils.newFolder(temporaryFolder, "shared");
+        Path checkpointSharedDirectory = Path.fromLocalFile(checkpointSharedFolder);
+
+        FileSystem fileSystem = checkpointPrivateDirectory.getFileSystem();
+        int fileStateSizeThreshold = 1024;
+        int headBytes = 512; // make sure just a part of origin state file
+        int writeBufferSize = 4096;
+        FsCheckpointStreamFactory checkpointStreamFactory =
+                new FsCheckpointStreamFactory(
+                        fileSystem,
+                        checkpointPrivateDirectory,
+                        checkpointSharedDirectory,
+                        fileStateSizeThreshold,
+                        writeBufferSize);
+
+        String localFolder = "local";
+        TempDirUtils.newFolder(temporaryFolder, localFolder);
+
+        Path sstFile = generateRandomSstFile(localFolder, 1, fileStateSizeThreshold);
+
+        try (ForStStateDataTransfer stateTransfer = new ForStStateDataTransfer(5)) {
+            HandleAndLocalPath handleAndLocalPath =
+                    stateTransfer.transferFileToCheckpointFs(
+                            sstFile,
+                            headBytes,
+                            checkpointStreamFactory,
+                            CheckpointedStateScope.SHARED,
+                            new CloseableRegistry(),
+                            new CloseableRegistry());
+
+            assertStateContentEqual(
+                    sstFile, headBytes, handleAndLocalPath.getHandle().openInputStream());
+        }
+    }
+
+    /** Test that transfer files with multi-thread correctly. */
+    @Test
+    void testMultiThreadTransferCorrectly() throws Exception {
+        File checkpointPrivateFolder = TempDirUtils.newFolder(temporaryFolder, "private");
+        Path checkpointPrivateDirectory = Path.fromLocalFile(checkpointPrivateFolder);
+
+        File checkpointSharedFolder = TempDirUtils.newFolder(temporaryFolder, "shared");
+        Path checkpointSharedDirectory = Path.fromLocalFile(checkpointSharedFolder);
+
+        FileSystem fileSystem = checkpointPrivateDirectory.getFileSystem();
+        int fileStateSizeThreshold = 1024;
+        int writeBufferSize = 4096;
+        FsCheckpointStreamFactory checkpointStreamFactory =
+                new FsCheckpointStreamFactory(
+                        fileSystem,
+                        checkpointPrivateDirectory,
+                        checkpointSharedDirectory,
+                        fileStateSizeThreshold,
+                        writeBufferSize);
+
+        String localFolder = "local";
+        TempDirUtils.newFolder(temporaryFolder, localFolder);
+
+        int sstFileCount = 6;
+        List<Path> sstFilePaths =
+                generateRandomSstFiles(localFolder, sstFileCount, fileStateSizeThreshold);
+
+        try (ForStStateDataTransfer stateTransfer = new ForStStateDataTransfer(5)) {
+            List<HandleAndLocalPath> sstFiles =
+                    stateTransfer.transferFilesToCheckpointFs(
+                            sstFilePaths,
+                            checkpointStreamFactory,
+                            CheckpointedStateScope.SHARED,
+                            new CloseableRegistry(),
+                            new CloseableRegistry());
+
+            for (Path path : sstFilePaths) {
+                assertStateContentEqual(
+                        path,
+                        -1,
+                        sstFiles.stream()
+                                .filter(e -> e.getLocalPath().equals(path.getName()))
+                                .findFirst()
+                                .get()
+                                .getHandle()
+                                .openInputStream());
+            }
+        }
+    }
+
+    private static CheckpointStateOutputStream createFailingCheckpointStateOutputStream(
+            IOException failureException) {
+        return new CheckpointStateOutputStream() {
+            @Nullable
+            @Override
+            public StreamStateHandle closeAndGetHandle() {
+                return new ByteStreamStateHandle("testHandle", "testHandle".getBytes());
+            }
+
+            @Override
+            public void close() {}
+
+            @Override
+            public long getPos() {
+                return 0;
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void sync() {}
+
+            @Override
+            public void write(int b) throws IOException {
+                throw failureException;
+            }
+        };
+    }
+
+    private List<Path> generateRandomSstFiles(
+            String localFolder, int fileCount, int fileStateSizeThreshold) throws IOException {
+        List<Path> sstFilePaths = new ArrayList<>(fileCount);
+        for (int i = 0; i < fileCount; ++i) {
+            sstFilePaths.add(generateRandomSstFile(localFolder, i, fileStateSizeThreshold));
+        }
+        return sstFilePaths;
+    }
+
+    private Path generateRandomSstFile(String localFolder, int fileNum, int fileStateSizeThreshold)
+            throws IOException {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        File file =
+                TempDirUtils.newFile(
+                        temporaryFolder, String.format("%s/%d.sst", localFolder, fileNum));
+        generateRandomFileContent(
+                file.getPath(), random.nextInt(1_000_000) + fileStateSizeThreshold);
+
+        return Path.fromLocalFile(file);
+    }
+
+    private void generateRandomFileContent(String filePath, int fileLength) throws IOException {
+        FileOutputStream fileStream = new FileOutputStream(filePath);
+        byte[] contents = new byte[fileLength];
+        ThreadLocalRandom.current().nextBytes(contents);
+        fileStream.write(contents);
+        fileStream.close();
+    }
+
+    private void assertStateContentEqual(
+            Path stateFilePath, long headBytes, FSDataInputStream inputStream) throws IOException {
+        byte[] excepted = readHeadBytes(stateFilePath, headBytes);
+        byte[] actual = new byte[excepted.length];
+        IOUtils.readFully(inputStream, actual, 0, actual.length);
+        // make sure there is no more bytes in inputStream
+        assertThat(inputStream.read()).isEqualTo(-1);
+        assertThat(actual).isEqualTo(excepted);
+        inputStream.close();
+    }
+
+    private byte[] readHeadBytes(Path path, long headBytes) throws IOException {
+        FileSystem fileSystem = path.getFileSystem();
+        FileStatus fileStatus = fileSystem.getFileStatus(path);
+        Preconditions.checkNotNull(fileStatus);
+
+        long len = fileStatus.getLen();
+        Preconditions.checkState(len >= headBytes);
+
+        try (FSDataInputStream inputStream = fileSystem.open(path)) {
+
+            int toRead = (int) (headBytes > 0 ? headBytes : len);
+            byte[] content = new byte[toRead];
+
+            int offset = 0;
+            final int singleReadSize = 16 * 1024;
+
+            while (toRead > 0) {
+                int num = inputStream.read(content, offset, Math.min(toRead, singleReadSize));
+                if (num == -1) {
+                    break;
+                }
+                offset += num;
+                toRead -= num;
+            }
+
+            return content;
+        }
+    }
+
+    private static class SpecifiedException extends IOException {
+        SpecifiedException(String message) {
+            super(message);
+        }
+    }
+
+    /** The last stream will be broken stream. */
+    private static class LastFailingCheckpointStateOutputStreamFactory
+            implements CheckpointStreamFactory {
+
+        private final CheckpointStreamFactory checkpointStreamFactory;
+        private final int streamTotalCount;
+        private final AtomicInteger streamCount;
+        private final IOException expectedException;
+
+        private LastFailingCheckpointStateOutputStreamFactory(
+                CheckpointStreamFactory checkpointStreamFactory,
+                int streamTotalCount,
+                IOException expectedException) {
+            this.checkpointStreamFactory = checkpointStreamFactory;
+            this.streamTotalCount = streamTotalCount;
+            this.expectedException = expectedException;
+            this.streamCount = new AtomicInteger();
+        }
+
+        @Override
+        public CheckpointStateOutputStream createCheckpointStateOutputStream(
+                CheckpointedStateScope scope) throws IOException {
+            if (streamCount.incrementAndGet() == streamTotalCount) {
+                return createFailingCheckpointStateOutputStream(expectedException);
+            }
+            return checkpointStreamFactory.createCheckpointStateOutputStream(scope);
+        }
+
+        @Override
+        public boolean canFastDuplicate(
+                StreamStateHandle stateHandle, CheckpointedStateScope scope) {
+            return false;
+        }
+
+        @Override
+        public List<StreamStateHandle> duplicate(
+                List<StreamStateHandle> stateHandles, CheckpointedStateScope scope)
+                throws IOException {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.snapshot;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.state.ArrayListSerializer;
+import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory;
+import org.apache.flink.runtime.state.v2.RegisteredKeyValueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.v2.StateDescriptor;
+import org.apache.flink.state.forst.ForStExtension;
+import org.apache.flink.state.forst.ForStKeyedStateBackend;
+import org.apache.flink.state.forst.ForStStateDataTransfer;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.TreeMap;
+import java.util.UUID;
+
+import static org.apache.flink.core.fs.Path.fromLocalFile;
+import static org.apache.flink.core.fs.local.LocalFileSystem.getSharedInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ForStIncrementalSnapshotStrategy}. */
+class ForStIncrementalSnapshotStrategyTest {
+
+    @TempDir public Path tmp;
+
+    @RegisterExtension public ForStExtension forstExtension = new ForStExtension();
+
+    // Verify the next checkpoint is still incremental after a savepoint completed.
+    @Test
+    void testCheckpointIsIncremental() throws Exception {
+
+        try (CloseableRegistry closeableRegistry = new CloseableRegistry();
+                ForStIncrementalSnapshotStrategy<?> checkpointSnapshotStrategy =
+                        createSnapshotStrategy()) {
+            FsCheckpointStreamFactory checkpointStreamFactory = createFsCheckpointStreamFactory();
+
+            // make and notify checkpoint with id 1
+            snapshot(1L, checkpointSnapshotStrategy, checkpointStreamFactory, closeableRegistry);
+            checkpointSnapshotStrategy.notifyCheckpointComplete(1L);
+
+            // notify savepoint with id 2
+            checkpointSnapshotStrategy.notifyCheckpointComplete(2L);
+
+            // make checkpoint with id 3
+            IncrementalRemoteKeyedStateHandle incrementalRemoteKeyedStateHandle3 =
+                    snapshot(
+                            3L,
+                            checkpointSnapshotStrategy,
+                            checkpointStreamFactory,
+                            closeableRegistry);
+
+            // If 3rd checkpoint's full size > checkpointed size, it means 3rd checkpoint is
+            // incremental.
+            assertThat(incrementalRemoteKeyedStateHandle3.getStateSize())
+                    .isGreaterThan(incrementalRemoteKeyedStateHandle3.getCheckpointedSize());
+        }
+    }
+
+    private ForStIncrementalSnapshotStrategy<?> createSnapshotStrategy()
+            throws IOException, RocksDBException {
+
+        ColumnFamilyHandle columnFamilyHandle = forstExtension.createNewColumnFamily("test");
+        RocksDB db = forstExtension.getDB();
+        byte[] key = "checkpoint".getBytes();
+        byte[] val = "incrementalTest".getBytes();
+        db.put(columnFamilyHandle, key, val);
+
+        RegisteredKeyValueStateBackendMetaInfo<ArrayList<Integer>> metaInfo =
+                new RegisteredKeyValueStateBackendMetaInfo<>(
+                        "test",
+                        StateDescriptor.Type.VALUE,
+                        new ArrayListSerializer<>(IntSerializer.INSTANCE));
+        LinkedHashMap<String, ForStKeyedStateBackend.ForStKvStateInfo> kvStateInformation =
+                new LinkedHashMap<>();
+        kvStateInformation.putIfAbsent(
+                "test", new ForStKeyedStateBackend.ForStKvStateInfo(columnFamilyHandle, metaInfo));
+
+        return new ForStIncrementalSnapshotStrategy<>(
+                db,
+                forstExtension.getResourceGuard(),
+                forstExtension.getResourceContainer(),
+                IntSerializer.INSTANCE,
+                kvStateInformation,
+                new KeyGroupRange(0, 1),
+                CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(2),
+                UUID.randomUUID(),
+                new TreeMap<>(),
+                new ForStStateDataTransfer(ForStStateDataTransfer.DEFAULT_THREAD_NUM),
+                -1);
+    }
+
+    private FsCheckpointStreamFactory createFsCheckpointStreamFactory() throws IOException {
+        int threshold = 100;
+        File checkpointsDir = TempDirUtils.newFolder(tmp, "checkpointsDir");
+        File sharedStateDir = TempDirUtils.newFolder(tmp, "sharedStateDir");
+        return new FsCheckpointStreamFactory(
+                getSharedInstance(),
+                fromLocalFile(checkpointsDir),
+                fromLocalFile(sharedStateDir),
+                threshold,
+                threshold);
+    }
+
+    private IncrementalRemoteKeyedStateHandle snapshot(
+            long checkpointId,
+            ForStIncrementalSnapshotStrategy<?> snapshotStrategy,
+            FsCheckpointStreamFactory checkpointStreamFactory,
+            CloseableRegistry closeableRegistry)
+            throws Exception {
+
+        ForStIncrementalSnapshotStrategy.ForStNativeSnapshotResources snapshotResources =
+                snapshotStrategy.syncPrepareResources(checkpointId);
+
+        return (IncrementalRemoteKeyedStateHandle)
+                snapshotStrategy
+                        .asyncSnapshot(
+                                snapshotResources,
+                                checkpointId,
+                                checkpointId,
+                                checkpointStreamFactory,
+                                CheckpointOptions.forCheckpointWithDefaultLocation())
+                        .get(closeableRegistry)
+                        .getJobManagerOwnedSnapshot();
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategyTest.java
@@ -99,10 +99,11 @@ class ForStIncrementalSnapshotStrategyTest {
         byte[] val = "incrementalTest".getBytes();
         db.put(columnFamilyHandle, key, val);
 
-        RegisteredKeyValueStateBackendMetaInfo<ArrayList<Integer>> metaInfo =
+        RegisteredKeyValueStateBackendMetaInfo<Integer, ArrayList<Integer>> metaInfo =
                 new RegisteredKeyValueStateBackendMetaInfo<>(
                         "test",
                         StateDescriptor.Type.VALUE,
+                        IntSerializer.INSTANCE,
                         new ArrayListSerializer<>(IntSerializer.INSTANCE));
         LinkedHashMap<String, ForStKeyedStateBackend.ForStKvStateInfo> kvStateInformation =
                 new LinkedHashMap<>();


### PR DESCRIPTION
…r ForStStateBackend

## What is the purpose of the change

Use low DB api implement a basic incremental checkpoint for ForStStatebackend, follow steps:

1. db.disableFileDeletions()
2. db.getLiveFiles(true)
3. db.entableFileDeletes(false)

## Brief change log

  - Introduce ForStStateDataTransfer
  - Introduce ForStIncrementalSnapshotStrategy

## Verifying this change

This change added tests and can be verified as follows:

  - Added test ForStStateDataTransferTest
  - Added test ForStIncrementalSnapshotStrategyTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)
