### PR TITLE
[FLINK-35201][table] Support the execution of drop materialized table in full refresh mode

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -220,10 +220,6 @@ public class MaterializedTableManager {
             // atomicity is guaranteed
             operationExecutor.callExecutableOperation(
                     handle, new DropMaterializedTableOperation(materializedTableIdentifier, true));
-            LOG.error(
-                    "Submit continuous refresh job for materialized table {} occur exception.",
-                    materializedTableIdentifier,
-                    e);
             throw new SqlExecutionException(
                     String.format(
                             "Submit continuous refresh job for materialized table %s occur exception.",
@@ -279,10 +275,6 @@ public class MaterializedTableManager {
         } catch (Exception e) {
             // drop materialized table while create refresh workflow occur exception. Thus, weak
             // atomicity is guaranteed
-            LOG.error(
-                    "Create refresh workflow occur exception, drop materialized table {}.",
-                    materializedTableIdentifier,
-                    e);
             operationExecutor.callExecutableOperation(
                     handle, new DropMaterializedTableOperation(materializedTableIdentifier, true));
             throw new SqlExecutionException(
@@ -337,10 +329,6 @@ public class MaterializedTableManager {
                     updateRefreshHandler.asSummaryString(),
                     serializeContinuousHandler(updateRefreshHandler));
         } catch (Exception e) {
-            LOG.error(
-                    "Failed to suspend the continuous refresh job for materialized table {}.",
-                    tableIdentifier,
-                    e);
             throw new SqlExecutionException(
                     String.format(
                             "Failed to suspend the continuous refresh job for materialized table %s.",
@@ -378,10 +366,6 @@ public class MaterializedTableManager {
                     refreshHandler.asSummaryString(),
                     materializedTable.getSerializedRefreshHandler());
         } catch (Exception e) {
-            LOG.error(
-                    "Failed to suspend the refresh workflow for materialized table {}.",
-                    tableIdentifier,
-                    e);
             throw new SqlExecutionException(
                     String.format(
                             "Failed to suspend the refresh workflow for materialized table %s.",
@@ -438,10 +422,6 @@ public class MaterializedTableManager {
                     dynamicOptions,
                     restorePath);
         } catch (Exception e) {
-            LOG.error(
-                    "Failed to resume the continuous refresh job for materialized table {}.",
-                    tableIdentifier,
-                    e);
             throw new SqlExecutionException(
                     String.format(
                             "Failed to resume the continuous refresh job for materialized table %s.",
@@ -480,10 +460,6 @@ public class MaterializedTableManager {
                     refreshHandler.asSummaryString(),
                     catalogMaterializedTable.getSerializedRefreshHandler());
         } catch (Exception e) {
-            LOG.error(
-                    "Failed to resume the refresh workflow for materialized table {}.",
-                    tableIdentifier,
-                    e);
             throw new SqlExecutionException(
                     String.format(
                             "Failed to resume the refresh workflow for materialized table %s.",
@@ -630,11 +606,6 @@ public class MaterializedTableManager {
                                     StringData.fromString(jobId),
                                     new GenericMapData(clusterInfo))));
         } catch (Exception e) {
-            // log and throw exception
-            LOG.error(
-                    "Manually refreshing the materialized table {} occur exception.",
-                    materializedTableIdentifier,
-                    e);
             throw new SqlExecutionException(
                     String.format(
                             "Manually refreshing the materialized table %s occur exception.",
@@ -857,10 +828,6 @@ public class MaterializedTableManager {
             DeleteRefreshWorkflow deleteRefreshWorkflow = new DeleteRefreshWorkflow(refreshHandler);
             workflowScheduler.deleteRefreshWorkflow(deleteRefreshWorkflow);
         } catch (Exception e) {
-            LOG.error(
-                    "Failed to delete the refresh workflow for materialized table {}.",
-                    tableIdentifier,
-                    e);
             throw new SqlExecutionException(
                     String.format(
                             "Failed to delete the refresh workflow for materialized table %s.",

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/scheduler/EmbeddedQuartzScheduler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/workflow/scheduler/EmbeddedQuartzScheduler.java
@@ -271,11 +271,6 @@ public class EmbeddedQuartzScheduler {
         JobKey jobKey = JobKey.jobKey(workflowName, workflowGroup);
         lock.writeLock().lock();
         try {
-            String errorMsg =
-                    String.format(
-                            "Failed to delete a non-existent quartz schedule job: %s.", jobKey);
-            checkJobExists(jobKey, errorMsg);
-
             quartzScheduler.deleteJob(jobKey);
         } catch (org.quartz.SchedulerException e) {
             LOG.error("Failed to delete quartz schedule job: {}.", jobKey, e);

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractMaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractMaterializedTableStatementITCase.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
-import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.gateway.api.operation.OperationHandle;
 import org.apache.flink.table.gateway.api.results.TableInfo;
@@ -196,20 +195,14 @@ public abstract class AbstractMaterializedTableStatementITCase {
             ResolvedCatalogBaseTable<?> resolvedTable =
                     service.getTable(sessionHandle, tableInfo.getIdentifier());
             if (CatalogBaseTable.TableKind.MATERIALIZED_TABLE == resolvedTable.getTableKind()) {
-                ResolvedCatalogMaterializedTable catalogMaterializedTable =
-                        (ResolvedCatalogMaterializedTable) resolvedTable;
-                if (catalogMaterializedTable.getRefreshMode()
-                        == ResolvedCatalogMaterializedTable.RefreshMode.CONTINUOUS) {
-                    // drop materialized table (batch refresh job will be dropped automatically
-                    String dropTableDDL =
-                            String.format(
-                                    "DROP MATERIALIZED TABLE %s",
-                                    tableInfo.getIdentifier().asSerializableString());
-                    OperationHandle dropTableHandle =
-                            service.executeStatement(
-                                    sessionHandle, dropTableDDL, -1, new Configuration());
-                    awaitOperationTermination(service, sessionHandle, dropTableHandle);
-                }
+                String dropTableDDL =
+                        String.format(
+                                "DROP MATERIALIZED TABLE %s",
+                                tableInfo.getIdentifier().asSerializableString());
+                OperationHandle dropTableHandle =
+                        service.executeStatement(
+                                sessionHandle, dropTableDDL, -1, new Configuration());
+                awaitOperationTermination(service, sessionHandle, dropTableHandle);
             }
         }
     }

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
@@ -271,7 +271,7 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
     }
 
     @Test
-    void testCreateMaterializedTableFailed() throws Exception {
+    void testCreateMaterializedTableFailedInInContinuousMode() {
         // create a materialized table with invalid SQL
         String materializedTableDDL =
                 "CREATE MATERIALIZED TABLE users_shops"
@@ -450,7 +450,8 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
     }
 
     @Test
-    void testAlterMaterializedTableSuspendAndResume(@TempDir Path temporaryPath) throws Exception {
+    void testAlterMaterializedTableSuspendAndResumeInContinuousMode(@TempDir Path temporaryPath)
+            throws Exception {
         String materializedTableDDL =
                 "CREATE MATERIALIZED TABLE users_shops"
                         + " PARTITIONED BY (ds)\n"
@@ -593,7 +594,8 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
     }
 
     @Test
-    void testAlterMaterializedTableWithoutSavepointDirConfigured() throws Exception {
+    void testAlterMaterializedTableWithoutSavepointDirConfiguredInContinuousMode()
+            throws Exception {
         String materializedTableDDL =
                 "CREATE MATERIALIZED TABLE users_shops"
                         + " PARTITIONED BY (ds)\n"
@@ -751,7 +753,7 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
     }
 
     @Test
-    void testDropMaterializedTable() throws Exception {
+    void testDropMaterializedTableInContinuousMode() throws Exception {
         String materializedTableDDL =
                 "CREATE MATERIALIZED TABLE users_shops"
                         + " PARTITIONED BY (ds)\n"
@@ -976,7 +978,7 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
     }
 
     @Test
-    void testRefreshMaterializedTableWithStaticPartition() throws Exception {
+    void testRefreshMaterializedTableWithStaticPartitionInContinuousMode() throws Exception {
         List<Row> data = new ArrayList<>();
         data.add(Row.of(1L, 1L, 1L, "2024-01-01"));
         data.add(Row.of(2L, 2L, 2L, "2024-01-02"));
@@ -1160,7 +1162,7 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
     }
 
     @Test
-    void testRefreshMaterializedTableWithInvalidParameter() throws Exception {
+    void testRefreshMaterializedTableWithInvalidParameterInContinuousMode() throws Exception {
         List<Row> data = new ArrayList<>();
         data.add(Row.of(1L, 1L, 1L, "2024-01-01"));
         data.add(Row.of(2L, 2L, 2L, "2024-01-02"));

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/EmbeddedSchedulerRelatedITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/workflow/EmbeddedSchedulerRelatedITCase.java
@@ -228,18 +228,7 @@ public class EmbeddedSchedulerRelatedITCase extends RestAPIITCaseBase {
                         EmptyMessageParameters.getInstance(),
                         nonExistsWorkflow);
 
-        assertThatFuture(suspendFuture)
-                .failsWithin(5, TimeUnit.SECONDS)
-                .withThrowableOfType(ExecutionException.class)
-                .withCauseInstanceOf(RestClientException.class)
-                .withMessageContaining(
-                        "Failed to delete a non-existent quartz schedule job: default_group.non-exists.")
-                .satisfies(
-                        e ->
-                                assertThat(
-                                                ((RestClientException) e.getCause())
-                                                        .getHttpResponseStatus())
-                                        .isEqualTo(HttpResponseStatus.INTERNAL_SERVER_ERROR));
+        assertThatFuture(suspendFuture).succeedsWithin(5, TimeUnit.SECONDS);
     }
 
     @Test
@@ -304,7 +293,7 @@ public class EmbeddedSchedulerRelatedITCase extends RestAPIITCaseBase {
     }
 
     @Test
-    void testNonExistsWorkflowByWorkflowSchedulerInterface() {
+    void testNonExistsWorkflowByWorkflowSchedulerInterface() throws WorkflowException {
         // suspend case
         assertThatThrownBy(
                         () ->
@@ -331,16 +320,8 @@ public class EmbeddedSchedulerRelatedITCase extends RestAPIITCaseBase {
                                 + "}.");
 
         // delete case
-        assertThatThrownBy(
-                        () ->
-                                embeddedWorkflowScheduler.deleteRefreshWorkflow(
-                                        new DeleteRefreshWorkflow<>(nonExistsHandler)))
-                .isInstanceOf(WorkflowException.class)
-                .hasMessage(
-                        "Failed to delete refresh workflow {\n"
-                                + "  workflowName: non-exits,\n"
-                                + "  workflowGroup: default_group\n"
-                                + "}.");
+        embeddedWorkflowScheduler.deleteRefreshWorkflow(
+                new DeleteRefreshWorkflow<>(nonExistsHandler));
     }
 
     /** Just used for test. */


### PR DESCRIPTION
## What is the purpose of the change

*Support the execution of drop materialized table in full refresh mode*


## Brief change log

* Support the execution of drop materialized table in full refresh mode


## Verifying this change

* Add test case `testDropMaterializedTableInFullMode` to verify the execution of drop materialized table in full mode. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Will be added in a separate pr)
