### PR TITLE
[FLINK-35526] Use more up to date jq docker image for Flink e2e tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_s3_operations.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3_operations.sh
@@ -150,7 +150,7 @@ function s3_get_number_of_lines_by_prefix() {
 
   # find all files that have the given prefix
   parts=$(aws_cli s3api list-objects --bucket "$IT_CASE_S3_BUCKET" --prefix "$1" |
-    docker run -i --rm ghcr.io/jqlang/jq -r '[.Contents[].Key] | join(" ")')
+    docker run -i --rm ghcr.io/jqlang/jq:1.7.1 -r '[.Contents[].Key] | join(" ")')
 
   # in parallel (N tasks), query the number of lines, store result in a file named lines
   N=10

--- a/flink-end-to-end-tests/test-scripts/common_s3_operations.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3_operations.sh
@@ -150,7 +150,7 @@ function s3_get_number_of_lines_by_prefix() {
 
   # find all files that have the given prefix
   parts=$(aws_cli s3api list-objects --bucket "$IT_CASE_S3_BUCKET" --prefix "$1" |
-    docker run -i --rm ddev/ddev-utilities jq -r '[.Contents[].Key] | join(" ")')
+    docker run -i --rm ghcr.io/jqlang/jq -r '[.Contents[].Key] | join(" ")')
 
   # in parallel (N tasks), query the number of lines, store result in a file named lines
   N=10

--- a/flink-end-to-end-tests/test-scripts/common_s3_operations.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3_operations.sh
@@ -150,7 +150,7 @@ function s3_get_number_of_lines_by_prefix() {
 
   # find all files that have the given prefix
   parts=$(aws_cli s3api list-objects --bucket "$IT_CASE_S3_BUCKET" --prefix "$1" |
-    docker run -i --rm stedolan/jq -r '[.Contents[].Key] | join(" ")')
+    docker run -i --rm ddev/ddev-utilities jq -r '[.Contents[].Key] | join(" ")')
 
   # in parallel (N tasks), query the number of lines, store result in a file named lines
   N=10


### PR DESCRIPTION
Our CI logs contain this warning: https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=60060&view=logs&j=af184cdd-c6d8-5084-0b69-7e9c67b35f7a&t=0f3adb59-eefa-51c6-2858-3654d9e0749d&l=3828

```
latest: Pulling from stedolan/jq
[DEPRECATION NOTICE] Docker Image Format v1, and Docker Image manifest version 2, schema 1 support will be removed in an upcoming release. Suggest the author of docker.io/stedolan/jq:latest to upgrade the image to the OCI Format, or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```