### PR TITLE
[FLINK-20217][task] Allow certains operators to yield to unaligned checkpoint in case timers are firing

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -87,6 +87,12 @@
             <td>Forces unaligned checkpoints, particularly allowing them for iterative jobs.</td>
         </tr>
         <tr>
+            <td><h5>execution.checkpointing.unaligned.interruptible-timers.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Allows unaligned checkpoints to skip timers that are currently being fired.</td>
+        </tr>
+        <tr>
             <td><h5>execution.checkpointing.unaligned.max-subtasks-per-channel-state-file</h5></td>
             <td style="word-wrap: break-word;">5</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/api/common/operators/MailboxExecutor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/operators/MailboxExecutor.java
@@ -245,4 +245,13 @@ public interface MailboxExecutor {
      * @throws RuntimeException if executed {@link RunnableWithException} thrown an exception.
      */
     boolean tryYield() throws FlinkRuntimeException;
+
+    /**
+     * Return if operator/function should interrupt a longer computation and return from the
+     * currently processed elemenent/watermark, for example in order to let Flink perform a
+     * checkpoint.
+     *
+     * @return whether operator/function should interrupt its computation.
+     */
+    boolean shouldInterrupt();
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -632,6 +632,14 @@ public class CheckpointingOptions {
                                             "Forces unaligned checkpoints, particularly allowing them for iterative jobs.")
                                     .build());
 
+    @Experimental
+    public static final ConfigOption<Boolean> ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS =
+            ConfigOptions.key("execution.checkpointing.unaligned.interruptible-timers.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Allows unaligned checkpoints to skip timers that are currently being fired.");
+
     public static final ConfigOption<Boolean> ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH =
             ConfigOptions.key("execution.checkpointing.checkpoints-after-tasks-finish.enabled")
                     .booleanType()

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -161,6 +161,11 @@ public class CepOperator<IN, KEY, OUT>
     }
 
     @Override
+    public boolean useSplittableTimers() {
+        return true;
+    }
+
+    @Override
     public void setup(
             StreamTask<?, ?> containingTask,
             StreamConfig config,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -844,5 +844,10 @@ class AsyncExecutionControllerTest {
         public boolean tryYield() throws FlinkRuntimeException {
             return false;
         }
+
+        @Override
+        public boolean shouldInterrupt() {
+            return false;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/mailbox/SyncMailboxExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/mailbox/SyncMailboxExecutor.java
@@ -43,4 +43,9 @@ public class SyncMailboxExecutor implements MailboxExecutor {
     public boolean tryYield() throws FlinkRuntimeException {
         return false;
     }
+
+    @Override
+    public boolean shouldInterrupt() {
+        return false;
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -656,6 +656,16 @@ public class CheckpointConfig implements java.io.Serializable {
         return configuration.get(CheckpointingOptions.ENABLE_UNALIGNED);
     }
 
+    @Experimental
+    public void enableUnalignedCheckpointsInterruptibleTimers(boolean enabled) {
+        configuration.set(CheckpointingOptions.ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS, enabled);
+    }
+
+    @Experimental
+    public boolean isUnalignedCheckpointsInterruptibleTimersEnabled() {
+        return configuration.get(CheckpointingOptions.ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS);
+    }
+
     /**
      * Only relevant if {@link #isUnalignedCheckpointsEnabled} is enabled.
      *
@@ -1065,6 +1075,9 @@ public class CheckpointConfig implements java.io.Serializable {
         configuration
                 .getOptional(CheckpointingOptions.ENABLE_UNALIGNED)
                 .ifPresent(this::enableUnalignedCheckpoints);
+        configuration
+                .getOptional(CheckpointingOptions.ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS)
+                .ifPresent(this::enableUnalignedCheckpointsInterruptibleTimers);
         configuration
                 .getOptional(StateRecoveryOptions.CHECKPOINT_ID_OF_IGNORED_IN_FLIGHT_DATA)
                 .ifPresent(this::setCheckpointIdOfIgnoredInFlightData);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -532,6 +532,14 @@ public class StreamConfig implements Serializable {
         return config.get(CheckpointingOptions.ENABLE_UNALIGNED, false);
     }
 
+    public void setUnalignedCheckpointsSplittableTimersEnabled(boolean enabled) {
+        config.setBoolean(CheckpointingOptions.ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS, enabled);
+    }
+
+    public boolean isUnalignedCheckpointsSplittableTimersEnabled() {
+        return config.get(CheckpointingOptions.ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS);
+    }
+
     public boolean isExactlyOnceCheckpointMode() {
         return getCheckpointMode() == CheckpointingMode.EXACTLY_ONCE;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -1142,6 +1142,8 @@ public class StreamingJobGraphGenerator {
                         streamGraph.isEnableCheckpointsAfterTasksFinish());
         config.setCheckpointMode(getCheckpointingMode(checkpointCfg));
         config.setUnalignedCheckpointsEnabled(checkpointCfg.isUnalignedCheckpointsEnabled());
+        config.setUnalignedCheckpointsSplittableTimersEnabled(
+                checkpointCfg.isUnalignedCheckpointsInterruptibleTimersEnabled());
         config.setAlignedCheckpointTimeout(checkpointCfg.getAlignedCheckpointTimeout());
         config.setMaxSubtasksPerChannelStateFile(checkpointCfg.getMaxSubtasksPerChannelStateFile());
         config.setMaxConcurrentCheckpoints(checkpointCfg.getMaxConcurrentCheckpoints());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.IndexedCombinedWatermarkStatus;
+import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.state.KeyedStateStore;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
@@ -62,6 +63,8 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Optional;
@@ -90,6 +93,8 @@ public abstract class AbstractStreamOperatorV2<OUT>
     protected final StreamConfig config;
     protected final Output<StreamRecord<OUT>> output;
     private final StreamingRuntimeContext runtimeContext;
+    private final MailboxExecutor mailboxExecutor;
+
     private final ExecutionConfig executionConfig;
     private final ClassLoader userCodeClassLoader;
     private final CloseableRegistry cancelables;
@@ -104,6 +109,7 @@ public abstract class AbstractStreamOperatorV2<OUT>
 
     protected StreamOperatorStateHandler stateHandler;
     protected InternalTimeServiceManager<?> timeServiceManager;
+    private @Nullable MailboxWatermarkProcessor watermarkProcessor;
 
     public AbstractStreamOperatorV2(StreamOperatorParameters<OUT> parameters, int numberOfInputs) {
         final Environment environment = parameters.getContainingTask().getEnvironment();
@@ -136,6 +142,8 @@ public abstract class AbstractStreamOperatorV2<OUT>
                         processingTimeService,
                         null,
                         environment.getExternalResourceInfoProvider());
+
+        mailboxExecutor = parameters.getMailboxExecutor();
     }
 
     private LatencyStats createLatencyStats(
@@ -214,6 +222,33 @@ public abstract class AbstractStreamOperatorV2<OUT>
         stateHandler = new StreamOperatorStateHandler(context, getExecutionConfig(), cancelables);
         timeServiceManager = context.internalTimerServiceManager();
         stateHandler.initializeOperatorState(this);
+
+        if (useSplittableTimers()
+                && areSplittableTimersConfigured()
+                && getTimeServiceManager().isPresent()) {
+            watermarkProcessor =
+                    new MailboxWatermarkProcessor(
+                            output, mailboxExecutor, getTimeServiceManager().get());
+        }
+    }
+
+    /**
+     * Can be overridden to disable splittable timers for this particular operator even if config
+     * option is enabled. By default, splittable timers are disabled.
+     *
+     * @return {@code true} if splittable timers should be used (subject to {@link
+     *     StreamConfig#isUnalignedCheckpointsEnabled()} and {@link
+     *     StreamConfig#isUnalignedCheckpointsSplittableTimersEnabled()}. {@code false} if
+     *     splittable timers should never be used.
+     */
+    @Internal
+    public boolean useSplittableTimers() {
+        return false;
+    }
+
+    @Internal
+    private boolean areSplittableTimersConfigured() {
+        return AbstractStreamOperator.areSplittableTimersConfigured(config);
     }
 
     /**
@@ -481,6 +516,14 @@ public abstract class AbstractStreamOperatorV2<OUT>
     }
 
     public void processWatermark(Watermark mark) throws Exception {
+        if (watermarkProcessor != null) {
+            watermarkProcessor.emitWatermarkInsideMailbox(mark);
+        } else {
+            emitWatermarkDirectly(mark);
+        }
+    }
+
+    private void emitWatermarkDirectly(Watermark mark) throws Exception {
         if (timeServiceManager != null) {
             timeServiceManager.advanceWatermark(mark);
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
@@ -245,6 +245,17 @@ public class InternalTimeServiceManagerImpl<K> implements InternalTimeServiceMan
         }
     }
 
+    @Override
+    public boolean tryAdvanceWatermark(
+            Watermark watermark, ShouldStopAdvancingFn shouldStopAdvancingFn) throws Exception {
+        for (InternalTimerServiceImpl<?, ?> service : timerServices.values()) {
+            if (!service.tryAdvanceWatermark(watermark.getTimestamp(), shouldStopAdvancingFn)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     //////////////////				Fault Tolerance Methods				///////////////////
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/MailboxWatermarkProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/MailboxWatermarkProcessor.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A helper class to let operators emit watermarks incrementally from mailbox. Instead of emitting
+ * all the watermarks at once in a single {@code processWatermark} call, if a mail in mailbox is
+ * present, the process of firing timers is interrupted and a continuation to finish it off later is
+ * scheduled via a mailbox mail.
+ *
+ * <p>Note that interrupting firing timers can change order of some invocations. It is possible that
+ * between firing timers, some records might be processed.
+ */
+@Internal
+public class MailboxWatermarkProcessor<OUT> {
+    protected static final Logger LOG = LoggerFactory.getLogger(MailboxWatermarkProcessor.class);
+
+    private final Output<StreamRecord<OUT>> output;
+    private final MailboxExecutor mailboxExecutor;
+    private final InternalTimeServiceManager<?> internalTimeServiceManager;
+    /**
+     * Flag to indicate whether a progress watermark is scheduled in the mailbox. This is used to
+     * avoid duplicate scheduling in case we have multiple watermarks to process.
+     */
+    private boolean progressWatermarkScheduled = false;
+
+    private Watermark maxInputWatermark = Watermark.UNINITIALIZED;
+
+    public MailboxWatermarkProcessor(
+            Output<StreamRecord<OUT>> output,
+            MailboxExecutor mailboxExecutor,
+            InternalTimeServiceManager<?> internalTimeServiceManager) {
+        this.output = checkNotNull(output);
+        this.mailboxExecutor = checkNotNull(mailboxExecutor);
+        this.internalTimeServiceManager = checkNotNull(internalTimeServiceManager);
+    }
+
+    public void emitWatermarkInsideMailbox(Watermark mark) throws Exception {
+        maxInputWatermark =
+                new Watermark(Math.max(maxInputWatermark.getTimestamp(), mark.getTimestamp()));
+        emitWatermarkInsideMailbox();
+    }
+
+    private void emitWatermarkInsideMailbox() throws Exception {
+        // Try to progress min watermark as far as we can.
+        if (internalTimeServiceManager.tryAdvanceWatermark(
+                maxInputWatermark, mailboxExecutor::shouldInterrupt)) {
+            // In case output watermark has fully progressed emit it downstream.
+            output.emitWatermark(maxInputWatermark);
+        } else if (!progressWatermarkScheduled) {
+            progressWatermarkScheduled = true;
+            // We still have work to do, but we need to let other mails to be processed first.
+            mailboxExecutor.execute(
+                    () -> {
+                        progressWatermarkScheduled = false;
+                        emitWatermarkInsideMailbox();
+                    },
+                    "emitWatermarkInsideMailbox");
+        } else {
+            // We're not guaranteed that MailboxProcessor is going to process all mails before
+            // processing additional input, so the advanceWatermark could be called before the
+            // previous watermark is fully processed.
+            LOG.debug("emitWatermarkInsideMailbox is already scheduled, skipping.");
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
@@ -86,7 +86,8 @@ public class StreamOperatorFactoryUtil {
                                 processingTimeService != null
                                         ? () -> processingTimeService
                                         : processingTimeServiceFactory,
-                                operatorEventDispatcher));
+                                operatorEventDispatcher,
+                                mailboxExecutor));
         if (op instanceof YieldingOperator) {
             ((YieldingOperator<?>) op).setMailboxExecutor(mailboxExecutor);
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
@@ -87,6 +87,9 @@ public class StreamOperatorFactoryUtil {
                                         ? () -> processingTimeService
                                         : processingTimeServiceFactory,
                                 operatorEventDispatcher));
+        if (op instanceof YieldingOperator) {
+            ((YieldingOperator<?>) operatorFactory).setMailboxExecutor(mailboxExecutor);
+        }
         return new Tuple2<>(op, Optional.ofNullable(processingTimeService));
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorFactoryUtil.java
@@ -88,7 +88,7 @@ public class StreamOperatorFactoryUtil {
                                         : processingTimeServiceFactory,
                                 operatorEventDispatcher));
         if (op instanceof YieldingOperator) {
-            ((YieldingOperator<?>) operatorFactory).setMailboxExecutor(mailboxExecutor);
+            ((YieldingOperator<?>) op).setMailboxExecutor(mailboxExecutor);
         }
         return new Tuple2<>(op, Optional.ofNullable(processingTimeService));
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorParameters.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorParameters.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.runtime.operators.coordination.OperatorEventDispatcher;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -44,6 +45,7 @@ public class StreamOperatorParameters<OUT> {
     private final Output<StreamRecord<OUT>> output;
     private final Supplier<ProcessingTimeService> processingTimeServiceFactory;
     private final OperatorEventDispatcher operatorEventDispatcher;
+    private final MailboxExecutor mailboxExecutor;
 
     /**
      * The ProcessingTimeService, lazily created, but cached so that we don't create more than one.
@@ -55,12 +57,14 @@ public class StreamOperatorParameters<OUT> {
             StreamConfig config,
             Output<StreamRecord<OUT>> output,
             Supplier<ProcessingTimeService> processingTimeServiceFactory,
-            OperatorEventDispatcher operatorEventDispatcher) {
+            OperatorEventDispatcher operatorEventDispatcher,
+            MailboxExecutor mailboxExecutor) {
         this.containingTask = containingTask;
         this.config = config;
         this.output = output;
         this.processingTimeServiceFactory = processingTimeServiceFactory;
         this.operatorEventDispatcher = operatorEventDispatcher;
+        this.mailboxExecutor = mailboxExecutor;
     }
 
     public StreamTask<?, ?> getContainingTask() {
@@ -84,5 +88,9 @@ public class StreamOperatorParameters<OUT> {
 
     public OperatorEventDispatcher getOperatorEventDispatcher() {
         return operatorEventDispatcher;
+    }
+
+    public MailboxExecutor getMailboxExecutor() {
+        return mailboxExecutor;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/YieldingOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/YieldingOperator.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+
+/**
+ * A V1 operator that needs access to the {@link MailboxExecutor} should implement this interface.
+ * Note, this interface is not needed when using {@link StreamOperatorFactory} or {@link
+ * AbstractStreamOperatorV2} as those have access to the {@link MailboxExecutor} via {@link
+ * StreamOperatorParameters#getMailboxExecutor()}
+ */
+@Internal
+public interface YieldingOperator<OUT> extends StreamOperator<OUT> {
+    void setMailboxExecutor(MailboxExecutor mailboxExecutor);
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/YieldingOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/YieldingOperatorFactory.java
@@ -21,10 +21,14 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 
 /**
- * An operator that needs access to the {@link MailboxExecutor} to yield to downstream operators
+ * This class is no longer needed. {@link MailboxExecutor} is accessible via {@link
+ * StreamOperatorParameters#getMailboxExecutor()}.
+ *
+ * <p>An operator that needs access to the {@link MailboxExecutor} to yield to downstream operators
  * needs to be created through a factory implementing this interface.
  */
 @Experimental
+@Deprecated
 public interface YieldingOperatorFactory<OUT> extends StreamOperatorFactory<OUT> {
     void setMailboxExecutor(MailboxExecutor mailboxExecutor);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
@@ -92,6 +92,13 @@ public class BatchExecutionInternalTimeServiceManager<K>
     }
 
     @Override
+    public boolean tryAdvanceWatermark(
+            Watermark watermark, ShouldStopAdvancingFn shouldStopAdvancingFn) {
+        advanceWatermark(watermark);
+        return true;
+    }
+
+    @Override
     public void snapshotToRawKeyedState(
             KeyedStateCheckpointOutputStream context, String operatorName) throws Exception {
         throw new UnsupportedOperationException("Checkpoints are not supported in BATCH execution");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -955,6 +955,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     }
 
     @VisibleForTesting
+    public boolean runSingleMailboxLoop() throws Exception {
+        return mailboxProcessor.runSingleMailboxLoop();
+    }
+
+    @VisibleForTesting
     public boolean runMailboxStep() throws Exception {
         return mailboxProcessor.runMailboxStep();
     }
@@ -1124,6 +1129,10 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
     public MailboxExecutorFactory getMailboxExecutorFactory() {
         return this.mailboxProcessor::getMailboxExecutor;
+    }
+
+    public boolean hasMail() {
+        return mailboxProcessor.hasMail();
     }
 
     private boolean taskIsAvailable() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxExecutorImpl.java
@@ -103,4 +103,11 @@ public final class MailboxExecutorImpl implements MailboxExecutor {
             return false;
         }
     }
+
+    @Override
+    public boolean shouldInterrupt() {
+        // TODO: FLINK-35051 we shouldn't interrupt for every mail, but only for the time sensitive
+        // ones, for example related to checkpointing.
+        return mailbox.hasMail();
+    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -245,6 +245,22 @@ public class MailboxProcessor implements Closeable {
      * @return true if something was processed.
      */
     @VisibleForTesting
+    public boolean runSingleMailboxLoop() throws Exception {
+        suspended = !mailboxLoopRunning;
+        boolean processed = processMail(mailbox, true);
+        if (isDefaultActionAvailable() && isNextLoopPossible()) {
+            mailboxDefaultAction.runDefaultAction(new MailboxController(this));
+            processed = true;
+        }
+        return processed;
+    }
+
+    /**
+     * Execute a single (as small as possible) step of the mailbox.
+     *
+     * @return true if something was processed.
+     */
+    @VisibleForTesting
     public boolean runMailboxStep() throws Exception {
         suspended = !mailboxLoopRunning;
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/CheckpointConfigFromConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/CheckpointConfigFromConfigurationTest.java
@@ -151,6 +151,14 @@ public class CheckpointConfigFromConfigurationTest {
                         .viaSetter(CheckpointConfig::enableUnalignedCheckpoints)
                         .getterVia(CheckpointConfig::isUnalignedCheckpointsEnabled)
                         .nonDefaultValue(true),
+                TestSpec.testValue(true)
+                        .whenSetFromFile(
+                                "execution.checkpointing.unaligned.interruptible-timers.enabled",
+                                "true")
+                        .viaSetter(CheckpointConfig::enableUnalignedCheckpointsInterruptibleTimers)
+                        .getterVia(
+                                CheckpointConfig::isUnalignedCheckpointsInterruptibleTimersEnabled)
+                        .nonDefaultValue(true),
                 TestSpec.testValue(
                                 (CheckpointStorage)
                                         new FileSystemCheckpointStorage(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/PrintSinkTest.java
@@ -246,5 +246,10 @@ class PrintSinkTest {
         public boolean tryYield() throws FlinkRuntimeException {
             return false;
         }
+
+        @Override
+        public boolean shouldInterrupt() {
+            return false;
+        }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/MailboxWatermarkProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/MailboxWatermarkProcessorTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
+import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
+import org.apache.flink.streaming.runtime.tasks.mailbox.Mail;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+import org.apache.flink.streaming.util.CollectorOutput;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link MailboxWatermarkProcessor}. */
+class MailboxWatermarkProcessorTest {
+
+    @Test
+    void testEmitWatermarkInsideMailbox() throws Exception {
+        final List<StreamElement> emittedElements = new ArrayList<>();
+        final TaskMailboxImpl mailbox = new TaskMailboxImpl();
+        final InternalTimeServiceManager<?> timerService = new NoOpInternalTimeServiceManager();
+
+        final MailboxWatermarkProcessor<StreamRecord<String>> watermarkProcessor =
+                new MailboxWatermarkProcessor<>(
+                        new CollectorOutput<>(emittedElements),
+                        new MailboxExecutorImpl(mailbox, 0, StreamTaskActionExecutor.IMMEDIATE),
+                        timerService);
+        final List<Watermark> expectedOutput = new ArrayList<>();
+        watermarkProcessor.emitWatermarkInsideMailbox(new Watermark(1));
+        watermarkProcessor.emitWatermarkInsideMailbox(new Watermark(2));
+        watermarkProcessor.emitWatermarkInsideMailbox(new Watermark(3));
+        expectedOutput.add(new Watermark(1));
+        expectedOutput.add(new Watermark(2));
+        expectedOutput.add(new Watermark(3));
+
+        assertThat(emittedElements).containsExactlyElementsOf(expectedOutput);
+
+        mailbox.put(new Mail(() -> {}, TaskMailbox.MIN_PRIORITY, "checkpoint mail"));
+
+        watermarkProcessor.emitWatermarkInsideMailbox(new Watermark(4));
+        watermarkProcessor.emitWatermarkInsideMailbox(new Watermark(5));
+
+        assertThat(emittedElements).containsExactlyElementsOf(expectedOutput);
+
+        while (mailbox.hasMail()) {
+            mailbox.take(TaskMailbox.MIN_PRIORITY).run();
+        }
+        // Watermark(4) is processed together with Watermark(5)
+        expectedOutput.add(new Watermark(5));
+
+        assertThat(emittedElements).containsExactlyElementsOf(expectedOutput);
+    }
+
+    private static class NoOpInternalTimeServiceManager
+            implements InternalTimeServiceManager<Object> {
+        @Override
+        public <N> InternalTimerService<N> getInternalTimerService(
+                String name,
+                TypeSerializer<Object> keySerializer,
+                TypeSerializer<N> namespaceSerializer,
+                Triggerable<Object, N> triggerable) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <N> InternalTimerService<N> getAsyncInternalTimerService(
+                String name,
+                TypeSerializer<Object> keySerializer,
+                TypeSerializer<N> namespaceSerializer,
+                Triggerable<Object, N> triggerable,
+                AsyncExecutionController<Object> asyncExecutionController) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void advanceWatermark(Watermark watermark) throws Exception {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean tryAdvanceWatermark(
+                Watermark watermark, ShouldStopAdvancingFn shouldStopAdvancingFn) throws Exception {
+            return !shouldStopAdvancingFn.test();
+        }
+
+        @Override
+        public void snapshotToRawKeyedState(
+                KeyedStateCheckpointOutputStream stateCheckpointOutputStream, String operatorName)
+                throws Exception {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsInterruptibleTimersTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsInterruptibleTimersTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.checkpointing;
+
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.MailboxWatermarkProcessor;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.operators.YieldingOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTask;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarness;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskMailboxTestHarnessBuilder;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nullable;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests interaction between {@link CheckpointingOptions#ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS} and
+ * unaligned checkpoints.
+ */
+@ExtendWith(TestLoggerExtension.class)
+class UnalignedCheckpointsInterruptibleTimersTest {
+
+    @Test
+    void testSingleWatermarkHoldingOperatorInTheChain() throws Exception {
+        final Instant firstWindowEnd = Instant.ofEpochMilli(1000L);
+        final int numFirstWindowTimers = 2;
+        final Instant secondWindowEnd = Instant.ofEpochMilli(2000L);
+        final int numSecondWindowTimers = 2;
+
+        try (final StreamTaskMailboxTestHarness<String> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(OneInputStreamTask::new, Types.STRING)
+                        .modifyStreamConfig(
+                                UnalignedCheckpointsInterruptibleTimersTest::setupStreamConfig)
+                        .addInput(Types.STRING)
+                        .setupOperatorChain(
+                                SimpleOperatorFactory.of(
+                                        new MultipleTimersAtTheSameTimestamp()
+                                                .withTimers(firstWindowEnd, numFirstWindowTimers)
+                                                .withTimers(
+                                                        secondWindowEnd, numSecondWindowTimers)))
+                        .name("first")
+                        .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                        .build()) {
+            harness.processElement(new StreamRecord<>("register timers"));
+            harness.processAll();
+            harness.processElement(asWatermark(firstWindowEnd));
+            harness.processElement(asWatermark(secondWindowEnd));
+
+            assertThat(harness.getOutput())
+                    .containsExactly(
+                            asFiredRecord("key-0"),
+                            asMailRecord("key-0"),
+                            asFiredRecord("key-1"),
+                            asMailRecord("key-1"),
+                            asWatermark(firstWindowEnd),
+                            asFiredRecord("key-0"),
+                            asMailRecord("key-0"),
+                            asFiredRecord("key-1"),
+                            asMailRecord("key-1"),
+                            asWatermark(secondWindowEnd));
+        }
+    }
+
+    @Test
+    void testWatermarkProgressWithNoTimers() throws Exception {
+        final Instant firstWindowEnd = Instant.ofEpochMilli(1000L);
+        final Instant secondWindowEnd = Instant.ofEpochMilli(2000L);
+
+        try (final StreamTaskMailboxTestHarness<String> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(OneInputStreamTask::new, Types.STRING)
+                        .modifyStreamConfig(
+                                UnalignedCheckpointsInterruptibleTimersTest::setupStreamConfig)
+                        .addInput(Types.STRING)
+                        .setupOperatorChain(
+                                SimpleOperatorFactory.of(new MultipleTimersAtTheSameTimestamp()))
+                        .name("first")
+                        .finishForSingletonOperatorChain(StringSerializer.INSTANCE)
+                        .build()) {
+            harness.setAutoProcess(false);
+            harness.processElement(new StreamRecord<>("impulse"));
+            harness.processAll();
+            harness.processElement(asWatermark(firstWindowEnd));
+            harness.processElement(asWatermark(secondWindowEnd));
+
+            final List<Watermark> seenWatermarks = new ArrayList<>();
+            while (seenWatermarks.size() < 2) {
+                harness.processSingleStep();
+                Object outputElement;
+                while ((outputElement = harness.getOutput().poll()) != null) {
+                    if (outputElement instanceof Watermark) {
+                        seenWatermarks.add((Watermark) outputElement);
+                    }
+                }
+            }
+            assertThat(seenWatermarks)
+                    .containsExactly(asWatermark(firstWindowEnd), asWatermark(secondWindowEnd));
+        }
+    }
+
+    private static Watermark asWatermark(Instant timestamp) {
+        return new Watermark(timestamp.toEpochMilli());
+    }
+
+    private static StreamRecord<String> asFiredRecord(String key) {
+        return new StreamRecord("fired-" + key);
+    }
+
+    private static StreamRecord<String> asMailRecord(String key) {
+        return new StreamRecord("mail-" + key);
+    }
+
+    private static void setupStreamConfig(StreamConfig cfg) {
+        cfg.setUnalignedCheckpointsEnabled(true);
+        cfg.setUnalignedCheckpointsSplittableTimersEnabled(true);
+        cfg.setStateKeySerializer(StringSerializer.INSTANCE);
+    }
+
+    private static class MultipleTimersAtTheSameTimestamp extends AbstractStreamOperator<String>
+            implements OneInputStreamOperator<String, String>,
+                    Triggerable<String, String>,
+                    YieldingOperator<String> {
+
+        private final Map<Instant, Integer> timersToRegister;
+        private transient @Nullable MailboxExecutor mailboxExecutor;
+        private transient @Nullable MailboxWatermarkProcessor watermarkProcessor;
+
+        MultipleTimersAtTheSameTimestamp() {
+            this(Collections.emptyMap());
+        }
+
+        MultipleTimersAtTheSameTimestamp(Map<Instant, Integer> timersToRegister) {
+            this.timersToRegister = timersToRegister;
+        }
+
+        @Override
+        public void setMailboxExecutor(MailboxExecutor mailboxExecutor) {
+            this.mailboxExecutor = mailboxExecutor;
+        }
+
+        @Override
+        public void open() throws Exception {
+            super.open();
+            if (getTimeServiceManager().isPresent()) {
+                this.watermarkProcessor =
+                        new MailboxWatermarkProcessor(
+                                output, mailboxExecutor, getTimeServiceManager().get());
+            }
+        }
+
+        @Override
+        public void processElement(StreamRecord<String> element) {
+            if (!timersToRegister.isEmpty()) {
+                final InternalTimerService<String> timers =
+                        getInternalTimerService("timers", StringSerializer.INSTANCE, this);
+                for (Map.Entry<Instant, Integer> entry : timersToRegister.entrySet()) {
+                    for (int keyIdx = 0; keyIdx < entry.getValue(); keyIdx++) {
+                        final String key = String.format("key-%d", keyIdx);
+                        setCurrentKey(key);
+                        timers.registerEventTimeTimer(
+                                String.format("window-%s", entry.getKey()),
+                                entry.getKey().toEpochMilli());
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void processWatermark(Watermark mark) throws Exception {
+            if (watermarkProcessor == null) {
+                super.processWatermark(mark);
+            } else {
+                watermarkProcessor.emitWatermarkInsideMailbox(mark);
+            }
+        }
+
+        @Override
+        public void onEventTime(InternalTimer<String, String> timer) throws Exception {
+            mailboxExecutor.execute(
+                    () -> output.collect(asMailRecord(timer.getKey())), "mail-" + timer.getKey());
+            output.collect(asFiredRecord(timer.getKey()));
+        }
+
+        @Override
+        public void onProcessingTime(InternalTimer<String, String> timer) throws Exception {}
+
+        MultipleTimersAtTheSameTimestamp withTimers(Instant timestamp, int count) {
+            final Map<Instant, Integer> copy = new HashMap<>(timersToRegister);
+            copy.put(timestamp, count);
+            return new MultipleTimersAtTheSameTimestamp(copy);
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/UnalignedCheckpointsTest.java
@@ -548,7 +548,7 @@ class UnalignedCheckpointsTest {
     }
 
     @Test
-    void testNotifyAbortCheckpointBeforeCanellingAsyncCheckpoint() throws Exception {
+    public void testNotifyAbortCheckpointBeforeCancellingAsyncCheckpoint() throws Exception {
         ValidateAsyncFutureNotCompleted handler = new ValidateAsyncFutureNotCompleted(1);
         inputGate = createInputGate(2, handler);
         handler.setInputGate(inputGate);
@@ -699,7 +699,7 @@ class UnalignedCheckpointsTest {
      * Tests {@link
      * SingleCheckpointBarrierHandler#processCancellationBarrier(CancelCheckpointMarker,
      * InputChannelInfo)} abort the current pending checkpoint triggered by {@link
-     * CheckpointBarrierHandler#processBarrier(CheckpointBarrier, InputChannelInfo)}.
+     * CheckpointBarrierHandler#processBarrier(CheckpointBarrier, InputChannelInfo, boolean)}.
      */
     @Test
     void testProcessCancellationBarrierAfterProcessBarrier() throws Exception {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
@@ -52,12 +52,6 @@ public abstract class TableStreamOperator<OUT> extends AbstractStreamOperator<OU
         this.ctx = new ContextImpl(getProcessingTimeService());
     }
 
-    @Override
-    public void processWatermark(Watermark mark) throws Exception {
-        super.processWatermark(mark);
-        currentWatermark = mark.getTimestamp();
-    }
-
     /** Compute memory size from memory faction. */
     public long computeMemorySize() {
         final Environment environment = getContainingTask().getEnvironment();
@@ -72,6 +66,11 @@ public abstract class TableStreamOperator<OUT> extends AbstractStreamOperator<OU
                                         environment.getUserCodeClassLoader().asClassLoader()));
     }
 
+    @Override
+    public void processWatermark(Watermark mark) throws Exception {
+        currentWatermark = mark.getTimestamp();
+        super.processWatermark(mark);
+    }
     /** Information available in an invocation of processElement. */
     protected class ContextImpl implements TimerService {
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/TableStreamOperator.java
@@ -52,6 +52,11 @@ public abstract class TableStreamOperator<OUT> extends AbstractStreamOperator<OU
         this.ctx = new ContextImpl(getProcessingTimeService());
     }
 
+    @Override
+    public boolean useSplittableTimers() {
+        return true;
+    }
+
     /** Compute memory size from memory faction. */
     public long computeMemorySize() {
         final Environment environment = getContainingTask().getEnvironment();
@@ -71,6 +76,7 @@ public abstract class TableStreamOperator<OUT> extends AbstractStreamOperator<OU
         currentWatermark = mark.getTimestamp();
         super.processWatermark(mark);
     }
+
     /** Information available in an invocation of processElement. */
     protected class ContextImpl implements TimerService {
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputStreamOperatorBase.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputStreamOperatorBase.java
@@ -272,7 +272,8 @@ public abstract class MultipleInputStreamOperatorBase extends AbstractStreamOper
                 streamConfig,
                 output,
                 multipleInputOperatorParameters::getProcessingTimeService,
-                multipleInputOperatorParameters.getOperatorEventDispatcher());
+                multipleInputOperatorParameters.getOperatorEventDispatcher(),
+                multipleInputOperatorParameters.getMailboxExecutor());
     }
 
     protected StreamConfig createStreamConfig(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/multipleinput/MultipleInputTestBase.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -154,6 +155,7 @@ public class MultipleInputTestBase {
                 createStreamConfig(),
                 output,
                 TestProcessingTimeService::new,
-                null);
+                null,
+                new SyncMailboxExecutor());
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/BufferDataOverWindowOperatorTest.java
@@ -20,10 +20,7 @@ package org.apache.flink.table.runtime.operators.over;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
-import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
-import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.memory.MemoryManagerBuilder;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.streaming.api.graph.StreamConfig;
@@ -55,7 +52,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowOperatorTest.comparator;
 import static org.apache.flink.table.runtime.operators.over.NonBufferOverWindowOperatorTest.function;
@@ -70,14 +66,10 @@ import static org.mockito.Mockito.when;
 /** Test for {@link BufferDataOverWindowOperator}. */
 public class BufferDataOverWindowOperatorTest {
 
-    private static final int MEMORY_SIZE = 50 * 1024 * 32;
     private RowType valueType =
             new RowType(Collections.singletonList(new RowType.RowField("f0", new BigIntType())));
 
     private List<GenericRowData> collect;
-    private MemoryManager memoryManager =
-            MemoryManagerBuilder.newBuilder().setMemorySize(MEMORY_SIZE).build();
-    private IOManager ioManager;
     private BufferDataOverWindowOperator operator;
     private GeneratedRecordComparator boundComparator =
             new GeneratedRecordComparator("", "", new Object[0]) {
@@ -89,7 +81,6 @@ public class BufferDataOverWindowOperatorTest {
 
     @Before
     public void before() throws Exception {
-        ioManager = new IOManagerAsync();
         collect = new ArrayList<>();
     }
 
@@ -195,66 +186,45 @@ public class BufferDataOverWindowOperatorTest {
     }
 
     private void test(OverWindowFrame[] frames, GenericRowData[] expect) throws Exception {
-        MockEnvironment env =
-                new MockEnvironmentBuilder()
-                        .setIOManager(ioManager)
-                        .setMemoryManager(memoryManager)
-                        .build();
+        MockEnvironment env = new MockEnvironmentBuilder().build();
         StreamTask<Object, StreamOperator<Object>> task =
                 new StreamTask<Object, StreamOperator<Object>>(env) {
                     @Override
                     protected void init() {}
                 };
+        StreamConfig streamConfig = mock(StreamConfig.class);
+        when(streamConfig.<RowData>getTypeSerializerIn1(
+                        Thread.currentThread().getContextClassLoader()))
+                .thenReturn(inputSer);
+        when(streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(
+                        eq(ManagedMemoryUseCase.OPERATOR),
+                        any(Configuration.class),
+                        any(Configuration.class),
+                        any(ClassLoader.class)))
+                .thenReturn(0.99);
+        when(streamConfig.getOperatorID()).thenReturn(new OperatorID());
         operator =
                 new BufferDataOverWindowOperator(frames, comparator, true) {
-                    {
-                        output =
-                                new NonBufferOverWindowOperatorTest.ConsumerOutput(
-                                        new Consumer<RowData>() {
-                                            @Override
-                                            public void accept(RowData r) {
-                                                collect.add(
-                                                        GenericRowData.of(
-                                                                r.getInt(0),
-                                                                r.getLong(1),
-                                                                r.getLong(2),
-                                                                r.getLong(3),
-                                                                r.getLong(4)));
-                                            }
-                                        });
-                    }
-
-                    @Override
-                    public ClassLoader getUserCodeClassloader() {
-                        return Thread.currentThread().getContextClassLoader();
-                    }
-
-                    @Override
-                    public StreamConfig getOperatorConfig() {
-                        StreamConfig conf = mock(StreamConfig.class);
-                        when(conf.<RowData>getTypeSerializerIn1(getUserCodeClassloader()))
-                                .thenReturn(inputSer);
-                        when(conf.getManagedMemoryFractionOperatorUseCaseOfSlot(
-                                        eq(ManagedMemoryUseCase.OPERATOR),
-                                        any(Configuration.class),
-                                        any(Configuration.class),
-                                        any(ClassLoader.class)))
-                                .thenReturn(0.99);
-                        return conf;
-                    }
-
-                    @Override
-                    public StreamTask<?, ?> getContainingTask() {
-                        return task;
-                    }
-
                     @Override
                     public StreamingRuntimeContext getRuntimeContext() {
                         return mock(StreamingRuntimeContext.class);
                     }
                 };
         operator.setProcessingTimeService(new TestProcessingTimeService());
+        operator.setup(
+                task,
+                streamConfig,
+                new NonBufferOverWindowOperatorTest.ConsumerOutput(
+                        r ->
+                                collect.add(
+                                        GenericRowData.of(
+                                                r.getInt(0),
+                                                r.getLong(1),
+                                                r.getLong(2),
+                                                r.getLong(3),
+                                                r.getLong(4)))));
         operator.open();
+
         addRow(0, 1L, 4L); /* 1 **/
         addRow(0, 1L, 1L); /* 2 **/
         addRow(0, 1L, 1L); /* 3 **/

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/NonBufferOverWindowOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/over/NonBufferOverWindowOperatorTest.java
@@ -18,13 +18,20 @@
 
 package org.apache.flink.table.runtime.operators.over;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.table.data.GenericRowData;
@@ -48,6 +55,8 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -119,44 +128,42 @@ public class NonBufferOverWindowOperatorTest {
     }
 
     private void test(boolean[] resetAccumulators, GenericRowData[] expect) throws Exception {
+        MockEnvironment env = new MockEnvironmentBuilder().build();
+        StreamTask<Object, StreamOperator<Object>> task =
+                new StreamTask<Object, StreamOperator<Object>>(env) {
+                    @Override
+                    protected void init() {}
+                };
+        StreamConfig streamConfig = mock(StreamConfig.class);
+        when(streamConfig.<RowData>getTypeSerializerIn1(
+                        Thread.currentThread().getContextClassLoader()))
+                .thenReturn(inputSer);
+        when(streamConfig.getManagedMemoryFractionOperatorUseCaseOfSlot(
+                        eq(ManagedMemoryUseCase.OPERATOR),
+                        any(Configuration.class),
+                        any(Configuration.class),
+                        any(ClassLoader.class)))
+                .thenReturn(0.99);
+        when(streamConfig.getOperatorID()).thenReturn(new OperatorID());
         operator =
                 new NonBufferOverWindowOperator(functions, comparator, resetAccumulators) {
-                    {
-                        output =
-                                new ConsumerOutput(
-                                        new Consumer<RowData>() {
-                                            @Override
-                                            public void accept(RowData r) {
-                                                collect.add(
-                                                        GenericRowData.of(
-                                                                r.getInt(0),
-                                                                r.getLong(1),
-                                                                r.getLong(2),
-                                                                r.getLong(3),
-                                                                r.getLong(4)));
-                                            }
-                                        });
-                    }
-
-                    @Override
-                    public ClassLoader getUserCodeClassloader() {
-                        return Thread.currentThread().getContextClassLoader();
-                    }
-
-                    @Override
-                    public StreamConfig getOperatorConfig() {
-                        StreamConfig conf = mock(StreamConfig.class);
-                        when(conf.<RowData>getTypeSerializerIn1(getUserCodeClassloader()))
-                                .thenReturn(inputSer);
-                        return conf;
-                    }
-
-                    @Override
                     public StreamingRuntimeContext getRuntimeContext() {
                         return mock(StreamingRuntimeContext.class);
                     }
                 };
         operator.setProcessingTimeService(new TestProcessingTimeService());
+        operator.setup(
+                task,
+                streamConfig,
+                new ConsumerOutput(
+                        r ->
+                                collect.add(
+                                        GenericRowData.of(
+                                                r.getInt(0),
+                                                r.getLong(1),
+                                                r.getLong(2),
+                                                r.getLong(3),
+                                                r.getLong(4)))));
         operator.open();
         addRow(0, 1L, 4L);
         addRow(0, 1L, 1L);

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -120,6 +120,8 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
                     Duration.ofMillis(100),
                     Duration.ofSeconds(2));
             randomize(conf, CheckpointingOptions.CLEANER_PARALLEL_MODE, true, false);
+            randomize(
+                    conf, CheckpointingOptions.ENABLE_UNALIGNED_INTERRUPTIBLE_TIMERS, true, false);
             randomize(conf, ExecutionOptions.SNAPSHOT_COMPRESSION, true, false);
             if (!conf.contains(CheckpointingOptions.FILE_MERGING_ENABLED)) {
                 randomize(conf, CheckpointingOptions.FILE_MERGING_ENABLED, true);


### PR DESCRIPTION
## What is the purpose of the change

Currently many operators when processing watermarks, are firing multiple timers each producing potentially multiple output records. If this happens under back-pressure, it can quite easily block the subtask thread in the hard back-pressure state for an extended period of time blocking mailbox from processing any incoming mails, like processing checkpoint barriers and completing unaligned checkpoints.

To address this issue, we would like to propose to make firing multiple timers interruptible in such a way, that Flink would be able to interrupt firing timers, perform checkpoint and return back to firing timers.

## Brief change log

Please check individual commit messages.

## Verifying this change

Covered by both existing tests and added new tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
