### PR TITLE
[FLINK-35531] Avoid calling hsync in flush method in BaseHadoopFsRecoverableFsDataOutputStream

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
@@ -59,7 +59,7 @@ public abstract class BaseHadoopFsRecoverableFsDataOutputStream
 
     @Override
     public void flush() throws IOException {
-        out.hsync();
+        out.hflush();
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

In the flush method in BaseHadoopFsRecoverableFsDataOutputStream, use hflush instead of hsync.

## Brief change log

FLINK-30128 modified the flush method of `HadoopRecoverableFsDataOutputStream` from hflush to hsync, which caused Flink's performance to decrease when writing to HDFS.


## Verifying this change

local test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
