### PR TITLE
[FLINK-35522][runtime] Fix the issue that the source task may get stuck in speculative execution mode.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -654,14 +654,14 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
                 assignmentTracker.uncheckpointedAssignments().get(subtaskIndex);
 
         if (cachedSplits != null) {
-            if (supportsConcurrentExecutionAttempts) {
-                assignSplitsToAttempt(subtaskIndex, attemptNumber, new ArrayList<>(cachedSplits));
-                if (hasNoMoreSplits(subtaskIndex)) {
-                    signalNoMoreSplitsToAttempt(subtaskIndex, attemptNumber);
-                }
-            } else {
+            if (!supportsConcurrentExecutionAttempts) {
                 throw new IllegalStateException("No cached split is expected.");
             }
+            assignSplitsToAttempt(subtaskIndex, attemptNumber, new ArrayList<>(cachedSplits));
+        }
+
+        if (supportsConcurrentExecutionAttempts && hasNoMoreSplits(subtaskIndex)) {
+            signalNoMoreSplitsToAttempt(subtaskIndex, attemptNumber);
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/SpeculativeSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/SpeculativeSchedulerITCase.java
@@ -40,7 +40,10 @@ import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceEnumerator;
 import org.apache.flink.api.connector.source.lib.util.IteratorSourceReader;
 import org.apache.flink.api.connector.source.lib.util.IteratorSourceSplit;
 import org.apache.flink.api.java.tuple.Tuple3;
@@ -77,6 +80,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -177,6 +181,13 @@ class SpeculativeSchedulerITCase {
     @Test
     void testSpeculativeExecutionOfNewSource() throws Exception {
         executeJob(this::setupJobWithSlowNewSource);
+        waitUntilJobArchived();
+        checkResults();
+    }
+
+    @Test
+    void testSpeculativeExecutionOfNewSourceWithFailure() throws Exception {
+        executeJob(env -> setupJobWithSlowNewSource(env, true));
         waitUntilJobArchived();
         checkResults();
     }
@@ -355,9 +366,14 @@ class SpeculativeSchedulerITCase {
     }
 
     private void setupJobWithSlowNewSource(StreamExecutionEnvironment env) {
+        setupJobWithSlowNewSource(env, false);
+    }
+
+    private void setupJobWithSlowNewSource(
+            StreamExecutionEnvironment env, boolean forceFailureFlag) {
         final DataStream<Long> source =
                 env.fromSource(
-                        new TestingNumberSequenceSource(),
+                        new TestingNumberSequenceSource(forceFailureFlag),
                         WatermarkStrategy.noWatermarks(),
                         "source");
         addSink(source);
@@ -522,14 +538,39 @@ class SpeculativeSchedulerITCase {
     }
 
     private static class TestingNumberSequenceSource extends NumberSequenceSource {
-        private TestingNumberSequenceSource() {
+
+        private final boolean forceFailureFlag;
+        // When forceFailureCounter > 0, the source task will throw an exception on reader close
+        // until forceFailureCounter reaches 0.
+        public static AtomicInteger forceFailureCounter = new AtomicInteger(0);
+
+        private TestingNumberSequenceSource(boolean forceFailureFlag) {
             super(0, NUMBERS_TO_PRODUCE - 1);
+            this.forceFailureFlag = forceFailureFlag;
+            if (forceFailureFlag) {
+                forceFailureCounter = new AtomicInteger(1);
+            }
         }
 
         @Override
         public SourceReader<Long, NumberSequenceSplit> createReader(
                 SourceReaderContext readerContext) {
             return new TestingIteratorSourceReader(readerContext);
+        }
+
+        @Override
+        public SplitEnumerator<NumberSequenceSplit, Collection<NumberSequenceSplit>>
+                createEnumerator(final SplitEnumeratorContext<NumberSequenceSplit> enumContext) {
+
+            int splitSize = enumContext.currentParallelism();
+            // Simulating the case that the splits number less than the parallelism to verify
+            // unassigned source tasks and failover.
+            if (forceFailureFlag) {
+                splitSize = 1;
+            }
+            final List<NumberSequenceSplit> splits =
+                    splitNumberRange(0, NUMBERS_TO_PRODUCE - 1, splitSize);
+            return new IteratorSourceEnumerator<>(enumContext, splits);
         }
     }
 
@@ -545,6 +586,14 @@ class SpeculativeSchedulerITCase {
         public InputStatus pollNext(ReaderOutput<E> output) {
             maybeSleep();
             return super.pollNext(output);
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (TestingNumberSequenceSource.forceFailureCounter.get() > 0) {
+                TestingNumberSequenceSource.forceFailureCounter.decrementAndGet();
+                throw new RuntimeException("Forced failure for testing");
+            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

If the source task does not get assigned a split because the SplitEnumerator has no more splits, and a failover occurs during the closing process, the SourceCoordinatorContext will not resend the NoMoreSplit event to the newly started source task, causing the source vertex to remain stuck indefinitely.
This case may only occur in batch jobs where speculative execution has been enabled.

## Brief change log

fix the issue that the source task may get stuck in speculative execution mode.


## Verifying this change

  - *Added it case to verify the issue.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
