### PR TITLE
[FLINK-35537][BP-1.19] Fix exception when setting 'state.backend.rocksdb.compression.per.level' in yaml

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackend.java
@@ -64,6 +64,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -814,6 +815,8 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
             base = new Configuration();
         }
         Configuration configuration = new Configuration();
+        Map<String, String> baseMap = base.toMap();
+        Map<String, String> onTopMap = onTop.toMap();
         for (ConfigOption<?> option : RocksDBConfigurableOptions.CANDIDATE_CONFIGS) {
             Optional<?> baseValue = base.getOptional(option);
             Optional<?> topValue = onTop.getOptional(option);
@@ -821,7 +824,11 @@ public class EmbeddedRocksDBStateBackend extends AbstractManagedMemoryStateBacke
             if (topValue.isPresent() || baseValue.isPresent()) {
                 Object validValue = topValue.isPresent() ? topValue.get() : baseValue.get();
                 RocksDBConfigurableOptions.checkArgumentValid(option, validValue);
-                configuration.setString(option.key(), validValue.toString());
+                String valueString =
+                        topValue.isPresent()
+                                ? onTopMap.get(option.key())
+                                : baseMap.get(option.key());
+                configuration.setString(option.key(), valueString);
             }
         }
         return configuration;


### PR DESCRIPTION
## Backporting to 1.19, See #24902 

## What is the purpose of the change

See FLINK-35537, an exception thrown when setting 'state.backend.rocksdb.compression.per.level' in flink 1.19.0. I have confirmed that the problem comes from the `EmbeddedRocksDBStateBackend#mergeConfigurableOptions`, which merges two configuration map into one. It uses `toString` of each already parsed value and insert the value string into a new raw map. The `toString` gives the string format of enum list, not the legacy yaml form of the value. The new raw map get parsed later, that's when the error happens.

This PR fixes `EmbeddedRocksDBStateBackend#mergeConfigurableOptions`.

## Brief change log

 - `EmbeddedRocksDBStateBackend#mergeConfigurableOptions`.
 - Added test `testConfigureRocksDBCompressionPerLevel`


## Verifying this change

Newly added test `testConfigureRocksDBCompressionPerLevel`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
