### PR TITLE
[FLINK-35550][runtime] Move rescaling functionality into dedicated class RescaleManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultRescaleManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultRescaleManager.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.Temporal;
+import java.util.function.Supplier;
+
+/**
+ * {@code DefaultRescaleManager} manages triggering the next rescaling based on when the previous
+ * rescale operation happened and the available resources. It handles the event based on the
+ * following phases (in that order):
+ *
+ * <ol>
+ *   <li>Cooldown phase: No rescaling takes place (its upper threshold is defined by {@code
+ *       scalingIntervalMin}.
+ *   <li>Soft-rescaling phase: Rescaling is triggered if the desired amount of resources is
+ *       available.
+ *   <li>Hard-rescaling phase: Rescaling is triggered if a sufficient amount of resources is
+ *       available (its lower threshold is defined by (@code scalingIntervalMax}).
+ * </ol>
+ *
+ * @see Executing
+ */
+public class DefaultRescaleManager implements RescaleManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultRescaleManager.class);
+
+    private final Temporal initializationTime;
+    private final Supplier<Temporal> clock;
+
+    @VisibleForTesting final Duration scalingIntervalMin;
+    @VisibleForTesting @Nullable final Duration scalingIntervalMax;
+
+    private final RescaleManager.Context rescaleContext;
+
+    private boolean rescaleScheduled = false;
+
+    DefaultRescaleManager(
+            Temporal initializationTime,
+            RescaleManager.Context rescaleContext,
+            Duration scalingIntervalMin,
+            @Nullable Duration scalingIntervalMax) {
+        this(
+                initializationTime,
+                Instant::now,
+                rescaleContext,
+                scalingIntervalMin,
+                scalingIntervalMax);
+    }
+
+    @VisibleForTesting
+    DefaultRescaleManager(
+            Temporal initializationTime,
+            Supplier<Temporal> clock,
+            RescaleManager.Context rescaleContext,
+            Duration scalingIntervalMin,
+            @Nullable Duration scalingIntervalMax) {
+        this.initializationTime = initializationTime;
+        this.clock = clock;
+
+        Preconditions.checkArgument(
+                scalingIntervalMax == null || scalingIntervalMin.compareTo(scalingIntervalMax) <= 0,
+                "scalingIntervalMax should at least match or be longer than scalingIntervalMin.");
+        this.scalingIntervalMin = scalingIntervalMin;
+        this.scalingIntervalMax = scalingIntervalMax;
+
+        this.rescaleContext = rescaleContext;
+    }
+
+    @Override
+    public void onChange() {
+        if (timeSinceLastRescale().compareTo(scalingIntervalMin) > 0) {
+            maybeRescale();
+        } else if (!rescaleScheduled) {
+            rescaleScheduled = true;
+            rescaleContext.scheduleOperation(this::maybeRescale, scalingIntervalMin);
+        }
+    }
+
+    private Duration timeSinceLastRescale() {
+        return Duration.between(this.initializationTime, clock.get());
+    }
+
+    private void maybeRescale() {
+        rescaleScheduled = false;
+        if (rescaleContext.hasDesiredResources()) {
+            LOG.info("Desired parallelism for job was reached: Rescaling will be triggered.");
+            rescaleContext.rescale();
+        } else if (scalingIntervalMax != null) {
+            LOG.info(
+                    "The longer the pipeline runs, the more the (small) resource gain is worth the restarting time. "
+                            + "Last resource added does not meet the configured minimal parallelism change. Forced rescaling will be triggered after {} if the resource is still there.",
+                    scalingIntervalMax);
+
+            // reasoning for inconsistent scheduling:
+            // https://lists.apache.org/thread/m2w2xzfjpxlw63j0k7tfxfgs0rshhwwr
+            if (timeSinceLastRescale().compareTo(scalingIntervalMax) > 0) {
+                rescaleWithSufficientResources();
+            } else {
+                rescaleContext.scheduleOperation(
+                        this::rescaleWithSufficientResources, scalingIntervalMax);
+            }
+        }
+    }
+
+    private void rescaleWithSufficientResources() {
+        if (rescaleContext.hasSufficientResources()) {
+            LOG.info(
+                    "Resources for desired job parallelism couldn't be collected after {}: Rescaling will be enforced.",
+                    scalingIntervalMax);
+            rescaleContext.rescale();
+        }
+    }
+
+    public static class Factory implements RescaleManager.Factory {
+
+        private final Duration scalingIntervalMin;
+        @Nullable private final Duration scalingIntervalMax;
+
+        /**
+         * Creates a {@code Factory} instance based on the {@link AdaptiveScheduler}'s {@code
+         * Settings} for rescaling.
+         */
+        public static Factory fromSettings(AdaptiveScheduler.Settings settings) {
+            // it's not ideal that we use a AdaptiveScheduler internal class here. We might want to
+            // change that as part of a more general alignment of the rescaling configuration.
+            return new Factory(settings.getScalingIntervalMin(), settings.getScalingIntervalMax());
+        }
+
+        private Factory(Duration scalingIntervalMin, @Nullable Duration scalingIntervalMax) {
+            this.scalingIntervalMin = scalingIntervalMin;
+            this.scalingIntervalMax = scalingIntervalMax;
+        }
+
+        @Override
+        public DefaultRescaleManager create(Context rescaleContext, Instant lastRescale) {
+            return new DefaultRescaleManager(
+                    lastRescale, rescaleContext, scalingIntervalMin, scalingIntervalMax);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/RescaleManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/RescaleManager.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/** The {@code RescaleManager} decides on whether rescaling should happen or not. */
+public interface RescaleManager {
+
+    /** Is called if the environment changed in a way that a rescaling could be considered. */
+    void onChange();
+
+    /**
+     * The interface that can be used by the {@code RescaleManager} to communicate with the
+     * underlying system.
+     */
+    interface Context {
+
+        /**
+         * Returns {@code true} if the available resources are sufficient enough for a state
+         * transition; otherwise {@code false}.
+         */
+        boolean hasSufficientResources();
+
+        /**
+         * Returns {@code true} if the available resources meet the desired resources for the job;
+         * otherwise {@code false}.
+         */
+        boolean hasDesiredResources();
+
+        /** Triggers the rescaling of the job. */
+        void rescale();
+
+        /** Runs operation with a given delay in the underlying main thread. */
+        void scheduleOperation(Runnable callback, Duration delay);
+    }
+
+    /** Interface for creating {@code RescaleManager} instances. */
+    interface Factory {
+
+        /**
+         * Creates a {@code RescaleManager} instance for the given {@code rescaleContext} and
+         * previous rescale time.
+         */
+        RescaleManager create(Context rescaleContext, Instant lastRescale);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/scalingpolicy/EnforceMinimalIncreaseRescalingController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/scalingpolicy/EnforceMinimalIncreaseRescalingController.java
@@ -17,11 +17,8 @@
 
 package org.apache.flink.runtime.scheduler.adaptive.scalingpolicy;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
-
-import static org.apache.flink.configuration.JobManagerOptions.MIN_PARALLELISM_INCREASE;
 
 /**
  * Simple scaling policy. The user can configure a minimum cumulative parallelism increase to allow
@@ -31,8 +28,8 @@ public class EnforceMinimalIncreaseRescalingController implements RescalingContr
 
     private final int minParallelismIncrease;
 
-    public EnforceMinimalIncreaseRescalingController(Configuration configuration) {
-        minParallelismIncrease = configuration.get(MIN_PARALLELISM_INCREASE);
+    public EnforceMinimalIncreaseRescalingController(int minParallelismIncrease) {
+        this.minParallelismIncrease = minParallelismIncrease;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultRescaleManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultRescaleManagerTest.java
@@ -1,0 +1,553 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DefaultRescaleManagerTest {
+
+    @Test
+    void testProperConfiguration() {
+        final Duration scalingIntervalMin = Duration.ofMillis(1337);
+        final Duration scalingIntervalMax = Duration.ofMillis(7331);
+
+        final Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN, scalingIntervalMin);
+        configuration.set(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MAX, scalingIntervalMax);
+
+        final DefaultRescaleManager testInstance =
+                DefaultRescaleManager.Factory.fromSettings(
+                                AdaptiveScheduler.Settings.of(configuration))
+                        .create(TestingRescaleManagerContext.stableContext(), Instant.now());
+        assertThat(testInstance.scalingIntervalMin).isEqualTo(scalingIntervalMin);
+        assertThat(testInstance.scalingIntervalMax).isEqualTo(scalingIntervalMax);
+    }
+
+    @Test
+    void testInvalidConfiguration() {
+        final Duration cooldownThreshold = Duration.ofMinutes(2);
+        final TestingRescaleManagerContext ctx = TestingRescaleManagerContext.stableContext();
+        assertThatThrownBy(
+                        () ->
+                                new DefaultRescaleManager(
+                                        Instant.now(),
+                                        ctx,
+                                        cooldownThreshold,
+                                        cooldownThreshold.minusNanos(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testDesiredChangeEventDuringCooldown() {
+        final TestingRescaleManagerContext softScalePossibleCtx =
+                TestingRescaleManagerContext.stableContext().withDesiredRescaling();
+        final DefaultRescaleManager testInstance =
+                softScalePossibleCtx.createTestInstanceInCooldownPhase();
+
+        testInstance.onChange();
+
+        assertIntermediateStateWithoutRescale(softScalePossibleCtx);
+
+        softScalePossibleCtx.transitionIntoSoftScalingTimeframe();
+
+        assertFinalStateWithRescale(softScalePossibleCtx);
+    }
+
+    @Test
+    void testDesiredChangeEventInSoftRescalePhase() {
+        final TestingRescaleManagerContext desiredRescalePossibleCtx =
+                TestingRescaleManagerContext.stableContext().withDesiredRescaling();
+        final DefaultRescaleManager testInstance =
+                desiredRescalePossibleCtx.createTestInstanceInSoftRescalePhase();
+
+        testInstance.onChange();
+
+        assertFinalStateWithRescale(desiredRescalePossibleCtx);
+    }
+
+    @Test
+    void testDesiredChangeEventInHardRescalePhase() {
+        final TestingRescaleManagerContext desiredRescalePossibleCtx =
+                TestingRescaleManagerContext.stableContext().withDesiredRescaling();
+        final DefaultRescaleManager testInstance =
+                desiredRescalePossibleCtx.createTestInstanceInHardRescalePhase();
+
+        testInstance.onChange();
+
+        assertFinalStateWithRescale(desiredRescalePossibleCtx);
+    }
+
+    @Test
+    void testNoRescaleInCooldownPhase() {
+        final TestingRescaleManagerContext noRescalePossibleCtx =
+                TestingRescaleManagerContext.stableContext();
+        final DefaultRescaleManager testInstance =
+                noRescalePossibleCtx.createTestInstanceInCooldownPhase();
+
+        testInstance.onChange();
+
+        assertIntermediateStateWithoutRescale(noRescalePossibleCtx);
+
+        noRescalePossibleCtx.transitionIntoSoftScalingTimeframe();
+
+        assertIntermediateStateWithoutRescale(noRescalePossibleCtx);
+
+        noRescalePossibleCtx.transitionIntoHardScalingTimeframe();
+
+        assertThat(noRescalePossibleCtx.rescaleWasTriggered())
+                .as("No rescaling should have happened even in the hard-rescaling phase.")
+                .isFalse();
+        assertThat(noRescalePossibleCtx.additionalTasksWaiting())
+                .as("No further tasks should have been waiting for execution.")
+                .isFalse();
+    }
+
+    @Test
+    void testNoRescaleInSoftRescalePhase() {
+        final TestingRescaleManagerContext noRescalePossibleCtx =
+                TestingRescaleManagerContext.stableContext();
+        final DefaultRescaleManager testInstance =
+                noRescalePossibleCtx.createTestInstanceInSoftRescalePhase();
+
+        testInstance.onChange();
+
+        assertIntermediateStateWithoutRescale(noRescalePossibleCtx);
+
+        noRescalePossibleCtx.transitionIntoHardScalingTimeframe();
+
+        assertThat(noRescalePossibleCtx.rescaleWasTriggered())
+                .as("No rescaling should have happened even in the hard-rescaling phase.")
+                .isFalse();
+        assertThat(noRescalePossibleCtx.additionalTasksWaiting())
+                .as("No further tasks should have been waiting for execution.")
+                .isFalse();
+    }
+
+    @Test
+    void testNoResaleInHardRescalePhase() {
+        final TestingRescaleManagerContext noRescalePossibleCtx =
+                TestingRescaleManagerContext.stableContext();
+        final DefaultRescaleManager testInstance =
+                noRescalePossibleCtx.createTestInstanceInHardRescalePhase();
+
+        testInstance.onChange();
+
+        assertThat(noRescalePossibleCtx.rescaleWasTriggered())
+                .as("No rescaling should have happened even in the hard-rescaling phase.")
+                .isFalse();
+        assertThat(noRescalePossibleCtx.additionalTasksWaiting())
+                .as("No further tasks should have been waiting for execution.")
+                .isFalse();
+    }
+
+    @Test
+    void testSufficientChangeInCooldownPhase() {
+        final TestingRescaleManagerContext hardRescalePossibleCtx =
+                TestingRescaleManagerContext.stableContext().withSufficientRescaling();
+        final DefaultRescaleManager testInstance =
+                hardRescalePossibleCtx.createTestInstanceInCooldownPhase();
+
+        testInstance.onChange();
+
+        assertIntermediateStateWithoutRescale(hardRescalePossibleCtx);
+
+        hardRescalePossibleCtx.transitionIntoSoftScalingTimeframe();
+
+        assertIntermediateStateWithoutRescale(hardRescalePossibleCtx);
+
+        hardRescalePossibleCtx.transitionIntoHardScalingTimeframe();
+
+        assertFinalStateWithRescale(hardRescalePossibleCtx);
+    }
+
+    @Test
+    void testSufficientChangeInSoftRescalePhase() {
+        final TestingRescaleManagerContext hardRescalePossibleCtx =
+                TestingRescaleManagerContext.stableContext().withSufficientRescaling();
+        final DefaultRescaleManager testInstance =
+                hardRescalePossibleCtx.createTestInstanceInSoftRescalePhase();
+
+        testInstance.onChange();
+
+        assertIntermediateStateWithoutRescale(hardRescalePossibleCtx);
+
+        hardRescalePossibleCtx.transitionIntoHardScalingTimeframe();
+
+        assertFinalStateWithRescale(hardRescalePossibleCtx);
+    }
+
+    @Test
+    void testSufficientChangeInHardRescalePhase() {
+        final TestingRescaleManagerContext hardRescalePossibleCtx =
+                TestingRescaleManagerContext.stableContext().withSufficientRescaling();
+        final DefaultRescaleManager testInstance =
+                hardRescalePossibleCtx.createTestInstanceInHardRescalePhase();
+
+        testInstance.onChange();
+
+        assertFinalStateWithRescale(hardRescalePossibleCtx);
+    }
+
+    @Test
+    void testSufficientChangeInCooldownWithSubsequentDesiredChangeInSoftRescalePhase() {
+        final TestingRescaleManagerContext ctx =
+                TestingRescaleManagerContext.stableContext().withSufficientRescaling();
+        final DefaultRescaleManager testInstance = ctx.createTestInstanceInCooldownPhase();
+
+        testInstance.onChange();
+
+        assertIntermediateStateWithoutRescale(ctx);
+
+        ctx.transitionIntoSoftScalingTimeframe();
+
+        ctx.withDesiredRescaling();
+
+        testInstance.onChange();
+
+        assertThat(ctx.rescaleWasTriggered()).isTrue();
+        assertThat(ctx.numberOfTasksWaiting())
+                .as(
+                        "There should be a task scheduled that allows transitioning into hard-rescaling phase.")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testSufficientChangeWithSubsequentDesiredChangeInSoftRescalePhase() {
+        final TestingRescaleManagerContext ctx =
+                TestingRescaleManagerContext.stableContext().withSufficientRescaling();
+        final DefaultRescaleManager testInstance = ctx.createTestInstanceInSoftRescalePhase();
+
+        testInstance.onChange();
+
+        assertIntermediateStateWithoutRescale(ctx);
+
+        assertThat(ctx.numberOfTasksWaiting())
+                .as(
+                        "There should be a task scheduled that allows transitioning into hard-rescaling phase.")
+                .isEqualTo(1);
+
+        ctx.withDesiredRescaling();
+
+        testInstance.onChange();
+
+        assertThat(ctx.rescaleWasTriggered()).isTrue();
+    }
+
+    @Test
+    void
+            testRevokedSufficientChangeInSoftRescalePhaseWithSubsequentSufficientChangeInHardRescalingPhase() {
+        final TestingRescaleManagerContext ctx =
+                TestingRescaleManagerContext.stableContext().withSufficientRescaling();
+        final DefaultRescaleManager testInstance = ctx.createTestInstanceInSoftRescalePhase();
+
+        testInstance.onChange();
+
+        assertIntermediateStateWithoutRescale(ctx);
+
+        assertThat(ctx.numberOfTasksWaiting())
+                .as(
+                        "There should be a task scheduled that allows transitioning into hard-rescaling phase.")
+                .isEqualTo(1);
+
+        ctx.revertAnyParallelismImprovements();
+
+        testInstance.onChange();
+
+        assertIntermediateStateWithoutRescale(ctx);
+
+        assertThat(ctx.numberOfTasksWaiting())
+                .as(
+                        "There should be a task scheduled that allows transitioning into hard-rescaling phase.")
+                .isEqualTo(1);
+
+        ctx.transitionIntoHardScalingTimeframe();
+
+        assertThat(ctx.rescaleWasTriggered())
+                .as(
+                        "No rescaling should have been triggered because of the previous revert of the additional resources.")
+                .isFalse();
+        assertThat(ctx.additionalTasksWaiting())
+                .as(
+                        "The transition to hard-rescaling should have happened without any additional tasks in waiting state.")
+                .isFalse();
+
+        ctx.withSufficientRescaling();
+
+        testInstance.onChange();
+
+        assertFinalStateWithRescale(ctx);
+    }
+
+    @Test
+    void testRevokedChangeInHardRescalingPhaseCausesWithSubsequentSufficientChange() {
+        final TestingRescaleManagerContext ctx = TestingRescaleManagerContext.stableContext();
+        final DefaultRescaleManager testInstance = ctx.createTestInstanceInHardRescalePhase();
+
+        testInstance.onChange();
+
+        assertThat(ctx.rescaleWasTriggered()).isFalse();
+        assertThat(ctx.additionalTasksWaiting()).isFalse();
+
+        ctx.withSufficientRescaling();
+
+        testInstance.onChange();
+
+        assertFinalStateWithRescale(ctx);
+    }
+
+    private static void assertIntermediateStateWithoutRescale(TestingRescaleManagerContext ctx) {
+        assertThat(ctx.rescaleWasTriggered())
+                .as("The rescale should not have been triggered, yet.")
+                .isFalse();
+        assertThat(ctx.additionalTasksWaiting())
+                .as("There should be still tasks being scheduled.")
+                .isTrue();
+    }
+
+    private static void assertFinalStateWithRescale(TestingRescaleManagerContext ctx) {
+        assertThat(ctx.rescaleWasTriggered())
+                .as("The rescale should have been triggered already.")
+                .isTrue();
+        assertThat(ctx.additionalTasksWaiting())
+                .as("All scheduled tasks should have been executed.")
+                .isFalse();
+    }
+
+    /**
+     * {@code TestingRescaleManagerContext} provides methods for adjusting the elapsed time and for
+     * adjusting the available resources for rescaling.
+     */
+    private static class TestingRescaleManagerContext implements RescaleManager.Context {
+
+        // default configuration values to allow for easy transitioning between the phases
+        private static final Duration SCALING_MIN = Duration.ofHours(1);
+        private static final Duration SCALING_MAX = Duration.ofHours(2);
+
+        // configuration that defines what kind of rescaling would be possible
+        private boolean hasSufficientResources = false;
+        private boolean hasDesiredResources = false;
+
+        // internal state used for assertions
+        private final AtomicBoolean rescaleTriggered = new AtomicBoolean();
+        private final SortedMap<Instant, List<Runnable>> scheduledTasks = new TreeMap<>();
+
+        // Instant.MIN makes debugging easier because timestamps become human-readable
+        private final Instant initializationTime = Instant.MIN;
+        private Duration elapsedTime = Duration.ZERO;
+
+        // ///////////////////////////////////////////////
+        // Context creation
+        // ///////////////////////////////////////////////
+
+        public static TestingRescaleManagerContext stableContext() {
+            return new TestingRescaleManagerContext();
+        }
+
+        private TestingRescaleManagerContext() {
+            // no rescaling is enabled by default
+            revertAnyParallelismImprovements();
+        }
+
+        public void revertAnyParallelismImprovements() {
+            this.hasSufficientResources = false;
+            this.hasDesiredResources = false;
+        }
+
+        public TestingRescaleManagerContext withDesiredRescaling() {
+            // having desired resources should also mean that the sufficient resources are met
+            this.hasSufficientResources = true;
+            this.hasDesiredResources = true;
+
+            return this;
+        }
+
+        public TestingRescaleManagerContext withSufficientRescaling() {
+            this.hasSufficientResources = true;
+            this.hasDesiredResources = false;
+
+            return this;
+        }
+
+        // ///////////////////////////////////////////////
+        // RescaleManager.Context interface methods
+        // ///////////////////////////////////////////////
+
+        @Override
+        public boolean hasSufficientResources() {
+            return this.hasSufficientResources;
+        }
+
+        @Override
+        public boolean hasDesiredResources() {
+            return this.hasDesiredResources;
+        }
+
+        @Override
+        public void rescale() {
+            rescaleTriggered.set(true);
+        }
+
+        @Override
+        public void scheduleOperation(Runnable callback, Duration delay) {
+            final Instant triggerTime =
+                    Objects.requireNonNull(initializationTime).plus(elapsedTime).plus(delay);
+            if (!scheduledTasks.containsKey(triggerTime)) {
+                scheduledTasks.put(triggerTime, new ArrayList<>());
+            }
+
+            scheduledTasks.get(triggerTime).add(callback);
+        }
+
+        // ///////////////////////////////////////////////
+        // Test instance creation
+        // ///////////////////////////////////////////////
+
+        /**
+         * Creates the {@code DefaultRescaleManager} test instance and transitions into a period in
+         * time where the instance is in cooldown phase.
+         */
+        public DefaultRescaleManager createTestInstanceInCooldownPhase() {
+            return createTestInstance(this::transitionIntoCooldownTimeframe);
+        }
+
+        /**
+         * Creates the {@code DefaultRescaleManager} test instance and transitions into a period in
+         * time where the instance is in soft-rescaling phase.
+         */
+        public DefaultRescaleManager createTestInstanceInSoftRescalePhase() {
+            return createTestInstance(this::transitionIntoSoftScalingTimeframe);
+        }
+
+        /**
+         * Creates the {@code DefaultRescaleManager} test instance and transitions into a period in
+         * time where the instance is in hard-rescaling phase.
+         */
+        public DefaultRescaleManager createTestInstanceInHardRescalePhase() {
+            return createTestInstance(this::transitionIntoHardScalingTimeframe);
+        }
+
+        /**
+         * Initializes the test instance and sets the context's elapsed time based on the passed
+         * callback.
+         */
+        private DefaultRescaleManager createTestInstance(Runnable timeTransitioning) {
+            final DefaultRescaleManager testInstance =
+                    new DefaultRescaleManager(
+                            initializationTime,
+                            // clock that returns the time based on the configured elapsedTime
+                            () -> Objects.requireNonNull(initializationTime).plus(elapsedTime),
+                            this,
+                            SCALING_MIN,
+                            SCALING_MAX) {
+                        @Override
+                        public void onChange() {
+                            super.onChange();
+
+                            // hack to avoid calling this method in every test method
+                            // we want to trigger tasks that are meant to run right-away
+                            TestingRescaleManagerContext.this.triggerOutdatedTasks();
+                        }
+                    };
+
+            timeTransitioning.run();
+            return testInstance;
+        }
+
+        // ///////////////////////////////////////////////
+        // Time-adjustment functionality
+        // ///////////////////////////////////////////////
+
+        /**
+         * Transitions the context's time to a moment that falls into the test instance's cooldown
+         * phase.
+         */
+        public void transitionIntoCooldownTimeframe() {
+            this.elapsedTime = SCALING_MIN.dividedBy(2);
+            this.triggerOutdatedTasks();
+        }
+
+        /**
+         * Transitions the context's time to a moment that falls into the test instance's
+         * soft-scaling phase.
+         */
+        public void transitionIntoSoftScalingTimeframe() {
+            // the state transition is scheduled based on the current event's time rather than the
+            // initializationTime
+            this.elapsedTime = elapsedTime.plus(SCALING_MIN);
+
+            // make sure that we're still below the scalingIntervalMax
+            this.elapsedTime = elapsedTime.plus(SCALING_MAX.minus(elapsedTime).dividedBy(2));
+            this.triggerOutdatedTasks();
+        }
+
+        /**
+         * Transitions the context's time to a moment that falls into the test instance's
+         * hard-scaling phase.
+         */
+        public void transitionIntoHardScalingTimeframe() {
+            // the state transition is scheduled based on the current event's time rather than the
+            // initializationTime
+            this.elapsedTime = elapsedTime.plus(SCALING_MAX).plusMinutes(1);
+            this.triggerOutdatedTasks();
+        }
+
+        private void triggerOutdatedTasks() {
+            while (!scheduledTasks.isEmpty()) {
+                final Instant timeOfExecution = scheduledTasks.firstKey();
+                if (!timeOfExecution.isAfter(
+                        Objects.requireNonNull(initializationTime).plus(elapsedTime))) {
+                    scheduledTasks.remove(timeOfExecution).forEach(Runnable::run);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // ///////////////////////////////////////////////
+        // Methods for verifying the context's state
+        // ///////////////////////////////////////////////
+
+        public boolean rescaleWasTriggered() {
+            return rescaleTriggered.get();
+        }
+
+        public int numberOfTasksWaiting() {
+            return scheduledTasks.size();
+        }
+
+        public boolean additionalTasksWaiting() {
+            return !scheduledTasks.isEmpty();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -62,6 +62,7 @@ import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.scheduler.DefaultVertexParallelismInfo;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
 import org.apache.flink.runtime.scheduler.exceptionhistory.RootExceptionHistoryEntry;
 import org.apache.flink.runtime.scheduler.exceptionhistory.TestingAccessExecution;
@@ -94,6 +95,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -149,8 +151,8 @@ class ExecutingTest {
                     ctx,
                     ClassLoader.getSystemClassLoader(),
                     new ArrayList<>(),
-                    Duration.ZERO,
-                    null,
+                    TestingRescaleManager.Factory.noOpFactory(),
+                    1,
                     Instant.now());
             assertThat(mockExecutionVertex.isDeployCalled()).isFalse();
         }
@@ -176,8 +178,8 @@ class ExecutingTest {
                                         ctx,
                                         ClassLoader.getSystemClassLoader(),
                                         new ArrayList<>(),
-                                        Duration.ZERO,
-                                        null,
+                                        TestingRescaleManager.Factory.noOpFactory(),
+                                        1,
                                         Instant.now());
                             }
                         })
@@ -265,117 +267,6 @@ class ExecutingTest {
                             assertThat(archivedExecutionGraph.getState())
                                     .isEqualTo(JobStatus.SUSPENDED));
             exec.suspend(new RuntimeException("suspend"));
-        }
-    }
-
-    @Test
-    void testNotifyNewResourcesAvailableBeforeCooldownIsOverScheduledStateChange()
-            throws Exception {
-        try (MockExecutingContext ctx = new MockExecutingContext()) {
-            // do not wait too long in the test
-            final Duration scalingIntervalMin = Duration.ofSeconds(1L);
-            final ExecutingStateBuilder executingStateBuilder =
-                    new ExecutingStateBuilder().setScalingIntervalMin(scalingIntervalMin);
-            Executing exec = executingStateBuilder.build(ctx);
-            // => rescale
-            ctx.setCanScaleUp(true);
-            // scheduled rescale should restart the job after cooldown
-            ctx.setExpectRestarting(
-                    restartingArguments ->
-                            assertThat(restartingArguments.getBackoffTime())
-                                    .isEqualTo(Duration.ZERO));
-            exec.onNewResourcesAvailable();
-        }
-    }
-
-    @Test
-    void testNotifyNewResourcesAvailableAfterCooldownIsOverStateChange() throws Exception {
-        try (MockExecutingContext ctx = new MockExecutingContext()) {
-            final ExecutingStateBuilder executingStateBuilder =
-                    new ExecutingStateBuilder()
-                            .setScalingIntervalMin(Duration.ofSeconds(20L))
-                            .setLastRescale(Instant.now().minus(Duration.ofSeconds(30L)));
-            Executing exec = executingStateBuilder.build(ctx);
-            // => rescale
-            ctx.setCanScaleUp(true);
-            // immediate rescale
-            ctx.setExpectRestarting(
-                    restartingArguments ->
-                            assertThat(restartingArguments.getBackoffTime())
-                                    .isEqualTo(Duration.ZERO));
-            exec.onNewResourcesAvailable();
-        }
-    }
-
-    @Test
-    void testNotifyNewResourcesAvailableWithCanScaleUpWithoutForceTransitionsToRestarting()
-            throws Exception {
-        try (MockExecutingContext ctx = new MockExecutingContext()) {
-            Executing exec = new ExecutingStateBuilder().build(ctx);
-
-            ctx.setExpectRestarting(
-                    restartingArguments ->
-                            // immediate rescale
-                            assertThat(restartingArguments.getBackoffTime())
-                                    .isEqualTo(Duration.ZERO));
-            ctx.setCanScaleUp(true); // => rescale
-            exec.onNewResourcesAvailable();
-        }
-    }
-
-    @Test
-    void testNotifyNewResourcesAvailableWithCantScaleUpWithoutForceAndCantScaleUpWithForce()
-            throws Exception {
-        try (MockExecutingContext ctx = new MockExecutingContext()) {
-            Executing exec =
-                    new ExecutingStateBuilder()
-                            .setScalingIntervalMax(Duration.ofSeconds(1L))
-                            .build(ctx);
-            // => schedule force rescale but resource lost on timeout => no rescale
-            ctx.setCanScaleUp(false, false);
-            exec.onNewResourcesAvailable();
-            ctx.assertNoStateTransition();
-        }
-    }
-
-    @Test
-    void testNotifyNewResourcesAvailableWithCantScaleUpWithoutForceAndCanScaleUpWithForceScheduled()
-            throws Exception {
-        try (MockExecutingContext ctx = new MockExecutingContext()) {
-            final ExecutingStateBuilder executingStateBuilder =
-                    new ExecutingStateBuilder()
-                            .setScalingIntervalMin(Duration.ofSeconds(20L))
-                            .setScalingIntervalMax(Duration.ofSeconds(30L))
-                            .setLastRescale(Instant.now().minus(Duration.ofSeconds(25L)));
-            Executing exec = executingStateBuilder.build(ctx);
-            // => schedule force rescale and resource still there after timeout => rescale
-            ctx.setCanScaleUp(false, true);
-            // rescale after scaling-interval.max
-            ctx.setExpectRestarting(
-                    restartingArguments ->
-                            assertThat(restartingArguments.getBackoffTime())
-                                    .isEqualTo(Duration.ZERO));
-            exec.onNewResourcesAvailable();
-        }
-    }
-
-    @Test
-    void testNotifyNewResourcesAvailableWithCantScaleUpWithoutForceAndCanScaleUpWithForceImmediate()
-            throws Exception {
-        try (MockExecutingContext ctx = new MockExecutingContext()) {
-            final ExecutingStateBuilder executingStateBuilder =
-                    new ExecutingStateBuilder()
-                            .setScalingIntervalMin(Duration.ofSeconds(20L))
-                            .setScalingIntervalMax(Duration.ofSeconds(30L))
-                            .setLastRescale(Instant.now().minus(Duration.ofSeconds(70L)));
-            Executing exec = executingStateBuilder.build(ctx);
-            // => immediate force rescale and resource still there after timeout => rescale
-            ctx.setCanScaleUp(false, true);
-            ctx.setExpectRestarting(
-                    restartingArguments ->
-                            assertThat(restartingArguments.getBackoffTime())
-                                    .isEqualTo(Duration.ZERO));
-            exec.onNewResourcesAvailable();
         }
     }
 
@@ -569,14 +460,14 @@ class ExecutingTest {
     @Test
     void testExecutingChecksForNewResourcesWhenBeingCreated() throws Exception {
         try (MockExecutingContext ctx = new MockExecutingContext()) {
-            ctx.setCanScaleUp(true);
-            ctx.setExpectRestarting(
-                    restartingArguments ->
-                            // immediate rescale
-                            assertThat(restartingArguments.getBackoffTime())
-                                    .isEqualTo(Duration.ZERO));
+            final AtomicBoolean scaleEventTriggered = new AtomicBoolean();
+            new ExecutingStateBuilder()
+                    .setRescaleManagerFactory(
+                            new TestingRescaleManager.Factory(() -> scaleEventTriggered.set(true)))
+                    .build(ctx);
 
-            new ExecutingStateBuilder().build(ctx);
+            ctx.triggerExecutors();
+            assertThat(scaleEventTriggered.get()).isTrue();
         }
     }
 
@@ -591,9 +482,8 @@ class ExecutingTest {
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .build(EXECUTOR_EXTENSION.getExecutor());
         private OperatorCoordinatorHandler operatorCoordinatorHandler;
-        private Duration scalingIntervalMin = Duration.ZERO;
-        @Nullable private Duration scalingIntervalMax;
-        private Instant lastRescale = Instant.now();
+        private TestingRescaleManager.Factory rescaleManagerFactory =
+                TestingRescaleManager.Factory.noOpFactory();
 
         private ExecutingStateBuilder() throws JobException, JobExecutionException {
             operatorCoordinatorHandler = new TestingOperatorCoordinatorHandler();
@@ -610,18 +500,9 @@ class ExecutingTest {
             return this;
         }
 
-        public ExecutingStateBuilder setScalingIntervalMin(Duration scalingIntervalMin) {
-            this.scalingIntervalMin = scalingIntervalMin;
-            return this;
-        }
-
-        public ExecutingStateBuilder setScalingIntervalMax(Duration scalingIntervalMax) {
-            this.scalingIntervalMax = scalingIntervalMax;
-            return this;
-        }
-
-        public ExecutingStateBuilder setLastRescale(Instant lastRescale) {
-            this.lastRescale = lastRescale;
+        public ExecutingStateBuilder setRescaleManagerFactory(
+                TestingRescaleManager.Factory rescaleManagerFactory) {
+            this.rescaleManagerFactory = rescaleManagerFactory;
             return this;
         }
 
@@ -637,9 +518,10 @@ class ExecutingTest {
                         ctx,
                         ClassLoader.getSystemClassLoader(),
                         new ArrayList<>(),
-                        scalingIntervalMin,
-                        scalingIntervalMax,
-                        lastRescale);
+                        rescaleManagerFactory,
+                        1,
+                        // will be ignored by the TestingRescaleManager.Factory
+                        Instant.now());
             } finally {
                 Preconditions.checkState(
                         !ctx.hadStateTransition,
@@ -665,8 +547,6 @@ class ExecutingTest {
                 new StateValidator<>("cancelling");
 
         private Function<Throwable, FailureResult> howToHandleFailure;
-        private boolean canScaleUpWithoutForce = false;
-        private boolean canScaleUpWithForce = false;
         private StateValidator<StopWithSavepointArguments> stopWithSavepointValidator =
                 new StateValidator<>("stopWithSavepoint");
         private CompletableFuture<String> mockedStopWithSavepointOperationFuture =
@@ -692,15 +572,6 @@ class ExecutingTest {
             this.howToHandleFailure = function;
         }
 
-        public void setCanScaleUp(boolean canScaleUpWithoutForce, boolean canScaleUpWithForce) {
-            this.canScaleUpWithoutForce = canScaleUpWithoutForce;
-            this.canScaleUpWithForce = canScaleUpWithForce;
-        }
-
-        public void setCanScaleUp(boolean canScaleUpWithoutForce) {
-            this.canScaleUpWithoutForce = canScaleUpWithoutForce;
-        }
-
         // --------- Interface Implementations ------- //
 
         @Override
@@ -722,12 +593,8 @@ class ExecutingTest {
         }
 
         @Override
-        public boolean shouldRescale(ExecutionGraph executionGraph, boolean forceRescale) {
-            if (forceRescale) {
-                return canScaleUpWithForce;
-            } else {
-                return canScaleUpWithoutForce;
-            }
+        public Optional<VertexParallelism> getAvailableVertexParallelism() {
+            return Optional.empty();
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingRescaleManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingRescaleManager.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import java.time.Instant;
+
+public class TestingRescaleManager implements RescaleManager {
+
+    private final Runnable onChangeRunnable;
+
+    private TestingRescaleManager(Runnable onChangeRunnable) {
+        this.onChangeRunnable = onChangeRunnable;
+    }
+
+    @Override
+    public void onChange() {
+        this.onChangeRunnable.run();
+    }
+
+    public static class Factory implements RescaleManager.Factory {
+
+        private final Runnable onChangeRunnable;
+
+        public static TestingRescaleManager.Factory noOpFactory() {
+            return new Factory(() -> {});
+        }
+
+        public Factory(Runnable onChangeRunnable) {
+            this.onChangeRunnable = onChangeRunnable;
+        }
+
+        @Override
+        public RescaleManager create(Context ignoredContext, Instant ignoredLastRescale) {
+            return new TestingRescaleManager(onChangeRunnable);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/scalingpolicy/EnforceMinimalIncreaseRescalingControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/scalingpolicy/EnforceMinimalIncreaseRescalingControllerTest.java
@@ -17,8 +17,6 @@
 
 package org.apache.flink.runtime.scheduler.adaptive.scalingpolicy;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 
@@ -30,15 +28,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link RescalingController}. */
 class EnforceMinimalIncreaseRescalingControllerTest {
-    private static final Configuration TEST_CONFIG =
-            new Configuration().set(JobManagerOptions.MIN_PARALLELISM_INCREASE, 2);
 
     private static final JobVertexID jobVertexId = new JobVertexID();
 
     @Test
     void testScaleUp() {
         final RescalingController rescalingController =
-                new EnforceMinimalIncreaseRescalingController(TEST_CONFIG);
+                new EnforceMinimalIncreaseRescalingController(2);
         assertThat(rescalingController.shouldRescale(forParallelism(1), forParallelism(4)))
                 .isTrue();
     }
@@ -46,7 +42,7 @@ class EnforceMinimalIncreaseRescalingControllerTest {
     @Test
     void testNoScaleUp() {
         final RescalingController rescalingController =
-                new EnforceMinimalIncreaseRescalingController(TEST_CONFIG);
+                new EnforceMinimalIncreaseRescalingController(2);
         assertThat(rescalingController.shouldRescale(forParallelism(2), forParallelism(3)))
                 .isFalse();
     }
@@ -54,7 +50,7 @@ class EnforceMinimalIncreaseRescalingControllerTest {
     @Test
     void testAlwaysScaleDown() {
         final RescalingController rescalingController =
-                new EnforceMinimalIncreaseRescalingController(TEST_CONFIG);
+                new EnforceMinimalIncreaseRescalingController(2);
         assertThat(rescalingController.shouldRescale(forParallelism(2), forParallelism(1)))
                 .isTrue();
     }
@@ -62,7 +58,7 @@ class EnforceMinimalIncreaseRescalingControllerTest {
     @Test
     void testNoScaleOnSameParallelism() {
         final RescalingController rescalingController =
-                new EnforceMinimalIncreaseRescalingController(TEST_CONFIG);
+                new EnforceMinimalIncreaseRescalingController(2);
         assertThat(rescalingController.shouldRescale(forParallelism(2), forParallelism(2)))
                 .isFalse();
     }


### PR DESCRIPTION
## PR Chain

* ⭐ FLINK-35550: https://github.com/apache/flink/pull/24909
* FLINK-35551: https://github.com/apache/flink/pull/24910
* FLINK-35552: https://github.com/apache/flink/pull/24911
* FLINK-35553: https://github.com/apache/flink/pull/24912

## What is the purpose of the change

The purpose of this PR is the reorganization of responsibilities for rescaling.

## Brief change log

[Class diagrams](https://app.diagrams.net/#G13IwZnJrZ_NBxkDYdAUz2IydP3A5qv8uH#%7B%22pageId%22%3A%22C5RBs43oDa-KdzZeNtuy%22%7D)

* Introduction of new interfaces `RescaleManager`, `RescaleManager.Context` and `RescaleManager.Factory`
* Responsibilities:
  * `AdaptiveScheduler` only provides the available parallelism (through the `SlotManager`). The rescalingControllers moved into `RescaleManager`
  * `Executing` is only in charge of state transitition and savepoints
  * `RescaleManager` handles the rescale decisions


## Verifying this change

The tests were reorganized accordingly. Some additional unit tests are added to improve coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable