### PR TITLE
[FLINK-35551][runtime] Introduces RescaleManager#onTrigger endpoint

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.max-delay-for-scale-trigger</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and %dx of the checkpointing interval if checkpointing is enabled).</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -87,6 +87,12 @@
             <td>The size of the write buffer of JobEventStore. The content will be flushed to external file system once the buffer is full</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.max-delay-for-scale-trigger</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and %dx of the checkpointing interval if checkpointing is enabled).</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.max-delay-for-scale-trigger</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and %dx of the checkpointing interval if checkpointing is enabled).</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -39,6 +39,7 @@ import static org.apache.flink.configuration.description.TextElement.text;
 public class JobManagerOptions {
 
     public static final MemorySize MIN_JVM_HEAP_SIZE = MemorySize.ofMebiBytes(128);
+    public static final int FACTOR_FOR_DEFAULT_MAXIMUM_DELAY_FOR_RESCALE_TRIGGER = 3;
 
     /**
      * The config parameter defining the network address to connect to for communication with the
@@ -571,6 +572,24 @@ public class JobManagerOptions {
                                             "If %s is configured to %s, this configuration value will default to a negative value to disable the resource timeout.",
                                             code(SCHEDULER_MODE.key()),
                                             code(SchedulerExecutionMode.REACTIVE.name()))
+                                    .build());
+
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
+    public static final ConfigOption<Duration> MAXIMUM_DELAY_FOR_SCALE_TRIGGER =
+            key("jobmanager.adaptive-scheduler.max-delay-for-scale-trigger")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled "
+                                                    + "and %dx of the checkpointing interval if checkpointing is enabled).",
+                                            text(
+                                                    String.valueOf(
+                                                            FACTOR_FOR_DEFAULT_MAXIMUM_DELAY_FOR_RESCALE_TRIGGER)))
                                     .build());
 
     @Documentation.Section({

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerFactory.java
@@ -119,7 +119,8 @@ public class AdaptiveSchedulerFactory implements SchedulerNGFactory {
                         partitionTracker);
 
         return new AdaptiveScheduler(
-                AdaptiveScheduler.Settings.of(jobMasterConfiguration),
+                AdaptiveScheduler.Settings.of(
+                        jobMasterConfiguration, jobGraph.getCheckpointingSettings()),
                 jobGraph,
                 JobResourceRequirements.readFromJobGraph(jobGraph).orElse(null),
                 jobMasterConfiguration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -95,7 +95,7 @@ class Executing extends StateWithExecutionGraph
         deploy();
 
         // check if new resources have come available in the meantime
-        context.runIfState(this, rescaleManager::onChange, Duration.ZERO);
+        context.runIfState(this, this::evaluateRescaling, Duration.ZERO);
     }
 
     @Override
@@ -194,12 +194,17 @@ class Executing extends StateWithExecutionGraph
 
     @Override
     public void onNewResourcesAvailable() {
-        rescaleManager.onChange();
+        evaluateRescaling();
     }
 
     @Override
     public void onNewResourceRequirements() {
+        evaluateRescaling();
+    }
+
+    private void evaluateRescaling() {
         rescaleManager.onChange();
+        rescaleManager.onTrigger();
     }
 
     CompletableFuture<String> stopWithSavepoint(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/RescaleManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/RescaleManager.java
@@ -28,6 +28,12 @@ public interface RescaleManager {
     void onChange();
 
     /**
+     * Is called when any previous observed environment changes shall be verified possibly
+     * triggering a rescale operation.
+     */
+    void onTrigger();
+
+    /**
      * The interface that can be used by the {@code RescaleManager} to communicate with the
      * underlying system.
      */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingRescaleManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingRescaleManager.java
@@ -23,9 +23,11 @@ import java.time.Instant;
 public class TestingRescaleManager implements RescaleManager {
 
     private final Runnable onChangeRunnable;
+    private final Runnable onTriggerRunnable;
 
-    private TestingRescaleManager(Runnable onChangeRunnable) {
+    private TestingRescaleManager(Runnable onChangeRunnable, Runnable onTriggerRunnable) {
         this.onChangeRunnable = onChangeRunnable;
+        this.onTriggerRunnable = onTriggerRunnable;
     }
 
     @Override
@@ -33,21 +35,28 @@ public class TestingRescaleManager implements RescaleManager {
         this.onChangeRunnable.run();
     }
 
+    @Override
+    public void onTrigger() {
+        this.onTriggerRunnable.run();
+    }
+
     public static class Factory implements RescaleManager.Factory {
 
         private final Runnable onChangeRunnable;
+        private final Runnable onTriggerRunnable;
 
         public static TestingRescaleManager.Factory noOpFactory() {
-            return new Factory(() -> {});
+            return new Factory(() -> {}, () -> {});
         }
 
-        public Factory(Runnable onChangeRunnable) {
+        public Factory(Runnable onChangeRunnable, Runnable onTriggerRunnable) {
             this.onChangeRunnable = onChangeRunnable;
+            this.onTriggerRunnable = onTriggerRunnable;
         }
 
         @Override
         public RescaleManager create(Context ignoredContext, Instant ignoredLastRescale) {
-            return new TestingRescaleManager(onChangeRunnable);
+            return new TestingRescaleManager(onChangeRunnable, onTriggerRunnable);
         }
     }
 }


### PR DESCRIPTION
## PR Chain

* FLINK-35550: https://github.com/apache/flink/pull/24909
* ⭐ FLINK-35551: https://github.com/apache/flink/pull/24910
* FLINK-35552: https://github.com/apache/flink/pull/24911
* FLINK-35553: https://github.com/apache/flink/pull/24912

## What is the purpose of the change

Introduces new `RescaleManager#onTrigger` endpoint that can be used to initiate a possible rescaling.

## Brief change log

* Introduces `RescaleManager#onTrigger` as a new interface method
* Adds `DefaultRescaleManager#onTrigger` implementation
* Makes `Executing` call the new `onTrigger` method subsequently to `onChange` to simulate the old behavior

## Verifying this change

* Adapted `DefaultRescaleManagerTest` to run `onTrigger` subsequently to `onChange` for now
* Adds new test for checking noop behaviour if only on `onTrigger` is called (i.e. for AUTO-649 this means that a checkpoint is completed w/o a previous rescale event)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? configuration docs