### PR TITLE
[FLINK-35553][runtime] Wires up the RescaleManager with the CheckpointLifecycleListener interface

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -12,7 +12,7 @@
             <td><h5>jobmanager.adaptive-scheduler.max-delay-for-scale-trigger</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and %dx of the checkpointing interval if checkpointing is enabled).</td>
+            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count if checkpointing is enabled).</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>
@@ -31,6 +31,12 @@
             <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
+            <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.scaling-interval.max</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -90,7 +90,7 @@
             <td><h5>jobmanager.adaptive-scheduler.max-delay-for-scale-trigger</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and %dx of the checkpointing interval if checkpointing is enabled).</td>
+            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count if checkpointing is enabled).</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>
@@ -109,6 +109,12 @@
             <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
+            <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.scaling-interval.max</h5></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>jobmanager.adaptive-scheduler.max-delay-for-scale-trigger</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and %dx of the checkpointing interval if checkpointing is enabled).</td>
+            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count if checkpointing is enabled).</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.min-parallelism-increase</h5></td>
@@ -31,6 +31,12 @@
             <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
+            <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.adaptive-scheduler.scaling-interval.max</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -39,7 +39,6 @@ import static org.apache.flink.configuration.description.TextElement.text;
 public class JobManagerOptions {
 
     public static final MemorySize MIN_JVM_HEAP_SIZE = MemorySize.ofMebiBytes(128);
-    public static final int FACTOR_FOR_DEFAULT_MAXIMUM_DELAY_FOR_RESCALE_TRIGGER = 3;
 
     /**
      * The config parameter defining the network address to connect to for communication with the
@@ -578,6 +577,20 @@ public class JobManagerOptions {
         Documentation.Sections.EXPERT_SCHEDULING,
         Documentation.Sections.ALL_JOB_MANAGER
     })
+    public static final ConfigOption<Integer> SCHEDULER_SCALE_ON_FAILED_CHECKPOINTS_COUNT =
+            key("jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count")
+                    .intType()
+                    .defaultValue(2)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.")
+                                    .build());
+
+    @Documentation.Section({
+        Documentation.Sections.EXPERT_SCHEDULING,
+        Documentation.Sections.ALL_JOB_MANAGER
+    })
     public static final ConfigOption<Duration> MAXIMUM_DELAY_FOR_SCALE_TRIGGER =
             key("jobmanager.adaptive-scheduler.max-delay-for-scale-trigger")
                     .durationType()
@@ -586,10 +599,8 @@ public class JobManagerOptions {
                             Description.builder()
                                     .text(
                                             "The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled "
-                                                    + "and %dx of the checkpointing interval if checkpointing is enabled).",
-                                            text(
-                                                    String.valueOf(
-                                                            FACTOR_FOR_DEFAULT_MAXIMUM_DELAY_FOR_RESCALE_TRIGGER)))
+                                                    + "and the checkpointing interval multiplied by the by-1-incremented parameter value of %s if checkpointing is enabled).",
+                                            text(SCHEDULER_SCALE_ON_FAILED_CHECKPOINTS_COUNT.key()))
                                     .build());
 
     @Documentation.Section({

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsListener.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+/** An interface that allows listening on the checkpoint lifecycle. */
+public interface CheckpointStatsListener {
+
+    /** Called when a checkpoint was completed successfully. */
+    default void onCompletedCheckpoint() {
+        // No-op.
+    }
+
+    /** Called when a checkpoint failed. */
+    default void onFailedCheckpoint() {
+        // No-op.
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -33,8 +33,10 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
+import org.apache.flink.runtime.checkpoint.CheckpointStatsListener;
 import org.apache.flink.runtime.checkpoint.CheckpointsCleaner;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
+import org.apache.flink.runtime.checkpoint.NoOpCheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointIDCounter;
 import org.apache.flink.runtime.checkpoint.StandaloneCompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.TestingCheckpointIDCounter;
@@ -64,6 +66,7 @@ import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGate
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexResourceRequirements;
@@ -75,6 +78,8 @@ import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultAllocatedSlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPool;
+import org.apache.flink.runtime.jobmaster.slotpool.TestingDeclarativeSlotPoolBuilder;
+import org.apache.flink.runtime.jobmaster.slotpool.TestingFreeSlotInfoTracker;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.metrics.MetricNames;
@@ -89,6 +94,8 @@ import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraph
 import org.apache.flink.runtime.scheduler.DefaultSchedulerTest;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerNG;
+import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
+import org.apache.flink.runtime.scheduler.TestingPhysicalSlot;
 import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.adaptive.allocator.TestSlotInfo;
@@ -106,6 +113,7 @@ import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.traces.Span;
 import org.apache.flink.traces.SpanBuilder;
+import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.Preconditions;
@@ -141,6 +149,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
@@ -150,6 +159,7 @@ import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.crea
 import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.offerSlots;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.enableCheckpointing;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the {@link AdaptiveScheduler}. */
@@ -1280,7 +1290,8 @@ public class AdaptiveSchedulerTest {
         return new Configuration()
                 .set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, Duration.ofMillis(-1L))
                 .set(JobManagerOptions.RESOURCE_STABILIZATION_TIMEOUT, Duration.ofMillis(1L))
-                .set(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN, Duration.ofMillis(1L));
+                .set(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN, Duration.ofMillis(1L))
+                .set(JobManagerOptions.MAXIMUM_DELAY_FOR_SCALE_TRIGGER, Duration.ZERO);
     }
 
     private AdaptiveSchedulerBuilder prepareSchedulerWithNoTimeouts(
@@ -2112,7 +2123,7 @@ public class AdaptiveSchedulerTest {
     }
 
     @Test
-    public void testScalingIntervalConfigurationIsRespected() {
+    void testScalingIntervalConfigurationIsRespected() throws ConfigurationException {
         final Duration scalingIntervalMin = Duration.ofMillis(1337);
         final Duration scalingIntervalMax = Duration.ofMillis(7331);
         final Configuration configuration = createConfigurationWithNoTimeouts();
@@ -2124,9 +2135,150 @@ public class AdaptiveSchedulerTest {
         assertThat(settings.getScalingIntervalMax()).isEqualTo(scalingIntervalMax);
     }
 
+    @Test
+    void testOnCompletedCheckpointIsHandledInMainThread() throws Exception {
+        testCheckpointStatsEventBeingExecutedInTheMainThread(
+                CheckpointStatsListener::onCompletedCheckpoint, 1, Integer.MAX_VALUE);
+    }
+
+    @Test
+    void testOnFailedCheckpointIsHandledInMainThread() throws Exception {
+        testCheckpointStatsEventBeingExecutedInTheMainThread(
+                CheckpointStatsListener::onFailedCheckpoint, 2, 2);
+    }
+
+    private void testCheckpointStatsEventBeingExecutedInTheMainThread(
+            Consumer<CheckpointStatsListener> eventCallback,
+            int eventRepetitions,
+            int triggerOnFailedCheckpointCount)
+            throws Exception {
+
+        final CompletableFuture<CheckpointStatsListener> statsListenerInstantiatedFuture =
+                new CompletableFuture<>();
+        final BlockingQueue<Integer> eventQueue = new ArrayBlockingQueue<>(1);
+
+        final AdaptiveScheduler testInstance =
+                createSchedulerThatReachesExecutingState(
+                        PARALLELISM,
+                        triggerOnFailedCheckpointCount,
+                        eventQueue,
+                        statsListenerInstantiatedFuture);
+
+        try {
+            // start scheduling to reach Executing state
+            singleThreadMainThreadExecutor.execute(testInstance::startScheduling);
+
+            final CheckpointStatsListener statsListener = statsListenerInstantiatedFuture.get();
+            assertThat(statsListener)
+                    .as("The CheckpointStatsListener should have been instantiated.")
+                    .isNotNull();
+
+            // the first trigger happens in the Executing initialization - let's wait for that event
+            // to pass
+            assertThat(eventQueue.take())
+                    .as(
+                            "The first event should have been appeared during Executing state initialization and should be ignored.")
+                    .isEqualTo(0);
+
+            // counting the failed checkpoints only starts on a change event
+            testInstance.updateJobResourceRequirements(
+                    JobResourceRequirements.newBuilder()
+                            .setParallelismForJobVertex(JOB_VERTEX.getID(), 1, PARALLELISM - 1)
+                            .build());
+
+            for (int i = 0; i < eventRepetitions; i++) {
+                assertThatNoException()
+                        .as(
+                                "Triggering the event from outside the main thread should not have caused an error.")
+                        .isThrownBy(() -> eventCallback.accept(statsListener));
+            }
+
+            assertThat(eventQueue.take())
+                    .as("Only one event should have been observed.")
+                    .isEqualTo(1);
+        } finally {
+            final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+            singleThreadMainThreadExecutor.execute(
+                    () -> FutureUtils.forward(testInstance.closeAsync(), closeFuture));
+            assertThatFuture(closeFuture).eventuallySucceeds();
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Utils
     // ---------------------------------------------------------------------------------------------
+
+    private AdaptiveScheduler createSchedulerThatReachesExecutingState(
+            int parallelism,
+            int onFailedCheckpointCount,
+            BlockingQueue<Integer> eventQueue,
+            CompletableFuture<CheckpointStatsListener> statsListenerInstantiatedFuture)
+            throws Exception {
+        final Configuration config = new Configuration();
+        config.set(
+                JobManagerOptions.SCHEDULER_SCALE_ON_FAILED_CHECKPOINTS_COUNT,
+                onFailedCheckpointCount);
+
+        final JobGraph jobGraph =
+                JobGraphBuilder.newStreamingJobGraphBuilder()
+                        .addJobVertices(Collections.singletonList(JOB_VERTEX))
+                        .setJobCheckpointingSettings(
+                                new JobCheckpointingSettings(
+                                        new CheckpointCoordinatorConfiguration
+                                                        .CheckpointCoordinatorConfigurationBuilder()
+                                                .build(),
+                                        null))
+                        .build();
+        SchedulerTestingUtils.enableCheckpointing(jobGraph);
+
+        // testing SlotPool instance that would allow for the scheduler to transition to Executing
+        // state
+        final DeclarativeSlotPool slotPool =
+                new TestingDeclarativeSlotPoolBuilder()
+                        .setContainsFreeSlotFunction(allocationID -> true)
+                        .setReserveFreeSlotFunction(
+                                (allocationId, resourceProfile) ->
+                                        TestingPhysicalSlot.builder()
+                                                .withAllocationID(allocationId)
+                                                .build())
+                        .setGetFreeSlotInfoTrackerSupplier(
+                                () ->
+                                        TestingFreeSlotInfoTracker.newBuilder()
+                                                .setGetFreeSlotsInformationSupplier(
+                                                        () ->
+                                                                IntStream.range(0, parallelism)
+                                                                        .mapToObj(
+                                                                                v ->
+                                                                                        new TestSlotInfo())
+                                                                        .collect(
+                                                                                Collectors.toSet()))
+                                                .build())
+                        .build();
+
+        final AtomicInteger eventCounter = new AtomicInteger();
+        return new AdaptiveSchedulerBuilder(
+                        jobGraph, singleThreadMainThreadExecutor, EXECUTOR_RESOURCE.getExecutor())
+                .setJobMasterConfiguration(config)
+                .setDeclarativeSlotPool(slotPool)
+                .setRescaleManagerFactory(
+                        new TestingRescaleManager.Factory(
+                                () -> {},
+                                () -> {
+                                    singleThreadMainThreadExecutor.assertRunningInMainThread();
+
+                                    eventQueue.offer(eventCounter.getAndIncrement());
+                                }))
+                .setCheckpointStatsTrackerFactory(
+                        (metricGroup, listener) -> {
+                            assertThat(statsListenerInstantiatedFuture)
+                                    .as(
+                                            "The CheckpointStatsListener should be only instantiated once.")
+                                    .isNotCompleted();
+                            statsListenerInstantiatedFuture.complete(listener);
+                            return NoOpCheckpointStatsTracker.INSTANCE;
+                        })
+                .build();
+    }
 
     private CompletableFuture<ArchivedExecutionGraph> getArchivedExecutionGraphForRunningJob(
             SchedulerNG scheduler) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultRescaleManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultRescaleManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.util.ConfigurationException;
 
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class DefaultRescaleManagerTest {
 
     @Test
-    void testProperConfiguration() {
+    void testProperConfiguration() throws ConfigurationException {
         final Duration scalingIntervalMin = Duration.ofMillis(1337);
         final Duration scalingIntervalMax = Duration.ofMillis(7331);
         final Duration maximumDelayForRescaleTrigger = Duration.ofMillis(4242);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -97,9 +97,12 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 import static org.apache.flink.runtime.scheduler.adaptive.WaitingForResourcesTest.assertNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -154,6 +157,7 @@ class ExecutingTest {
                     new ArrayList<>(),
                     TestingRescaleManager.Factory.noOpFactory(),
                     1,
+                    1,
                     Instant.now());
             assertThat(mockExecutionVertex.isDeployCalled()).isFalse();
         }
@@ -181,10 +185,122 @@ class ExecutingTest {
                                         new ArrayList<>(),
                                         TestingRescaleManager.Factory.noOpFactory(),
                                         1,
+                                        1,
                                         Instant.now());
                             }
                         })
                 .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testTriggerRescaleOnCompletedCheckpoint() throws Exception {
+        final AtomicBoolean rescaleTriggered = new AtomicBoolean();
+        final RescaleManager.Factory rescaleManagerFactory =
+                new TestingRescaleManager.Factory(() -> {}, () -> rescaleTriggered.set(true));
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            final Executing testInstance =
+                    new ExecutingStateBuilder()
+                            .setRescaleManagerFactory(rescaleManagerFactory)
+                            .build(ctx);
+
+            assertThat(rescaleTriggered).isFalse();
+            testInstance.onCompletedCheckpoint();
+            assertThat(rescaleTriggered).isTrue();
+        }
+    }
+
+    @Test
+    public void testTriggerRescaleOnFailedCheckpoint() throws Exception {
+        final AtomicInteger rescaleTriggerCount = new AtomicInteger();
+        final RescaleManager.Factory rescaleManagerFactory =
+                new TestingRescaleManager.Factory(() -> {}, rescaleTriggerCount::incrementAndGet);
+        final int rescaleOnFailedCheckpointsCount = 3;
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            final Executing testInstance =
+                    new ExecutingStateBuilder()
+                            .setRescaleManagerFactory(rescaleManagerFactory)
+                            .setRescaleOnFailedCheckpointCount(rescaleOnFailedCheckpointsCount)
+                            .build(ctx);
+
+            // do multiple rescale iterations to verify that subsequent failed checkpoints after a
+            // rescale result in the expected behavior
+            for (int rescaleIteration = 1; rescaleIteration <= 3; rescaleIteration++) {
+
+                // trigger an initial failed checkpoint event to show that the counting only starts
+                // with the subsequent change event
+                testInstance.onFailedCheckpoint();
+
+                // trigger change
+                testInstance.onNewResourceRequirements();
+
+                for (int i = 0; i < rescaleOnFailedCheckpointsCount; i++) {
+                    assertThat(rescaleTriggerCount)
+                            .as(
+                                    "No rescale operation should have been triggered for iteration #%d, yet.",
+                                    rescaleIteration)
+                            .hasValue(rescaleIteration - 1);
+                    testInstance.onFailedCheckpoint();
+                }
+
+                assertThat(rescaleTriggerCount)
+                        .as(
+                                "The rescale operation for iteration #%d should have been properly triggered.",
+                                rescaleIteration)
+                        .hasValue(rescaleIteration);
+            }
+        }
+    }
+
+    @Test
+    public void testOnCompletedCheckpointResetsFailedCheckpointCount() throws Exception {
+        final AtomicInteger rescaleTriggeredCount = new AtomicInteger();
+        final RescaleManager.Factory rescaleManagerFactory =
+                new TestingRescaleManager.Factory(() -> {}, rescaleTriggeredCount::incrementAndGet);
+        final int rescaleOnFailedCheckpointsCount = 3;
+        try (MockExecutingContext ctx = new MockExecutingContext()) {
+            final Executing testInstance =
+                    new ExecutingStateBuilder()
+                            .setRescaleManagerFactory(rescaleManagerFactory)
+                            .setRescaleOnFailedCheckpointCount(rescaleOnFailedCheckpointsCount)
+                            .build(ctx);
+
+            // trigger an initial failed checkpoint event to show that the counting only starts with
+            // the subsequent change event
+            testInstance.onFailedCheckpoint();
+
+            // trigger change
+            testInstance.onNewResourcesAvailable();
+
+            IntStream.range(0, rescaleOnFailedCheckpointsCount - 1)
+                    .forEach(ignored -> testInstance.onFailedCheckpoint());
+
+            assertThat(rescaleTriggeredCount)
+                    .as("No rescaling should have been trigger, yet.")
+                    .hasValue(0);
+
+            testInstance.onCompletedCheckpoint();
+
+            // trigger change
+            testInstance.onNewResourceRequirements();
+
+            assertThat(rescaleTriggeredCount)
+                    .as("The completed checkpoint should have triggered a rescale.")
+                    .hasValue(1);
+
+            IntStream.range(0, rescaleOnFailedCheckpointsCount - 1)
+                    .forEach(ignored -> testInstance.onFailedCheckpoint());
+
+            assertThat(rescaleTriggeredCount)
+                    .as(
+                            "No additional rescaling should have been trigger by any subsequent failed checkpoint, yet.")
+                    .hasValue(1);
+
+            testInstance.onFailedCheckpoint();
+
+            assertThat(rescaleTriggeredCount)
+                    .as("The previous failed checkpoint should have triggered the rescale.")
+                    .hasValue(2);
+        }
     }
 
     @Test
@@ -490,8 +606,9 @@ class ExecutingTest {
                 TestingDefaultExecutionGraphBuilder.newBuilder()
                         .build(EXECUTOR_EXTENSION.getExecutor());
         private OperatorCoordinatorHandler operatorCoordinatorHandler;
-        private TestingRescaleManager.Factory rescaleManagerFactory =
+        private RescaleManager.Factory rescaleManagerFactory =
                 TestingRescaleManager.Factory.noOpFactory();
+        private int rescaleOnFailedCheckpointCount = 1;
 
         private ExecutingStateBuilder() throws JobException, JobExecutionException {
             operatorCoordinatorHandler = new TestingOperatorCoordinatorHandler();
@@ -509,8 +626,14 @@ class ExecutingTest {
         }
 
         public ExecutingStateBuilder setRescaleManagerFactory(
-                TestingRescaleManager.Factory rescaleManagerFactory) {
+                RescaleManager.Factory rescaleManagerFactory) {
             this.rescaleManagerFactory = rescaleManagerFactory;
+            return this;
+        }
+
+        public ExecutingStateBuilder setRescaleOnFailedCheckpointCount(
+                int rescaleOnFailedCheckpointCount) {
+            this.rescaleOnFailedCheckpointCount = rescaleOnFailedCheckpointCount;
             return this;
         }
 
@@ -528,6 +651,7 @@ class ExecutingTest {
                         new ArrayList<>(),
                         rescaleManagerFactory,
                         1,
+                        rescaleOnFailedCheckpointCount,
                         // will be ignored by the TestingRescaleManager.Factory
                         Instant.now());
             } finally {

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/RescaleOnCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/RescaleOnCheckpointITCase.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.scheduling;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.WebOptions;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
+import org.apache.flink.test.junit5.InjectClusterClient;
+import org.apache.flink.test.junit5.InjectMiniCluster;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.testutils.TestingUtils;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.Iterator;
+
+import static org.apache.flink.test.scheduling.UpdateJobResourceRequirementsITCase.waitForAvailableSlots;
+import static org.apache.flink.test.scheduling.UpdateJobResourceRequirementsITCase.waitForRunningTasks;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(TestLoggerExtension.class)
+class RescaleOnCheckpointITCase {
+
+    // Scaling down is used here because scaling up is not supported by the NumberSequenceSource
+    // that's used in this test.
+    private static final int NUMBER_OF_SLOTS = 4;
+    private static final int BEFORE_RESCALE_PARALLELISM = NUMBER_OF_SLOTS;
+    private static final int AFTER_RESCALE_PARALLELISM = NUMBER_OF_SLOTS - 1;
+
+    // This timeout is used to wait for any possible rescale after the JobRequirement
+    // update (which shouldn't happen). A longer gap makes the test more reliable (it's hard to test
+    // that something didn't happen) but also increases the runtime of the test.
+    private static final Duration REQUIREMENT_UPDATE_TO_CHECKPOINT_GAP = Duration.ofSeconds(2);
+
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(createConfiguration())
+                            .setNumberSlotsPerTaskManager(NUMBER_OF_SLOTS)
+                            .build());
+
+    private static Configuration createConfiguration() {
+        final Configuration configuration = new Configuration();
+        configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);
+
+        // speed the test suite up
+        // - lower refresh interval -> controls how fast we invalidate ExecutionGraphCache
+        // - lower slot idle timeout -> controls how fast we return idle slots to TM
+        configuration.set(WebOptions.REFRESH_INTERVAL, Duration.ofMillis(50L));
+        configuration.set(JobManagerOptions.SLOT_IDLE_TIMEOUT, Duration.ofMillis(50L));
+
+        // no checkpoints shall be triggered by Flink itself
+        configuration.set(
+                CheckpointingOptions.CHECKPOINTING_INTERVAL, TestingUtils.infiniteDuration());
+
+        // rescale shouldn't be triggered due to the timeout
+        configuration.set(
+                JobManagerOptions.MAXIMUM_DELAY_FOR_SCALE_TRIGGER, TestingUtils.infiniteDuration());
+
+        // no cooldown to avoid delaying the test even more
+        configuration.set(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN, Duration.ZERO);
+
+        return configuration;
+    }
+
+    @Test
+    void testRescaleOnCheckpoint(
+            @InjectMiniCluster MiniCluster miniCluster,
+            @InjectClusterClient RestClusterClient<?> restClusterClient)
+            throws Exception {
+        final Configuration config = new Configuration();
+
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.setParallelism(BEFORE_RESCALE_PARALLELISM);
+        env.fromSequence(0, Integer.MAX_VALUE).sinkTo(new DiscardingSink<>());
+
+        final JobGraph jobGraph = env.getStreamGraph().getJobGraph();
+        final Iterator<JobVertex> jobVertexIterator = jobGraph.getVertices().iterator();
+        assertThat(jobVertexIterator.hasNext())
+                .as("There needs to be at least one JobVertex.")
+                .isTrue();
+        final JobResourceRequirements jobResourceRequirements =
+                JobResourceRequirements.newBuilder()
+                        .setParallelismForJobVertex(
+                                jobVertexIterator.next().getID(), 1, AFTER_RESCALE_PARALLELISM)
+                        .build();
+        assertThat(jobVertexIterator.hasNext())
+                .as("This test expects to have only one JobVertex.")
+                .isFalse();
+
+        restClusterClient.submitJob(jobGraph).join();
+        try {
+            final JobID jobId = jobGraph.getJobID();
+
+            waitForRunningTasks(restClusterClient, jobId, BEFORE_RESCALE_PARALLELISM);
+
+            restClusterClient.updateJobResourceRequirements(jobId, jobResourceRequirements).join();
+
+            // timeout to allow any unexpected rescaling to happen anyway
+            Thread.sleep(REQUIREMENT_UPDATE_TO_CHECKPOINT_GAP.toMillis());
+
+            // verify that the previous timeout didn't result in a change of parallelism
+            waitForRunningTasks(restClusterClient, jobId, BEFORE_RESCALE_PARALLELISM);
+
+            miniCluster.triggerCheckpoint(jobId);
+
+            waitForRunningTasks(restClusterClient, jobId, AFTER_RESCALE_PARALLELISM);
+
+            waitForAvailableSlots(restClusterClient, NUMBER_OF_SLOTS - AFTER_RESCALE_PARALLELISM);
+        } finally {
+            restClusterClient.cancel(jobGraph.getJobID()).join();
+        }
+    }
+}


### PR DESCRIPTION
## PR Chain

* FLINK-35550: https://github.com/apache/flink/pull/24909
* FLINK-35551: https://github.com/apache/flink/pull/24910
* FLINK-35552: https://github.com/apache/flink/pull/24911
* ⭐ FLINK-35553: https://github.com/apache/flink/pull/24912

## What is the purpose of the change

Make rescale be synchronized with the checkpoint creation for faster recovery.

## Brief change log

* Introduced new `CheckpointLifecyclListener` that allows the `AdaptiveScheduler` to monitor checkpoint completion
* `RescaleManager.Context.onTrigger` will be called if a checkpoint was completed or if a configured amount of subsequent failed checkpoints appeared (new configuration parameter: `jobmanager.adaptive-scheduler.rescale-on-failed-checkpoints-count`)  

## Verifying this change

Additional tests were added to check the trigger behavior in `ExecutingTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? configuration docs