### PR TITLE
[FLINK-35555] Make ListSerializer allow null values

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializerSnapshot.java
@@ -20,14 +20,22 @@ package org.apache.flink.api.common.typeutils.base;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
 
+import java.io.IOException;
 import java.util.List;
 
 /** Snapshot class for the {@link ListSerializer}. */
 public class ListSerializerSnapshot<T>
         extends CompositeTypeSerializerSnapshot<List<T>, ListSerializer<T>> {
 
-    private static final int CURRENT_VERSION = 1;
+    private static final int CURRENT_VERSION = 2;
+
+    private static final int FIRST_VERSION_WITH_NULL_MASK = 2;
+
+    private boolean hasNullMask = true;
 
     /** Constructor for read instantiation. */
     public ListSerializerSnapshot() {}
@@ -35,6 +43,7 @@ public class ListSerializerSnapshot<T>
     /** Constructor to create the snapshot for writing. */
     public ListSerializerSnapshot(ListSerializer<T> listSerializer) {
         super(listSerializer);
+        this.hasNullMask = listSerializer.isHasNullMask();
     }
 
     @Override
@@ -43,11 +52,42 @@ public class ListSerializerSnapshot<T>
     }
 
     @Override
+    protected void readOuterSnapshot(
+            int readOuterSnapshotVersion, DataInputView in, ClassLoader userCodeClassLoader)
+            throws IOException {
+        if (readOuterSnapshotVersion < FIRST_VERSION_WITH_NULL_MASK) {
+            hasNullMask = false;
+        } else {
+            hasNullMask = in.readBoolean();
+        }
+    }
+
+    @Override
+    protected void writeOuterSnapshot(DataOutputView out) throws IOException {
+        out.writeBoolean(hasNullMask);
+    }
+
+    @Override
+    protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(
+            TypeSerializerSnapshot<List<T>> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof ListSerializerSnapshot)) {
+            return OuterSchemaCompatibility.INCOMPATIBLE;
+        }
+
+        ListSerializerSnapshot<T> oldListSerializerSnapshot =
+                (ListSerializerSnapshot<T>) oldSerializerSnapshot;
+        if (hasNullMask != oldListSerializerSnapshot.hasNullMask) {
+            return OuterSchemaCompatibility.COMPATIBLE_AFTER_MIGRATION;
+        }
+        return OuterSchemaCompatibility.COMPATIBLE_AS_IS;
+    }
+
+    @Override
     protected ListSerializer<T> createOuterSerializerWithNestedSerializers(
             TypeSerializer<?>[] nestedSerializers) {
         @SuppressWarnings("unchecked")
         TypeSerializer<T> elementSerializer = (TypeSerializer<T>) nestedSerializers[0];
-        return new ListSerializer<>(elementSerializer);
+        return new ListSerializer<>(elementSerializer, hasNullMask);
     }
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerTest.java
@@ -75,6 +75,16 @@ class ListSerializerTest extends SerializerTestBase<List<Long>> {
             list8.add(rnd.nextLong());
         }
 
-        return (List<Long>[]) new List[] {list1, list2, list3, list4, list5, list6, list7, list8};
+        // null-value lists
+        final List<Long> list9 = Collections.singletonList(null);
+        final List<Long> list10 = new LinkedList<>();
+        list10.add(null);
+        final List<Long> list11 = new ArrayList<>();
+        list11.add(null);
+
+        return (List<Long>[])
+                new List[] {
+                    list1, list2, list3, list4, list5, list6, list7, list8, list9, list10, list11
+                };
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/ListSerializerUpgradeTest.java
@@ -95,7 +95,11 @@ class ListSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<List<Strin
         @Override
         public Condition<TypeSerializerSchemaCompatibility<List<String>>>
                 schemaCompatibilityCondition(FlinkVersion version) {
-            return TypeSerializerConditions.isCompatibleAsIs();
+            if (version.isNewerVersionThan(FlinkVersion.v1_19)) {
+                return TypeSerializerConditions.isCompatibleAsIs();
+            } else {
+                return TypeSerializerConditions.isCompatibleAfterMigration();
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Make ListSerializer allow null values. Background: see [FLINK-35555](https://issues.apache.org/jira/browse/FLINK-35555).

## Brief change log

- Add a binary mask for marking null values in `ListSerializer`.
- Update `ListSerializerSnapshot` to deal with state-compatibility.

## Verifying this change

- Add tests on lists with null values in `ListSerializerTest`.
- Updated `ListSerializerUpgradeTest` to test state-compatibility.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
