### PR TITLE
[FLINK-35570] Consider PlaceholderStreamStateHandle in checkpoint file merging

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
+import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.filemerging.DirectoryStreamStateHandle;
@@ -360,5 +361,11 @@ public interface FileMergingSnapshotManager extends Closeable {
                     + logicalFileSize.get()
                     + '}';
         }
+    }
+
+    static boolean isFileMergingHandle(StreamStateHandle handle) {
+        return (handle instanceof SegmentFileStateHandle)
+                || (handle instanceof PlaceholderStreamStateHandle
+                        && ((PlaceholderStreamStateHandle) handle).isFileMerged());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
@@ -571,7 +571,8 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
                 if (file != null) {
                     file.advanceLastCheckpointId(checkpointId);
                 }
-            } else if (stateHandle instanceof PlaceholderStreamStateHandle) {
+            } else if (stateHandle instanceof PlaceholderStreamStateHandle
+                    && ((PlaceholderStreamStateHandle) stateHandle).isFileMerged()) {
                 // Since the rocksdb state backend will leverage the PlaceholderStreamStateHandle,
                 // the manager should recognize this.
                 LogicalFile file =
@@ -640,6 +641,16 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
             LogicalFile file =
                     knownLogicalFiles.get(
                             ((SegmentFileStateHandle) stateHandle).getLogicalFileId());
+            if (file != null) {
+                return file.getPhysicalFile().isCouldReuse();
+            }
+        } else if (stateHandle instanceof PlaceholderStreamStateHandle
+                && ((PlaceholderStreamStateHandle) stateHandle).isFileMerged()) {
+            // Since the rocksdb state backend will leverage the PlaceholderStreamStateHandle,
+            // the manager should recognize this.
+            LogicalFile file =
+                    knownLogicalFiles.get(
+                            new LogicalFileId(stateHandle.getStreamStateHandleID().getKeyString()));
             if (file != null) {
                 return file.getPhysicalFile().isCouldReuse();
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CheckpointStreamFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
+import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -91,13 +91,8 @@ public interface CheckpointStreamFactory {
      * @return true if it can be reused.
      */
     default boolean couldReuseStateHandle(StreamStateHandle stateHandle) {
-
         // By default, the CheckpointStreamFactory doesn't support snapshot-file-merging, so the
         // SegmentFileStateHandle type of stateHandle can not be reused.
-        if (stateHandle instanceof SegmentFileStateHandle) {
-            return false;
-        }
-
-        return true;
+        return !FileMergingSnapshotManager.isFileMergingHandle(stateHandle);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/PlaceholderStreamStateHandle.java
@@ -35,10 +35,13 @@ public class PlaceholderStreamStateHandle implements StreamStateHandle {
 
     private final PhysicalStateHandleID physicalID;
     private final long stateSize;
+    private final boolean fileMerged;
 
-    public PlaceholderStreamStateHandle(PhysicalStateHandleID physicalID, long stateSize) {
+    public PlaceholderStreamStateHandle(
+            PhysicalStateHandleID physicalID, long stateSize, boolean fileMerged) {
         this.physicalID = physicalID;
         this.stateSize = stateSize;
+        this.fileMerged = fileMerged;
     }
 
     @Override
@@ -66,5 +69,9 @@ public class PlaceholderStreamStateHandle implements StreamStateHandle {
     @Override
     public long getStateSize() {
         return stateSize;
+    }
+
+    public boolean isFileMerged() {
+        return fileMerged;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerUtilsTest.java
@@ -114,7 +114,7 @@ class SchedulerUtilsTest {
                 buildIncrementalHandle(
                         localPath,
                         new PlaceholderStreamStateHandle(
-                                handle.getStreamStateHandleID(), handle.getStateSize()),
+                                handle.getStreamStateHandleID(), handle.getStateSize(), false),
                         backendId);
         newHandle.registerSharedStates(sharedStateRegistry, 1L);
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBSnapshotStrategyBase.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBSnapshotStrategyBase.java
@@ -24,6 +24,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDb
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointStreamWithResultProvider;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
@@ -418,7 +419,9 @@ public abstract class RocksDBSnapshotStrategyBase<K, R extends SnapshotResources
                 // (created from a previous checkpoint).
                 return Optional.of(
                         new PlaceholderStreamStateHandle(
-                                handle.getStreamStateHandleID(), handle.getStateSize()));
+                                handle.getStreamStateHandleID(),
+                                handle.getStateSize(),
+                                FileMergingSnapshotManager.isFileMergingHandle(handle)));
             } else {
                 // Don't use any uploaded but not confirmed handles because they might be deleted
                 // (by TM) if the previous checkpoint failed. See FLINK-25395


### PR DESCRIPTION
## What is the purpose of the change

In checkpoint file merging, we should take `PlaceholderStreamStateHandle` into account during lifecycle, since it can be a file merged one.

## Brief change log

 - take `PlaceholderStreamStateHandle` into account in `reusePreviousStateHandle` and `couldReuseStateHandle`

## Verifying this change


This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
