### PR TITLE
[FLINK-30400][docs] Add some notes about changes for flink-connector-base dependency in externalized connectors

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/overview.md
+++ b/docs/content.zh/docs/connectors/datastream/overview.md
@@ -58,6 +58,13 @@ Currently these systems are supported as part of the Apache Flink project:
 要注意这些列举的连接器是 Flink 工程的一部分，包含在发布的源码中，但是不包含在二进制发行版中。
 更多说明可以参考对应的子部分。
 
+{{< hint info >}}
+由于 flink-connector-base 依赖已经在 flink-dist 中提供，
+在<a href="https://issues.apache.org/jira/browse/FLINK-30400">FLINK-30400</a>完成后，
+这些外部连接器开始停止打包 flink-connector-base 依赖。
+如果需要在本地环境测试运行，请确保 flink-connector-base 依赖被正确的提供，而且能在 classpath 下找到。
+{{< /hint >}}
+
 ## Apache Bahir 中的连接器
 
 Flink 还有些一些额外的连接器通过 [Apache Bahir](https://bahir.apache.org/) 发布, 包括:

--- a/docs/content/docs/connectors/datastream/overview.md
+++ b/docs/content/docs/connectors/datastream/overview.md
@@ -61,6 +61,14 @@ Note also that while the streaming connectors listed in this section are part of
 Flink project and are included in source releases, they are not included in the binary distributions. 
 Further instructions can be found in the corresponding subsections.
 
+{{< hint info >}}
+Because the flink-connector-base dependency has been bundled in flink-dist,
+these externalized connectors start to stop bundling the flink-connector-base dependency. See more
+in <a href="https://issues.apache.org/jira/browse/FLINK-30400">FLINK-30400</a>.
+If you need to run examples locally, make sure that the flink-connector-base dependency is
+provided and can be found in your own classpath.
+{{< /hint >}}
+
 ## Connectors in Apache Bahir
 
 Additional streaming connectors for Flink are being released through [Apache Bahir](https://bahir.apache.org/), including:


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds some notes about changes for flink-connector-base dependency in externalized connectors.

## Brief change log

Add some notes about changes for flink-connector-base dependency in externalized connectors docs.

## Verifying this change

This change is a docs work without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
