### PR TITLE
[FLINK-32086][checkpointing] Cleanup useless file-merging managed directory on exit of TM

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
@@ -204,6 +204,8 @@ public interface FileMergingSnapshotManager extends Closeable {
      * the parallelism. Note that this key should be consistent across job attempts.
      */
     final class SubtaskKey {
+        private static final String MANAGED_DIR_FORMAT = "job_%s_op_%s_%d_%d";
+
         final String jobIDString;
         final String operatorIDString;
         final int subtaskIndex;
@@ -244,6 +246,11 @@ public interface FileMergingSnapshotManager extends Closeable {
                     environment.getTaskInfo());
         }
 
+        @VisibleForTesting
+        public String getJobIDString() {
+            return jobIDString;
+        }
+
         /**
          * Generate an unique managed directory name for one subtask.
          *
@@ -251,8 +258,11 @@ public interface FileMergingSnapshotManager extends Closeable {
          */
         public String getManagedDirName() {
             return String.format(
-                            "%s_%s_%d_%d_",
-                            jobIDString, operatorIDString, subtaskIndex, parallelism)
+                            MANAGED_DIR_FORMAT,
+                            jobIDString,
+                            operatorIDString,
+                            subtaskIndex,
+                            parallelism)
                     .replaceAll("[^a-zA-Z0-9\\-]", "_");
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManager.java
@@ -144,6 +144,15 @@ public interface FileMergingSnapshotManager extends Closeable {
             SubtaskKey subtaskKey, CheckpointedStateScope scope);
 
     /**
+     * Notifies the manager that the checkpoint with the given {@code checkpointId} has been
+     * started.
+     *
+     * @param subtaskKey the subtask key identifying the subtask.
+     * @param checkpointId The ID of the checkpoint that has been started.
+     */
+    void notifyCheckpointStart(SubtaskKey subtaskKey, long checkpointId);
+
+    /**
      * Notifies the manager that the checkpoint with the given {@code checkpointId} completed and
      * was committed.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
@@ -59,6 +59,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import static org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManagerBase.DirectoryHandleWithReferenceTrack.wrap;
 import static org.apache.flink.runtime.checkpoint.filemerging.PhysicalFile.PhysicalFileDeleter;
 
 /** Base implementation of {@link FileMergingSnapshotManager}. */
@@ -133,9 +134,10 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     private final Map<SubtaskKey, Path> managedSharedStateDir = new ConcurrentHashMap<>();
 
     /**
-     * The {@link DirectoryStreamStateHandle} for shared state directories, one for each subtask.
+     * The {@link DirectoryStreamStateHandle} with it ongoing checkpoint reference count for shared
+     * state directories, one for each subtask and job.
      */
-    private final Map<SubtaskKey, DirectoryStreamStateHandle> managedSharedStateDirHandles =
+    private final Map<SubtaskKey, DirectoryHandleWithReferenceTrack> managedSharedStateDirHandles =
             new ConcurrentHashMap<>();
 
     /**
@@ -145,10 +147,10 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     protected Path managedExclusiveStateDir;
 
     /**
-     * The {@link DirectoryStreamStateHandle} for private state directory, one for each task
-     * manager.
+     * The {@link DirectoryStreamStateHandle} with it ongoing checkpoint reference count for private
+     * state directory, one for each taskmanager and job.
      */
-    protected DirectoryStreamStateHandle managedExclusiveStateDirHandle;
+    protected DirectoryHandleWithReferenceTrack managedExclusiveStateDirHandle;
 
     /** The current space statistic, updated on file creation/deletion. */
     protected SpaceStat spaceStat;
@@ -198,7 +200,6 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
             this.checkpointDir = Preconditions.checkNotNull(checkpointBaseDir);
             this.sharedStateDir = Preconditions.checkNotNull(sharedStateDir);
             this.taskOwnedStateDir = Preconditions.checkNotNull(taskOwnedStateDir);
-            this.fileSystemInitiated = true;
             this.shouldSyncAfterClosingLogicalFile = shouldSyncAfterClosingLogicalFile(fileSystem);
             // Initialize the managed exclusive path using id as the child path name.
             // Currently, we use the task-owned directory to place the merged private state.
@@ -206,11 +207,12 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
             // to the FLIP-306, we later consider move these files to the new introduced
             // task-manager-owned directory.
             Path managedExclusivePath = new Path(taskOwnedStateDir, id);
-            createManagedDirectory(managedExclusivePath);
+            boolean newCreated = createManagedDirectory(managedExclusivePath);
             this.managedExclusiveStateDir = managedExclusivePath;
             this.managedExclusiveStateDirHandle =
-                    DirectoryStreamStateHandle.of(managedExclusivePath);
+                    wrap(DirectoryStreamStateHandle.of(managedExclusivePath), newCreated);
             this.writeBufferSize = writeBufferSize;
+            this.fileSystemInitiated = true;
         }
     }
 
@@ -219,10 +221,10 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
         String managedDirName = subtaskKey.getManagedDirName();
         Path managedPath = new Path(sharedStateDir, managedDirName);
         if (!managedSharedStateDir.containsKey(subtaskKey)) {
-            createManagedDirectory(managedPath);
+            boolean newCreated = createManagedDirectory(managedPath);
             managedSharedStateDir.put(subtaskKey, managedPath);
             managedSharedStateDirHandles.put(
-                    subtaskKey, DirectoryStreamStateHandle.of(managedPath));
+                    subtaskKey, wrap(DirectoryStreamStateHandle.of(managedPath), newCreated));
         }
     }
 
@@ -230,6 +232,8 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     public void unregisterSubtask(SubtaskKey subtaskKey) {
         if (managedSharedStateDir.containsKey(subtaskKey)) {
             managedSharedStateDir.remove(subtaskKey);
+            // try clean up before remove
+            managedSharedStateDirHandles.get(subtaskKey).tryCleanupQuietly();
             managedSharedStateDirHandles.remove(subtaskKey);
         }
     }
@@ -492,14 +496,50 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     //  Checkpoint Listener
     // ------------------------------------------------------------------------
 
+    /**
+     * {@link org.apache.flink.streaming.runtime.tasks.SubtaskCheckpointCoordinatorImpl} use this
+     * method let the file merging manager know an ongoing checkpoint may reference the managed
+     * dirs.
+     */
+    @Override
+    public void notifyCheckpointStart(SubtaskKey subtaskKey, long checkpointId) {
+        if (fileSystemInitiated) {
+            managedSharedStateDirHandles.computeIfPresent(
+                    subtaskKey,
+                    (k, v) -> {
+                        v.increaseRefCountWhenCheckpointStart(checkpointId);
+                        return v;
+                    });
+            managedExclusiveStateDirHandle.increaseRefCountWhenCheckpointStart(checkpointId);
+        }
+    }
+
     @Override
     public void notifyCheckpointComplete(SubtaskKey subtaskKey, long checkpointId)
             throws Exception {
-        // does nothing
+        if (fileSystemInitiated) {
+            managedSharedStateDirHandles.computeIfPresent(
+                    subtaskKey,
+                    (k, v) -> {
+                        v.handoverOwnershipWhenCheckpointComplete(checkpointId);
+                        return v;
+                    });
+            managedExclusiveStateDirHandle.handoverOwnershipWhenCheckpointComplete(checkpointId);
+        }
     }
 
     @Override
     public void notifyCheckpointAborted(SubtaskKey subtaskKey, long checkpointId) throws Exception {
+        if (fileSystemInitiated) {
+            managedSharedStateDirHandles.computeIfPresent(
+                    subtaskKey,
+                    (k, v) -> {
+                        v.decreaseRefCountWhenCheckpointAbort(checkpointId);
+                        return v;
+                    });
+            managedExclusiveStateDirHandle.decreaseRefCountWhenCheckpointAbort(checkpointId);
+        }
+
         synchronized (lock) {
             Set<LogicalFile> logicalFilesForCurrentCp = uploadedStates.get(checkpointId);
             if (logicalFilesForCurrentCp == null) {
@@ -515,6 +555,16 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     @Override
     public void notifyCheckpointSubsumed(SubtaskKey subtaskKey, long checkpointId)
             throws Exception {
+        if (fileSystemInitiated) {
+            managedSharedStateDirHandles.computeIfPresent(
+                    subtaskKey,
+                    (k, v) -> {
+                        v.handoverOwnershipWhenCheckpointSubsumed(checkpointId);
+                        return v;
+                    });
+            managedExclusiveStateDirHandle.handoverOwnershipWhenCheckpointSubsumed(checkpointId);
+        }
+
         synchronized (lock) {
             Iterator<Map.Entry<Long, Set<LogicalFile>>> uploadedStatesIterator =
                     uploadedStates.headMap(checkpointId, true).entrySet().iterator();
@@ -708,9 +758,11 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     public DirectoryStreamStateHandle getManagedDirStateHandle(
             SubtaskKey subtaskKey, CheckpointedStateScope scope) {
         if (scope.equals(CheckpointedStateScope.SHARED)) {
-            return managedSharedStateDirHandles.get(subtaskKey);
+            DirectoryHandleWithReferenceTrack handleWithTrack =
+                    managedSharedStateDirHandles.get(subtaskKey);
+            return handleWithTrack != null ? handleWithTrack.getHandle() : null;
         } else {
-            return managedExclusiveStateDirHandle;
+            return managedExclusiveStateDirHandle.getHandle();
         }
     }
 
@@ -725,7 +777,13 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     //  utilities
     // ------------------------------------------------------------------------
 
-    private void createManagedDirectory(Path managedPath) {
+    /**
+     * Create managed directory.
+     *
+     * @param managedPath the path.
+     * @return true if new created.
+     */
+    private boolean createManagedDirectory(Path managedPath) {
         try {
             FileStatus fileStatus = null;
             try {
@@ -736,8 +794,10 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
             if (fileStatus == null) {
                 fs.mkdirs(managedPath);
                 LOG.info("Created a directory {} for checkpoint file-merging.", managedPath);
+                return true;
             } else if (fileStatus.isDir()) {
                 LOG.info("Reusing previous directory {} for checkpoint file-merging.", managedPath);
+                return false;
             } else {
                 throw new FlinkRuntimeException(
                         "The managed path "
@@ -751,7 +811,25 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     }
 
     @Override
-    public void close() throws IOException {}
+    public void close() throws IOException {
+        if (fileSystemInitiated) {
+            quietlyCleanupManagedDir();
+        }
+    }
+
+    private void quietlyCleanupManagedDir() {
+        // Quietly clean up useless shared state dir.
+        managedSharedStateDirHandles.forEach(
+                (subtaskKey, handleWithTrack) -> handleWithTrack.tryCleanupQuietly());
+
+        // Quietly clean up useless exclusive state dir.
+        managedExclusiveStateDirHandle.tryCleanupQuietly();
+    }
+
+    @VisibleForTesting
+    public String getId() {
+        return id;
+    }
 
     // ------------------------------------------------------------------------
     //  restore
@@ -860,5 +938,83 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     @VisibleForTesting
     boolean isCheckpointDiscard(long checkpointId) {
         return notifiedCheckpoint.contains(checkpointId);
+    }
+
+    /**
+     * This class wrap DirectoryStreamStateHandle with reference count by ongoing checkpoint. If an
+     * ongoing checkpoint which reference the directory handle complete, we will stop tracking the
+     * handle, because the ownership of the handle is handover to JobManager.
+     */
+    protected static class DirectoryHandleWithReferenceTrack {
+
+        private final DirectoryStreamStateHandle directoryHandle;
+        // reference count by ongoing checkpoint
+        private final AtomicLong ongoingRefCount;
+        private boolean tracking;
+
+        DirectoryHandleWithReferenceTrack(DirectoryStreamStateHandle directoryHandle, boolean own) {
+            this.directoryHandle = directoryHandle;
+            this.ongoingRefCount = new AtomicLong(0);
+            this.tracking = own;
+        }
+
+        static DirectoryHandleWithReferenceTrack wrap(
+                DirectoryStreamStateHandle directoryHandle, boolean own) {
+            return new DirectoryHandleWithReferenceTrack(directoryHandle, own);
+        }
+
+        DirectoryStreamStateHandle getHandle() {
+            return directoryHandle;
+        }
+
+        void increaseRefCountWhenCheckpointStart(long checkpointId) {
+            if (tracking) {
+                LOG.debug(
+                        "checkpoint:{} start, increase ref-count to file-merging managed shared dir : {}",
+                        checkpointId,
+                        directoryHandle.getDirectory());
+                ongoingRefCount.incrementAndGet();
+            }
+        }
+
+        void decreaseRefCountWhenCheckpointAbort(long checkpointId) {
+            if (tracking) {
+                LOG.debug(
+                        "checkpoint:{} aborted, decrease ref-count to file-merging managed shared dir : {}",
+                        checkpointId,
+                        directoryHandle.getDirectory());
+                ongoingRefCount.decrementAndGet();
+            }
+        }
+
+        void handoverOwnershipWhenCheckpointComplete(long checkpointId) {
+            if (tracking) {
+                LOG.debug(
+                        "checkpoint:{} complete, handover ownership of file-merging managed shared dir to JobManager : {}",
+                        checkpointId,
+                        directoryHandle.getDirectory());
+                tracking = false;
+            }
+        }
+
+        void handoverOwnershipWhenCheckpointSubsumed(long checkpointId) {
+            if (tracking) {
+                LOG.debug(
+                        "checkpoint:{} subsumed, handover ownership of file-merging managed shared dir to JobManager : {}",
+                        checkpointId,
+                        directoryHandle.getDirectory());
+                tracking = false;
+            }
+        }
+
+        void tryCleanupQuietly() {
+            if (tracking && ongoingRefCount.get() == 0 && directoryHandle != null) {
+                try {
+                    directoryHandle.discardState();
+                } catch (Exception e) {
+                    // ignore
+                }
+            }
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collection;
@@ -210,8 +209,7 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
             createManagedDirectory(managedExclusivePath);
             this.managedExclusiveStateDir = managedExclusivePath;
             this.managedExclusiveStateDirHandle =
-                    DirectoryStreamStateHandle.forPathWithZeroSize(
-                            new File(managedExclusivePath.getPath()).toPath());
+                    DirectoryStreamStateHandle.of(managedExclusivePath);
             this.writeBufferSize = writeBufferSize;
         }
     }
@@ -224,9 +222,7 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
             createManagedDirectory(managedPath);
             managedSharedStateDir.put(subtaskKey, managedPath);
             managedSharedStateDirHandles.put(
-                    subtaskKey,
-                    DirectoryStreamStateHandle.forPathWithZeroSize(
-                            new File(managedPath.getPath()).toPath()));
+                    subtaskKey, DirectoryStreamStateHandle.of(managedPath));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBuilder.java
@@ -19,6 +19,8 @@ package org.apache.flink.runtime.checkpoint.filemerging;
 
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -28,8 +30,12 @@ import java.util.concurrent.Executor;
 /** A builder that builds the {@link FileMergingSnapshotManager}. */
 public class FileMergingSnapshotManagerBuilder {
 
-    /** The id for identifying a {@link FileMergingSnapshotManager}. */
-    private final String id;
+    // Id format for FileMergingSnapshotManager, consist with jobId and tmId
+    private static final String ID_FORMAT = "job_%s_tm_%s";
+
+    private final JobID jobId;
+
+    private final ResourceID tmResourceId;
 
     /** The file merging type. */
     private final FileMergingType fileMergingType;
@@ -52,8 +58,10 @@ public class FileMergingSnapshotManagerBuilder {
      *
      * @param id the id of the manager.
      */
-    public FileMergingSnapshotManagerBuilder(String id, FileMergingType type) {
-        this.id = id;
+    public FileMergingSnapshotManagerBuilder(
+            JobID jobId, ResourceID tmResourceId, FileMergingType type) {
+        this.jobId = jobId;
+        this.tmResourceId = tmResourceId;
         this.fileMergingType = type;
     }
 
@@ -104,7 +112,7 @@ public class FileMergingSnapshotManagerBuilder {
         switch (fileMergingType) {
             case MERGE_WITHIN_CHECKPOINT:
                 return new WithinCheckpointFileMergingSnapshotManager(
-                        id,
+                        String.format(ID_FORMAT, jobId, tmResourceId),
                         maxFileSize,
                         filePoolType,
                         maxSpaceAmplification,
@@ -115,7 +123,7 @@ public class FileMergingSnapshotManagerBuilder {
                                 : metricGroup);
             case MERGE_ACROSS_CHECKPOINT:
                 return new AcrossCheckpointFileMergingSnapshotManager(
-                        id,
+                        String.format(ID_FORMAT, jobId, tmResourceId),
                         maxFileSize,
                         filePoolType,
                         maxSpaceAmplification,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBuilder.java
@@ -17,10 +17,10 @@
 
 package org.apache.flink.runtime.checkpoint.filemerging;
 
-import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
-import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -73,7 +73,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -675,17 +674,13 @@ public abstract class MetadataV2V3SerializerBase {
                 Preconditions.checkArgument(stateHandle instanceof SegmentFileStateHandle);
                 return isEmpty
                         ? new EmptyFileMergingOperatorStreamStateHandle(
-                                DirectoryStreamStateHandle.forPathWithZeroSize(
-                                        new File(taskOwnedDirPathStr).toPath()),
-                                DirectoryStreamStateHandle.forPathWithZeroSize(
-                                        new File(sharedDirPathStr).toPath()),
+                                DirectoryStreamStateHandle.of(new Path(taskOwnedDirPathStr)),
+                                DirectoryStreamStateHandle.of(new Path(sharedDirPathStr)),
                                 offsetsMap,
                                 stateHandle)
                         : new FileMergingOperatorStreamStateHandle(
-                                DirectoryStreamStateHandle.forPathWithZeroSize(
-                                        new File(taskOwnedDirPathStr).toPath()),
-                                DirectoryStreamStateHandle.forPathWithZeroSize(
-                                        new File(sharedDirPathStr).toPath()),
+                                DirectoryStreamStateHandle.of(new Path(taskOwnedDirPathStr)),
+                                DirectoryStreamStateHandle.of(new Path(sharedDirPathStr)),
                                 offsetsMap,
                                 stateHandle);
             } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorFileMergingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorFileMergingManager.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManage
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManagerBuilder;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingType;
 import org.apache.flink.runtime.checkpoint.filemerging.PhysicalFilePool;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.util.ShutdownHookUtil;
@@ -83,6 +84,7 @@ public class TaskExecutorFileMergingManager {
      */
     public @Nullable FileMergingSnapshotManager fileMergingSnapshotManagerForTask(
             @Nonnull JobID jobId,
+            @Nonnull ResourceID tmResourceId,
             @Nonnull ExecutionAttemptID executionAttemptID,
             Configuration clusterConfiguration,
             Configuration jobConfiguration,
@@ -131,7 +133,7 @@ public class TaskExecutorFileMergingManager {
                 fileMergingSnapshotManagerAndRetainedExecutions =
                         Tuple2.of(
                                 new FileMergingSnapshotManagerBuilder(
-                                                jobId.toString(), fileMergingType)
+                                                jobId, tmResourceId, fileMergingType)
                                         .setMaxFileSize(maxFileSize.getBytes())
                                         .setFilePoolType(
                                                 usingBlockingPool

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -779,6 +779,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             final FileMergingSnapshotManager fileMergingSnapshotManager =
                     fileMergingManager.fileMergingSnapshotManagerForTask(
                             jobId,
+                            getResourceID(),
                             tdd.getExecutionAttemptId(),
                             taskManagerConfiguration.getConfiguration(),
                             jobInformation.getJobConfiguration(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -50,7 +50,6 @@ import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -212,11 +211,9 @@ public class CheckpointTestUtils {
         boolean enableFileMerging = rnd.nextBoolean();
         if (enableFileMerging) {
             DirectoryStreamStateHandle taskOwnedDirHandle =
-                    DirectoryStreamStateHandle.forPathWithZeroSize(
-                            new File(String.valueOf(createRandomUUID(rnd))).toPath());
+                    DirectoryStreamStateHandle.of(new Path(createRandomUUID(rnd).toString()));
             DirectoryStreamStateHandle sharedDirHandle =
-                    DirectoryStreamStateHandle.forPathWithZeroSize(
-                            new File(String.valueOf(createRandomUUID(rnd))).toPath());
+                    DirectoryStreamStateHandle.of(new Path(createRandomUUID(rnd).toString()));
             return rnd.nextBoolean()
                     ? new FileMergingOperatorStreamStateHandle(
                             taskOwnedDirHandle,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.state;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.serialization.SerializerConfigImpl;
 import org.apache.flink.api.common.state.BroadcastState;
 import org.apache.flink.api.common.state.ListState;
@@ -41,6 +42,7 @@ import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManage
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager.SubtaskKey;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManagerBuilder;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingType;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.filemerging.FileMergingOperatorStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
@@ -451,8 +453,9 @@ class OperatorStateBackendTest {
                         checkpointBaseDir,
                         AbstractFsCheckpointStorageAccess.CHECKPOINT_TASK_OWNED_STATE_DIR);
 
+        JobID jobId = JobID.generate();
         final FileMergingSnapshotManager.SubtaskKey subtaskKey =
-                new FileMergingSnapshotManager.SubtaskKey("jobId", "opId", 1, 1);
+                new FileMergingSnapshotManager.SubtaskKey(jobId.toHexString(), "opId", 1, 1);
         LocalFileSystem fs = getSharedInstance();
         CheckpointStorageLocationReference cslReference =
                 AbstractFsCheckpointStorageAccess.encodePathAsReference(
@@ -1123,7 +1126,9 @@ class OperatorStateBackendTest {
             SubtaskKey subtaskKey) {
         FileMergingSnapshotManager mgr =
                 new FileMergingSnapshotManagerBuilder(
-                                "test-1", FileMergingType.MERGE_WITHIN_CHECKPOINT)
+                                JobID.fromHexString(subtaskKey.getJobIDString()),
+                                new ResourceID("test-1"),
+                                FileMergingType.MERGE_WITHIN_CHECKPOINT)
                         .build();
 
         mgr.initFileSystem(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorFileMergingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorFileMergingManagerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager.SubtaskKey;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 
@@ -37,6 +38,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TaskExecutorFileMergingManagerTest {
     @Test
     public void testCheckpointScope(@TempDir java.nio.file.Path testBaseDir) throws IOException {
+        ResourceID tmResourceId1 = ResourceID.generate();
+        ResourceID tmResourceId2 = ResourceID.generate();
+        ResourceID tmResourceId3 = ResourceID.generate();
+        ResourceID tmResourceId4 = ResourceID.generate();
+
         TaskExecutorFileMergingManager taskExecutorFileMergingManager =
                 new TaskExecutorFileMergingManager();
         JobID job1 = new JobID(1234L, 4321L);
@@ -53,6 +59,7 @@ public class TaskExecutorFileMergingManagerTest {
         FileMergingSnapshotManager manager1 =
                 taskExecutorFileMergingManager.fileMergingSnapshotManagerForTask(
                         job1,
+                        tmResourceId1,
                         executionID1,
                         clusterConfig,
                         jobConfig,
@@ -68,6 +75,7 @@ public class TaskExecutorFileMergingManagerTest {
         FileMergingSnapshotManager manager2 =
                 taskExecutorFileMergingManager.fileMergingSnapshotManagerForTask(
                         job1,
+                        tmResourceId2,
                         executionID2,
                         clusterConfig,
                         jobConfig,
@@ -83,6 +91,7 @@ public class TaskExecutorFileMergingManagerTest {
         FileMergingSnapshotManager manager3 =
                 taskExecutorFileMergingManager.fileMergingSnapshotManagerForTask(
                         job2,
+                        tmResourceId3,
                         executionID3,
                         clusterConfig,
                         jobConfig,
@@ -123,6 +132,7 @@ public class TaskExecutorFileMergingManagerTest {
         FileMergingSnapshotManager manager4 =
                 taskExecutorFileMergingManager.fileMergingSnapshotManagerForTask(
                         job1,
+                        tmResourceId4,
                         executionID4,
                         clusterConfig,
                         jobConfig,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.state.filesystem;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
@@ -25,6 +26,8 @@ import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManager;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingSnapshotManagerBuilder;
 import org.apache.flink.runtime.checkpoint.filemerging.FileMergingType;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
@@ -60,12 +63,16 @@ public class FsMergingCheckpointStorageLocationTest {
 
     private final Random random = new Random();
 
+    private static final JobID jobId = JobID.generate();
+    private static final OperatorID opId = new OperatorID();
+
     private static final String SNAPSHOT_MGR_ID = "snapshotMgrId";
     private static final int FILE_STATE_SIZE_THRESHOLD = 1024;
     private static final int WRITE_BUFFER_SIZE = 1024;
 
     private static final FileMergingSnapshotManager.SubtaskKey SUBTASK_KEY =
-            new FileMergingSnapshotManager.SubtaskKey("jobId", "opId", 1, 1);
+            new FileMergingSnapshotManager.SubtaskKey(
+                    jobId.toHexString(), opId.toHexString(), 1, 1);
 
     @Before
     public void prepareDirectories() {
@@ -222,7 +229,9 @@ public class FsMergingCheckpointStorageLocationTest {
     private FileMergingSnapshotManager createFileMergingSnapshotManager(long maxFileSize) {
         FileMergingSnapshotManager mgr =
                 new FileMergingSnapshotManagerBuilder(
-                                SNAPSHOT_MGR_ID, FileMergingType.MERGE_WITHIN_CHECKPOINT)
+                                jobId,
+                                new ResourceID(SNAPSHOT_MGR_ID),
+                                FileMergingType.MERGE_WITHIN_CHECKPOINT)
                         .build();
 
         mgr.initFileSystem(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -314,6 +314,12 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             return;
         }
 
+        if (fileMergingSnapshotManager != null) {
+            // notify file merging snapshot manager for managed dir lifecycle management
+            fileMergingSnapshotManager.notifyCheckpointStart(
+                    FileMergingSnapshotManager.SubtaskKey.of(env), metadata.getCheckpointId());
+        }
+
         // if checkpoint has been previously unaligned, but was forced to be aligned (pointwise
         // connection), revert it here so that it can jump over output data
         if (options.getAlignment() == CheckpointOptions.AlignmentType.FORCED_ALIGNED) {


### PR DESCRIPTION
## What is the purpose of the change

Clean up useless file-merging managed directory (which never be include in any checkpoint) on exit of TM.

## Brief change log

1. Normalize file-merging sub dir
  - format file-merging subtask dir to `job_{jobId}_op_{operatorId}_{subtaskIndex}_{parallelism}`
  - format file-merging exclusive dir to `job_{jobId}_tm_{tmResourceId}`
2. Track managed directory reference and clean up useless one when exit.

## Verifying this change

Normalize file-merging sub dir can be verified by *FileMergingSnapshotManagerTestBase#testCreateFileMergingSnapshotManager*.

And useless file-merging managed dir clean up can be verified by tests add in this change : *FileMergingSnapshotManagerTestBase#testManagedDirCleanup*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

Please help review this change @Zakelly , thanks.
