### PR TITLE
[FLINK-35597][test] Fix unstable LocatableSplitAssignerTest#testConcurrentSplitAssignmentForMultipleHosts

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/io/LocatableSplitAssignerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/io/LocatableSplitAssignerTest.java
@@ -428,7 +428,7 @@ class LocatableSplitAssignerTest {
         assertThat(ia.getNextInputSplit("testhost", 0)).isNull();
 
         // at least one fraction of hosts needs be local, no matter how bad the thread races
-        assertThat(ia.getNumberOfRemoteAssignments())
+        assertThat(ia.getNumberOfLocalAssignments())
                 .isGreaterThanOrEqualTo(NUM_SPLITS / hosts.length);
     }
 


### PR DESCRIPTION
## Brief change log

* To ensure at least one fraction of hosts to be local, it should be `ia.getNumberOfLocalAssignments()` as before.