### PR TITLE
[hotfix] Fix exception when setting 'state.backend.forst.compression.per.level' in yaml

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
@@ -53,6 +53,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
@@ -544,6 +545,8 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
             base = new Configuration();
         }
         Configuration configuration = new Configuration();
+        Map<String, String> baseMap = base.toMap();
+        Map<String, String> onTopMap = onTop.toMap();
         for (ConfigOption<?> option : ForStConfigurableOptions.CANDIDATE_CONFIGS) {
             Optional<?> baseValue = base.getOptional(option);
             Optional<?> topValue = onTop.getOptional(option);
@@ -552,6 +555,11 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
                 Object validValue = topValue.isPresent() ? topValue.get() : baseValue.get();
                 ForStConfigurableOptions.checkArgumentValid(option, validValue);
                 configuration.setString(option.key(), validValue.toString());
+                String valueString =
+                        topValue.isPresent()
+                                ? onTopMap.get(option.key())
+                                : baseMap.get(option.key());
+                configuration.setString(option.key(), valueString);
             }
         }
         return configuration;


### PR DESCRIPTION
## What is the purpose of the change

Just like #24902, the bug also exist in forst side, which should also be fixed.

## Brief change log

 - Fix `ForStStateBackend#mergeConfigurableOptions`
 - Added test `testConfigureForStCompressionPerLevel`


## Verifying this change

Newly added test `testConfigureForStCompressionPerLevel`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
