### PR TITLE
[FLINK-35625][cli] Merge "flink run" and "flink run-application" functionality, deprecate "run-application"

### DIFF
--- a/docs/layouts/shortcodes/generated/deployment_configuration.html
+++ b/docs/layouts/shortcodes/generated/deployment_configuration.html
@@ -60,7 +60,7 @@
             <td><h5>execution.target</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The deployment target for the execution. This can take one of the following values when calling <code class="highlighter-rouge">bin/flink run</code>:<ul><li>remote</li><li>local</li><li>yarn-per-job (deprecated)</li><li>yarn-session</li><li>kubernetes-session</li></ul>And one of the following values when calling <code class="highlighter-rouge">bin/flink run-application</code>:<ul><li>yarn-application</li><li>kubernetes-application</li></ul></td>
+            <td>The deployment target for the execution. This can take one of the following values when calling <code class="highlighter-rouge">bin/flink run</code>:<ul><li>remote</li><li>local</li><li>yarn-application</li><li>yarn-per-job (deprecated)</li><li>yarn-session</li><li>kubernetes-application</li><li>kubernetes-session</li></ul>And one of the following values when calling <code class="highlighter-rouge">bin/flink run-application</code> (deprecated):<ul><li>yarn-application</li><li>kubernetes-application</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -561,6 +561,7 @@ public class CliFrontendParser {
         formatter.setLeftPadding(5);
         formatter.setWidth(80);
 
+        System.out.println("\nDEPRECATED: Please use \"run\" for Application Mode as well.");
         System.out.println("\nAction \"run-application\" runs an application in Application Mode.");
         System.out.println("\n  Syntax: run-application [OPTIONS] <jar-file> <arguments>");
         formatter.setSyntaxPrefix("  \"run-application\" action options:");

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/GenericCLI.java
@@ -31,7 +31,9 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
+import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -44,6 +46,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class GenericCLI implements CustomCommandLine {
 
     private static final String ID = "Generic CLI";
+    private static final String DELIMITER = ", ";
 
     private final Option executorOption =
             new Option(
@@ -56,7 +59,7 @@ public class GenericCLI implements CustomCommandLine {
                             + DeploymentOptions.TARGET.key()
                             + "\" config option. The "
                             + "currently available executors are: "
-                            + getExecutorFactoryNames()
+                            + getTargetNames()
                             + ".");
 
     private final Option targetOption =
@@ -69,10 +72,10 @@ public class GenericCLI implements CustomCommandLine {
                             + DeploymentOptions.TARGET.key()
                             + "\" config option. For the \"run\" action the "
                             + "currently available targets are: "
-                            + getExecutorFactoryNames()
-                            + ". For the \"run-application\" action"
+                            + getTargetNames()
+                            + ". For the \"run-application\" (deprecated) action"
                             + " the currently available targets are: "
-                            + getApplicationModeTargetNames()
+                            + String.join(DELIMITER, getApplicationModeTargetNames())
                             + ".");
 
     private final Configuration configuration;
@@ -128,12 +131,15 @@ public class GenericCLI implements CustomCommandLine {
         return resultConfiguration;
     }
 
-    private static String getExecutorFactoryNames() {
-        return new DefaultExecutorServiceLoader()
-                .getExecutorNames()
-                .map(name -> String.format("\"%s\"", name))
-                .map(name -> addDeprecationNoticeToYarnPerJobMode(name))
-                .collect(Collectors.joining(", "));
+    private static String getTargetNames() {
+        final Stream<String> executorNames =
+                new DefaultExecutorServiceLoader()
+                        .getExecutorNames()
+                        .map(name -> String.format("\"%s\"", name))
+                        .map(GenericCLI::addDeprecationNoticeToYarnPerJobMode);
+
+        return Stream.concat(executorNames, getApplicationModeTargetNames().stream())
+                .collect(Collectors.joining(DELIMITER));
     }
 
     private static String addDeprecationNoticeToYarnPerJobMode(String name) {
@@ -143,10 +149,10 @@ public class GenericCLI implements CustomCommandLine {
         return name;
     }
 
-    private static String getApplicationModeTargetNames() {
+    private static List<String> getApplicationModeTargetNames() {
         return new DefaultClusterClientServiceLoader()
                 .getApplicationModeTargetNames()
                 .map(name -> String.format("\"%s\"", name))
-                .collect(Collectors.joining(", "));
+                .collect(Collectors.toList());
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -19,21 +19,28 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.client.cli.util.DummyClusterClientServiceLoader;
 import org.apache.flink.client.deployment.ClusterClientServiceLoader;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.TestingClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.execution.RestoreMode;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.util.FlinkException;
 
 import org.apache.commons.cli.CommandLine;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.stream.Stream;
 
 import static org.apache.flink.client.cli.CliFrontendTestUtils.getTestJarPath;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -255,6 +262,77 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
                 configuration, getCli(), parameters, ExecutionConfig.PARALLELISM_DEFAULT, false);
     }
 
+    private static Stream<Arguments> notApplicationTypeParams() {
+        return Stream.of(
+                Arguments.of("-e", "local"),
+                Arguments.of("-e", "remote"),
+                Arguments.of("-e", "yarn-per-job"),
+                Arguments.of("-e", "yarn-session"),
+                Arguments.of("-e", "kubernetes-session"),
+                Arguments.of("-t", "local"),
+                Arguments.of("-t", "remote"),
+                Arguments.of("-t", "yarn-per-job"),
+                Arguments.of("-t", "yarn-session"),
+                Arguments.of("-t", "kubernetes-session"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("notApplicationTypeParams")
+    void testRunWithNotApplicationTypeDeployment(String option, String value) throws Exception {
+        final Configuration configuration = new Configuration();
+        final RunApplicationTestingCliFrontend testFrontend =
+                new RunApplicationTestingCliFrontend(
+                        configuration,
+                        new GenericCLI(configuration, CliFrontendTestUtils.getConfigDir()));
+
+        testFrontend.run(new String[] {option, value, getTestJarPath()});
+        assertThat(testFrontend.runApplicationCalled).isFalse();
+        assertThat(testFrontend.runCalled).isTrue();
+        assertThat(testFrontend.application).isFalse();
+        assertThat(testFrontend.executeProgramCalled).isTrue();
+    }
+
+    private static Stream<Arguments> applicationTypeParams() {
+        return Stream.of(
+                Arguments.of("-e", "yarn-application"),
+                Arguments.of("-e", "kubernetes-application"),
+                Arguments.of("-t", "yarn-application"),
+                Arguments.of("-t", "kubernetes-application"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("applicationTypeParams")
+    void testRunWithApplicationTypeDeployment(String option, String value) throws Exception {
+        final Configuration configuration = new Configuration();
+        final RunApplicationTestingCliFrontend testFrontend =
+                new RunApplicationTestingCliFrontend(
+                        configuration,
+                        new GenericCLI(configuration, CliFrontendTestUtils.getConfigDir()));
+
+        testFrontend.run(new String[] {option, value, getTestJarPath()});
+        assertThat(testFrontend.runApplicationCalled).isFalse();
+        assertThat(testFrontend.runCalled).isTrue();
+        assertThat(testFrontend.application).isTrue();
+        assertThat(testFrontend.executeProgramCalled).isFalse();
+    }
+
+    @ParameterizedTest
+    @MethodSource("applicationTypeParams")
+    void testRunApplicationWithApplicationTypeDeployment(String option, String value)
+            throws Exception {
+        final Configuration configuration = new Configuration();
+        final RunApplicationTestingCliFrontend testFrontend =
+                new RunApplicationTestingCliFrontend(
+                        configuration,
+                        new GenericCLI(configuration, CliFrontendTestUtils.getConfigDir()));
+
+        testFrontend.runApplication(new String[] {option, value, getTestJarPath()});
+        assertThat(testFrontend.runApplicationCalled).isTrue();
+        assertThat(testFrontend.runCalled).isTrue();
+        assertThat(testFrontend.application).isTrue();
+        assertThat(testFrontend.executeProgramCalled).isFalse();
+    }
+
     // --------------------------------------------------------------------------------------------
 
     public static void verifyCliFrontend(
@@ -265,45 +343,24 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
             boolean isDetached)
             throws Exception {
         RunTestingCliFrontend testFrontend =
-                new RunTestingCliFrontend(
-                        configuration,
-                        new DefaultClusterClientServiceLoader(),
-                        cli,
-                        expectedParallelism,
-                        isDetached);
-        testFrontend.run(parameters); // verifies the expected values (see below)
-    }
-
-    public static void verifyCliFrontend(
-            Configuration configuration,
-            ClusterClientServiceLoader clusterClientServiceLoader,
-            AbstractCustomCommandLine cli,
-            String[] parameters,
-            int expectedParallelism,
-            boolean isDetached)
-            throws Exception {
-        RunTestingCliFrontend testFrontend =
-                new RunTestingCliFrontend(
-                        configuration,
-                        clusterClientServiceLoader,
-                        cli,
-                        expectedParallelism,
-                        isDetached);
+                new RunTestingCliFrontend(configuration, cli, expectedParallelism, isDetached);
         testFrontend.run(parameters); // verifies the expected values (see below)
     }
 
     private static final class RunTestingCliFrontend extends CliFrontend {
+
+        private static final ClusterClientServiceLoader CLUSTER_CLIENT_SERVICE_LOADER =
+                new DefaultClusterClientServiceLoader();
 
         private final int expectedParallelism;
         private final boolean isDetached;
 
         private RunTestingCliFrontend(
                 Configuration configuration,
-                ClusterClientServiceLoader clusterClientServiceLoader,
                 AbstractCustomCommandLine cli,
                 int expectedParallelism,
                 boolean isDetached) {
-            super(configuration, clusterClientServiceLoader, Collections.singletonList(cli));
+            super(configuration, CLUSTER_CLIENT_SERVICE_LOADER, Collections.singletonList(cli));
             this.expectedParallelism = expectedParallelism;
             this.isDetached = isDetached;
         }
@@ -314,6 +371,47 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
                     ExecutionConfigAccessor.fromConfiguration(configuration);
             assertThat(executionConfigAccessor.getDetachedMode()).isEqualTo(isDetached);
             assertThat(executionConfigAccessor.getParallelism()).isEqualTo(expectedParallelism);
+        }
+    }
+
+    private static final class RunApplicationTestingCliFrontend extends CliFrontend {
+
+        private boolean runCalled;
+        private boolean runApplicationCalled;
+        private boolean application;
+        private boolean executeProgramCalled;
+
+        private RunApplicationTestingCliFrontend(
+                Configuration configuration, CustomCommandLine cli) {
+            super(
+                    configuration,
+                    new DummyClusterClientServiceLoader<>(new TestingClusterClient<>()),
+                    Collections.singletonList(cli));
+        }
+
+        @Override
+        protected void run(String[] args) throws Exception {
+            super.run(args);
+            runCalled = true;
+        }
+
+        @Override
+        protected void runApplication(String[] args) throws Exception {
+            super.runApplication(args);
+            runApplicationCalled = true;
+        }
+
+        @Override
+        protected boolean isDeploymentTargetApplication(
+                CustomCommandLine activeCustomCommandLine, CommandLine commandLine)
+                throws FlinkException {
+            application = super.isDeploymentTargetApplication(activeCustomCommandLine, commandLine);
+            return application;
+        }
+
+        @Override
+        protected void executeProgram(Configuration configuration, PackagedProgram program) {
+            executeProgramCalled = true;
         }
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/util/DummyClusterDescriptor.java
@@ -55,7 +55,7 @@ public class DummyClusterDescriptor<T> implements ClusterDescriptor<T> {
     public ClusterClientProvider<T> deployApplicationCluster(
             final ClusterSpecification clusterSpecification,
             final ApplicationConfiguration applicationConfiguration) {
-        throw new UnsupportedOperationException("Application Mode not supported.");
+        return () -> clusterClient;
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -45,11 +45,13 @@ public class DeploymentOptions {
                                     .list(
                                             text("remote"),
                                             text("local"),
+                                            text("yarn-application"),
                                             text("yarn-per-job (deprecated)"),
                                             text("yarn-session"),
+                                            text("kubernetes-application"),
                                             text("kubernetes-session"))
                                     .text(
-                                            "And one of the following values when calling %s:",
+                                            "And one of the following values when calling %s (deprecated):",
                                             TextElement.code("bin/flink run-application"))
                                     .list(text("yarn-application"), text("kubernetes-application"))
                                     .build());


### PR DESCRIPTION
## What is the purpose of the change

Merge the functionality of "flink run" and "flink run-application" under the "run" command to make job deployment more consistent. Also deprecate "run-application" so it can be removed together with "yarn-per-job" in the future.

## Brief change log

- Introduced `isApplication(...)` check method in `FrontendCli` to determine necessary deployment steps.
- Handle application mode deployment in `FrontendCli#run`.
- In `FrontendCli#runApplication`, simply call `FrontendCli#run` after argument check.
- Added unit tests to cover the introduced code flow changes in `CliFrontendRunTests`.
- Updated, adapted CLI help/usage messages, and relevant config option documentation.
- Marked `run-application` deprecated in code, config docs, and help/usage messages. 

## Verifying this change

Unit tests were added to cover the introduced changes.

Also did a manual check, where I executed the following on a locally built Flink and `minikube` setup:
```sh
$ ./bin/flink run-application \
    --target kubernetes-application \
    -Dkubernetes.cluster-id=flink-app-cluster-1 \
    -Dkubernetes.container.image.ref=flink:1.19 \
    local:///opt/flink/examples/streaming/TopSpeedWindowing.jar

$ ./bin/flink run \
    --target kubernetes-application \
    -Dkubernetes.cluster-id=flink-app-cluster-2 \
    -Dkubernetes.container.image.ref=flink:1.19 \
    local:///opt/flink/examples/streaming/TopSpeedWindowing.jar

$ kubectl get pods
NAME                                         READY   STATUS    RESTARTS   AGE
flink-app-cluster-1-778bb58994-q8hg5         1/1     Running   0          30s
flink-app-cluster-1-taskmanager-1-1          1/1     Running   0          22s
flink-app-cluster-2-6555f5fc76-2sspj         1/1     Running   0          18s
flink-app-cluster-2-taskmanager-1-1          1/1     Running   0          9s
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable