### PR TITLE
[BP-1.19][FLINK-35639][runtime] Fixes wrong deprecation in RestartStrategies#FixedDelayRestartStrategyConfiguration

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/restartstrategy/RestartStrategies.java
@@ -239,6 +239,12 @@ public class RestartStrategies {
         private final int restartAttempts;
         private final Duration delayBetweenAttemptsInterval;
 
+        @Deprecated
+        FixedDelayRestartStrategyConfiguration(
+                int restartAttempts, Time delayBetweenAttemptsInterval) {
+            this(restartAttempts, Time.toDuration(delayBetweenAttemptsInterval));
+        }
+
         FixedDelayRestartStrategyConfiguration(
                 int restartAttempts, Duration delayBetweenAttemptsInterval) {
             this.restartAttempts = restartAttempts;


### PR DESCRIPTION
1.19 backport for PR #24954 

## What is the purpose of the change

The package-private constructor slipped through when deprecating the `Time` classes in FLINK-32570 causing the the `ClassCastException` when deserializing the 1.18 `JobGraph` with 1.19 as described in FLINK-35639:
```
[...]
Caused by: java.lang.ClassCastException: cannot assign instance of org.apache.flink.api.common.time.Time to field org.apache.flink.api.common.restartstrategy.RestartStrategies$FixedDelayRestartStrategyConfiguration.delayBetweenAttemptsInterval of type java.time.Duration in instance of org.apache.flink.api.common.restartstrategy.RestartStrategies$FixedDelayRestartStrategyConfiguration
    at java.io.ObjectStreamClass$FieldReflector.setObjFieldValues(ObjectStreamClass.java:2096) ~[?:?]
    at java.io.ObjectStreamClass$FieldReflector.checkObjectFieldValueTypes(ObjectStreamClass.java:2060) ~[?:?]
    at java.io.ObjectStreamClass.checkObjFieldValueTypes(ObjectStreamClass.java:1347) ~[?:?]
    at java.io.ObjectInputStream$FieldValues.defaultCheckFieldValues(ObjectInputStream.java:2679) ~[?:?]
    at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2486) ~[?:?]
    at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257) ~[?:?]
    at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733) ~[?:?]
    at java.io.ObjectInputStream$FieldValues.<init>(ObjectInputStream.java:2606) ~[?:?]
    at java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2457) ~[?:?]
    at java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257) ~[?:?]
    at java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733) ~[?:?]
    at java.io.ObjectInputStream.readObject(ObjectInputStream.java:509) ~[?:?]
    at java.io.ObjectInputStream.readObject(ObjectInputStream.java:467) ~[?:?]
```

## Brief change log

* Added package-private constructor back and marked it as deprecated

## Verifying this change

I verified once more that we don't have any other similar error in the FLINK-32570 related commits: https://github.com/apache/flink/commit/99d6fd3c68f46daf0397a35566414e1d19774c3d and https://github.com/apache/flink/commit/c943ab49

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable