### PR TITLE
[hotfix] update doc version and japicmp for 1.19.1

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -34,7 +34,7 @@ pygmentsUseClasses = true
   # we change the version for the complete docs when forking of a release branch
   # etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "1.19.0"
+  Version = "1.19.1"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@ under the License.
 		<minikdc.version>3.2.4</minikdc.version>
 		<hive.version>2.3.9</hive.version>
 		<orc.version>1.5.6</orc.version>
-		<japicmp.referenceVersion>1.19.0</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.19.1</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<spotless.version>2.27.1</spotless.version>
 		<spotless.scalafmt.version>3.4.3</spotless.scalafmt.version>


### PR DESCRIPTION
I see that `1.19.1` has been announced but these were not updated for now.

cc @hlteoh37 In case you forget it :)