### PR TITLE
[FLINK-35656][hive] Fix the issue that Hive Source incorrectly set max parallelism in dynamic inference mode

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicParallelismInferenceFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicParallelismInferenceFactory.java
@@ -62,6 +62,18 @@ class HiveDynamicParallelismInferenceFactory implements HiveParallelismInference
                                         globalMaxParallelism),
                         globalMaxParallelism);
         int parallelism = ExecutionConfig.PARALLELISM_DEFAULT;
+        adjustInferMaxParallelism(jobConf, inferMaxParallelism);
         return new HiveParallelismInference(tablePath, infer, inferMaxParallelism, parallelism);
+    }
+
+    /**
+     * Reset infer source max parallelism in jobConf, and {@link
+     * HiveSourceFileEnumerator#createInputSplits} will infer InputSplits based on the
+     * inferMaxParallelism.
+     */
+    private void adjustInferMaxParallelism(JobConf jobConf, int inferMaxParallelism) {
+        jobConf.set(
+                HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM_MAX.key(),
+                String.valueOf(inferMaxParallelism));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix the issue that Hive Source incorrectly set max parallelism in dynamic inference mode

## Brief change log
  - *when `table.exec.hive.infer-source-parallelism.max` is not configured, it will use `execution.batch.adaptive.auto-parallelism.default-source-parallelism` as the upper bound for parallelism inference in dynamic parallelism inference mode.*


## Verifying this change
This change added tests and can be verified as follows:
  - *Added ut to verify the logic.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)
