### PR TITLE
[FLINK-26940][table] Add the built-in function SUBSTRING_INDEX

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -492,7 +492,19 @@ string:
       index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>, exprs <BINARY | VARBINARY>
       
       The result has the type of the least common type of all expressions. `NULL` if index is `NULL` or out of range.
-
+  - sql: SUBSTRING_INDEX(expr, delim, count)
+    table: expr.substringIndex(delim, count)
+    description: | 
+      Returns the substring of expr before count occurrences of delim. 
+      
+      If count is positive, everything to the left of the final delim (counting from the left) is returned. 
+      If count is negative, everything to the right of the final delim (counting from the right) is returned.
+      
+      `expr <CHAR | VARCHAR>, delim <CHAR | VARCHAR>, count <TINYINT | SMALLINT | INTEGER | BIGINT>`
+      
+      `expr <BINARY | VARBINARY>, delim <BINARY | VARBINARY>, count <TINYINT | SMALLINT | INTEGER | BIGINT>`
+      
+      The result type matches the type of expr. `NULL` if any of the arguments are `NULL`.
 temporal:
   - sql: DATE string
     table: STRING.toDate()

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -589,7 +589,19 @@ string:
       index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>, exprs <BINARY | VARBINARY>
       
       结果类型为所有 expr 的公共类型。如果 index 为 `NULL` 或超出范围，则返回 `NULL`。
-
+  - sql: SUBSTRING_INDEX(expr, delim, count)
+    table: expr.substringIndex(delim, count)
+    description: |
+      返回 expr 中分隔符 delim 出现第 count 次前的子串。
+      
+      如果 count 为正，则返回最终分隔符左侧的所有内容（从左侧开始计数）。
+      如果 count 为负，则返回最终分隔符右侧的所有内容（从右侧开始计数）。
+      
+      `expr <CHAR | VARCHAR>, delim <CHAR | VARCHAR>, count <TINYINT | SMALLINT | INTEGER | BIGINT>`
+      
+      `expr <BINARY | VARBINARY>, delim <BINARY | VARBINARY>, count <TINYINT | SMALLINT | INTEGER | BIGINT>`
+      
+      返回值类型与 expr 一致。任意参数为 `NULL` 则返回 `NULL`。
 temporal:
   - sql: DATE string
     table: STRING.toDate()

--- a/flink-connectors/flink-connector-hive/src/test/resources/endpoint/hive_module.q
+++ b/flink-connectors/flink-connector-hive/src/test/resources/endpoint/hive_module.q
@@ -297,9 +297,9 @@ SHOW FULL MODULES;
 !ok
 
 # use hive built-in function without using hive module
-SELECT SUBSTRING_INDEX('www.apache.org', '.', 2) FROM (VALUES (1, 'Hello World'));
+SELECT NEXT_DAY('2024-07-12', 'TU');
 !output
-org.apache.calcite.sql.validate.SqlValidatorException: No match found for function signature SUBSTRING_INDEX(<CHARACTER>, <CHARACTER>, <NUMERIC>)
+org.apache.calcite.sql.validate.SqlValidatorException: No match found for function signature NEXT_DAY(<CHARACTER>, <CHARACTER>)
 !error
 
 # ==========================================================================

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -207,6 +207,7 @@ string functions
     Expression.split_index
     Expression.str_to_map
     Expression.elt
+    Expression.substring_index
 
 temporal functions
 ------------------

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1481,6 +1481,26 @@ class Expression(Generic[T]):
                      for e in exprs]
         return _ternary_op("elt")(self, expr, to_jarray(gateway.jvm.Object, expr_list))
 
+    def substring_index(self, delim, count) -> 'Expression':
+        """
+        Returns the substring of expr before count occurrences of delim.
+        expr and delim allow binary type, and the result matches the type of expr.
+        null if any of the arguments are null.
+
+        If count is positive, everything to the left of the final delim
+        (counting from the left) is returned.
+        If count is negative, everything to the right of the final delim
+        (counting from the right) is returned.
+
+        null if any of the arguments are null.
+
+        :param delim: A STRING or BINARY expression matching the type of expr specifying the
+         delimiter.
+        :param count: An INTEGER expression to count the delimiters.
+        :return: The result matches the type of expr.
+        """
+        return _ternary_op("substringIndex")(self, delim, count)
+
     # ---------------------------- temporal functions ----------------------------------
 
     @property

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -172,6 +172,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("ELT(1, a)", str(lit(1).elt(expr1)))
         self.assertEqual('ELT(3, a, b, c)', str(lit(3).elt(expr1, expr2, expr3)))
         self.assertEqual("PRINTF('%d %s', a, b)", str(lit("%d %s").printf(expr1, expr2)))
+        self.assertEqual("SUBSTRING_INDEX(a, b, 1)", str(expr1.substring_index(expr2, 1)))
 
         # regexp functions
         self.assertEqual("regexp(a, b)", str(expr1.regexp(expr2)))

--- a/flink-table/flink-sql-client/src/test/resources/sql/module.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/module.q
@@ -50,9 +50,9 @@ org.apache.flink.table.api.ValidationException: A module with name 'core' alread
 !error
 
 # use hive built-in function without loading hive module
-SELECT SUBSTRING_INDEX('www.apache.org', '.', 2) FROM (VALUES (1, 'Hello World')) AS T(id, str);
+SELECT NEXT_DAY('2024-07-12', 'TU');
 [ERROR] Could not execute SQL statement. Reason:
-org.apache.calcite.sql.validate.SqlValidatorException: No match found for function signature SUBSTRING_INDEX(<CHARACTER>, <CHARACTER>, <NUMERIC>)
+org.apache.calcite.sql.validate.SqlValidatorException: No match found for function signature NEXT_DAY(<CHARACTER>, <CHARACTER>)
 !error
 
 # load dummy module with module name as string literal

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -192,6 +192,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STDDEV
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STR_TO_MAP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SUBSTR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SUBSTRING;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SUBSTRING_INDEX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SUM;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SUM0;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TAN;
@@ -1471,6 +1472,28 @@ public abstract class BaseExpressions<InType, OutType> {
                                 Arrays.stream(exprs).map(ApiExpressionUtils::objectToExpression))
                         .toArray(Expression[]::new);
         return toApiSpecificExpression(unresolvedCall(ELT, args));
+    }
+
+    /**
+     * Returns the substring of {@code expr} before {@code count} occurrences of the delimiter
+     * {@code delim}. <br>
+     * If count is positive, everything to the left of the final delimiter (counting from the left)
+     * is returned. <br>
+     * If count is negative, everything to the right of the final delimiter (counting from the
+     * right) is returned.
+     *
+     * @param delim A STRING or BINARY expression matching the type of {@code expr} specifying the
+     *     delimiter.
+     * @param count An INTEGER expression to count the delimiters.
+     * @return The result matches the type of {@code expr}. null if any of the arguments are null.
+     */
+    public OutType substringIndex(InType delim, InType count) {
+        return toApiSpecificExpression(
+                unresolvedCall(
+                        SUBSTRING_INDEX,
+                        toExpr(),
+                        objectToExpression(delim),
+                        objectToExpression(count)));
     }
 
     // Temporal operations

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1501,6 +1501,29 @@ public final class BuiltInFunctionDefinitions {
                     .runtimeClass("org.apache.flink.table.runtime.functions.scalar.EltFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition SUBSTRING_INDEX =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("SUBSTRING_INDEX")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            Arrays.asList("expr", "delim", "count"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                                    logical(LogicalTypeFamily.INTEGER_NUMERIC))),
+                                    sequence(
+                                            Arrays.asList("expr", "delim", "count"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.BINARY_STRING),
+                                                    logical(LogicalTypeFamily.BINARY_STRING),
+                                                    logical(LogicalTypeFamily.INTEGER_NUMERIC)))))
+                    .outputTypeStrategy(forceNullable(varyingString(argument(0))))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.SubstringIndexFunction")
+                    .build();
+
     // --------------------------------------------------------------------------------------------
     // Math functions
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SubstringIndexFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/SubstringIndexFunction.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#SUBSTRING_INDEX}. */
+@Internal
+public class SubstringIndexFunction extends BuiltInScalarFunction {
+    public SubstringIndexFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.SUBSTRING_INDEX, context);
+    }
+
+    public @Nullable StringData eval(
+            @Nullable StringData expr, @Nullable StringData delim, @Nullable Number count) {
+        if (expr == null
+                || delim == null
+                || count == null
+                || count.longValue() > Integer.MAX_VALUE
+                || count.longValue() < Integer.MIN_VALUE) {
+            return null;
+        }
+
+        int cnt = count.intValue();
+        if (cnt == 0
+                || BinaryStringDataUtil.isEmpty((BinaryStringData) expr)
+                || BinaryStringDataUtil.isEmpty((BinaryStringData) delim)) {
+            return BinaryStringData.EMPTY_UTF8;
+        }
+
+        String str = expr.toString();
+        String delimiter = delim.toString();
+
+        try {
+            if (cnt > 0) {
+                // get index of the count-th occurrences of delimiter
+                int idx = StringUtils.ordinalIndexOf(str, delimiter, cnt);
+                if (idx != StringUtils.INDEX_NOT_FOUND) {
+                    return StringData.fromString(str.substring(0, idx));
+                }
+            } else {
+                // get index of the last -count-th occurrences of delimiter
+                int idx = StringUtils.lastOrdinalIndexOf(str, delimiter, -cnt);
+                if (idx != StringUtils.INDEX_NOT_FOUND) {
+                    return StringData.fromString(str.substring(idx + delimiter.length()));
+                }
+            }
+        } catch (Throwable t) {
+            return null;
+        }
+
+        // can not find enough delimiter
+        return expr;
+    }
+
+    public @Nullable byte[] eval(
+            @Nullable byte[] expr, @Nullable byte[] delim, @Nullable Number count) {
+        if (expr == null
+                || delim == null
+                || count == null
+                || count.longValue() > Integer.MAX_VALUE
+                || count.longValue() < Integer.MIN_VALUE) {
+            return null;
+        }
+
+        int cnt = count.intValue();
+        if (expr.length == 0 || delim.length == 0 || cnt == 0) {
+            return new byte[0];
+        }
+
+        if (cnt > 0) {
+            int idx = -1;
+            while (cnt > 0) {
+                // get index of the next occurrence of delim
+                idx = find(expr, idx + 1, delim);
+                if (idx >= 0) {
+                    --cnt;
+                } else {
+                    // can not find enough delim
+                    return expr;
+                }
+            }
+            if (idx == 0) {
+                return new byte[0];
+            }
+            return Arrays.copyOfRange(expr, 0, idx);
+
+        } else {
+            int idx = expr.length - delim.length + 1;
+            while (cnt < 0) {
+                // get index of the previous occurrence of delim
+                idx = rfind(expr, idx - 1, delim);
+                if (idx >= 0) {
+                    ++cnt;
+                } else {
+                    // can not find enough delim
+                    return expr;
+                }
+            }
+            if (idx + delim.length == expr.length) {
+                return new byte[0];
+            }
+            return Arrays.copyOfRange(expr, idx + delim.length, expr.length);
+        }
+    }
+
+    private static int find(byte[] str, int beginIdx, byte[] target) {
+        final int endIdx = str.length - target.length;
+        while (beginIdx <= endIdx) {
+            if (match(str, beginIdx, target)) {
+                return beginIdx;
+            }
+            ++beginIdx;
+        }
+        return -1;
+    }
+
+    private static int rfind(byte[] str, int beginIdx, byte[] target) {
+        while (beginIdx >= 0) {
+            if (match(str, beginIdx, target)) {
+                return beginIdx;
+            }
+            --beginIdx;
+        }
+        return -1;
+    }
+
+    private static boolean match(byte[] str, int beginIdx, byte[] target) {
+        for (int i = 0; i < target.length; ++i) {
+            if (str[beginIdx + i] != target[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
Add SUBSTRING_INDEX supported in SQL & Table API.
Examples:
```sql
> SELECT substring_index('www.apache.org', '.', 2);
 www.apache 
```

## Brief change log

[FLINK-26940](https://issues.apache.org/jira/browse/FLINK-26940)

## Verifying this change
This change added tests and can be verified as follows: `StringFunctionsITCase#substringIndexTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
