### PR TITLE
 [hotfix][parquet] fix row group filter support issue

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
@@ -136,7 +136,7 @@ public abstract class ParquetVectorizedInputFormat<T, SplitT extends FileSourceS
 
         checkSchema(fileSchema, requestedSchema);
 
-        final long totalRowCount = parquetFileReader.getFilteredRecordCount();
+        final long totalRowCount = parquetFileReader.getRecordCount();
         final Pool<ParquetReaderBatch<T>> poolOfBatches =
                 createPoolOfBatches(split, requestedSchema, numBatchesToCirculate(config));
 
@@ -405,7 +405,7 @@ public abstract class ParquetVectorizedInputFormat<T, SplitT extends FileSourceS
         }
 
         private void readNextRowGroup() throws IOException {
-            PageReadStore pages = reader.readNextFilteredRowGroup();
+            PageReadStore pages = reader.readNextRowGroup();
             if (pages == null) {
                 throw new IOException(
                         "expecting more rows but reached last block. Read "

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
@@ -405,7 +405,7 @@ public abstract class ParquetVectorizedInputFormat<T, SplitT extends FileSourceS
         }
 
         private void readNextRowGroup() throws IOException {
-            PageReadStore pages = reader.readNextRowGroup();
+            PageReadStore pages = reader.readNextFilteredRowGroup();
             if (pages == null) {
                 throw new IOException(
                         "expecting more rows but reached last block. Read "

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReader.java
@@ -303,7 +303,7 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     }
 
     private void readNextRowGroup() throws IOException {
-        PageReadStore pages = reader.readNextRowGroup();
+        PageReadStore pages = reader.readNextFilteredRowGroup();
         if (pages == null) {
             throw new IOException(
                     "expecting more rows but reached last block. Read "

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReader.java
@@ -303,7 +303,7 @@ public class ParquetColumnarRowSplitReader implements Closeable {
     }
 
     private void readNextRowGroup() throws IOException {
-        PageReadStore pages = reader.readNextFilteredRowGroup();
+        PageReadStore pages = reader.readNextRowGroup();
         if (pages == null) {
             throw new IOException(
                     "expecting more rows but reached last block. Read "


### PR DESCRIPTION
## What is the purpose of the change

In `ParquetVectorizedInputFormat.java` the row group filter is set
```
FilterCompat.Filter filter = getFilter(hadoopConfig.conf());
ParquetReadOptions parquetReadOptions =
        ParquetReadOptions.builder()
                .withRange(splitOffset, splitOffset + splitLength)
                .withRecordFilter(filter)
                .build();
```
But the row groups are read incorrectly using `readNextRowGroup` instead of `readNextFilteredRowGroup`. This affects the performance (filters are not working because all row groups are read) and also could lead to incorrect result because eventually returning here (totalRowCount are calculated with filters applied):
```
if (rowsReturned >= totalRowCount) {
        return false;
}
```

## Brief change log

  - *Changed `readNextRowGroup` to `readNextFilteredRowGroup` in `ParquetColumnarRowSplitReader::readNextRowGroup`*
  - *Changed `readNextRowGroup` to `readNextFilteredRowGroup` in `ParquetVectorizedInputFormat::readNextRowGroup`*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / no / **don't know**)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
