### PR TITLE
 [hotfix][Table SQL / API] fix create table from values decimal issue

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static java.lang.Math.max;
+
 /**
  * Value-based data type extractor that supports extraction of clearly identifiable data types for
  * input conversion.
@@ -119,8 +121,8 @@ public final class ValueDataTypeConverter {
     }
 
     private static DataType convertToDecimalType(BigDecimal decimal) {
-        final int precision = decimal.precision();
         final int scale = decimal.scale();
+        final int precision = max(decimal.precision(), scale);
         // let underlying layers check if precision and scale are supported
         if (scale < 0) {
             // negative scale is not supported, normalize it


### PR DESCRIPTION
## What is the purpose of the change

The following code fails on the second `fromValues`:
```
List<Row> rows1 = new ArrayList<>();
rows1.add(Row.of(new BigDecimal("1.01")));
final Table table1 = tableEnv().fromValues(rows1);
List<Row> rows2 = new ArrayList<>();
rows2.add(Row.of(new BigDecimal("0.01")));
final Table table2 = tableEnv().fromValues(rows2);
```
with an exception
```
org.apache.flink.table.api.ValidationException: Decimal scale must be between 0 and the precision 1 (both inclusive).

	at org.apache.flink.table.types.logical.DecimalType.<init>(DecimalType.java:76)
	at org.apache.flink.table.types.logical.DecimalType.<init>(DecimalType.java:85)
	at org.apache.flink.table.api.DataTypes.DECIMAL(DataTypes.java:283)
	at org.apache.flink.table.types.utils.ValueDataTypeConverter.convertToDecimalType(ValueDataTypeConverter.java:131)
	at org.apache.flink.table.types.utils.ValueDataTypeConverter.extractDataType(ValueDataTypeConverter.java:69)
	at org.apache.flink.table.expressions.ValueLiteralExpression.deriveDataTypeFromValue(ValueLiteralExpression.java:354)
```

The reason is that the object `new BigDecimal("0.01")` has scale = 2 and precision = 1, which is not appropriate for Flink Decimal type. So, Flink Decimal type creation from BigDecimal value should be adjusted.

## Brief change log

  - *Added precision adjustment in `ValueDataTypeConverter::convertToDecimalType` to reflect that `BigDecimal` could have precision less than scale*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
