### PR TITLE
[FLINK-35707][Table SQL / API] Allow column definition in CREATE TABLE AS (CTAS)

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableAs.java
@@ -125,12 +125,6 @@ public class SqlCreateTableAs extends SqlCreateTable {
                     "CREATE TABLE AS SELECT syntax does not support to create temporary table yet.");
         }
 
-        if (getColumnList().size() > 0) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    "CREATE TABLE AS SELECT syntax does not support to specify explicit columns yet.");
-        }
-
         if (getWatermark().isPresent()) {
             throw new SqlValidateException(
                     getParserPosition(),

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -2853,10 +2853,7 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     @Test
     void testCreateTableAsSelectWithExplicitColumns() {
         sql("CREATE TABLE t (col1 string) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "CREATE TABLE AS SELECT syntax does not support to specify explicit columns yet."));
+                .node(new ValidationMatcher().ok());
     }
 
     @Test
@@ -3279,6 +3276,7 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     private static class ValidationMatcher extends BaseMatcher<SqlNode> {
         private String expectedColumnSql;
         private String failMsg;
+        private boolean ok;
 
         public ValidationMatcher expectColumnSql(String s) {
             this.expectedColumnSql = s;
@@ -3287,6 +3285,13 @@ class FlinkSqlParserImplTest extends SqlParserTest {
 
         public ValidationMatcher fails(String failMsg) {
             this.failMsg = failMsg;
+            this.ok = false;
+            return this;
+        }
+
+        public ValidationMatcher ok() {
+            this.failMsg = null;
+            this.ok = true;
             return this;
         }
 
@@ -3299,7 +3304,14 @@ class FlinkSqlParserImplTest extends SqlParserTest {
         public boolean matches(Object item) {
             if (item instanceof ExtendedSqlNode) {
                 ExtendedSqlNode createTable = (ExtendedSqlNode) item;
-                if (failMsg != null) {
+
+                if (ok) {
+                    try {
+                        createTable.validate();
+                    } catch (SqlValidateException e) {
+                        fail("unexpected exception", e);
+                    }
+                } else if (failMsg != null) {
                     try {
                         createTable.validate();
                         fail("expected exception");
@@ -3307,6 +3319,7 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                         assertThat(e).hasMessage(failMsg);
                     }
                 }
+
                 if (expectedColumnSql != null && item instanceof SqlCreateTable) {
                     assertThat(((SqlCreateTable) createTable).getColumnSqlString())
                             .isEqualTo(expectedColumnSql);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/MergeTableAsUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/MergeTableAsUtil.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.sql.parser.ddl.SqlCreateTableAs;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlComputedColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlMetadataColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Schema.UnresolvedColumn;
+import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsImplicitCast;
+
+/** A utility class with logic for handling the {@code CREATE TABLE ... AS SELECT} clause. */
+public class MergeTableAsUtil {
+    private final SqlValidator validator;
+    private final Function<SqlNode, String> escapeExpression;
+    private final DataTypeFactory dataTypeFactory;
+
+    MergeTableAsUtil(
+            SqlValidator validator,
+            Function<SqlNode, String> escapeExpression,
+            DataTypeFactory dataTypeFactory) {
+        this.validator = validator;
+        this.escapeExpression = escapeExpression;
+        this.dataTypeFactory = dataTypeFactory;
+    }
+
+    /**
+     * Merges the schema part of the {@code sqlCreateTableAs} with the {@code sourceSchema}.
+     *
+     * <p>It is expected that the {@code sourceSchema} contains only physical/regular columns, which
+     * is behavior of the CTAS statement to generate such schema.
+     *
+     * <p>Columns of {@code sourceSchema} are appended to the schema of {@code sqlCreateTableAs}. If
+     * a column in the {@code sqlCreateTableAs} is already defined in {@code sourceSchema}, then the
+     * types of the columns are implicit cast and must be compatible based on the implicit cast
+     * rules. If they're compatible, then the column position in the schema stays the same as
+     * defined in the appended {@code sourceSchema}.
+     */
+    public Schema mergeSchemas(SqlCreateTableAs sqlCreateTableAs, ResolvedSchema sourceSchema) {
+        SchemaBuilder schemaBuilder =
+                new SchemaBuilder(
+                        (FlinkTypeFactory) validator.getTypeFactory(),
+                        dataTypeFactory,
+                        validator,
+                        escapeExpression);
+
+        schemaBuilder.mergeColumns(
+                sqlCreateTableAs.getColumnList(),
+                Schema.newBuilder().fromResolvedSchema(sourceSchema).build().getColumns());
+
+        return schemaBuilder.build();
+    }
+
+    /**
+     * Builder class for constructing a {@link Schema} based on the rules of the {@code CREATE TABLE
+     * ... AS SELECT} statement.
+     */
+    private static class SchemaBuilder extends SchemaBuilderUtil {
+        Map<String, UnresolvedColumn> columns = new LinkedHashMap<>();
+
+        // Mapping required to find the type of column when evaluating compute column expressions.
+        Map<String, RelDataType> allFieldNamesToTypes = new LinkedHashMap<>();
+
+        FlinkTypeFactory typeFactory;
+
+        SchemaBuilder(
+                FlinkTypeFactory typeFactory,
+                DataTypeFactory dataTypeFactory,
+                SqlValidator sqlValidator,
+                Function<SqlNode, String> escapeExpressions) {
+            super(sqlValidator, escapeExpressions, dataTypeFactory);
+            this.typeFactory = typeFactory;
+        }
+
+        /**
+         * Merges the sink columns with the source columns. The resulted schema will contain columns
+         * of the sink schema first, followed by the columns of the source schema.
+         *
+         * <p>If a column in the sink schema is already defined in the source schema, then the types
+         * of the columns overrides the types of the columns in the source schema. The column
+         * position in the schema stays the same as defined in the source schema.
+         *
+         * <p>Column types overridden follows the same implicit cast rules defined for INSERT INTO
+         * statements.
+         */
+        private void mergeColumns(List<SqlNode> sinkCols, List<UnresolvedColumn> sourceCols) {
+            Map<String, UnresolvedColumn> sinkSchemaCols = new LinkedHashMap<>();
+            Map<String, UnresolvedColumn> sourceSchemaCols = new LinkedHashMap<>();
+
+            populateColumnsFromSource(sourceCols, sourceSchemaCols);
+
+            int sinkColumnPos = -1;
+            for (SqlNode sinkColumn : sinkCols) {
+                String name = ((SqlTableColumn) sinkColumn).getName().getSimple();
+                sinkColumnPos++;
+
+                if (sinkSchemaCols.containsKey(name)) {
+                    throw new ValidationException(
+                            String.format(
+                                    "A column named '%s' already exists in the schema. ", name));
+                }
+
+                UnresolvedColumn unresolvedSinkColumn;
+
+                if (sinkColumn instanceof SqlRegularColumn) {
+                    unresolvedSinkColumn =
+                            toUnresolvedPhysicalColumn((SqlRegularColumn) sinkColumn);
+
+                    allFieldNamesToTypes.put(
+                            name, toRelDataType(((SqlRegularColumn) sinkColumn).getType()));
+                } else if (sinkColumn instanceof SqlMetadataColumn) {
+                    unresolvedSinkColumn =
+                            toUnresolvedMetadataColumn((SqlMetadataColumn) sinkColumn);
+
+                    allFieldNamesToTypes.put(
+                            name, toRelDataType(((SqlMetadataColumn) sinkColumn).getType()));
+                } else if (sinkColumn instanceof SqlComputedColumn) {
+                    unresolvedSinkColumn =
+                            toUnresolvedComputedColumn(
+                                    (SqlComputedColumn) sinkColumn, allFieldNamesToTypes);
+                } else {
+                    throw new ValidationException("Unsupported column type: " + sinkColumn);
+                }
+
+                if (sourceSchemaCols.containsKey(name)) {
+                    // If the column is already defined in the source schema, then check if
+                    // the types are compatible.
+                    validateImplicitCastCompatibility(
+                            name, sinkColumnPos, sourceSchemaCols.get(name), unresolvedSinkColumn);
+
+                    // Replace the source schema column with the new sink schema column, which
+                    // keeps the position of the source schema column but with the data type
+                    // of the sink column.
+                    sourceSchemaCols.put(name, unresolvedSinkColumn);
+                } else {
+                    sinkSchemaCols.put(name, unresolvedSinkColumn);
+                }
+            }
+
+            columns.clear();
+            sinkSchemaCols.forEach(columns::put);
+            sourceSchemaCols.forEach(columns::put);
+        }
+
+        /**
+         * Populates the schema columns from the source schema. The source schema is expected to
+         * contain only physical columns.
+         */
+        private void populateColumnsFromSource(
+                List<UnresolvedColumn> columns, Map<String, UnresolvedColumn> schemaCols) {
+            for (UnresolvedColumn column : columns) {
+                if (!(column instanceof UnresolvedPhysicalColumn)) {
+                    throw new ValidationException(
+                            "Computed columns and metadata columns are not expected "
+                                    + "in the source schema.");
+                }
+
+                if (schemaCols.containsKey(column.getName())) {
+                    throw new ValidationException(
+                            String.format(
+                                    "A column named '%s' already exists in the schema. ",
+                                    column.getName()));
+                }
+
+                String name = column.getName();
+                LogicalType sourceColumnType = getLogicalType(((UnresolvedPhysicalColumn) column));
+
+                schemaCols.put(column.getName(), column);
+                allFieldNamesToTypes.put(
+                        name, typeFactory.createFieldTypeFromLogicalType(sourceColumnType));
+            }
+        }
+
+        private void validateImplicitCastCompatibility(
+                String columnName,
+                int columnPos,
+                UnresolvedColumn sourceColumn,
+                UnresolvedColumn sinkColumn) {
+            if (!(sinkColumn instanceof UnresolvedPhysicalColumn)) {
+                throw new ValidationException(
+                        String.format(
+                                "A column named '%s' already exists in the source schema. "
+                                        + "Computed and metadata columns cannot overwrite "
+                                        + "regular columns.",
+                                columnName));
+            }
+
+            LogicalType sourceColumnType =
+                    getLogicalType(((UnresolvedPhysicalColumn) sourceColumn));
+            LogicalType sinkColumnType = getLogicalType(((UnresolvedPhysicalColumn) sinkColumn));
+
+            if (!supportsImplicitCast(sourceColumnType, sinkColumnType)) {
+                throw new ValidationException(
+                        String.format(
+                                "Incompatible types for sink column '%s' at position %d. "
+                                        + "The source column has type '%s', "
+                                        + "while the target column has type '%s'.",
+                                columnName, columnPos, sourceColumnType, sinkColumnType));
+            }
+        }
+
+        public Schema build() {
+            Schema.Builder resultBuilder = Schema.newBuilder();
+            resultBuilder.fromColumns(new ArrayList<>(columns.values()));
+
+            return resultBuilder.build();
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SchemaBuilderUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SchemaBuilderUtil.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlComputedColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlMetadataColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
+import org.apache.flink.table.api.Schema.UnresolvedComputedColumn;
+import org.apache.flink.table.api.Schema.UnresolvedMetadataColumn;
+import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.expressions.SqlCallExpression;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static org.apache.flink.table.planner.calcite.FlinkTypeFactory.toLogicalType;
+import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
+
+/** A utility class for {@link MergeTableAsUtil} and {@link MergeTableLikeUtil} classes. */
+public class SchemaBuilderUtil {
+    protected final SqlValidator sqlValidator;
+    protected final Function<SqlNode, String> escapeExpressions;
+    protected final DataTypeFactory dataTypeFactory;
+
+    public SchemaBuilderUtil(
+            SqlValidator sqlValidator,
+            Function<SqlNode, String> escapeExpressions,
+            DataTypeFactory dataTypeFactory) {
+        this.sqlValidator = sqlValidator;
+        this.escapeExpressions = escapeExpressions;
+        this.dataTypeFactory = dataTypeFactory;
+    }
+
+    /** Converts a {@link SqlRegularColumn} to an {@link UnresolvedPhysicalColumn} object. */
+    public UnresolvedPhysicalColumn toUnresolvedPhysicalColumn(SqlRegularColumn column) {
+        final String name = column.getName().getSimple();
+        final Optional<String> comment = getComment(column);
+        final LogicalType logicalType = toLogicalType(toRelDataType(column.getType()));
+
+        return new UnresolvedPhysicalColumn(
+                name, fromLogicalToDataType(logicalType), comment.orElse(null));
+    }
+
+    /** Converts a {@link SqlComputedColumn} to an {@link UnresolvedComputedColumn} object. */
+    public UnresolvedComputedColumn toUnresolvedComputedColumn(
+            SqlComputedColumn column, Map<String, RelDataType> accessibleFieldNamesToTypes) {
+        final String name = column.getName().getSimple();
+        final Optional<String> comment = getComment(column);
+
+        final SqlNode validatedExpr =
+                sqlValidator.validateParameterizedExpression(
+                        column.getExpr(), accessibleFieldNamesToTypes);
+
+        return new UnresolvedComputedColumn(
+                name,
+                new SqlCallExpression(escapeExpressions.apply(validatedExpr)),
+                comment.orElse(null));
+    }
+
+    /** Converts a {@link SqlMetadataColumn} to an {@link UnresolvedMetadataColumn} object. */
+    public UnresolvedMetadataColumn toUnresolvedMetadataColumn(SqlMetadataColumn column) {
+        final String name = column.getName().getSimple();
+        final Optional<String> comment = getComment(column);
+        final LogicalType logicalType = toLogicalType(toRelDataType(column.getType()));
+
+        return new UnresolvedMetadataColumn(
+                name,
+                fromLogicalToDataType(logicalType),
+                column.getMetadataAlias().orElse(null),
+                column.isVirtual(),
+                comment.orElse(null));
+    }
+
+    /**
+     * Gets the column data type of {@link UnresolvedPhysicalColumn} column and convert it to a
+     * {@link LogicalType}.
+     */
+    public LogicalType getLogicalType(UnresolvedPhysicalColumn column) {
+        return dataTypeFactory.createDataType(column.getDataType()).getLogicalType();
+    }
+
+    public Optional<String> getComment(SqlTableColumn column) {
+        return column.getComment().map(c -> ((SqlLiteral) c).getValueAs(String.class));
+    }
+
+    public RelDataType toRelDataType(SqlDataTypeSpec type) {
+        boolean nullable = type.getNullable() == null || type.getNullable();
+        return type.deriveType(sqlValidator, nullable);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/SqlRewriterUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/SqlRewriterUtils.scala
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.calcite
+
+import org.apache.flink.sql.parser.`type`.SqlMapTypeNameSpec
+import org.apache.flink.table.planner.calcite.SqlRewriterUtils.{rewriteSqlSelect, rewriteSqlValues}
+
+import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeFactory}
+import org.apache.calcite.sql.`type`.SqlTypeUtil
+import org.apache.calcite.sql.{SqlCall, SqlDataTypeSpec, SqlKind, SqlNode, SqlNodeList, SqlSelect}
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.sql.parser.SqlParserPos
+
+import java.util
+import java.util.Collections
+
+import scala.collection.JavaConversions._
+
+class SqlRewriterUtils(validator: FlinkCalciteSqlValidator) {
+  def rewriteSelect(
+      select: SqlSelect,
+      targetRowType: RelDataType,
+      assignedFields: util.LinkedHashMap[Integer, SqlNode],
+      targetPosition: util.List[Int]): SqlCall = {
+    rewriteSqlSelect(validator, select, targetRowType, assignedFields, targetPosition)
+  }
+
+  def rewriteValues(
+      svalues: SqlCall,
+      targetRowType: RelDataType,
+      assignedFields: util.LinkedHashMap[Integer, SqlNode],
+      targetPosition: util.List[Int]): SqlCall = {
+    rewriteSqlValues(svalues, targetRowType, assignedFields, targetPosition)
+  }
+
+  // This code snippet is copied from the SqlValidatorImpl.
+  def maybeCast(
+      node: SqlNode,
+      currentType: RelDataType,
+      desiredType: RelDataType,
+      typeFactory: RelDataTypeFactory): SqlNode = {
+    if (
+      currentType == desiredType
+      || (currentType.isNullable != desiredType.isNullable
+        && typeFactory.createTypeWithNullability(currentType, desiredType.isNullable)
+        == desiredType)
+    ) {
+      node
+    } else {
+      // See FLINK-26460 for more details
+      val sqlDataTypeSpec =
+        if (SqlTypeUtil.isNull(currentType) && SqlTypeUtil.isMap(desiredType)) {
+          val keyType = desiredType.getKeyType
+          val valueType = desiredType.getValueType
+          new SqlDataTypeSpec(
+            new SqlMapTypeNameSpec(
+              SqlTypeUtil.convertTypeToSpec(keyType).withNullable(keyType.isNullable),
+              SqlTypeUtil.convertTypeToSpec(valueType).withNullable(valueType.isNullable),
+              SqlParserPos.ZERO),
+            SqlParserPos.ZERO)
+        } else {
+          SqlTypeUtil.convertTypeToSpec(desiredType)
+        }
+      SqlStdOperatorTable.CAST.createCall(SqlParserPos.ZERO, node, sqlDataTypeSpec)
+    }
+  }
+}
+
+object SqlRewriterUtils {
+  def rewriteSqlSelect(
+      validator: FlinkCalciteSqlValidator,
+      select: SqlSelect,
+      targetRowType: RelDataType,
+      assignedFields: util.LinkedHashMap[Integer, SqlNode],
+      targetPosition: util.List[Int]): SqlCall = {
+    // Expands the select list first in case there is a star(*).
+    // Validates the select first to register the where scope.
+    validator.validate(select)
+    val sourceList = validator.expandStar(select.getSelectList, select, false).getList
+
+    val fixedNodes = new util.ArrayList[SqlNode]
+    val currentNodes =
+      if (targetPosition.isEmpty) {
+        new util.ArrayList[SqlNode](sourceList)
+      } else {
+        reorder(new util.ArrayList[SqlNode](sourceList), targetPosition)
+      }
+    (0 until targetRowType.getFieldList.length).foreach {
+      idx =>
+        if (assignedFields.containsKey(idx)) {
+          fixedNodes.add(assignedFields.get(idx))
+        } else if (currentNodes.size() > 0) {
+          fixedNodes.add(currentNodes.remove(0))
+        }
+    }
+    // Although it is error case, we still append the old remaining
+    // projection nodes to new projection.
+    if (currentNodes.size > 0) {
+      fixedNodes.addAll(currentNodes)
+    }
+    select.setSelectList(new SqlNodeList(fixedNodes, select.getSelectList.getParserPosition))
+    select
+  }
+
+  def rewriteSqlValues(
+      values: SqlCall,
+      targetRowType: RelDataType,
+      assignedFields: util.LinkedHashMap[Integer, SqlNode],
+      targetPosition: util.List[Int]): SqlCall = {
+    val fixedNodes = new util.ArrayList[SqlNode]
+    (0 until values.getOperandList.size()).foreach {
+      valueIdx =>
+        val value = values.getOperandList.get(valueIdx)
+        val valueAsList = if (value.getKind == SqlKind.ROW) {
+          value.asInstanceOf[SqlCall].getOperandList
+        } else {
+          Collections.singletonList(value)
+        }
+        val currentNodes =
+          if (targetPosition.isEmpty) {
+            new util.ArrayList[SqlNode](valueAsList)
+          } else {
+            reorder(new util.ArrayList[SqlNode](valueAsList), targetPosition)
+          }
+        val fieldNodes = new util.ArrayList[SqlNode]
+        (0 until targetRowType.getFieldList.length).foreach {
+          fieldIdx =>
+            if (assignedFields.containsKey(fieldIdx)) {
+              fieldNodes.add(assignedFields.get(fieldIdx))
+            } else if (currentNodes.size() > 0) {
+              fieldNodes.add(currentNodes.remove(0))
+            }
+        }
+        // Although it is error case, we still append the old remaining
+        // value items to new item list.
+        if (currentNodes.size > 0) {
+          fieldNodes.addAll(currentNodes)
+        }
+        fixedNodes.add(SqlStdOperatorTable.ROW.createCall(value.getParserPosition, fieldNodes))
+    }
+    SqlStdOperatorTable.VALUES.createCall(values.getParserPosition, fixedNodes)
+  }
+
+  /**
+   * Reorder sourceList to targetPosition. For example:
+   *   - sourceList(f0, f1, f2).
+   *   - targetPosition(1, 2, 0).
+   *   - Output(f1, f2, f0).
+   *
+   * @param sourceList
+   *   input fields.
+   * @param targetPosition
+   *   reorder mapping.
+   * @return
+   *   reorder fields.
+   */
+  private def reorder(
+      sourceList: util.ArrayList[SqlNode],
+      targetPosition: util.List[Int]): util.ArrayList[SqlNode] = {
+    new util.ArrayList[SqlNode](targetPosition.map(sourceList.get))
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Allow defining new columns and/or overriding source column types in the `CREATE` clause on CTAS statements.
Syntax supported:
```
CREATE TABLE table_name [( <column_definition>[, ...n] )]
AS SELECT query_expression;
```

## Brief change log
- *Added support for column definition in the CREATE clause*

## Verifying this change

This change added tests and can be verified as follows: 
- *Added unit tests to validation and converter classes*
- *Manually verified the change by running a single node cluster and sql client*

Quick test using a compute column to check the expression is evaluated using source columns:
```
Flink SQL> create table t1(id int, name string) with ('connector'='filesystem', 'format'='json', 'path'='/tmp/t1');
[INFO] Execute statement succeeded.

Flink SQL> insert into t1 values (1, 's1');
[INFO] Submitting SQL update statement to the cluster...
[INFO] SQL update statement has been successfully submitted to the cluster:
Job ID: bf61390313b4e173c1afb8e60ef5c2c9

Flink SQL> create table s1_1(id_2x as id * 2) with ('connector'='filesystem', 'format'='json', 'path'='/tmp/s1_1') as select id, name from t1;
[INFO] Submitting SQL update statement to the cluster...
[INFO] SQL update statement has been successfully submitted to the cluster:
Job ID: b5cf09801d323c9008fbe7a20006e83e

Flink SQL> describe s1_1;
+-------+--------+------+-----+-------------+-----------+
|  name |   type | null | key |      extras | watermark |
+-------+--------+------+-----+-------------+-----------+
| id_2x |    INT | TRUE |     | AS `id` * 2 |           |
|    id |    INT | TRUE |     |             |           |
|  name | STRING | TRUE |     |             |           |
+-------+--------+------+-----+-------------+-----------+
3 rows in set

Flink SQL> select * from s1_1;

       id_2x          id                           name
           2           1                             s1
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs (will follow-up with another PR to update docs)
