### PR TITLE
[FLINK-26943][Table SQL / API] Add DATE_ADD supported in SQL & Table API

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -538,6 +538,14 @@ temporal:
         CURRENT_WATERMARK(ts) IS NULL
         OR ts > CURRENT_WATERMARK(ts)
       ```
+  - sql: DATE_ADD(startDate, numDays>)
+    table: startDate.dateAdd(numDays)
+    description: |
+      startDate <DATE>, numDays <TINYINT | SMALLINT | INTEGER>
+      Returns a DATE, null if any of arguments are null.
+      Returns the date numDays after startDate.
+      If numDays is negative, -numDays are subtracted from startDate.
+      If the result date overflows, the function raises an error.
 
 conditional:
   - sql: |

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -669,6 +669,14 @@ temporal:
         CURRENT_WATERMARK(ts) IS NULL
         OR ts > CURRENT_WATERMARK(ts)
       ```
+  - sql: DATE_ADD(startDate, numDays>)
+    table: startDate.dateAdd(numDays)
+    description: |
+      startDate <DATE>, numDays <TINYINT | SMALLINT | INTEGER>
+      返回一个 DATE，如果任何一个参数为 null，则返回 null。
+      返回起始日期 startDate 之后 numDays 天的日期。
+      如果 numDays 为负数，则从 startDate 中减去 -numDays 天。
+      如果结果日期溢出，函数会引发一个错误。
 
 conditional:
   - sql: |

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -86,6 +86,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COSH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COUNT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DATE_ADD;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DECODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DEGREES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DISTINCT;
@@ -1333,6 +1334,20 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType ceil(TimeIntervalUnit timeIntervalUnit) {
         return toApiSpecificExpression(
                 unresolvedCall(CEIL, toExpr(), valueLiteral(timeIntervalUnit)));
+    }
+
+    /**
+     * Adds {@code numDays} days to {@code startDate}.
+     *
+     * @param numDays an INTEGER expression
+     * @return a DATE. {@code null} if any of its arguments are {@code null}. <br>
+     *     If {@code numDays} is negative, {@code -numDays} are subtracted from {@code startDate}.
+     *     <br>
+     *     If the result date overflows, the function raises an error.
+     */
+    public OutType dateAdd(InType numDays) {
+        return toApiSpecificExpression(
+                unresolvedCall(DATE_ADD, toExpr(), objectToExpression(numDays)));
     }
 
     // Advanced type helper functions

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -2022,6 +2022,24 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(TIMESTAMP(3))))
                     .build();
 
+    // TODO add support for python
+    public static final BuiltInFunctionDefinition DATE_ADD =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("DATE_ADD")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Arrays.asList("startDate", "numDays"),
+                                    Arrays.asList(
+                                            logical(LogicalTypeRoot.DATE),
+                                            or(
+                                                    logical(LogicalTypeRoot.TINYINT),
+                                                    logical(LogicalTypeRoot.SMALLINT),
+                                                    logical(LogicalTypeRoot.INTEGER)))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.DATE())))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.DateAddFunction")
+                    .build();
+
     // --------------------------------------------------------------------------------------------
     // Collection functions
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -127,11 +127,17 @@ public class DateTimeUtils {
     /** The valid minimum epoch seconds ('0000-01-01 00:00:00 UTC+0'). */
     private static final long MIN_EPOCH_SECONDS = -62167219200L;
 
+    /** The valid minimum epoch days ('0000-01-01 UTC+0'). */
+    private static final long MIN_EPOCH_DAYS = -719528L;
+
     /** The valid maximum epoch milliseconds ('9999-12-31 23:59:59.999 UTC+0'). */
     private static final long MAX_EPOCH_MILLS = 253402300799999L;
 
     /** The valid maximum epoch seconds ('9999-12-31 23:59:59 UTC+0'). */
     private static final long MAX_EPOCH_SECONDS = 253402300799L;
+
+    /** The valid maximum epoch days ('9999-12-31 UTC+0'). */
+    private static final long MAX_EPOCH_DAYS = 2932896L;
 
     private static final DateTimeFormatter DEFAULT_TIMESTAMP_FORMATTER =
             new DateTimeFormatterBuilder()
@@ -1695,6 +1701,20 @@ public class DateTimeUtils {
             --x;
         }
         return x;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // ADD/REMOVE days
+    // --------------------------------------------------------------------------------------------
+
+    /** Adds a given number of days to a date, represented as the number of days since the epoch. */
+    public static int addDays(int startDate, int numDays) throws DateTimeException {
+        long date = (long) startDate + numDays;
+        if (date < MIN_EPOCH_DAYS || date > MAX_EPOCH_DAYS) {
+            throw new DateTimeException(
+                    "Date result overflows, the valid range is from '0000-01-01' to '9999-12-31'.");
+        }
+        return (int) date;
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateAddFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.utils.DateTimeUtils;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#DATE_ADD}. */
+public class DateAddFunction extends BuiltInScalarFunction {
+    public DateAddFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.DATE_ADD, context);
+    }
+
+    public Integer eval(@Nullable Integer startDate, @Nullable Number numDays) {
+        if (startDate == null || numDays == null) {
+            return null;
+        }
+        return DateTimeUtils.addDays(startDate, numDays.intValue());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add DATE_ADD supported in SQL & Table API.
Examples:

```SQL
> SELECT date_add('2016-07-30', 1); 
2016-07-31  
```

## Brief change log

DATE_ADD for Table API and SQL
[FLINK-26943](https://issues.apache.org/jira/browse/FLINK-26943)


## Verifying this change

This change added tests and can be verified as follows: `TimeFunctionsITCase#dateAddTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
