### PR TITLE
[BP-1.19][FLINK-35699][k8s] Fix shading Jackson through fabric8

### DIFF
--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -141,8 +141,30 @@ under the License.
 										<exclude>license.header</exclude>
 									</excludes>
 								</filter>
+								<filter>
+									<artifact>com.fasterxml.jackson*:*</artifact>
+									<excludes>
+										<exclude>META-INF/**/module-info.class</exclude>
+										<exclude>META-INF/*LICENSE</exclude>
+										<exclude>META-INF/*NOTICE</exclude>
+									</excludes>
+								</filter>
 							</filters>
 							<relocations>
+								<!-- When "io.fabric8:kubernetes-client" is bumped, make sure to check JDK-specific Jackson classes,
+								 	 and introduce new versions when necessary. -->
+								<relocation>
+									<pattern>META-INF/versions/11/com/fasterxml/jackson</pattern>
+									<shadedPattern>META-INF/versions/11/org/apache/flink/kubernetes/shaded/com/fasterxml/jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/17/com/fasterxml/jackson</pattern>
+									<shadedPattern>META-INF/versions/17/org/apache/flink/kubernetes/shaded/com/fasterxml/jackson</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>META-INF/versions/19/com/fasterxml/jackson</pattern>
+									<shadedPattern>META-INF/versions/19/org/apache/flink/kubernetes/shaded/com/fasterxml/jackson</shadedPattern>
+								</relocation>
 								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.kubernetes.shaded.com.fasterxml.jackson</shadedPattern>


### PR DESCRIPTION
## What is the purpose of the change
The `flink-kubernetes` artifact shades Jackson classes coming through fabric8, but since Jackson 2.15, Jackson is a [multi-release JAR](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15#jar-changes), which requires some additional relocations for correct shading.

What Jackson does itself can be checked [here](https://github.com/FasterXML/jackson-core/blob/80e6c424ef876f31f07d3ce12c68ecd5294fe004/pom.xml#L192).

## Brief change log
- Added exclusions for Jackson related meta files, which otherwise overwrites the Flink ones.
- Added relocations for JDK-specific code.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no