### PR TITLE
[FLINK-35717][table] Allow defining partition keys and table distribution in CREATE TABLE AS (CTAS)

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableAs.java
@@ -124,18 +124,6 @@ public class SqlCreateTableAs extends SqlCreateTable {
                     getParserPosition(),
                     "CREATE TABLE AS SELECT syntax does not support to create temporary table yet.");
         }
-
-        if (getDistribution() != null) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    "CREATE TABLE AS SELECT syntax does not support creating distributed tables yet.");
-        }
-        // TODO flink dialect supports dynamic partition
-        if (getPartitionKeyList().size() > 0) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    "CREATE TABLE AS SELECT syntax does not support to create partitioned table yet.");
-        }
     }
 
     public SqlNode getAsQuery() {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -2885,19 +2885,13 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     @Test
     void testCreateTableAsSelectWithDistribution() {
         sql("CREATE TABLE t DISTRIBUTED BY(col1) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "CREATE TABLE AS SELECT syntax does not support creating distributed tables yet."));
+                .node(new ValidationMatcher().ok());
     }
 
     @Test
     void testCreateTableAsSelectWithPartitionKey() {
         sql("CREATE TABLE t PARTITIONED BY(col1) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "CREATE TABLE AS SELECT syntax does not support to create partitioned table yet."));
+                .node(new ValidationMatcher().ok());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

*Allows defining PARTITIONED BY and DISTRIBUTED BY in the CTAS statement.*

Syntax supported:
```
CREATE TABLE table_name
[PARTITIONED BY (cols)]
[DISTRIBUTED BY [HASH|RANGE|RANDOM](cols) [INTO n BUCKETS]]
AS SELECT query_expression;
```

## Brief change log

- *Added support for DISTRIBUTED BY syntax in CTAS*
- - *Added support for PARTITIONED BY syntax in CTAS*

## Verifying this change

This change added tests and can be verified as follows:
- Added unit tests to validation and converter classes
- Manually verified the change by running a single node cluster and sql client

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs (will follow-up with another PR to update docs)
