### PR TITLE
[FLINK-20539][table-planner] Fix type mismatch when casting ROW

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/ExtendedSqlRowTypeNameSpec.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/type/ExtendedSqlRowTypeNameSpec.java
@@ -20,6 +20,7 @@ package org.apache.flink.sql.parser.type;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.StructKind;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlDataTypeSpec;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -44,6 +45,8 @@ import java.util.stream.Collectors;
  *   <li>Support comment syntax for every field
  *   <li>Field data type default is nullable
  *   <li>Support ROW type with empty fields, e.g. ROW()
+ *   <li>Use {@link StructKind#PEEK_FIELDS_NO_EXPAND} in Flink instead of {@link
+ *       StructKind#FULLY_QUALIFIED} in Calcite
  * </ul>
  */
 public class ExtendedSqlRowTypeNameSpec extends SqlTypeNameSpec {
@@ -155,6 +158,7 @@ public class ExtendedSqlRowTypeNameSpec extends SqlTypeNameSpec {
     public RelDataType deriveType(SqlValidator sqlValidator) {
         final RelDataTypeFactory typeFactory = sqlValidator.getTypeFactory();
         return typeFactory.createStructType(
+                StructKind.PEEK_FIELDS_NO_EXPAND,
                 fieldTypes.stream()
                         .map(dt -> dt.deriveType(sqlValidator))
                         .collect(Collectors.toList()),

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/Fixture.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/Fixture.java
@@ -19,6 +19,7 @@
 package org.apache.flink.sql.parser;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.StructKind;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 import java.util.List;
@@ -109,7 +110,7 @@ public class Fixture {
     }
 
     public RelDataType createStructType(List<RelDataType> keyTypes, List<String> names) {
-        return typeFactory.createStructType(keyTypes, names);
+        return typeFactory.createStructType(StructKind.PEEK_FIELDS_NO_EXPAND, keyTypes, names);
     }
 
     public RelDataType createRawType(String className, String serializerString) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java
@@ -93,16 +93,18 @@ class CastFunctionMiscITCase extends BuiltInFunctionTestBase {
                                                         FIELD(
                                                                 "r",
                                                                 ROW(
-                                                                        FIELD("s", STRING()),
+                                                                        FIELD(
+                                                                                "s",
+                                                                                STRING().notNull()),
                                                                         FIELD("b", BOOLEAN()),
                                                                         FIELD("i", INT()))),
                                                         FIELD("s", STRING()))),
                                 "CAST(f0 AS ROW<r ROW<s STRING NOT NULL, b BOOLEAN, i INT>, s STRING>)",
                                 Row.of(Row.of("12", true, null), "Hello"),
-                                // the inner NOT NULL is ignored in SQL because the outer ROW is
-                                // nullable and the cast does not allow setting the outer
-                                // nullability but derives it from the source operand
-                                DataTypes.of("ROW<r ROW<s STRING, b BOOLEAN, i INT>, s STRING>")),
+                                // For nested rows we keep the nullability property.
+                                // See more at FlinkTypeFactory#createTypeWithNullability
+                                DataTypes.of(
+                                        "ROW<r ROW<s STRING NOT NULL, b BOOLEAN, i INT>, s STRING>")),
                 TestSetSpec.forFunction(
                                 BuiltInFunctionDefinitions.CAST,
                                 "explicit with nested rows and explicit nullability change")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -834,7 +834,7 @@ public class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversion
                                 + " ROW<`tmstmp` TIMESTAMP(3)>.");
     }
 
-    @Test // TODO: tweak the tests when FLINK-13604 is fixed.
+    @Test
     public void testCreateTableWithFullDataTypes() {
         final List<TestItem> testItems =
                 Arrays.asList(
@@ -908,17 +908,15 @@ public class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversion
                         createTestItem(
                                 "MAP<BIGINT, BOOLEAN>",
                                 DataTypes.MAP(DataTypes.BIGINT(), DataTypes.BOOLEAN())),
-                        // Expect to be ROW<`f0` INT NOT NULL, `f1` BOOLEAN>.
                         createTestItem(
                                 "ROW<f0 INT NOT NULL, f1 BOOLEAN>",
                                 DataTypes.ROW(
-                                        DataTypes.FIELD("f0", DataTypes.INT()),
+                                        DataTypes.FIELD("f0", DataTypes.INT().notNull()),
                                         DataTypes.FIELD("f1", DataTypes.BOOLEAN()))),
-                        // Expect to be ROW<`f0` INT NOT NULL, `f1` BOOLEAN>.
                         createTestItem(
                                 "ROW(f0 INT NOT NULL, f1 BOOLEAN)",
                                 DataTypes.ROW(
-                                        DataTypes.FIELD("f0", DataTypes.INT()),
+                                        DataTypes.FIELD("f0", DataTypes.INT().notNull()),
                                         DataTypes.FIELD("f1", DataTypes.BOOLEAN()))),
                         createTestItem(
                                 "ROW<`f0` INT>",
@@ -928,12 +926,11 @@ public class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversion
                                 DataTypes.ROW(DataTypes.FIELD("f0", DataTypes.INT()))),
                         createTestItem("ROW<>", DataTypes.ROW()),
                         createTestItem("ROW()", DataTypes.ROW()),
-                        // Expect to be ROW<`f0` INT NOT NULL '...', `f1` BOOLEAN '...'>.
                         createTestItem(
                                 "ROW<f0 INT NOT NULL 'This is a comment.',"
                                         + " f1 BOOLEAN 'This as well.'>",
                                 DataTypes.ROW(
-                                        DataTypes.FIELD("f0", DataTypes.INT()),
+                                        DataTypes.FIELD("f0", DataTypes.INT().notNull()),
                                         DataTypes.FIELD("f1", DataTypes.BOOLEAN()))),
                         createTestItem(
                                 "ARRAY<ROW<f0 INT, f1 BOOLEAN>>",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcTest.xml
@@ -502,4 +502,21 @@ Calc(select=[ROW(1, 'Hi', a) AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCastRow">
+    <Resource name="sql">
+      <![CDATA[SELECT b, c, cast(row(b, c) as row(b_val int, c_val string)) as col FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$1], c=[$2], col=[CAST(ROW($1, $2)):RecordType:peek_no_expand(INTEGER b_val, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" c_val) NOT NULL])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, c, CAST(ROW(b, c) AS RecordType:peek_no_expand(INTEGER b_val, VARCHAR(2147483647) c_val)) AS col])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/CalcTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/table/CalcTest.xml
@@ -232,4 +232,19 @@ Calc(select=[hashCode(c) AS _c0, b])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCastRow">
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], col=[$2])
++- LogicalProject(a=[$0], b=[$1], col=[CAST(ROW($0, $1)):RecordType:peek_no_expand(INTEGER a_val, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" b_val) NOT NULL])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, CAST(ROW(a, b) AS RecordType:peek_no_expand(INTEGER a_val, VARCHAR(2147483647) b_val)) AS col])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
@@ -485,4 +485,21 @@ Calc(select=[ROW(1, 'Hi', a) AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCastRow">
+    <Resource name="sql">
+      <![CDATA[SELECT b, c, cast(row(b, c) as row(b_val int, c_val string)) as col FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$1], c=[$2], col=[CAST(ROW($1, $2)):RecordType:peek_no_expand(INTEGER b_val, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" c_val) NOT NULL])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, c, CAST(ROW(b, c) AS RecordType:peek_no_expand(INTEGER b_val, VARCHAR(2147483647) c_val)) AS col])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CalcTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CalcTest.xml
@@ -184,4 +184,19 @@ GroupWindowAggregate(window=[TumblingGroupWindow('w, rowtime, 5)], select=[COUNT
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCastRow">
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], col=[$2])
++- LogicalProject(a=[$0], b=[$1], col=[CAST(ROW($0, $1)):RecordType:peek_no_expand(INTEGER a_val, VARCHAR(2147483647) CHARACTER SET "UTF-16LE" b_val) NOT NULL])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, CAST(ROW(a, b) AS RecordType:peek_no_expand(INTEGER a_val, VARCHAR(2147483647) b_val)) AS col])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/CalcTest.scala
@@ -207,4 +207,11 @@ class CalcTest extends TableTestBase {
     val sqlQuery = "SELECT a FROM (SELECT a, b FROM MyTable) t WHERE random_udf(b) > 10"
     util.verifyRelPlan(sqlQuery)
   }
+
+  @Test
+  def testCastRow(): Unit = {
+    val sqlQuery =
+      "SELECT b, c, cast(row(b, c) as row(b_val int, c_val string)) as col FROM MyTable"
+    util.verifyExecPlan(sqlQuery)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/CalcTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/table/CalcTest.scala
@@ -176,6 +176,17 @@ class CalcTest extends TableTestBase {
 
     util.verifyExecPlan(resultTable)
   }
+
+  @Test
+  def testCastRow(): Unit = {
+    val util = streamTestUtil()
+
+    util.addTableSource[(Int, String)]("MyTable", 'a, 'b)
+    val view = util.tableEnv.sqlQuery(
+      "SELECT a, b, CAST(ROW(a, b) as ROW(a_val INT, b_val STRING)) as col FROM MyTable")
+    util.tableEnv.createTemporaryView("MyView", view)
+    util.verifyExecPlan("SELECT * from MyView")
+  }
 }
 
 object CalcTest {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/CalcTest.scala
@@ -201,4 +201,11 @@ class CalcTest extends TableTestBase {
     val sqlQuery = "SELECT a FROM (SELECT a, b FROM MyTable) t WHERE random_udf(b) > 10"
     util.verifyRelPlan(sqlQuery)
   }
+
+  @Test
+  def testCastRow(): Unit = {
+    val sqlQuery =
+      "SELECT b, c, cast(row(b, c) as row(b_val int, c_val string)) as col FROM MyTable"
+    util.verifyExecPlan(sqlQuery)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CalcTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CalcTest.scala
@@ -155,4 +155,15 @@ class CalcTest extends TableTestBase {
 
     util.verifyExecPlan(resultTable)
   }
+
+  @Test
+  def testCastRow(): Unit = {
+    val util = streamTestUtil()
+
+    util.addTableSource[(Int, String)]("MyTable", 'a, 'b)
+    val view = util.tableEnv.sqlQuery(
+      "SELECT a, b, CAST(ROW(a, b) as ROW(a_val INT, b_val STRING)) as col FROM MyTable")
+    util.tableEnv.createTemporaryView("MyView", view)
+    util.verifyExecPlan("SELECT * from MyView")
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

When using cast, Flink uses `ExtendedSqlRowTypeNameSpec` to derive the row type, and we should change the `StructKind` from `FULLY_QUALIFIED` in Calcite to `PEEK_FIELDS_NO_EXPAND` in Flink.

## Brief change log

  - *Return a Row type with PEEK_FIELDS_NO_EXPAND as the target type in CAST*
  - *Add tests to verify this pr.*


## Verifying this change

Some tests are added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
