### PR TITLE
[FLINK-34130][core] Mark setBytes and getBytes of Configuration as @Internal

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -593,6 +593,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      *     with the given key.
      * @return the (default) value associated with the given key.
      */
+    @Internal
     public byte[] getBytes(String key, byte[] defaultValue) {
         return getRawValue(key)
                 .map(
@@ -616,6 +617,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * @param key The key under which the bytes are added.
      * @param bytes The bytes to be added.
      */
+    @Internal
     public void setBytes(String key, byte[] bytes) {
         setValueInternal(key, bytes);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -2383,6 +2383,9 @@ under the License.
 								<exclude>org.apache.flink.util.function.SerializableFunction</exclude>
 								<exclude>org.apache.flink.util.function.SupplierWithException</exclude>
 								<exclude>org.apache.flink.util.function.ThrowingConsumer</exclude>
+								<!-- Mark these 2 methods to @Internal. Tracked under FLINK-34130 -->
+								<exclude>org.apache.flink.configuration.Configuration#getBytes()</exclude>
+								<exclude>org.apache.flink.configuration.Configuration#setBytes()</exclude>
 								<!-- Disable check for two sink methods. -->
 								<!-- TypeSerializer needs to be considered upgraded to Public. Tracked under FLINK-35566 -->
 								<exclude>org.apache.flink.api.connector.sink2.WriterInitContext#createInputSerializer()</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -2384,8 +2384,8 @@ under the License.
 								<exclude>org.apache.flink.util.function.SupplierWithException</exclude>
 								<exclude>org.apache.flink.util.function.ThrowingConsumer</exclude>
 								<!-- Mark these 2 methods to @Internal. Tracked under FLINK-34130 -->
-								<exclude>org.apache.flink.configuration.Configuration#getBytes()</exclude>
-								<exclude>org.apache.flink.configuration.Configuration#setBytes()</exclude>
+								<exclude>org.apache.flink.configuration.Configuration#getBytes(java.lang.String,byte[])</exclude>
+								<exclude>org.apache.flink.configuration.Configuration#setBytes(java.lang.String,byte[])</exclude>
 								<!-- Disable check for two sink methods. -->
 								<!-- TypeSerializer needs to be considered upgraded to Public. Tracked under FLINK-35566 -->
 								<exclude>org.apache.flink.api.connector.sink2.WriterInitContext#createInputSerializer()</exclude>


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-34130][core] Mark setBytes and getBytes of Configuration as @Internal


## Brief change log

[FLINK-34130][core] Mark setBytes and getBytes of Configuration as @Internal


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
