### PR TITLE
[BP-1.20][FLINK-35734][table] Do not override the user-defined checkpoint interval in continuous mode

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -541,10 +541,17 @@ public class MaterializedTableManager {
                         materializedTableIdentifier.asSerializableString());
         customConfig.set(NAME, jobName);
         customConfig.set(RUNTIME_MODE, STREAMING);
-        customConfig.set(
-                CheckpointingOptions.CHECKPOINTING_INTERVAL,
-                catalogMaterializedTable.getFreshness());
         restorePath.ifPresent(s -> customConfig.set(SAVEPOINT_PATH, s));
+
+        // Do not override the user-defined checkpoint interval
+        if (!operationExecutor
+                .getSessionContext()
+                .getSessionConf()
+                .contains(CheckpointingOptions.CHECKPOINTING_INTERVAL)) {
+            customConfig.set(
+                    CheckpointingOptions.CHECKPOINTING_INTERVAL,
+                    catalogMaterializedTable.getFreshness());
+        }
 
         String insertStatement =
                 getInsertStatement(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -621,9 +621,14 @@ public class MaterializedTableManager {
         // Set job name, runtime mode
         Configuration customConfig = new Configuration();
         String jobName =
-                String.format(
-                        "Materialized_table_%s_one_time_refresh_job",
-                        materializedTableIdentifier.asSerializableString());
+                isPeriodic
+                        ? String.format(
+                                "Materialized_table_%s_periodic_refresh_job",
+                                materializedTableIdentifier.asSerializableString())
+                        : String.format(
+                                "Materialized_table_%s_one_time_refresh_job",
+                                materializedTableIdentifier.asSerializableString());
+
         customConfig.set(NAME, jobName);
         customConfig.set(RUNTIME_MODE, BATCH);
 


### PR DESCRIPTION
BP 1.20 for https://github.com/apache/flink/pull/25002

## What is the purpose of the change

Currently, in continuous mode, the checkpoint interval is set based on freshness by default. However, if the user explicitly sets a checkpoint interval, we should follow the user's setting.


## Brief change log

* Fix periodic refresh job naming.
* Do not override the user-defined checkpoint interval in continuous mode


## Verifying this change

* Add test `testCreateMaterializedTableInContinuousModeWithCustomCheckpointInterval` in MaterializedTableStatementITCase to verify that we don't over write the user custom checkpoint interval.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
