### PR TITLE
[FLINK-35728][python] Move conda url from repo.continuum.io to repo.anaconda.com

### DIFF
--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -185,8 +185,8 @@ function install_wget() {
 # some packages including checks such as tox and flake8.
 
 function install_miniconda() {
-    OS_TO_CONDA_URL=("https://repo.continuum.io/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh" \
-        "https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh")
+    OS_TO_CONDA_URL=("https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh" \
+        "https://repo.anaconda.com/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh")
     if [ ! -f "$CONDA_INSTALL" ]; then
         print_function "STEP" "download miniconda..."
         download ${OS_TO_CONDA_URL[$1]} $CONDA_INSTALL_SH


### PR DESCRIPTION
## What is the purpose of the change

Update the Conda endpoint URL following the Conda community's decision to deprecate repo.continuum.io and migrate to the new endpoint repo.anaconda.com.


## Brief change log

Replaced all instances of repo.continuum.io with repo.anaconda.com.
Reference:
For more details, see the discussion in the Conda issue: [conda/conda#6886](https://github.com/conda/conda/issues/6886).

## Verifying this change

- Build tests are getting succeeded . 
- Verified PyFlink end-to-end test is executed and succeeded properly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) N/A