### PR TITLE
[FLINK-35735][sql-gateway] Don't list all catalogs when closing session

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
@@ -255,15 +255,13 @@ public class SessionContext {
     /** Close resources, e.g. catalogs. */
     public void close() {
         operationManager.close();
-        for (String name : sessionState.catalogManager.listCatalogs()) {
-            try {
-                sessionState.catalogManager.getCatalog(name).ifPresent(Catalog::close);
-            } catch (Throwable t) {
-                LOG.error(
-                        String.format(
-                                "Failed to close catalog %s for the session %s.", name, sessionId),
-                        t);
-            }
+
+        try {
+            sessionState.catalogManager.close();
+        } catch (Throwable t) {
+            LOG.error(
+                    String.format("Failed to close catalog manager for the session %s.", sessionId),
+                    t);
         }
         try {
             userClassloader.close();


### PR DESCRIPTION
## What is the purpose of the change

*Use CatalogManager#close when closing the session instead of listing all catalogs and then closing each of them. *


## Brief change log

  - *Close the catalog manager when closing the session*


## Verifying this change

No tests need be added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 

