### PR TITLE
[FLINK-35742] Don't create RocksDB Column Family if task cancellation is in progress

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/CloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/CloseableRegistry.java
@@ -33,21 +33,11 @@ import java.util.Map;
 
 import static org.apache.flink.shaded.guava31.com.google.common.collect.Lists.reverse;
 
-/**
- * This class allows to register instances of {@link Closeable}, which are all closed if this
- * registry is closed.
- *
- * <p>Registering to an already closed registry will throw an exception and close the provided
- * {@link Closeable}
- *
- * <p>All methods in this class are thread-safe.
- *
- * <p>This class closes all registered {@link Closeable}s in the reverse registration order.
- */
+/** {@link ICloseableRegistry} implementation. */
 @Internal
 public class CloseableRegistry
         extends AbstractAutoCloseableRegistry<Closeable, Closeable, Object, IOException>
-        implements Closeable {
+        implements ICloseableRegistry {
 
     private static final Object DUMMY = new Object();
 

--- a/flink-core/src/main/java/org/apache/flink/core/fs/ICloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/ICloseableRegistry.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.fs;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * This class allows to register instances of {@link Closeable}, which are all closed if this
+ * registry is closed.
+ *
+ * <p>Registering to an already closed registry will throw an exception and close the provided
+ * {@link Closeable}
+ *
+ * <p>All methods in this class are thread-safe.
+ *
+ * <p>This class closes all registered {@link Closeable}s in the reverse registration order.
+ */
+@Internal
+public interface ICloseableRegistry extends Closeable {
+
+    /**
+     * Registers a {@link Closeable} with the registry. In case the registry is already closed, this
+     * method throws an {@link IllegalStateException} and closes the passed {@link Closeable}.
+     *
+     * @param closeable Closeable to register.
+     * @throws IOException exception when the registry was closed before.
+     */
+    void registerCloseable(Closeable closeable) throws IOException;
+
+    /**
+     * Same as {@link #registerCloseable(Closeable)} but allows to {@link
+     * #unregisterCloseable(Closeable) unregister} the passed closeable by closing the returned
+     * closeable.
+     *
+     * @param closeable Closeable to register.
+     * @return another Closeable that unregisters the passed closeable.
+     * @throws IOException exception when the registry was closed before.
+     */
+    default Closeable registerCloseableTemporarily(Closeable closeable) throws IOException {
+        registerCloseable(closeable);
+        return () -> unregisterCloseable(closeable);
+    }
+
+    /**
+     * Removes a {@link Closeable} from the registry.
+     *
+     * @param closeable instance to remove from the registry.
+     * @return true if the closeable was previously registered and became unregistered through this
+     *     call.
+     */
+    boolean unregisterCloseable(Closeable closeable);
+
+    /** No-op implementation of {@link org.apache.flink.core.fs.ICloseableRegistry}. */
+    ICloseableRegistry NO_OP =
+            new ICloseableRegistry() {
+                @Override
+                public void registerCloseable(Closeable closeable) {}
+
+                @Override
+                public boolean unregisterCloseable(Closeable closeable) {
+                    return false;
+                }
+
+                @Override
+                public boolean isClosed() {
+                    return false;
+                }
+
+                @Override
+                public void close() {}
+            };
+
+    /** @return true if this registry was closed. */
+    boolean isClosed();
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -34,6 +34,7 @@ import org.apache.flink.contrib.streaming.state.snapshot.RocksDBSnapshotStrategy
 import org.apache.flink.contrib.streaming.state.sstmerge.RocksDBManualCompactionManager;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
 import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.ICloseableRegistry;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -716,7 +717,10 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                             db,
                             columnFamilyOptionsFactory,
                             ttlCompactFiltersManager,
-                            optionsContainer.getWriteBufferManagerCapacity());
+                            optionsContainer.getWriteBufferManagerCapacity(),
+                            // Using ICloseableRegistry.NO_OP here because there is no restore in
+                            // progress; created column families will be closed in dispose()
+                            ICloseableRegistry.NO_OP);
             RocksDBOperationUtils.registerKvStateInformation(
                     this.kvStateInformation,
                     this.nativeMetricMonitor,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackendBuilder.java
@@ -556,7 +556,8 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                     restoreStateHandles,
                     ttlCompactFiltersManager,
                     writeBatchSize,
-                    optionsContainer.getWriteBufferManagerCapacity());
+                    optionsContainer.getWriteBufferManagerCapacity(),
+                    cancelStreamRegistry);
         } else {
             return new RocksDBFullRestoreOperation<>(
                     keyGroupRange,
@@ -571,7 +572,8 @@ public class RocksDBKeyedStateBackendBuilder<K> extends AbstractKeyedStateBacken
                     restoreStateHandles,
                     ttlCompactFiltersManager,
                     writeBatchSize,
-                    optionsContainer.getWriteBufferManagerCapacity());
+                    optionsContainer.getWriteBufferManagerCapacity(),
+                    cancelStreamRegistry);
         }
     }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBPriorityQueueSetFactory.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.contrib.streaming.state.sstmerge.RocksDBManualCompactionManager;
+import org.apache.flink.core.fs.ICloseableRegistry;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.state.KeyExtractorFunction;
@@ -183,7 +184,10 @@ public class RocksDBPriorityQueueSetFactory implements PriorityQueueSetFactory {
                             db,
                             columnFamilyOptionsFactory,
                             null,
-                            writeBufferManagerCapacity);
+                            writeBufferManagerCapacity,
+                            // Using ICloseableRegistry.NO_OP here because there is no restore in
+                            // progress; created column families will be closed in dispose()
+                            ICloseableRegistry.NO_OP);
             RocksDBOperationUtils.registerKvStateInformation(
                     kvStateInformation, nativeMetricMonitor, stateName, stateInfo);
         } else {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
@@ -23,6 +23,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricMonitor;
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBOperationUtils;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
+import org.apache.flink.core.fs.ICloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
@@ -116,7 +117,8 @@ class RocksDBHandle implements AutoCloseable {
     void openDB(
             @Nonnull List<ColumnFamilyDescriptor> columnFamilyDescriptors,
             @Nonnull List<StateMetaInfoSnapshot> stateMetaInfoSnapshots,
-            @Nonnull Path restoreSourcePath)
+            @Nonnull Path restoreSourcePath,
+            @Nonnull ICloseableRegistry cancelStreamRegistryForRestore)
             throws IOException {
         this.columnFamilyDescriptors = columnFamilyDescriptors;
         this.columnFamilyHandles = new ArrayList<>(columnFamilyDescriptors.size() + 1);
@@ -125,7 +127,9 @@ class RocksDBHandle implements AutoCloseable {
         // Register CF handlers
         for (int i = 0; i < stateMetaInfoSnapshots.size(); i++) {
             getOrRegisterStateColumnFamilyHandle(
-                    columnFamilyHandles.get(i), stateMetaInfoSnapshots.get(i));
+                    columnFamilyHandles.get(i),
+                    stateMetaInfoSnapshots.get(i),
+                    cancelStreamRegistryForRestore);
         }
     }
 
@@ -149,7 +153,9 @@ class RocksDBHandle implements AutoCloseable {
     }
 
     RocksDbKvStateInfo getOrRegisterStateColumnFamilyHandle(
-            ColumnFamilyHandle columnFamilyHandle, StateMetaInfoSnapshot stateMetaInfoSnapshot) {
+            ColumnFamilyHandle columnFamilyHandle,
+            StateMetaInfoSnapshot stateMetaInfoSnapshot,
+            ICloseableRegistry cancelStreamRegistryForRestore) {
 
         RocksDbKvStateInfo registeredStateMetaInfoEntry =
                 kvStateInformation.get(stateMetaInfoSnapshot.getName());
@@ -166,7 +172,8 @@ class RocksDBHandle implements AutoCloseable {
                                 db,
                                 columnFamilyOptionsFactory,
                                 ttlCompactFiltersManager,
-                                writeBufferManagerCapacity);
+                                writeBufferManagerCapacity,
+                                cancelStreamRegistryForRestore);
             } else {
                 registeredStateMetaInfoEntry =
                         new RocksDbKvStateInfo(columnFamilyHandle, stateMetaInfo);
@@ -194,7 +201,8 @@ class RocksDBHandle implements AutoCloseable {
     /*
     void registerStateColumnFamilyHandleWithImport(
             RegisteredStateMetaInfoBase stateMetaInfo,
-            List<ExportImportFilesMetaData> cfMetaDataList) {
+            List<ExportImportFilesMetaData> cfMetaDataList,
+            ICloseableRegistry cancelStreamRegistryForRestore) {
 
         Preconditions.checkState(!kvStateInformation.containsKey(stateMetaInfo.getName()));
 
@@ -205,7 +213,8 @@ class RocksDBHandle implements AutoCloseable {
                         columnFamilyOptionsFactory,
                         ttlCompactFiltersManager,
                         writeBufferManagerCapacity,
-                        cfMetaDataList);
+                        cfMetaDataList,
+                        cancelStreamRegistryForRestore);
 
         RocksDBOperationUtils.registerKvStateInformation(
                 kvStateInformation, nativeMetricMonitor, stateMetaInfo.getName(), stateInfo);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHeapTimersFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHeapTimersFullRestoreOperation.java
@@ -22,6 +22,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBKeyedStateBackend.RocksDb
 import org.apache.flink.contrib.streaming.state.RocksDBNativeMetricOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBWriteBatchWrapper;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
+import org.apache.flink.core.fs.ICloseableRegistry;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
@@ -77,6 +78,7 @@ public class RocksDBHeapTimersFullRestoreOperation<K> implements RocksDBRestoreO
     private final RocksDBHandle rocksHandle;
     private final KeyGroupRange keyGroupRange;
     private final int keyGroupPrefixBytes;
+    private final ICloseableRegistry cancelStreamRegistryForRestore;
 
     public RocksDBHeapTimersFullRestoreOperation(
             KeyGroupRange keyGroupRange,
@@ -94,7 +96,8 @@ public class RocksDBHeapTimersFullRestoreOperation<K> implements RocksDBRestoreO
             @Nonnull Collection<KeyedStateHandle> restoreStateHandles,
             @Nonnull RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
             @Nonnegative long writeBatchSize,
-            Long writeBufferManagerCapacity) {
+            Long writeBufferManagerCapacity,
+            ICloseableRegistry cancelStreamRegistryForRestore) {
         this.writeBatchSize = writeBatchSize;
         this.rocksHandle =
                 new RocksDBHandle(
@@ -119,6 +122,7 @@ public class RocksDBHeapTimersFullRestoreOperation<K> implements RocksDBRestoreO
         this.keyGroupPrefixBytes =
                 CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(
                         numberOfKeyGroups);
+        this.cancelStreamRegistryForRestore = cancelStreamRegistryForRestore;
     }
 
     /** Restores all key-groups data that is referenced by the passed state handles. */
@@ -163,7 +167,7 @@ public class RocksDBHeapTimersFullRestoreOperation<K> implements RocksDBRestoreO
             } else {
                 RocksDbKvStateInfo registeredStateCFHandle =
                         this.rocksHandle.getOrRegisterStateColumnFamilyHandle(
-                                null, restoredMetaInfo);
+                                null, restoredMetaInfo, cancelStreamRegistryForRestore);
                 columnFamilyHandles.put(i, registeredStateCFHandle.columnFamilyHandle);
             }
         }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHeapTimersFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHeapTimersFullRestoreOperation.java
@@ -54,6 +54,7 @@ import org.rocksdb.RocksDBException;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -62,6 +63,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+
+import static org.apache.flink.core.fs.ICloseableRegistry.asCloseable;
 
 /** Encapsulates the process of restoring a RocksDB instance from a full snapshot. */
 public class RocksDBHeapTimersFullRestoreOperation<K> implements RocksDBRestoreOperation {
@@ -188,7 +191,10 @@ public class RocksDBHeapTimersFullRestoreOperation<K> implements RocksDBRestoreO
             throws IOException, RocksDBException, StateMigrationException {
         // for all key-groups in the current state handle...
         try (RocksDBWriteBatchWrapper writeBatchWrapper =
-                new RocksDBWriteBatchWrapper(this.rocksHandle.getDb(), writeBatchSize)) {
+                        new RocksDBWriteBatchWrapper(this.rocksHandle.getDb(), writeBatchSize);
+                Closeable ignored =
+                        cancelStreamRegistryForRestore.registerCloseableTemporarily(
+                                asCloseable(writeBatchWrapper))) {
             HeapPriorityQueueSnapshotRestoreWrapper<HeapPriorityQueueElement> restoredPQ = null;
             ColumnFamilyHandle handle = null;
             while (keyGroups.hasNext()) {


### PR DESCRIPTION
We observe a lot of TMs stuck for > 30s in RocksDBHandle.registerStateColumnFamilyHandleWithImport which boil down to native calls to create Column Family. This change registers prevents CF creation if task cancellation is in progress.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
