### PR TITLE
[FLINK-34487][ci] Adds Python Wheels nightly GHA workflow for 1.20

### DIFF
--- a/.github/actions/stringify/action.yml
+++ b/.github/actions/stringify/action.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: "Stringify"
+description: "Stringifies the given input value."
+inputs:
+  value:
+    description: "Input value to stringify."
+    required: true
+outputs:
+  stringified_value:
+    description: "Stringified output value."
+    value: ${{ steps.stringify-step.outputs.stringified_value }}
+runs:
+  using: "composite"
+  steps:
+    - name: "Stringify '${{ inputs.value }}'"
+      id: stringify-step
+      shell: bash
+      run: |
+        # adds a stringified version of the workflow name that can be used for generating unique build artifact names within a composite workflow
+        # - replaces any special characters (except for underscores and dots) with dashes
+        # - makes the entire string lowercase
+        # - condenses multiple dashes into a single one
+        # - removes leading and following dashes
+        stringified_value=$(echo "${{ inputs.value }}" | tr -C '[:alnum:]._' '-' |  tr '[:upper:]' '[:lower:]' | sed -e 's/--*/-/g' -e 's/^-*//g' -e 's/-*$//g')
+        echo "stringified_value=${stringified_value}" >> $GITHUB_OUTPUT

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -96,7 +96,7 @@ jobs:
       s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
 
   build_python_wheels:
-    name: "Build Python Wheels on ${{ matrix.os }}"
+    name: "Build Python Wheels on ${{ matrix.os_name }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -104,37 +104,40 @@ jobs:
         include:
           - os: ubuntu-latest
             os_name: linux
-            python-version: 3.9
           - os: macos-latest
             os_name: macos
-            python-version: 3.9
     steps:
       - name: "Checkout the repository"
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: "Install python"
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: "Stringify workflow name"
         uses: "./.github/actions/stringify"
         id: stringify_workflow
         with:
           value: ${{ github.workflow }}
+      # Used to host cibuildwheel
+      - name: "Setup Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: "Install cibuildwheel"
+        run: python -m pip install cibuildwheel==2.16.5
       - name: "Build python wheels for ${{ matrix.os_name }}"
-        if: matrix.os_name == 'linux'
-        run: |
-          cd flink-python
-          bash dev/build-wheels.sh
-      - name: "Build python wheels for ${{ matrix.os }}"
-        if: matrix.os_name == 'macos'
-        run: |
-          cd flink-python
-          python -m pip install --upgrade pip
-          pip install cibuildwheel==2.8.0
-          cibuildwheel --platform macos --output-dir dist .
+        run: python -m cibuildwheel --output-dir flink-python/dist flink-python
+        env:
+          # Skip -musllinux on Linux builds
+          CIBW_SKIP: "*-musllinux*"
+          # Use manylinux2014 on Linux
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_BEFORE_ALL_LINUX: pip install patchelf
+          CIBW_BEFORE_BUILD_LINUX: pip install -r flink-python/dev/dev-requirements.txt
+          CIBW_ENVIRONMENT_LINUX: CFLAGS="-I. -include ./dev/glibc_version_fix.h"
+          # Run auditwheel repair on Linux
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: "auditwheel repair -w {dest_dir} {wheel}"
+          # Skip repair on MacOS
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
       - name: "Tar python artifact"
         run: tar -czvf python-wheel-${{ matrix.os_name }}.tar.gz -C flink-python/dist .
       - name: "Upload python artifact"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,3 +94,51 @@ jobs:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
       s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
+
+  build_python_wheels:
+    name: "Build Python Wheels on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            os_name: linux
+            python-version: 3.9
+          - os: macos-latest
+            os_name: macos
+            python-version: 3.9
+    steps:
+      - name: "Checkout the repository"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: "Install python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: "Stringify workflow name"
+        uses: "./.github/actions/stringify"
+        id: stringify_workflow
+        with:
+          value: ${{ github.workflow }}
+      - name: "Build python wheels for ${{ matrix.os_name }}"
+        if: matrix.os_name == 'linux'
+        run: |
+          cd flink-python
+          bash dev/build-wheels.sh
+      - name: "Build python wheels for ${{ matrix.os }}"
+        if: matrix.os_name == 'macos'
+        run: |
+          cd flink-python
+          python -m pip install --upgrade pip
+          pip install cibuildwheel==2.8.0
+          cibuildwheel --platform macos --output-dir dist .
+      - name: "Tar python artifact"
+        run: tar -czvf python-wheel-${{ matrix.os_name }}.tar.gz -C flink-python/dist .
+      - name: "Upload python artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel_${{ matrix.os_name }}_${{ steps.stringify_workflow.outputs.stringified_value }}-${{ github.run_number }}
+          path: python-wheel-${{ matrix.os_name }}.tar.gz

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -80,7 +80,7 @@ jobs:
       # timeout in minutes - this environment variable is required by uploading_watchdog.sh
       GHA_JOB_TIMEOUT: 240
     outputs:
-      stringified-workflow-name: ${{ steps.workflow-prep-step.outputs.stringified-workflow-name }}
+      stringified-workflow-name: ${{ steps.workflow-prep-step.outputs.stringified_value }}
     steps:
       - name: "Flink Checkout"
         uses: actions/checkout@v4
@@ -96,15 +96,10 @@ jobs:
           target_directory: ${{ env.CONTAINER_LOCAL_WORKING_DIR }}
 
       - name: "Stringify workflow name"
+        uses: "./.github/actions/stringify"
         id: workflow-prep-step
-        run: |
-          # adds a stringified version of the workflow name that can be used for generating unique build artifact names within a composite workflow
-          # - replaces any special characters (except for underscores and dots) with dashes
-          # - makes the entire string lowercase
-          # - condenses multiple dashes into a single one
-          # - removes leading and following dashes
-          stringified_workflow_name=$(echo "${{ github.workflow }}-${{ inputs.workflow-caller-id }}" | tr -C '[:alnum:]._' '-' |  tr '[:upper:]' '[:lower:]' | sed -e 's/--*/-/g' -e 's/^-*//g' -e 's/-*$//g')
-          echo "stringified-workflow-name=${stringified_workflow_name}" >> $GITHUB_OUTPUT
+        with:
+          value: "${{ github.workflow }}-${{ inputs.workflow-caller-id }}"
 
       - name: "Compile Flink"
         uses: "./.github/actions/run_mvn"
@@ -122,7 +117,7 @@ jobs:
       - name: "Upload artifacts to make them available in downstream jobs"
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts-${{ steps.workflow-prep-step.outputs.stringified-workflow-name }}-${{ github.run_number }}
+          name: build-artifacts-${{ steps.workflow-prep-step.outputs.stringified_value }}-${{ github.run_number }}
           path: ${{ env.FLINK_ARTIFACT_DIR }}/${{ env.FLINK_ARTIFACT_FILENAME }}
           if-no-files-found: error
           # use minimum here because we only need these artifacts to speed up the build

--- a/flink-python/pyproject.toml
+++ b/flink-python/pyproject.toml
@@ -31,3 +31,6 @@ build = ["cp38-*", "cp39-*", "cp310-*", "cp311-*"]
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]


### PR DESCRIPTION
## What is the purpose of the change

Integrates Python Wheels build into the GitHub Actions (GHA) nightly workflow for 1.20 releases.

## Brief change log

- Adds Python Wheels GHA workflow, template.python-wheels-ci.yml
- Integrates the Python Wheels workflow to the nightly GHA workflow
- Verifying this change
- This changes does not change code.

But the successful nightly GHA run should verify the change.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation
- Does this pull request introduce a new feature? no
