### PR TITLE
[FLINK-35750][runtime/metrics] Fix that the latency marker metrics aren't updated after failover.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorMetricGroup.java
@@ -64,8 +64,8 @@ public class InternalOperatorMetricGroup extends ComponentMetricGroup<TaskMetric
         return parent.getIOMetricGroup();
     }
 
-    public final MetricGroup getJobMetricGroup() {
-        return parent.parent;
+    public final MetricGroup getTaskMetricGroup() {
+        return parent;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -209,10 +209,10 @@ public abstract class AbstractStreamOperator<OUT>
                         MetricOptions.LATENCY_SOURCE_GRANULARITY.key(),
                         granularity);
             }
-            MetricGroup jobMetricGroup = this.metrics.getJobMetricGroup();
+            MetricGroup taskMetricGroup = this.metrics.getTaskMetricGroup();
             this.latencyStats =
                     new LatencyStats(
-                            jobMetricGroup.addGroup("latency"),
+                            taskMetricGroup.addGroup("latency"),
                             historySize,
                             container.getIndexInSubtaskGroup(),
                             getOperatorID(),
@@ -221,7 +221,7 @@ public abstract class AbstractStreamOperator<OUT>
             LOG.warn("An error occurred while instantiating latency metrics.", e);
             this.latencyStats =
                     new LatencyStats(
-                            UnregisteredMetricGroups.createUnregisteredTaskManagerJobMetricGroup()
+                            UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
                                     .addGroup("latency"),
                             1,
                             0,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -173,9 +173,9 @@ public abstract class AbstractStreamOperatorV2<OUT>
                         MetricOptions.LATENCY_SOURCE_GRANULARITY.key(),
                         granularity);
             }
-            MetricGroup jobMetricGroup = this.metrics.getJobMetricGroup();
+            MetricGroup taskMetricGroup = this.metrics.getTaskMetricGroup();
             return new LatencyStats(
-                    jobMetricGroup.addGroup("latency"),
+                    taskMetricGroup.addGroup("latency"),
                     historySize,
                     indexInSubtaskGroup,
                     getOperatorID(),
@@ -183,7 +183,7 @@ public abstract class AbstractStreamOperatorV2<OUT>
         } catch (Exception e) {
             LOG.warn("An error occurred while instantiating latency metrics.", e);
             return new LatencyStats(
-                    UnregisteredMetricGroups.createUnregisteredTaskManagerJobMetricGroup()
+                    UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
                             .addGroup("latency"),
                     1,
                     0,


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix that the latency marker metrics aren't updated after failover.


## Brief change log

Change the latency metric into the TaskMetricsGroup.


## Verifying this change
Verified locally.  

<img width="1093" alt="image" src="https://github.com/apache/flink/assets/64569824/f25cc6b7-822e-46cd-afcb-87e417fc4ec2">

before the exception:  
<img width="1096" alt="image" src="https://github.com/apache/flink/assets/64569824/1d131bd7-f9a2-40c6-9459-29ec51753ef3">


after the exception:   
<img width="1123" alt="image" src="https://github.com/apache/flink/assets/64569824/4b0bdad0-5c68-4e69-a64b-c955cc71679d">


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
