### PR TITLE
[FLINK-35696] JSON_VALUE/QUERY functions incorrectly map floating numbers

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonValueCallGen.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/JsonValueCallGen.scala
@@ -64,7 +64,7 @@ class JsonValueCallGen extends CallGenerator {
               s"$BINARY_STRING.fromString(java.lang.String.valueOf($rawResultTerm))"
             case LogicalTypeRoot.BOOLEAN => s"(java.lang.Boolean) $rawResultTerm"
             case LogicalTypeRoot.INTEGER => s"(java.lang.Integer) $rawResultTerm"
-            case LogicalTypeRoot.DOUBLE => s"(java.lang.Double) $rawResultTerm"
+            case LogicalTypeRoot.DOUBLE => s"((java.math.BigDecimal) $rawResultTerm).doubleValue()"
             case _ =>
               throw new CodeGenException(
                 s"Unsupported type '$returnType' "

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -186,6 +186,20 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         STRING(),
                         STRING())
 
+                // floating numbers
+                .testResult(
+                        $("f0").jsonValue("$.longBalance"),
+                        "JSON_VALUE(f0, '$.longBalance')",
+                        "123456789.987654321",
+                        STRING(),
+                        STRING())
+                .testResult(
+                        $("f0").jsonValue("$.balance"),
+                        "JSON_VALUE(f0, '$.balance')",
+                        "13.37",
+                        STRING(),
+                        STRING())
+
                 // RETURNING + Supported Data Types
                 .testResult(
                         $("f0").jsonValue("$.type"),
@@ -207,6 +221,11 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                         $("f0").jsonValue("$.balance", DOUBLE()),
                         "JSON_VALUE(f0, '$.balance' RETURNING DOUBLE)",
                         13.37,
+                        DOUBLE())
+                .testResult(
+                        $("f0").jsonValue("$.longBalance", DOUBLE()),
+                        "JSON_VALUE(f0, '$.longBalance' RETURNING DOUBLE)",
+                        123456789.987654321,
                         DOUBLE())
 
                 // ON EMPTY / ON ERROR
@@ -459,9 +478,9 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").jsonQuery("$.items", ARRAY(STRING())),
                                 "JSON_QUERY(f0, '$.items' RETURNING ARRAY<STRING>)",
                                 new String[] {
-                                    "{\"itemId\":1234,\"count\":10}",
+                                    "{\"count\":10,\"itemId\":1234}",
                                     null,
-                                    "{\"itemId\":4567,\"count\":11}"
+                                    "{\"count\":11,\"itemId\":4567}"
                                 },
                                 ARRAY(STRING()))
                         .testResult(

--- a/flink-table/flink-table-planner/src/test/resources/json/json-value.json
+++ b/flink-table/flink-table-planner/src/test/resources/json/json-value.json
@@ -7,5 +7,6 @@
   },
   "roles": ["user", "viewer"],
   "balance": 13.37,
+  "longBalance": 123456789.987654321,
   "contains blank": "right"
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlJsonUtils.java
@@ -39,6 +39,7 @@ import org.apache.flink.shaded.com.jayway.jsonpath.spi.mapper.MappingProvider;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializationFeature;
@@ -66,13 +67,16 @@ public class SqlJsonUtils {
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
     private static final ObjectMapper MAPPER =
             new ObjectMapper(JSON_FACTORY)
-                    .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+                    .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+                    .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
     private static final Pattern JSON_PATH_BASE =
             Pattern.compile(
                     "^\\s*(?<mode>strict|lax)\\s+(?<spec>.+)$",
                     Pattern.CASE_INSENSITIVE | Pattern.DOTALL | Pattern.MULTILINE);
-    private static final JacksonJsonProvider JSON_PATH_JSON_PROVIDER = new JacksonJsonProvider();
-    private static final MappingProvider JSON_PATH_MAPPING_PROVIDER = new JacksonMappingProvider();
+    private static final JacksonJsonProvider JSON_PATH_JSON_PROVIDER =
+            new JacksonJsonProvider(MAPPER);
+    private static final MappingProvider JSON_PATH_MAPPING_PROVIDER =
+            new JacksonMappingProvider(MAPPER);
     private static final String JSON_QUERY_FUNCTION_NAME = "JSON_QUERY";
     private static final String JSON_VALUE_FUNCTION_NAME = "JSON_VALUE";
     private static final String JSON_EXISTS_FUNCTION_NAME = "JSON_EXISTS";


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes how floating numbers are parsed and then converted to STRING in `JSON_QUERY/JSON_VALUE` functions.


## Verifying this change

Added tests in `JsonFunctionsITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
