### PR TITLE
[FLINK-27355][runtime] Unregister JobManagerRunner after it's closed

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
@@ -86,13 +86,13 @@ public class DefaultJobManagerRunnerRegistry implements JobManagerRunnerRegistry
     public CompletableFuture<Void> localCleanupAsync(
             JobID jobId, Executor ignoredExecutor, Executor mainThreadExecutor) {
         if (isRegistered(jobId)) {
-            CompletableFuture<Void> resultFuture = this.jobManagerRunners.get(jobId).closeAsync();
-
-            return resultFuture.thenApplyAsync(
-                    result -> {
-                        mainThreadExecutor.execute(() -> unregister(jobId));
-                        return result;
-                    });
+            return get(jobId)
+                    .closeAsync()
+                    .thenApplyAsync(
+                            result -> {
+                                mainThreadExecutor.execute(() -> unregister(jobId));
+                                return result;
+                            });
         }
 
         return FutureUtils.completedVoidFuture();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
@@ -87,7 +87,7 @@ public class DefaultJobManagerRunnerRegistry implements JobManagerRunnerRegistry
         if (isRegistered(jobId)) {
             CompletableFuture<Void> resultFuture = this.jobManagerRunners.get(jobId).closeAsync();
 
-            return resultFuture.thenApply(
+            return resultFuture.thenApplyAsync(
                     result -> {
                         mainThreadExecutor.execute(() -> unregister(jobId));
                         return result;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
@@ -83,7 +83,8 @@ public class DefaultJobManagerRunnerRegistry implements JobManagerRunnerRegistry
     }
 
     @Override
-    public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor mainThreadExecutor) {
+    public CompletableFuture<Void> localCleanupAsync(
+            JobID jobId, Executor ignoredExecutor, Executor mainThreadExecutor) {
         if (isRegistered(jobId)) {
             CompletableFuture<Void> resultFuture = this.jobManagerRunners.get(jobId).closeAsync();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
@@ -84,7 +85,7 @@ public class DefaultJobManagerRunnerRegistry implements JobManagerRunnerRegistry
 
     @Override
     public CompletableFuture<Void> localCleanupAsync(
-            JobID jobId, Executor ignoredExecutor, Executor mainThreadExecutor) {
+            JobID jobId, Executor ignoredExecutor, ComponentMainThreadExecutor mainThreadExecutor) {
         if (isRegistered(jobId)) {
             return get(jobId)
                     .closeAsync()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerRegistry.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableInMainThreadResource;
+import org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableResourceWithMainThread;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 
 import java.util.Collection;
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 /** {@code JobManagerRunner} collects running jobs represented by {@link JobManagerRunner}. */
-public interface JobManagerRunnerRegistry extends LocallyCleanableInMainThreadResource {
+public interface JobManagerRunnerRegistry extends LocallyCleanableResourceWithMainThread {
 
     /**
      * Checks whether a {@link JobManagerRunner} is registered under the given {@link JobID}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JobManagerRunnerRegistry.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableResource;
+import org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableInMainThreadResource;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 
 import java.util.Collection;
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 /** {@code JobManagerRunner} collects running jobs represented by {@link JobManagerRunner}. */
-public interface JobManagerRunnerRegistry extends LocallyCleanableResource {
+public interface JobManagerRunnerRegistry extends LocallyCleanableInMainThreadResource {
 
     /**
      * Checks whether a {@link JobManagerRunner} is registered under the given {@link JobID}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
@@ -45,6 +45,10 @@ public class OnMainThreadJobManagerRunnerRegistry
             JobManagerRunnerRegistry delegate, ComponentMainThreadExecutor mainThreadExecutor) {
         this.delegate = delegate;
         this.mainThreadExecutor = mainThreadExecutor;
+
+        if (delegate instanceof DefaultJobManagerRunnerRegistry) {
+            ((DefaultJobManagerRunnerRegistry) delegate).setMainThreadExecutor(mainThreadExecutor);
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
@@ -45,10 +45,6 @@ public class OnMainThreadJobManagerRunnerRegistry
             JobManagerRunnerRegistry delegate, ComponentMainThreadExecutor mainThreadExecutor) {
         this.delegate = delegate;
         this.mainThreadExecutor = mainThreadExecutor;
-
-        if (delegate instanceof DefaultJobManagerRunnerRegistry) {
-            ((DefaultJobManagerRunnerRegistry) delegate).setMainThreadExecutor(mainThreadExecutor);
-        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
@@ -85,7 +85,7 @@ public class OnMainThreadJobManagerRunnerRegistry
 
     @Override
     public CompletableFuture<Void> localCleanupAsync(
-            JobID jobId, Executor cleanupExecutor, Executor mainThreadExecutor) {
+            JobID jobId, Executor cleanupExecutor, ComponentMainThreadExecutor mainThreadExecutor) {
         this.mainThreadExecutor.assertRunningInMainThread();
         return delegate.localCleanupAsync(jobId, cleanupExecutor, mainThreadExecutor);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
@@ -85,9 +85,9 @@ public class OnMainThreadJobManagerRunnerRegistry
 
     @Override
     public CompletableFuture<Void> localCleanupAsync(
-            JobID jobId, Executor cleanupExecutor, Executor executor) {
-        mainThreadExecutor.assertRunningInMainThread();
-        return delegate.localCleanupAsync(jobId, cleanupExecutor, executor);
+            JobID jobId, Executor cleanupExecutor, Executor mainThreadExecutor) {
+        this.mainThreadExecutor.assertRunningInMainThread();
+        return delegate.localCleanupAsync(jobId, cleanupExecutor, mainThreadExecutor);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/OnMainThreadJobManagerRunnerRegistry.java
@@ -84,9 +84,10 @@ public class OnMainThreadJobManagerRunnerRegistry
     }
 
     @Override
-    public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor executor) {
+    public CompletableFuture<Void> localCleanupAsync(
+            JobID jobId, Executor cleanupExecutor, Executor executor) {
         mainThreadExecutor.assertRunningInMainThread();
-        return delegate.localCleanupAsync(jobId, executor);
+        return delegate.localCleanupAsync(jobId, cleanupExecutor, executor);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
@@ -131,7 +131,7 @@ public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory 
      * @return Globally cleanable resource.
      */
     private static GloballyCleanableResource toGloballyCleanableResource(
-            LocallyCleanableInMainThreadResource localResource,
+            LocallyCleanableResourceWithMainThread localResource,
             ComponentMainThreadExecutor mainThreadExecutor) {
         return (jobId, cleanupExecutor) ->
                 localResource.localCleanupAsync(jobId, cleanupExecutor, mainThreadExecutor);
@@ -156,8 +156,9 @@ public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory 
      * @param localResource LocallyCleanableInMainThreadResource that we want to translate.
      * @return A LocallyCleanableResource.
      */
+    @VisibleForTesting
     public static LocallyCleanableResource toLocallyCleanableResource(
-            LocallyCleanableInMainThreadResource localResource,
+            LocallyCleanableResourceWithMainThread localResource,
             ComponentMainThreadExecutor mainThreadExecutor) {
         return (jobId, cleanupExecutor) ->
                 localResource.localCleanupAsync(jobId, cleanupExecutor, mainThreadExecutor);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactory.java
@@ -97,7 +97,7 @@ public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory 
                         mainThreadExecutor, cleanupExecutor, retryStrategy)
                 .withPrioritizedCleanup(
                         JOB_MANAGER_RUNNER_REGISTRY_LABEL,
-                        toLocallyCleanableResource(jobManagerRunnerRegistry, mainThreadExecutor))
+                        jobManagerRunnerRegistry.toLocallyCleanableResource(mainThreadExecutor))
                 .withRegularCleanup(JOB_GRAPH_STORE_LABEL, jobGraphWriter)
                 .withRegularCleanup(BLOB_SERVER_LABEL, blobServer)
                 .withRegularCleanup(JOB_MANAGER_METRIC_GROUP_LABEL, jobManagerMetricGroup)
@@ -148,19 +148,5 @@ public class DispatcherResourceCleanerFactory implements ResourceCleanerFactory 
     private static GloballyCleanableResource toGloballyCleanableResource(
             LocallyCleanableResource localResource) {
         return localResource::localCleanupAsync;
-    }
-
-    /**
-     * Converts a LocallyCleanableInMainThreadResource object to a LocallyCleanableResource object.
-     *
-     * @param localResource LocallyCleanableInMainThreadResource that we want to translate.
-     * @return A LocallyCleanableResource.
-     */
-    @VisibleForTesting
-    public static LocallyCleanableResource toLocallyCleanableResource(
-            LocallyCleanableResourceWithMainThread localResource,
-            ComponentMainThreadExecutor mainThreadExecutor) {
-        return (jobId, cleanupExecutor) ->
-                localResource.localCleanupAsync(jobId, cleanupExecutor, mainThreadExecutor);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableInMainThreadResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableInMainThreadResource.java
@@ -43,8 +43,10 @@ public interface LocallyCleanableInMainThreadResource {
      * {@code mainThreadExecutor} for cleanups. Thread-safety must be ensured.
      *
      * @param jobId The {@link JobID} of the job for which the local data should be cleaned up.
+     * @param cleanupExecutor The fallback executor for IO-heavy operations.
      * @param mainThreadExecutor The main thread executor.
      * @return The cleanup result future.
      */
-    CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor mainThreadExecutor);
+    CompletableFuture<Void> localCleanupAsync(
+            JobID jobId, Executor cleanupExecutor, Executor mainThreadExecutor);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableInMainThreadResource.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableInMainThreadResource.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher.cleanup;
+
+import org.apache.flink.api.common.JobID;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * {@code LocallyCleanableInMainThreadResource} is supposed to be implemented by any class that
+ * provides artifacts for a given job that need to be cleaned up in the main thread after the job
+ * reached a local terminal state. Local cleanups that needs to be triggered for a global terminal
+ * state as well, need to be implemented using the {@link GloballyCleanableResource}.
+ *
+ * <p>The {@link DispatcherResourceCleanerFactory} provides a workaround to trigger some {@code
+ * LocallyCleanableInMainThreadResource} as globally cleanable. FLINK-26175 is created to cover a
+ * refactoring and straighten things out.
+ *
+ * @see org.apache.flink.api.common.JobStatus
+ */
+@FunctionalInterface
+public interface LocallyCleanableInMainThreadResource {
+
+    /**
+     * {@code localCleanupAsync} is expected to be called from the main thread and uses the passed
+     * {@code mainThreadExecutor} for cleanups. Thread-safety must be ensured.
+     *
+     * @param jobId The {@link JobID} of the job for which the local data should be cleaned up.
+     * @param mainThreadExecutor The main thread executor.
+     * @return The cleanup result future.
+     */
+    CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor mainThreadExecutor);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResourceWithMainThread.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResourceWithMainThread.java
@@ -47,7 +47,7 @@ public interface LocallyCleanableResourceWithMainThread {
      * @return The cleanup result future.
      */
     CompletableFuture<Void> localCleanupAsync(
-            JobID jobId, Executor cleanupExecutor, Executor mainThreadExecutor);
+            JobID jobId, Executor cleanupExecutor, ComponentMainThreadExecutor mainThreadExecutor);
 
     default LocallyCleanableResource toLocallyCleanableResource(
             ComponentMainThreadExecutor mainThreadExecutor) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResourceWithMainThread.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResourceWithMainThread.java
@@ -24,19 +24,17 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
- * {@code LocallyCleanableInMainThreadResource} is supposed to be implemented by any class that
- * provides artifacts for a given job that need to be cleaned up in the main thread after the job
- * reached a local terminal state. Local cleanups that needs to be triggered for a global terminal
- * state as well, need to be implemented using the {@link GloballyCleanableResource}.
+ * {@code LocallyCleanableResourceWithMainThread} is an extension of the {@link
+ * LocallyCleanableResource} interface. It allows the {@link DispatcherResourceCleanerFactory} to
+ * inject the main thread as part of the cleanup procedure.
  *
- * <p>The {@link DispatcherResourceCleanerFactory} provides a workaround to trigger some {@code
- * LocallyCleanableInMainThreadResource} as globally cleanable. FLINK-26175 is created to cover a
- * refactoring and straighten things out.
+ * <p>See {@code LocallyCleanableResource} for further context on the proper contract of the two
+ * interfaces.
  *
- * @see org.apache.flink.api.common.JobStatus
+ * @see org.apache.flink.runtime.dispatcher.cleanup.LocallyCleanableResource
  */
 @FunctionalInterface
-public interface LocallyCleanableInMainThreadResource {
+public interface LocallyCleanableResourceWithMainThread {
 
     /**
      * {@code localCleanupAsync} is expected to be called from the main thread and uses the passed

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResourceWithMainThread.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/cleanup/LocallyCleanableResourceWithMainThread.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.dispatcher.cleanup;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -47,4 +48,10 @@ public interface LocallyCleanableResourceWithMainThread {
      */
     CompletableFuture<Void> localCleanupAsync(
             JobID jobId, Executor cleanupExecutor, Executor mainThreadExecutor);
+
+    default LocallyCleanableResource toLocallyCleanableResource(
+            ComponentMainThreadExecutor mainThreadExecutor) {
+        return (jobId, cleanupExecutor) ->
+                this.localCleanupAsync(jobId, cleanupExecutor, mainThreadExecutor);
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -154,9 +154,9 @@ class DefaultJobManagerRunnerRegistryTest {
                 .last()
                 .isEqualTo(expectedException);
         assertThat(testInstance.isRegistered(jobManagerRunner.getJobID()))
-                .isTrue()
                 .as(
-                        "Since the cleanup failed, the JobManagerRunner is expected to not have been unregistered.");
+                        "Since the cleanup failed, the JobManagerRunner is expected to not have been unregistered.")
+                .isTrue();
     }
 
     @Test
@@ -170,7 +170,9 @@ class DefaultJobManagerRunnerRegistryTest {
 
         // Wait for the unregister future to complete
         cleanupResult.get();
-        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isFalse();
+        FlinkAssertions.assertThatFuture(cleanupResult)
+                .as("Wait for the unregistration to complete")
+                .eventuallySucceeds();
     }
 
     @Test
@@ -189,9 +191,9 @@ class DefaultJobManagerRunnerRegistryTest {
                         Executors.directExecutor(),
                         Executors.directExecutor());
         assertThat(testInstance.isRegistered(jobManagerRunner.getJobID()))
-                .isTrue()
                 .as(
-                        "Since the cleanup failed, the JobManagerRunner is expected to not have been unregistered.");
+                        "Since the cleanup failed, the JobManagerRunner is expected to not have been unregistered.")
+                .isTrue();
         assertThatFuture(cleanupResult)
                 .isCompletedExceptionally()
                 .eventuallyFailsWith(ExecutionException.class)
@@ -215,9 +217,9 @@ class DefaultJobManagerRunnerRegistryTest {
                         Executors.directExecutor());
 
         assertThat(testInstance.isRegistered(jobManagerRunner.getJobID()))
-                .isTrue()
                 .as(
-                        "Since the cleanup future hasn't completed yet, the JobManagerRunner is expected to not have been unregistered.");
+                        "Since the cleanup failed, the JobManagerRunner is expected to not have been unregistered.")
+                .isTrue();
         assertThat(jobManagerRunner.getTerminationFuture()).isNotCompleted();
         assertThat(cleanupFuture).isNotCompleted();
 
@@ -227,8 +229,8 @@ class DefaultJobManagerRunnerRegistryTest {
         // Wait for the unregistration to complete
         cleanupFuture.get();
         assertThat(testInstance.isRegistered(jobManagerRunner.getJobID()))
-                .isFalse()
-                .as("The unregister future is complete now.");
+                .as("The unregister future is complete now.")
+                .isFalse();
     }
 
     private TestingJobManagerRunner registerTestingJobManagerRunner() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -144,7 +144,9 @@ class DefaultJobManagerRunnerRegistryTest {
 
         assertThatFuture(
                         testInstance.localCleanupAsync(
-                                jobManagerRunner.getJobID(), Executors.directExecutor()))
+                                jobManagerRunner.getJobID(),
+                                Executors.directExecutor(),
+                                Executors.directExecutor()))
                 .isCompletedExceptionally()
                 .eventuallyFailsWith(ExecutionException.class)
                 .extracting(FlinkAssertions::chainOfCauses, FlinkAssertions.STREAM_THROWABLE)
@@ -162,7 +164,9 @@ class DefaultJobManagerRunnerRegistryTest {
         final TestingJobManagerRunner jobManagerRunner = registerTestingJobManagerRunner();
         final CompletableFuture<Void> cleanupResult =
                 testInstance.localCleanupAsync(
-                        jobManagerRunner.getJobID(), Executors.directExecutor());
+                        jobManagerRunner.getJobID(),
+                        Executors.directExecutor(),
+                        Executors.directExecutor());
 
         // Wait for the unregister future to complete
         cleanupResult.get();
@@ -181,7 +185,9 @@ class DefaultJobManagerRunnerRegistryTest {
 
         final CompletableFuture<Void> cleanupResult =
                 testInstance.localCleanupAsync(
-                        jobManagerRunner.getJobID(), Executors.directExecutor());
+                        jobManagerRunner.getJobID(),
+                        Executors.directExecutor(),
+                        Executors.directExecutor());
         assertThat(testInstance.isRegistered(jobManagerRunner.getJobID()))
                 .isTrue()
                 .as(
@@ -204,7 +210,9 @@ class DefaultJobManagerRunnerRegistryTest {
         // this call shouldn't block
         final CompletableFuture<Void> cleanupFuture =
                 testInstance.localCleanupAsync(
-                        jobManagerRunner.getJobID(), Executors.directExecutor());
+                        jobManagerRunner.getJobID(),
+                        Executors.directExecutor(),
+                        Executors.directExecutor());
 
         assertThat(testInstance.isRegistered(jobManagerRunner.getJobID()))
                 .isTrue()
@@ -236,7 +244,11 @@ class DefaultJobManagerRunnerRegistryTest {
 
     @Test
     void testLocalCleanupAsyncOnUnknownJobId() {
-        assertThat(testInstance.localCleanupAsync(new JobID(), Executors.directExecutor()))
+        assertThat(
+                        testInstance.localCleanupAsync(
+                                new JobID(),
+                                Executors.directExecutor(),
+                                Executors.directExecutor()))
                 .isCompleted();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -146,7 +146,7 @@ class DefaultJobManagerRunnerRegistryTest {
                         testInstance.localCleanupAsync(
                                 jobManagerRunner.getJobID(),
                                 Executors.directExecutor(),
-                                Executors.directExecutor()))
+                                new TestComponentMainThreadExecutor(Thread.currentThread())))
                 .isCompletedExceptionally()
                 .eventuallyFailsWith(ExecutionException.class)
                 .extracting(FlinkAssertions::chainOfCauses, FlinkAssertions.STREAM_THROWABLE)
@@ -166,7 +166,7 @@ class DefaultJobManagerRunnerRegistryTest {
                 testInstance.localCleanupAsync(
                         jobManagerRunner.getJobID(),
                         Executors.directExecutor(),
-                        Executors.directExecutor());
+                        new TestComponentMainThreadExecutor(Thread.currentThread()));
 
         // Wait for the unregister future to complete
         cleanupResult.get();
@@ -189,7 +189,7 @@ class DefaultJobManagerRunnerRegistryTest {
                 testInstance.localCleanupAsync(
                         jobManagerRunner.getJobID(),
                         Executors.directExecutor(),
-                        Executors.directExecutor());
+                        new TestComponentMainThreadExecutor(Thread.currentThread()));
         assertThat(testInstance.isRegistered(jobManagerRunner.getJobID()))
                 .as(
                         "Since the cleanup failed, the JobManagerRunner is expected to not have been unregistered.")
@@ -214,7 +214,7 @@ class DefaultJobManagerRunnerRegistryTest {
                 testInstance.localCleanupAsync(
                         jobManagerRunner.getJobID(),
                         Executors.directExecutor(),
-                        Executors.directExecutor());
+                        new TestComponentMainThreadExecutor(Thread.currentThread()));
 
         assertThat(testInstance.isRegistered(jobManagerRunner.getJobID()))
                 .as(
@@ -250,7 +250,7 @@ class DefaultJobManagerRunnerRegistryTest {
                         testInstance.localCleanupAsync(
                                 new JobID(),
                                 Executors.directExecutor(),
-                                Executors.directExecutor()))
+                                new TestComponentMainThreadExecutor(Thread.currentThread())))
                 .isCompleted();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -168,8 +168,6 @@ class DefaultJobManagerRunnerRegistryTest {
                         Executors.directExecutor(),
                         new TestComponentMainThreadExecutor(Thread.currentThread()));
 
-        // Wait for the unregister future to complete
-        cleanupResult.get();
         FlinkAssertions.assertThatFuture(cleanupResult)
                 .as("Wait for the unregistration to complete")
                 .eventuallySucceeds();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -164,7 +164,8 @@ class DefaultJobManagerRunnerRegistryTest {
                 .hasExactlyElementsOfTypes(ExecutionException.class, expectedException.getClass())
                 .last()
                 .isEqualTo(expectedException);
-        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isFalse();
+        // Since the cleanup failed, the JobManagerRunner is expected to not have been unregistered.
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isTrue();
     }
 
     @Test
@@ -191,7 +192,8 @@ class DefaultJobManagerRunnerRegistryTest {
         final CompletableFuture<Void> cleanupResult =
                 testInstance.localCleanupAsync(
                         jobManagerRunner.getJobID(), Executors.directExecutor());
-        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isFalse();
+        // Since the cleanup failed, the JobManagerRunner is expected to not have been unregistered.
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isTrue();
         assertThatFuture(cleanupResult)
                 .isCompletedExceptionally()
                 .eventuallyFailsWith(ExecutionException.class)
@@ -212,7 +214,9 @@ class DefaultJobManagerRunnerRegistryTest {
                 testInstance.localCleanupAsync(
                         jobManagerRunner.getJobID(), UnsupportedOperationExecutor.INSTANCE);
 
-        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isFalse();
+        // Since the cleanup future hasn't completed yet, the JobManagerRunner is expected to not
+        // have been unregistered.
+        assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isTrue();
         assertThat(jobManagerRunner.getTerminationFuture()).isNotCompleted();
         assertThat(cleanupFuture).isNotCompleted();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.testutils.FlinkAssertions;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.UnsupportedOperationExecutor;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.TestingJobManagerRunner;
@@ -47,6 +48,8 @@ class DefaultJobManagerRunnerRegistryTest {
     @BeforeEach
     void setup() {
         testInstance = new DefaultJobManagerRunnerRegistry(4);
+        ((DefaultJobManagerRunnerRegistry) testInstance)
+                .setMainThreadExecutor(ComponentMainThreadExecutorServiceAdapter.forMainThread());
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherCleanupITCase.java
@@ -220,7 +220,8 @@ public class DispatcherCleanupITCase extends AbstractDispatcherTest {
         final JobManagerRunnerRegistry jobManagerRunnerRegistry =
                 TestingJobManagerRunnerRegistry.newSingleJobBuilder(jobManagerRunnerEntry)
                         .withLocalCleanupAsyncFunction(
-                                (actualJobId, executor) -> jobManagerRunnerCleanupFuture)
+                                (actualJobId, executor, mainThreadExector) ->
+                                        jobManagerRunnerCleanupFuture)
                         .build();
 
         final Dispatcher dispatcher =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -187,14 +187,12 @@ public class DispatcherResourceCleanupTest extends TestLogger {
         dispatcherGateway = dispatcher.getSelfGateway(DispatcherGateway.class);
     }
 
-    private TestingJobManagerRunnerRegistry createTestingJobManagerRunnerRegistry() {
-        return TestingJobManagerRunnerRegistry.newDefaultJobManagerRunnerRegistryBuilder(
-                        new DefaultJobManagerRunnerRegistry(2))
-                .build();
+    private DefaultJobManagerRunnerRegistry createTestJobManagerRunnerRegistry() {
+        return new DefaultJobManagerRunnerRegistry(2);
     }
 
     private TestingDispatcher.Builder createTestingDispatcherBuilder() {
-        return createTestingDispatcherBuilder(createTestingJobManagerRunnerRegistry());
+        return createTestingDispatcherBuilder(createTestJobManagerRunnerRegistry());
     }
 
     private TestingDispatcher.Builder createTestingDispatcherBuilder(
@@ -435,11 +433,11 @@ public class DispatcherResourceCleanupTest extends TestLogger {
      */
     @Test
     public void testJobSubmissionUnderSameJobId() throws Exception {
-        final TestingJobManagerRunnerRegistry testingJobManagerRunnerRegistry =
-                createTestingJobManagerRunnerRegistry();
+        final DefaultJobManagerRunnerRegistry testJobManagerRunnerRegistry =
+                createTestJobManagerRunnerRegistry();
 
         final TestingJobManagerRunnerFactory jobManagerRunnerFactory =
-                startDispatcherAndSubmitJob(testingJobManagerRunnerRegistry, 1);
+                startDispatcherAndSubmitJob(testJobManagerRunnerRegistry, 1);
 
         final TestingJobManagerRunner testingJobManagerRunner =
                 jobManagerRunnerFactory.takeCreatedJobManagerRunner();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DispatcherResourceCleanupTest.java
@@ -28,9 +28,6 @@ import org.apache.flink.runtime.blob.BlobUtils;
 import org.apache.flink.runtime.blob.TestingBlobStoreBuilder;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
 import org.apache.flink.runtime.client.JobSubmissionException;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
-import org.apache.flink.runtime.dispatcher.cleanup.DispatcherResourceCleanerFactory;
 import org.apache.flink.runtime.dispatcher.cleanup.TestingResourceCleanerFactory;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -122,7 +119,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
     private CompletableFuture<JobID> localCleanupFuture;
     private CompletableFuture<JobID> globalCleanupFuture;
-    private ComponentMainThreadExecutor mainThreadExecutor;
 
     @BeforeClass
     public static void setupClass() {
@@ -136,8 +132,6 @@ public class DispatcherResourceCleanupTest extends TestLogger {
 
         globalCleanupFuture = new CompletableFuture<>();
         localCleanupFuture = new CompletableFuture<>();
-
-        mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
 
         blobServer =
                 BlobUtils.createBlobServer(
@@ -214,9 +208,7 @@ public class DispatcherResourceCleanupTest extends TestLogger {
                                 // JobManagerRunnerRegistry needs to be added explicitly
                                 // because cleaning it will trigger the closeAsync latch
                                 // provided by TestingJobManagerRunner
-                                .withLocallyCleanableResource(
-                                        DispatcherResourceCleanerFactory.toLocallyCleanableResource(
-                                                jobManagerRunnerRegistry, mainThreadExecutor))
+                                .withLocallyCleanableInMainThreadResource(jobManagerRunnerRegistry)
                                 .withGloballyCleanableResource(
                                         (jobId, ignoredExecutor) -> {
                                             globalCleanupFuture.complete(jobId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestComponentMainThreadExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.dispatcher;
+
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.operators.coordination.EventReceivingTasks;
+
+public class TestComponentMainThreadExecutor
+        extends EventReceivingTasks.NoMainThreadCheckComponentMainThreadExecutor
+        implements ComponentMainThreadExecutor {
+    private final Thread executorThread;
+
+    public TestComponentMainThreadExecutor(Thread executor) {
+        super();
+        executorThread = executor;
+    }
+
+    @Override
+    public void assertRunningInMainThread() {
+        assert Thread.currentThread() == executorThread;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerRegistry.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.Preconditions;
@@ -110,7 +111,7 @@ public class TestingJobManagerRunnerRegistry implements JobManagerRunnerRegistry
 
     @Override
     public CompletableFuture<Void> localCleanupAsync(
-            JobID jobId, Executor executor, Executor mainThreadExecutor) {
+            JobID jobId, Executor executor, ComponentMainThreadExecutor mainThreadExecutor) {
         return localCleanupAsyncFunction.apply(jobId, executor, mainThreadExecutor);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerRegistry.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -201,8 +200,6 @@ public class TestingJobManagerRunnerRegistry implements JobManagerRunnerRegistry
                 localCleanupAsyncFunction =
                         (ignoredJobId, ignoredExecutor, mainThreadExecutor) ->
                                 FutureUtils.completedVoidFuture();
-        private BiFunction<JobID, Executor, CompletableFuture<Void>> globalCleanupAsyncFunction =
-                (ignoredJobId, ignoredExecutor) -> FutureUtils.completedVoidFuture();
 
         private Builder fromDefaultJobManagerRunnerRegistry(
                 DefaultJobManagerRunnerRegistry jobManagerRunnerRegistry) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/TestingJobManagerRunnerRegistry.java
@@ -166,11 +166,6 @@ public class TestingJobManagerRunnerRegistry implements JobManagerRunnerRegistry
                                         .orElse(FutureUtils.completedVoidFuture()));
     }
 
-    public static Builder newDefaultJobManagerRunnerRegistryBuilder(
-            DefaultJobManagerRunnerRegistry jobManagerRunnerRegistry) {
-        return builder().fromDefaultJobManagerRunnerRegistry(jobManagerRunnerRegistry);
-    }
-
     private static Optional<JobManagerRunner> unregisterFromReference(
             AtomicReference<JobManagerRunner> singleRunnerReference, JobID actualJobId) {
         return Optional.ofNullable(singleRunnerReference.get())
@@ -200,19 +195,6 @@ public class TestingJobManagerRunnerRegistry implements JobManagerRunnerRegistry
                 localCleanupAsyncFunction =
                         (ignoredJobId, ignoredExecutor, mainThreadExecutor) ->
                                 FutureUtils.completedVoidFuture();
-
-        private Builder fromDefaultJobManagerRunnerRegistry(
-                DefaultJobManagerRunnerRegistry jobManagerRunnerRegistry) {
-            this.isRegisteredFunction = jobManagerRunnerRegistry::isRegistered;
-            this.registerConsumer = jobManagerRunnerRegistry::register;
-            this.getFunction = jobManagerRunnerRegistry::get;
-            this.sizeSupplier = jobManagerRunnerRegistry::size;
-            this.getRunningJobIdsSupplier = jobManagerRunnerRegistry::getRunningJobIds;
-            this.getJobManagerRunnersSupplier = jobManagerRunnerRegistry::getJobManagerRunners;
-            this.unregisterFunction = jobManagerRunnerRegistry::unregister;
-            this.localCleanupAsyncFunction = jobManagerRunnerRegistry::localCleanupAsync;
-            return this;
-        }
 
         public Builder withIsRegisteredFunction(Function<JobID, Boolean> isRegisteredFunction) {
             this.isRegisteredFunction = isRegisteredFunction;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/DispatcherResourceCleanerFactoryTest.java
@@ -96,7 +96,7 @@ public class DispatcherResourceCleanerFactoryTest {
 
         return TestingJobManagerRunnerRegistry.builder()
                 .withLocalCleanupAsyncFunction(
-                        (jobId, executor) -> {
+                        (jobId, executor, mainThreadExecutor) -> {
                             jobManagerRunnerRegistryLocalCleanupFuture.complete(jobId);
                             return jobManagerRunnerRegistryLocalCleanupResultFuture;
                         })

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
@@ -30,16 +30,17 @@ import java.util.concurrent.Executor;
 /** {@code TestingResourceCleanerFactory} for adding custom {@link ResourceCleaner} creation. */
 public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
 
-    private final Collection<LocallyCleanableResource> locallyCleanableResources;
+    private final Collection<LocallyCleanableInMainThreadResource>
+            locallyCleanableInMainThreadResource;
     private final Collection<GloballyCleanableResource> globallyCleanableResources;
 
     private final Executor cleanupExecutor;
 
     private TestingResourceCleanerFactory(
-            Collection<LocallyCleanableResource> locallyCleanableResources,
+            Collection<LocallyCleanableInMainThreadResource> locallyCleanableInMainThreadResource,
             Collection<GloballyCleanableResource> globallyCleanableResources,
             Executor cleanupExecutor) {
-        this.locallyCleanableResources = locallyCleanableResources;
+        this.locallyCleanableInMainThreadResource = locallyCleanableInMainThreadResource;
         this.globallyCleanableResources = globallyCleanableResources;
         this.cleanupExecutor = cleanupExecutor;
     }
@@ -49,8 +50,8 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
             ComponentMainThreadExecutor mainThreadExecutor) {
         return createResourceCleaner(
                 mainThreadExecutor,
-                locallyCleanableResources,
-                LocallyCleanableResource::localCleanupAsync);
+                locallyCleanableInMainThreadResource,
+                LocallyCleanableInMainThreadResource::localCleanupAsync);
     }
 
     @Override
@@ -89,21 +90,23 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
     /** {@code Builder} for creating {@code TestingResourceCleanerFactory} instances. */
     public static class Builder {
 
-        private Collection<LocallyCleanableResource> locallyCleanableResources = new ArrayList<>();
+        private Collection<LocallyCleanableInMainThreadResource>
+                locallyCleanableInMainThreadResource = new ArrayList<>();
         private Collection<GloballyCleanableResource> globallyCleanableResources =
                 new ArrayList<>();
 
         private Executor cleanupExecutor = Executors.directExecutor();
 
-        public Builder setLocallyCleanableResources(
-                Collection<LocallyCleanableResource> locallyCleanableResources) {
-            this.locallyCleanableResources = locallyCleanableResources;
+        public Builder setLocallyCleanableInMainThreadResource(
+                Collection<LocallyCleanableInMainThreadResource>
+                        locallyCleanableInMainThreadResource) {
+            this.locallyCleanableInMainThreadResource = locallyCleanableInMainThreadResource;
             return this;
         }
 
         public Builder withLocallyCleanableResource(
-                LocallyCleanableResource locallyCleanableResource) {
-            this.locallyCleanableResources.add(locallyCleanableResource);
+                LocallyCleanableInMainThreadResource locallyCleanableResource) {
+            this.locallyCleanableInMainThreadResource.add(locallyCleanableResource);
             return this;
         }
 
@@ -126,7 +129,9 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
 
         public TestingResourceCleanerFactory build() {
             return new TestingResourceCleanerFactory(
-                    locallyCleanableResources, globallyCleanableResources, cleanupExecutor);
+                    locallyCleanableInMainThreadResource,
+                    globallyCleanableResources,
+                    cleanupExecutor);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
@@ -32,18 +32,20 @@ import java.util.stream.Collectors;
 public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
 
     private final Collection<LocallyCleanableResource> locallyCleanableResources;
-    private Collection<LocallyCleanableInMainThreadResource> locallyCleanableInMainThreadResources;
+    private Collection<LocallyCleanableResourceWithMainThread>
+            locallyCleanableResourceWithMainThreads;
     private final Collection<GloballyCleanableResource> globallyCleanableResources;
 
     private final Executor cleanupExecutor;
 
     private TestingResourceCleanerFactory(
             Collection<LocallyCleanableResource> locallyCleanableResources,
-            Collection<LocallyCleanableInMainThreadResource> locallyCleanableInMainThreadResources,
+            Collection<LocallyCleanableResourceWithMainThread>
+                    locallyCleanableResourceWithMainThreads,
             Collection<GloballyCleanableResource> globallyCleanableResources,
             Executor cleanupExecutor) {
         this.locallyCleanableResources = locallyCleanableResources;
-        this.locallyCleanableInMainThreadResources = locallyCleanableInMainThreadResources;
+        this.locallyCleanableResourceWithMainThreads = locallyCleanableResourceWithMainThreads;
         this.globallyCleanableResources = globallyCleanableResources;
         this.cleanupExecutor = cleanupExecutor;
     }
@@ -55,7 +57,7 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
                 this.locallyCleanableResources;
 
         locallyCleanableResources.addAll(
-                locallyCleanableInMainThreadResources.stream()
+                locallyCleanableResourceWithMainThreads.stream()
                         .map(
                                 r ->
                                         DispatcherResourceCleanerFactory.toLocallyCleanableResource(
@@ -105,16 +107,16 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
     public static class Builder {
 
         private Collection<LocallyCleanableResource> locallyCleanableResource = new ArrayList<>();
-        private Collection<LocallyCleanableInMainThreadResource>
-                locallyCleanableInMainThreadResources = new ArrayList<>();
+        private Collection<LocallyCleanableResourceWithMainThread>
+                locallyCleanableResourceWithMainThreads = new ArrayList<>();
         private Collection<GloballyCleanableResource> globallyCleanableResources =
                 new ArrayList<>();
 
         private Executor cleanupExecutor = Executors.directExecutor();
 
         public Builder setLocallyCleanableInMainThreadResource(
-                Collection<LocallyCleanableInMainThreadResource>
-                        locallyCleanableInMainThreadResource) {
+                Collection<LocallyCleanableResourceWithMainThread>
+                        locallyCleanableResourceWithMainThread) {
             this.locallyCleanableResource = locallyCleanableResource;
             return this;
         }
@@ -126,8 +128,8 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
         }
 
         public Builder withLocallyCleanableInMainThreadResource(
-                LocallyCleanableInMainThreadResource locallyCleanableResource) {
-            this.locallyCleanableInMainThreadResources.add(locallyCleanableResource);
+                LocallyCleanableResourceWithMainThread locallyCleanableResource) {
+            this.locallyCleanableResourceWithMainThreads.add(locallyCleanableResource);
             return this;
         }
 
@@ -151,7 +153,7 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
         public TestingResourceCleanerFactory build() {
             return new TestingResourceCleanerFactory(
                     locallyCleanableResource,
-                    locallyCleanableInMainThreadResources,
+                    locallyCleanableResourceWithMainThreads,
                     globallyCleanableResources,
                     cleanupExecutor);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
@@ -58,10 +58,7 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
 
         locallyCleanableResources.addAll(
                 locallyCleanableResourceWithMainThreads.stream()
-                        .map(
-                                r ->
-                                        DispatcherResourceCleanerFactory.toLocallyCleanableResource(
-                                                r, mainThreadExecutor))
+                        .map(r -> r.toLocallyCleanableResource(mainThreadExecutor))
                         .collect(Collectors.toList()));
 
         return createResourceCleaner(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/cleanup/TestingResourceCleanerFactory.java
@@ -30,17 +30,16 @@ import java.util.concurrent.Executor;
 /** {@code TestingResourceCleanerFactory} for adding custom {@link ResourceCleaner} creation. */
 public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
 
-    private final Collection<LocallyCleanableInMainThreadResource>
-            locallyCleanableInMainThreadResource;
+    private final Collection<LocallyCleanableResource> locallyCleanableResources;
     private final Collection<GloballyCleanableResource> globallyCleanableResources;
 
     private final Executor cleanupExecutor;
 
     private TestingResourceCleanerFactory(
-            Collection<LocallyCleanableInMainThreadResource> locallyCleanableInMainThreadResource,
+            Collection<LocallyCleanableResource> locallyCleanableResources,
             Collection<GloballyCleanableResource> globallyCleanableResources,
             Executor cleanupExecutor) {
-        this.locallyCleanableInMainThreadResource = locallyCleanableInMainThreadResource;
+        this.locallyCleanableResources = locallyCleanableResources;
         this.globallyCleanableResources = globallyCleanableResources;
         this.cleanupExecutor = cleanupExecutor;
     }
@@ -48,10 +47,13 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
     @Override
     public ResourceCleaner createLocalResourceCleaner(
             ComponentMainThreadExecutor mainThreadExecutor) {
+        Collection<LocallyCleanableResource> locallyCleanableResources =
+                this.locallyCleanableResources;
+
         return createResourceCleaner(
                 mainThreadExecutor,
-                locallyCleanableInMainThreadResource,
-                LocallyCleanableInMainThreadResource::localCleanupAsync);
+                locallyCleanableResources,
+                LocallyCleanableResource::localCleanupAsync);
     }
 
     @Override
@@ -90,8 +92,7 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
     /** {@code Builder} for creating {@code TestingResourceCleanerFactory} instances. */
     public static class Builder {
 
-        private Collection<LocallyCleanableInMainThreadResource>
-                locallyCleanableInMainThreadResource = new ArrayList<>();
+        private Collection<LocallyCleanableResource> locallyCleanableResource = new ArrayList<>();
         private Collection<GloballyCleanableResource> globallyCleanableResources =
                 new ArrayList<>();
 
@@ -100,13 +101,13 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
         public Builder setLocallyCleanableInMainThreadResource(
                 Collection<LocallyCleanableInMainThreadResource>
                         locallyCleanableInMainThreadResource) {
-            this.locallyCleanableInMainThreadResource = locallyCleanableInMainThreadResource;
+            this.locallyCleanableResource = locallyCleanableResource;
             return this;
         }
 
         public Builder withLocallyCleanableResource(
-                LocallyCleanableInMainThreadResource locallyCleanableResource) {
-            this.locallyCleanableInMainThreadResource.add(locallyCleanableResource);
+                LocallyCleanableResource locallyCleanableResource) {
+            this.locallyCleanableResource.add(locallyCleanableResource);
             return this;
         }
 
@@ -129,9 +130,7 @@ public class TestingResourceCleanerFactory implements ResourceCleanerFactory {
 
         public TestingResourceCleanerFactory build() {
             return new TestingResourceCleanerFactory(
-                    locallyCleanableInMainThreadResource,
-                    globallyCleanableResources,
-                    cleanupExecutor);
+                    locallyCleanableResource, globallyCleanableResources, cleanupExecutor);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/EventReceivingTasks.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/EventReceivingTasks.java
@@ -242,11 +242,11 @@ public class EventReceivingTasks implements SubtaskAccess.SubtaskAccessFactory {
      * An implementation of {@link ComponentMainThreadExecutor} that executes Runnables with a
      * wrapped {@link ScheduledExecutor} and disables {@link #assertRunningInMainThread()} checks.
      */
-    private static class NoMainThreadCheckComponentMainThreadExecutor
+    public static class NoMainThreadCheckComponentMainThreadExecutor
             implements ComponentMainThreadExecutor {
         private final ScheduledExecutor scheduledExecutor;
 
-        private NoMainThreadCheckComponentMainThreadExecutor() {
+        public NoMainThreadCheckComponentMainThreadExecutor() {
             this.scheduledExecutor =
                     new ScheduledExecutorServiceAdapter(new DirectScheduledExecutorService());
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Prevents early unregistration of `JobManagerRunner` before it's closed successfully.


## Brief change log

Moves the `JobManagerRunner` unregistration to another stage in the `CompletableFuture` in `DefaultJobManagerRunnerRegistry.localCleanupAsync()` to keep `JobManagerRunner` from being unregistered before it's closed successfully.

## Verifying this change

The existing tests have been modified to check the new behaviour.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
