### PR TITLE
[BP-1.20][FLINK-35778] Escape URI reserved characters when creating file-merging directories

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerBase.java
@@ -206,7 +206,7 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
             // According
             // to the FLIP-306, we later consider move these files to the new introduced
             // task-manager-owned directory.
-            Path managedExclusivePath = new Path(taskOwnedStateDir, id);
+            Path managedExclusivePath = new Path(taskOwnedStateDir, uriEscape(id));
             boolean newCreated = createManagedDirectory(managedExclusivePath);
             this.managedExclusiveStateDir = managedExclusivePath;
             this.managedExclusiveStateDirHandle =
@@ -219,7 +219,7 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
     @Override
     public void registerSubtaskForSharedStates(SubtaskKey subtaskKey) {
         String managedDirName = subtaskKey.getManagedDirName();
-        Path managedPath = new Path(sharedStateDir, managedDirName);
+        Path managedPath = new Path(sharedStateDir, uriEscape(managedDirName));
         if (!managedSharedStateDir.containsKey(subtaskKey)) {
             boolean newCreated = createManagedDirectory(managedPath);
             managedSharedStateDir.put(subtaskKey, managedPath);
@@ -771,6 +771,13 @@ public abstract class FileMergingSnapshotManagerBase implements FileMergingSnaps
         // TODO: Determine whether do file sync more wisely. Add an interface to FileSystem if
         // needed.
         return true;
+    }
+
+    private static String uriEscape(String input) {
+        // All reserved characters (RFC 2396) will be removed. This is enough for flink's resource
+        // id, job id and operator id.
+        // Ref: https://docs.oracle.com/javase/8/docs/api/index.html?java/net/URI.html
+        return input.replaceAll("[;/?:@&=+$,\\[\\]]", "-");
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Currently, the file-merging manager for checkpoint files will create directories based on tm resource id, job id and operator ids. While in some cases, these ids include some characters that are reserved in URI scheme. This PR does a simple escape for those ids.


## Brief change log
 - Add a tool method `uriEscape` in file-merging manager.


## Verifying this change

 - New UT `FileMergingSnapshotManagerTestBase#testSpecialCharactersInPath`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
