### PR TITLE
[BP-1.20] [FLINK-33192] Fix Memory Leak in WindowOperator due to Improper Timer Cleanup

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperator.java
@@ -376,10 +376,9 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
                 if (triggerResult.isFire()) {
                     ACC contents = windowState.get();
-                    if (contents == null) {
-                        continue;
+                    if (contents != null) {
+                        emitWindowContents(actualWindow, contents);
                     }
-                    emitWindowContents(actualWindow, contents);
                 }
 
                 if (triggerResult.isPurge()) {
@@ -409,10 +408,9 @@ public class WindowOperator<K, IN, ACC, OUT, W extends Window>
 
                 if (triggerResult.isFire()) {
                     ACC contents = windowState.get();
-                    if (contents == null) {
-                        continue;
+                    if (contents != null) {
+                        emitWindowContents(window, contents);
                     }
-                    emitWindowContents(window, contents);
                 }
 
                 if (triggerResult.isPurge()) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -3130,6 +3130,114 @@ class WindowOperatorTest {
         testHarness.close();
     }
 
+    @Test
+    void testCleanupTimerWithEmptyStateNoResultForTumblingWindows() throws Exception {
+        final int windowSize = 2;
+        final long lateness = 1;
+
+        ListStateDescriptor<Tuple2<String, Integer>> windowStateDesc =
+                new ListStateDescriptor<>(
+                        "window-contents",
+                        STRING_INT_TUPLE.createSerializer(new SerializerConfigImpl()));
+
+        WindowOperator<
+                        String,
+                        Tuple2<String, Integer>,
+                        Iterable<Tuple2<String, Integer>>,
+                        Tuple2<String, Integer>,
+                        TimeWindow>
+                operator =
+                        new WindowOperator<>(
+                                TumblingEventTimeWindows.of(Time.of(windowSize, TimeUnit.SECONDS)),
+                                new TimeWindow.Serializer(),
+                                new TupleKeySelector(),
+                                BasicTypeInfo.STRING_TYPE_INFO.createSerializer(
+                                        new SerializerConfigImpl()),
+                                windowStateDesc,
+                                new InternalIterableWindowFunction<>(new EmptyReturnFunction()),
+                                new FireEverytimeOnElementAndEventTimeTrigger(),
+                                lateness,
+                                null /* late data output tag */);
+
+        OneInputStreamOperatorTestHarness<Tuple2<String, Integer>, Tuple2<String, Integer>>
+                testHarness = createTestHarness(operator);
+
+        testHarness.open();
+
+        ConcurrentLinkedQueue<Object> expected = new ConcurrentLinkedQueue<>();
+        // normal element
+        testHarness.processElement(new StreamRecord<>(new Tuple2<>("test_key", 1), 1000));
+        assertThat(
+                        operator.processContext
+                                .windowState()
+                                .getListState(windowStateDesc)
+                                .get()
+                                .toString())
+                .isEqualTo("[(test_key,1)]");
+        testHarness.processWatermark(new Watermark(1599));
+        assertThat(
+                        operator.processContext
+                                .windowState()
+                                .getListState(windowStateDesc)
+                                .get()
+                                .toString())
+                .isEqualTo("[(test_key,1)]");
+        testHarness.processWatermark(new Watermark(1699));
+        assertThat(
+                        operator.processContext
+                                .windowState()
+                                .getListState(windowStateDesc)
+                                .get()
+                                .toString())
+                .isEqualTo("[(test_key,1)]");
+        testHarness.processWatermark(new Watermark(1799));
+        assertThat(
+                        operator.processContext
+                                .windowState()
+                                .getListState(windowStateDesc)
+                                .get()
+                                .toString())
+                .isEqualTo("[(test_key,1)]");
+        testHarness.processWatermark(new Watermark(1999));
+        assertThat(
+                        operator.processContext
+                                .windowState()
+                                .getListState(windowStateDesc)
+                                .get()
+                                .toString())
+                .isEqualTo("[(test_key,1)]");
+        testHarness.processWatermark(new Watermark(2000));
+        assertThat(
+                        operator.processContext
+                                .windowState()
+                                .getListState(windowStateDesc)
+                                .get()
+                                .toString())
+                .isEqualTo("[]");
+        testHarness.processWatermark(new Watermark(5000));
+        assertThat(
+                        operator.processContext
+                                .windowState()
+                                .getListState(windowStateDesc)
+                                .get()
+                                .toString())
+                .isEqualTo("[]");
+
+        expected.add(new Watermark(1599));
+        expected.add(new Watermark(1699));
+        expected.add(new Watermark(1799));
+        expected.add(new Watermark(1999)); // here it fires and purges
+        expected.add(new Watermark(2000)); // here is the cleanup timer
+        expected.add(new Watermark(5000));
+
+        TestHarnessUtil.assertOutputEqualsSorted(
+                "Output was not correct.",
+                expected,
+                testHarness.getOutput(),
+                new Tuple2ResultSortComparator());
+        testHarness.close();
+    }
+
     // ------------------------------------------------------------------------
     //  UDFs
     // ------------------------------------------------------------------------
@@ -3150,6 +3258,20 @@ class WindowOperatorTest {
                 out.collect(in);
             }
         }
+    }
+
+    private static class EmptyReturnFunction
+            implements WindowFunction<
+                    Tuple2<String, Integer>, Tuple2<String, Integer>, String, TimeWindow> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void apply(
+                String k,
+                TimeWindow window,
+                Iterable<Tuple2<String, Integer>> input,
+                Collector<Tuple2<String, Integer>> out)
+                throws Exception {}
     }
 
     private static class SumReducer implements ReduceFunction<Tuple2<String, Integer>> {
@@ -3420,5 +3542,33 @@ class WindowOperatorTest {
         public String toString() {
             return "EventTimeTrigger()";
         }
+    }
+
+    private static class FireEverytimeOnElementAndEventTimeTrigger
+            extends Trigger<Tuple2<String, Integer>, TimeWindow> {
+        @Override
+        public TriggerResult onElement(
+                Tuple2<String, Integer> element,
+                long timestamp,
+                TimeWindow window,
+                TriggerContext ctx)
+                throws Exception {
+            return TriggerResult.FIRE;
+        }
+
+        @Override
+        public TriggerResult onProcessingTime(long time, TimeWindow window, TriggerContext ctx)
+                throws Exception {
+            return TriggerResult.FIRE;
+        }
+
+        @Override
+        public TriggerResult onEventTime(long time, TimeWindow window, TriggerContext ctx)
+                throws Exception {
+            return TriggerResult.FIRE;
+        }
+
+        @Override
+        public void clear(TimeWindow window, TriggerContext ctx) throws Exception {}
     }
 }


### PR DESCRIPTION
1.20 backport for parent PR https://github.com/apache/flink/pull/24917

---

## What is the purpose of the change
* This Pull Request addresses an important state memory leak issue identified within the default window operator of Apache Flink. 
* After this change, the cleanup timer should be registered for every window that's added to the window state regardless of it emitting a result after it’s fired.
* This change is associated to the following bug: [FLINK-33192
](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-33192)


## Brief change log
Modified `org.apache.flink.streaming.runtime.operators.windowing.WindowOperator` to register clean up timer for window states regardless of whether emits a result or not. 

## Verifying this change
- WindowOperatorTest is working for functional correctness.
- Written a new test `testCleanupTimerWithEmptyStateNoResultForTumblingWindows`. This test simulates a empty returning aggregate function with tumbling windows. The passing of the test validates that the window contents are being cleared during the time the cleanup time is actually supposed to be called. Hence, the memory leak should not be happening after the change. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
