### PR TITLE
[FLINK-35780] Support state migration between disabling and enabling State TTL in RocksDBKeyedStateBackend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapKeyedStateBackend.java
@@ -51,6 +51,7 @@ import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTran
 import org.apache.flink.runtime.state.StateSnapshotTransformers;
 import org.apache.flink.runtime.state.StreamCompressionDecorator;
 import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
+import org.apache.flink.runtime.state.ttl.TtlAwareSerializer;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.StateMigrationException;
@@ -249,6 +250,17 @@ public class HeapKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                         "For heap backends, the new state serializer ("
                                 + newStateSerializer
                                 + ") must not be incompatible with the old state serializer ("
+                                + previousStateSerializer
+                                + ").");
+            }
+
+            // HeapKeyedStateBackend doesn't support ttl state migration currently.
+            if (TtlAwareSerializer.needTtlStateMigration(
+                    previousStateSerializer, newStateSerializer)) {
+                throw new StateMigrationException(
+                        "For heap backends, the new state serializer ("
+                                + newStateSerializer
+                                + ") must not need ttl state migration with the old state serializer ("
                                 + previousStateSerializer
                                 + ").");
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerSnapshot.java
@@ -25,6 +25,9 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
 import java.io.IOException;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * A {@link TypeSerializerSnapshot} for TtlAwareSerializer. This class wraps a {@link
@@ -52,11 +55,19 @@ public class TtlAwareSerializerSnapshot<T> implements TypeSerializerSnapshot<T> 
 
     public TtlAwareSerializerSnapshot(
             TypeSerializerSnapshot<T> typeSerializerSnapshot, boolean isTtlEnabled) {
+        checkArgument(
+                !(typeSerializerSnapshot instanceof TtlAwareSerializerSnapshot),
+                typeSerializerSnapshot
+                        + " is already instance of TtlAwareSerializerSnapshot, should not be wrapped repeatedly.");
         this.typeSerializerSnapshot = typeSerializerSnapshot;
         this.isTtlEnabled = isTtlEnabled;
     }
 
     public TtlAwareSerializerSnapshot(TypeSerializerSnapshot<T> typeSerializerSnapshot) {
+        checkArgument(
+                !(typeSerializerSnapshot instanceof TtlAwareSerializerSnapshot),
+                typeSerializerSnapshot
+                        + " is already instance of TtlAwareSerializerSnapshot, should not be wrapped repeatedly.");
         this.typeSerializerSnapshot = typeSerializerSnapshot;
         this.isTtlEnabled = typeSerializerSnapshot instanceof TtlStateFactory.TtlSerializerSnapshot;
     }
@@ -144,5 +155,23 @@ public class TtlAwareSerializerSnapshot<T> implements TypeSerializerSnapshot<T> 
         } else {
             return TypeSerializerSchemaCompatibility.incompatible();
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TtlAwareSerializerSnapshot<?> that = (TtlAwareSerializerSnapshot<?>) o;
+        return isTtlEnabled == that.isTtlEnabled
+                && Objects.equals(typeSerializerSnapshot, that.typeSerializerSnapshot);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isTtlEnabled, typeSerializerSnapshot);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -154,7 +154,7 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
                         e -> assertThat(e).hasCauseInstanceOf(StateMigrationException.class));
     }
 
-    private void testKeyedValueStateUpgrade(
+    protected void testKeyedValueStateUpgrade(
             ValueStateDescriptor<TestType> initialAccessDescriptor,
             ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore)
             throws Exception {
@@ -271,7 +271,7 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
                         e -> assertThat(e).hasCauseInstanceOf(StateMigrationException.class));
     }
 
-    private void testKeyedListStateUpgrade(
+    protected void testKeyedListStateUpgrade(
             ListStateDescriptor<TestType> initialAccessDescriptor,
             ListStateDescriptor<TestType> newAccessDescriptorAfterRestore)
             throws Exception {
@@ -431,7 +431,7 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
         return set.iterator();
     }
 
-    private void testKeyedMapStateUpgrade(
+    protected void testKeyedMapStateUpgrade(
             MapStateDescriptor<Integer, TestType> initialAccessDescriptor,
             MapStateDescriptor<Integer, TestType> newAccessDescriptorAfterRestore)
             throws Exception {
@@ -1203,7 +1203,7 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
     }
 
     @TestTemplate
-    void testStateMigrationAfterChangingTTLFromEnablingToDisabling() {
+    protected void testStateMigrationAfterChangingTTLFromEnablingToDisabling() throws Exception {
         final String stateName = "test-ttl";
 
         ValueStateDescriptor<TestType> initialAccessDescriptor =
@@ -1219,17 +1219,16 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
                                 testKeyedValueStateUpgrade(
                                         initialAccessDescriptor, newAccessDescriptorAfterRestore))
                 .satisfiesAnyOf(
-                        e -> assertThat(e).isInstanceOf(IllegalStateException.class),
-                        e -> assertThat(e).hasCauseInstanceOf(IllegalStateException.class));
+                        e -> assertThat(e).isInstanceOf(StateMigrationException.class),
+                        e -> assertThat(e).hasCauseInstanceOf(StateMigrationException.class));
     }
 
     @TestTemplate
-    void testStateMigrationAfterChangingTTLFromDisablingToEnabling() {
+    protected void testStateMigrationAfterChangingTTLFromDisablingToEnabling() throws Exception {
         final String stateName = "test-ttl";
 
         ValueStateDescriptor<TestType> initialAccessDescriptor =
                 new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
-
         ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
                 new ValueStateDescriptor<>(stateName, new TestType.V2TestTypeSerializer());
         newAccessDescriptorAfterRestore.enableTimeToLive(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/StateBackendTestContext.java
@@ -89,7 +89,7 @@ public abstract class StateBackendTestContext {
         }
     }
 
-    void createAndRestoreKeyedStateBackend(KeyedStateHandle snapshot) {
+    public void createAndRestoreKeyedStateBackend(KeyedStateHandle snapshot) {
         createAndRestoreKeyedStateBackend(NUMBER_OF_KEY_GROUPS, snapshot);
     }
 
@@ -144,7 +144,7 @@ public abstract class StateBackendTestContext {
         }
     }
 
-    KeyedStateHandle takeSnapshot() throws Exception {
+    public KeyedStateHandle takeSnapshot() throws Exception {
         SnapshotResult<KeyedStateHandle> snapshotResult = triggerSnapshot().get();
         KeyedStateHandle jobManagerOwnedSnapshot = snapshotResult.getJobManagerOwnedSnapshot();
         if (jobManagerOwnedSnapshot != null) {
@@ -171,7 +171,7 @@ public abstract class StateBackendTestContext {
     }
 
     @SuppressWarnings("unchecked")
-    <N, S extends State, V> S createState(
+    public <N, S extends State, V> S createState(
             StateDescriptor<S, V> stateDescriptor,
             @SuppressWarnings("SameParameterValue") N defaultNamespace)
             throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerUpgradeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlAwareSerializerUpgradeTest.java
@@ -155,8 +155,8 @@ public class TtlAwareSerializerUpgradeTest
             TypeSerializer<T> writeSerializer,
             Condition<T> testDataCondition)
             throws IOException {
-        TtlAwareSerializer<T> reader = (TtlAwareSerializer<T>) readSerializer;
-        TtlAwareSerializer<T> writer = (TtlAwareSerializer<T>) writeSerializer;
+        TtlAwareSerializer<T, ?> reader = (TtlAwareSerializer<T, ?>) readSerializer;
+        TtlAwareSerializer<T, ?> writer = (TtlAwareSerializer<T, ?>) writeSerializer;
 
         DataOutputSerializer migratedOut = new DataOutputSerializer(INITIAL_OUTPUT_BUFFER_SIZE);
         writer.migrateValueFromPriorSerializer(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -109,7 +109,7 @@ public abstract class TtlStateTestBase {
         return (TtlMergingStateTestContext<?, UV, ?>) ctx;
     }
 
-    private void initTest() throws Exception {
+    protected void initTest() throws Exception {
         initTest(
                 StateTtlConfig.UpdateType.OnCreateAndWrite,
                 StateTtlConfig.StateVisibility.NeverReturnExpired);
@@ -496,7 +496,7 @@ public abstract class TtlStateTestBase {
     }
 
     @TestTemplate
-    void testRestoreTtlAndRegisterNonTtlStateCompatFailure() throws Exception {
+    protected void testRestoreTtlAndRegisterNonTtlStateCompatFailure() throws Exception {
         assumeThat(this).isNotInstanceOf(MockTtlStateTest.class);
 
         initTest();

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendMigrationTest.java
@@ -64,4 +64,18 @@ public class ChangelogStateBackendMigrationTest
         // TODO support checking key serializer
         return false;
     }
+
+    @Override
+    protected void testStateMigrationAfterChangingTTLFromDisablingToEnabling() throws Exception {
+        if (!(this.delegatedStateBackendSupplier.get() instanceof EmbeddedRocksDBStateBackend)) {
+            super.testStateMigrationAfterChangingTTLFromDisablingToEnabling();
+        }
+    }
+
+    @Override
+    protected void testStateMigrationAfterChangingTTLFromEnablingToDisabling() throws Exception {
+        if (!(this.delegatedStateBackendSupplier.get() instanceof EmbeddedRocksDBStateBackend)) {
+            super.testStateMigrationAfterChangingTTLFromEnablingToDisabling();
+        }
+    }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBAggregatingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBAggregatingState.java
@@ -192,6 +192,7 @@ class RocksDBAggregatingState<K, N, T, ACC, R>
                                 ((AggregatingStateDescriptor) stateDesc).getAggregateFunction())
                         .setNamespaceSerializer(registerResult.f1.getNamespaceSerializer())
                         .setValueSerializer(registerResult.f1.getStateSerializer())
-                        .setDefaultValue(stateDesc.getDefaultValue());
+                        .setDefaultValue(stateDesc.getDefaultValue())
+                        .setColumnFamily(registerResult.f0);
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBMapState.java
@@ -32,6 +32,8 @@ import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.internal.InternalMapState;
+import org.apache.flink.runtime.state.ttl.TtlAwareSerializer;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StateMigrationException;
@@ -225,25 +227,33 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
             DataInputDeserializer serializedOldValueInput,
             DataOutputSerializer serializedMigratedValueOutput,
             TypeSerializer<Map<UK, UV>> priorSerializer,
-            TypeSerializer<Map<UK, UV>> newSerializer)
+            TypeSerializer<Map<UK, UV>> newSerializer,
+            TtlTimeProvider ttlTimeProvider)
             throws StateMigrationException {
 
-        checkArgument(priorSerializer instanceof MapSerializer);
-        checkArgument(newSerializer instanceof MapSerializer);
+        checkArgument(priorSerializer instanceof TtlAwareSerializer.TtlAwareMapSerializer);
+        checkArgument(newSerializer instanceof TtlAwareSerializer.TtlAwareMapSerializer);
 
-        TypeSerializer<UV> priorMapValueSerializer =
-                ((MapSerializer<UK, UV>) priorSerializer).getValueSerializer();
-        TypeSerializer<UV> newMapValueSerializer =
-                ((MapSerializer<UK, UV>) newSerializer).getValueSerializer();
+        TtlAwareSerializer<UV, ?> priorTtlAwareMapValueSerializer =
+                ((TtlAwareSerializer.TtlAwareMapSerializer<UK, UV>) priorSerializer)
+                        .getValueSerializer();
+        TtlAwareSerializer<UV, ?> newTtlAwareMapValueSerializer =
+                ((TtlAwareSerializer.TtlAwareMapSerializer<UK, UV>) newSerializer)
+                        .getValueSerializer();
 
         try {
             boolean isNull = serializedOldValueInput.readBoolean();
-            UV mapUserValue = null;
-            if (!isNull) {
-                mapUserValue = priorMapValueSerializer.deserialize(serializedOldValueInput);
+            serializedMigratedValueOutput.writeBoolean(isNull);
+
+            if (isNull) {
+                newTtlAwareMapValueSerializer.serialize(null, serializedMigratedValueOutput);
+            } else {
+                newTtlAwareMapValueSerializer.migrateValueFromPriorSerializer(
+                        priorTtlAwareMapValueSerializer,
+                        () -> priorTtlAwareMapValueSerializer.deserialize(serializedOldValueInput),
+                        serializedMigratedValueOutput,
+                        ttlTimeProvider);
             }
-            serializedMigratedValueOutput.writeBoolean(mapUserValue == null);
-            newMapValueSerializer.serialize(mapUserValue, serializedMigratedValueOutput);
         } catch (Exception e) {
             throw new StateMigrationException(
                     "Error while trying to migrate RocksDB map state.", e);
@@ -726,7 +736,8 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
                         .setValueSerializer(
                                 (TypeSerializer<Map<UK, UV>>)
                                         registerResult.f1.getStateSerializer())
-                        .setDefaultValue((Map<UK, UV>) stateDesc.getDefaultValue());
+                        .setDefaultValue((Map<UK, UV>) stateDesc.getDefaultValue())
+                        .setColumnFamily(registerResult.f0);
     }
 
     /**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBOperationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBOperationUtils.java
@@ -275,7 +275,7 @@ public class RocksDBOperationUtils {
                 .setMergeOperatorName(MERGE_OPERATOR_NAME);
     }
 
-    private static ColumnFamilyHandle createColumnFamily(
+    public static ColumnFamilyHandle createColumnFamily(
             ColumnFamilyDescriptor columnDescriptor,
             RocksDB db,
             List<ExportImportFilesMetaData> importFilesMetaData,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBReducingState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBReducingState.java
@@ -182,6 +182,7 @@ class RocksDBReducingState<K, N, V> extends AbstractRocksDBAppendingState<K, N, 
                         .setReduceFunction(
                                 ((ReducingStateDescriptor<SV>) stateDesc).getReduceFunction())
                         .setNamespaceSerializer(registerResult.f1.getNamespaceSerializer())
-                        .setDefaultValue(stateDesc.getDefaultValue());
+                        .setDefaultValue(stateDesc.getDefaultValue())
+                        .setColumnFamily(registerResult.f0);
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBValueState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/RocksDBValueState.java
@@ -134,6 +134,7 @@ class RocksDBValueState<K, N, V> extends AbstractRocksDBState<K, N, V>
                 ((RocksDBValueState<K, N, SV>) existingState)
                         .setNamespaceSerializer(registerResult.f1.getNamespaceSerializer())
                         .setValueSerializer(registerResult.f1.getStateSerializer())
-                        .setDefaultValue(stateDesc.getDefaultValue());
+                        .setDefaultValue(stateDesc.getDefaultValue())
+                        .setColumnFamily(registerResult.f0);
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/ttl/RocksDbTtlCompactFiltersManager.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/state/rocksdb/ttl/RocksDbTtlCompactFiltersManager.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.typeutils.base.ListSerializer;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
-import org.apache.flink.runtime.state.ttl.TtlStateFactory;
+import org.apache.flink.runtime.state.ttl.TtlAwareSerializer;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.state.ttl.TtlUtils;
 import org.apache.flink.runtime.state.ttl.TtlValue;
@@ -92,8 +92,7 @@ public class RocksDbTtlCompactFiltersManager {
         if (metaInfoBase instanceof RegisteredKeyValueStateBackendMetaInfo) {
             RegisteredKeyValueStateBackendMetaInfo kvMetaInfoBase =
                     (RegisteredKeyValueStateBackendMetaInfo) metaInfoBase;
-            if (TtlStateFactory.TtlSerializer.isTtlStateSerializer(
-                    kvMetaInfoBase.getStateSerializer())) {
+            if (TtlAwareSerializer.isSerializerTtlEnabled(kvMetaInfoBase.getStateSerializer())) {
                 createAndSetCompactFilterFactory(metaInfoBase.getName(), options);
             }
         }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/EmbeddedRocksDBStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/EmbeddedRocksDBStateBackendMigrationTest.java
@@ -18,21 +18,29 @@
 
 package org.apache.flink.state.rocksdb;
 
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackendMigrationTestBase;
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.runtime.testutils.statemigration.TestType;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.function.SupplierWithException;
 
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
@@ -78,5 +86,89 @@ public class EmbeddedRocksDBStateBackendMigrationTest
     @Override
     protected CheckpointStorage getCheckpointStorage() throws Exception {
         return storageSupplier.get();
+    }
+
+    /// Todo: Move to StateBackendMigrationTestBase when all backends support ttl state migration
+    @TestTemplate
+    protected void testStateMigrationAfterChangingTTLFromDisablingToEnabling() throws Exception {
+        final String stateName = "test-ttl";
+
+        ValueStateDescriptor<TestType> initialAccessDescriptor =
+                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
+                new ValueStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+        newAccessDescriptorAfterRestore.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+
+        ListStateDescriptor<TestType> initialAccessListDescriptor =
+                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
+                new ListStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+        newAccessListDescriptorAfterRestore.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+
+        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
+                new MapStateDescriptor<>(
+                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
+        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
+                new MapStateDescriptor<>(
+                        stateName,
+                        IntSerializer.INSTANCE,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+        newAccessMapDescriptorAfterRestore.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+
+        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
+        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
+        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
+    }
+
+    /// Todo: Move to StateBackendMigrationTestBase when all backends support ttl state migration
+    @TestTemplate
+    protected void testStateMigrationAfterChangingTTLFromEnablingToDisabling() throws Exception {
+        final String stateName = "test-ttl";
+
+        ValueStateDescriptor<TestType> initialAccessDescriptor =
+                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        initialAccessDescriptor.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
+                new ValueStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+
+        ListStateDescriptor<TestType> initialAccessListDescriptor =
+                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        initialAccessListDescriptor.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
+                new ListStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+
+        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
+                new MapStateDescriptor<>(
+                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
+        initialAccessMapDescriptor.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
+                new MapStateDescriptor<>(
+                        stateName,
+                        IntSerializer.INSTANCE,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+
+        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
+        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
+        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBStateBackendMigrationTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/state/rocksdb/RocksDBStateBackendMigrationTest.java
@@ -18,19 +18,27 @@
 
 package org.apache.flink.state.rocksdb;
 
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackendMigrationTestBase;
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
+import org.apache.flink.runtime.testutils.statemigration.TestType;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.TernaryBoolean;
 
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -69,5 +77,89 @@ public class RocksDBStateBackendMigrationTest
     protected CheckpointStorage getCheckpointStorage() throws Exception {
         String checkpointPath = TempDirUtils.newFolder(tempFolder).toURI().toString();
         return new FileSystemCheckpointStorage(checkpointPath);
+    }
+
+    /// Todo: Move to StateBackendMigrationTestBase when all backends support ttl state migration
+    @TestTemplate
+    protected void testStateMigrationAfterChangingTTLFromDisablingToEnabling() throws Exception {
+        final String stateName = "test-ttl";
+
+        ValueStateDescriptor<TestType> initialAccessDescriptor =
+                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
+                new ValueStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+        newAccessDescriptorAfterRestore.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+
+        ListStateDescriptor<TestType> initialAccessListDescriptor =
+                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
+                new ListStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+        newAccessListDescriptorAfterRestore.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+
+        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
+                new MapStateDescriptor<>(
+                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
+        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
+                new MapStateDescriptor<>(
+                        stateName,
+                        IntSerializer.INSTANCE,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+        newAccessMapDescriptorAfterRestore.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+
+        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
+        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
+        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
+    }
+
+    /// Todo: Move to StateBackendMigrationTestBase when all backends support ttl state migration
+    @TestTemplate
+    protected void testStateMigrationAfterChangingTTLFromEnablingToDisabling() throws Exception {
+        final String stateName = "test-ttl";
+
+        ValueStateDescriptor<TestType> initialAccessDescriptor =
+                new ValueStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        initialAccessDescriptor.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+        ValueStateDescriptor<TestType> newAccessDescriptorAfterRestore =
+                new ValueStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+
+        ListStateDescriptor<TestType> initialAccessListDescriptor =
+                new ListStateDescriptor<>(stateName, new TestType.V1TestTypeSerializer());
+        initialAccessListDescriptor.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+        ListStateDescriptor<TestType> newAccessListDescriptorAfterRestore =
+                new ListStateDescriptor<>(
+                        stateName,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+
+        MapStateDescriptor<Integer, TestType> initialAccessMapDescriptor =
+                new MapStateDescriptor<>(
+                        stateName, IntSerializer.INSTANCE, new TestType.V1TestTypeSerializer());
+        initialAccessMapDescriptor.enableTimeToLive(
+                StateTtlConfig.newBuilder(Duration.ofDays(1)).build());
+        MapStateDescriptor<Integer, TestType> newAccessMapDescriptorAfterRestore =
+                new MapStateDescriptor<>(
+                        stateName,
+                        IntSerializer.INSTANCE,
+                        // restore with a V2 serializer that has a different schema
+                        new TestType.V2TestTypeSerializer());
+
+        testKeyedValueStateUpgrade(initialAccessDescriptor, newAccessDescriptorAfterRestore);
+        testKeyedListStateUpgrade(initialAccessListDescriptor, newAccessListDescriptorAfterRestore);
+        testKeyedMapStateUpgrade(initialAccessMapDescriptor, newAccessMapDescriptorAfterRestore);
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/completeness/TypeSerializerTestCoverageTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/completeness/TypeSerializerTestCoverageTest.java
@@ -147,6 +147,8 @@ public class TypeSerializerTestCoverageTest extends TestLogger {
                         CoGroupedStreams.UnionSerializer.class.getName(),
                         TtlStateFactory.TtlSerializer.class.getName(),
                         TtlAwareSerializer.class.getName(),
+                        TtlAwareSerializer.TtlAwareListSerializer.class.getName(),
+                        TtlAwareSerializer.TtlAwareMapSerializer.class.getName(),
                         org.apache.flink.runtime.state.v2.ttl.TtlStateFactory.TtlSerializer.class
                                 .getName(),
                         TimeWindow.Serializer.class.getName(),
@@ -211,6 +213,8 @@ public class TypeSerializerTestCoverageTest extends TestLogger {
                         UnloadableDummyTypeSerializer.class.getName(),
                         TimeWindow.Serializer.class.getName(),
                         CoGroupedStreams.UnionSerializer.class.getName(),
+                        TtlAwareSerializer.TtlAwareListSerializer.class.getName(),
+                        TtlAwareSerializer.TtlAwareMapSerializer.class.getName(),
                         InternalTimersSnapshotReaderWriters.LegacyTimerSerializer.class.getName(),
                         TwoPhaseCommitSinkFunction.StateSerializer.class.getName(),
                         GlobalWindow.Serializer.class.getName(),


### PR DESCRIPTION
[FLINK-35780][state] Support state migration between disabling and enabling State TTL in RocksDBState

## What is the purpose of the change

Support state migration between disabling and enabling state for RocksDBState.


## Brief change log

  - Wrap all `stateSerializer` when creating states with `TtlAwareSerializer` 
  - Wrap all recovered `TypeSerializerSnapshot` with `TtlAwareSerializerSnapshot`
  - Re-create RocksDB Column Family in TTL state migration 
  - Change `migrateSerializedValue` in `AbstractRocksDBState`, `RocksDBListState` and `RocksDBMapState` to support ttl value migration
  - Support update `ColumnFamilyHandle` in `RocksDBKeyedStateBackend`.`StateUpdateFactory`
  - Compatible with `HeapKeyedStateBackend`
  - Override State Ttl migration test in `RocksDBTtlStateTestBase `, `EmbeddedRocksDBStateBackendMigrationTest` and `RocksDBStateBackendMigrationTest`


## Verifying this change

This change added tests and can be verified as follows:

  - Added Unit Test in `EmbeddedRocksDBStateBackendMigrationTest `.`testStateMigrationAfterChangingTTLFromDisablingToEnabling `
  - Added Unit Test in `EmbeddedRocksDBStateBackendMigrationTest`.`testStateMigrationAfterChangingTTLFromEnablingToDisabling `
  - Added Unit Test in `RocksDBTtlStateTestBase`.`testRestoreTtlAndRegisterNonTtlStateCompatFailure `
  - Manually verified the change by disabling state TTL at first and then enable it and then disable it. And check the checkpoint size.
![image](https://github.com/user-attachments/assets/b8c1646b-d26f-49c9-b869-48a98f0a502f)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes