### PR TITLE
[BP-1.19] [FLINK-35657][runtime-web] use parseFloat for metric value

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
@@ -104,7 +104,7 @@ export class JobManagerService {
         map(arr => {
           const result: MetricMap = {};
           arr.forEach(item => {
-            result[item.id] = parseInt(item.value, 10);
+            result[item.id] = parseFloat(item.value);
           });
           return result;
         })

--- a/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/metrics.service.ts
@@ -61,7 +61,7 @@ export class MetricsService {
         map(arr => {
           const result: MetricMap = {};
           arr.forEach(item => {
-            result[item.id] = parseInt(item.value, 10);
+            result[item.id] = parseFloat(item.value);
           });
           return {
             timestamp: Date.now(),

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
@@ -108,7 +108,7 @@ export class TaskManagerService {
         map(arr => {
           const result: MetricMap = {};
           arr.forEach(item => {
-            result[item.id] = parseInt(item.value, 10);
+            result[item.id] = parseFloat(item.value);
           });
           return result;
         })


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

master branch PR: https://github.com/apache/flink/pull/24964.

Flink UI always shows float metric value as int/long. For example, `outPoolUsage`/`inPoolUsage` are always 0 or 1 at UI. That's not helpful when troubleshooting from UI. 

After investigation, I found it's because we always parse the metric value via `parseInt` method. We should use `parseFloat` for it. The `parseFloat` can achieve what we expect because when the provided string is a integer, it'll also parsed as an integer, not float. Like this:

![image](https://github.com/apache/flink/assets/43372967/4e36783f-9afe-438f-9ab2-03e4e76f12e4)


Before this change, the UI is displayed like this:
![image](https://github.com/apache/flink/assets/43372967/c8c8ab18-ee31-4b03-9d58-8c6ad2152860)

After this change, the UI can display float value like this:
![image](https://github.com/apache/flink/assets/43372967/cf6cc91a-28ed-4fba-ae3e-5ad509b7d5e9)


## Brief change log

Replacing `parseInt` with `parseFloat` to parse metric value.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
