### PR TITLE
[FLINK-35784][checkpoint] Fix the missing shared state registration of file-merging directories

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/FileMergingOperatorStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filemerging/FileMergingOperatorStreamStateHandle.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.state.filemerging;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
-import org.apache.flink.runtime.state.SharedStateRegistryKey;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.util.Preconditions;
 
@@ -83,12 +82,9 @@ public class FileMergingOperatorStreamStateHandle extends OperatorStreamStateHan
         LOG.trace(
                 "Registering FileMergingOperatorStreamStateHandle for checkpoint {} from backend.",
                 checkpointId);
-        stateRegistry.registerReference(
-                new SharedStateRegistryKey(
-                        getDelegateStateHandle().getStreamStateHandleID().getKeyString()),
-                getDelegateStateHandle(),
-                checkpointId);
-
+        // Only register the directory here, leave the delegateStateHandle unregistered, since the
+        // OperatorSubtaskState will only take care of the keyed state while leaving others
+        // unregistered.
         stateRegistry.registerReference(
                 taskOwnedDirHandle.createStateRegistryKey(), taskOwnedDirHandle, checkpointId);
         stateRegistry.registerReference(


### PR DESCRIPTION
## What is the purpose of the change

The `OperatorSubtaskState` only make keyed state register with `SharedStateRegistry`. However, the file-merging directories's handle are wrapped in `FileMergingOperatorStreamStateHandle}` which is an `OperatorStreamStateHandle`. That means the `#registerSharedStates` is never called, so the registry(JM) will never know and delete the directories.


## Brief change log

 - In `OperatorSubtaskState`, we register `FileMergingOperatorStreamStateHandle`.


## Verifying this change

Modified tests in `SnapshotFileMergingCompatibilityITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
