### PR TITLE
[FLINK-35789][table] Allow defining watermarks & PRIMARY KEY in CREATE TABLE AS (CTAS)

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTableAs.java
@@ -125,11 +125,6 @@ public class SqlCreateTableAs extends SqlCreateTable {
                     "CREATE TABLE AS SELECT syntax does not support to create temporary table yet.");
         }
 
-        if (getWatermark().isPresent()) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    "CREATE TABLE AS SELECT syntax does not support to specify explicit watermark yet.");
-        }
         if (getDistribution() != null) {
             throw new SqlValidateException(
                     getParserPosition(),
@@ -140,11 +135,6 @@ public class SqlCreateTableAs extends SqlCreateTable {
             throw new SqlValidateException(
                     getParserPosition(),
                     "CREATE TABLE AS SELECT syntax does not support to create partitioned table yet.");
-        }
-        if (getFullConstraints().stream().anyMatch(SqlTableConstraint::isPrimaryKey)) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    "CREATE TABLE AS SELECT syntax does not support primary key constraints yet.");
         }
     }
 

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -2858,15 +2858,15 @@ class FlinkSqlParserImplTest extends SqlParserTest {
 
     @Test
     void testCreateTableAsSelectWithWatermark() {
-        sql("CREATE TABLE t (watermark FOR ts AS ts - interval '3' second) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "CREATE TABLE AS SELECT syntax does not support to specify explicit watermark yet."));
+        sql("CREATE TABLE t (watermark FOR col1 AS col1 - interval '3' second) WITH ('test' = 'zm') AS SELECT col1 FROM b")
+                .node(new ValidationMatcher().ok());
     }
 
     @Test
     void testCreateTableAsSelectWithConstraints() {
+        sql("CREATE TABLE t (PRIMARY KEY (col1) NOT ENFORCED) WITH ('test' = 'zm') AS SELECT col1 FROM b")
+                .node(new ValidationMatcher().ok());
+
         sql("CREATE TABLE t (PRIMARY KEY (col1)) WITH ('test' = 'zm') AS SELECT col1 FROM b")
                 .node(
                         new ValidationMatcher()

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
@@ -23,9 +23,9 @@ import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlComputedColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlMetadataColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
-import org.apache.flink.sql.parser.ddl.SqlTableLike;
 import org.apache.flink.sql.parser.ddl.SqlTableLike.FeatureOption;
 import org.apache.flink.sql.parser.ddl.SqlTableLike.MergingStrategy;
+import org.apache.flink.sql.parser.ddl.SqlTableLike.SqlTableLikeOption;
 import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.table.api.Schema;
@@ -33,31 +33,26 @@ import org.apache.flink.table.api.Schema.UnresolvedColumn;
 import org.apache.flink.table.api.Schema.UnresolvedComputedColumn;
 import org.apache.flink.table.api.Schema.UnresolvedMetadataColumn;
 import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
-import org.apache.flink.table.api.Schema.UnresolvedPrimaryKey;
 import org.apache.flink.table.api.Schema.UnresolvedWatermarkSpec;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.TableDistribution;
-import org.apache.flink.table.expressions.SqlCallExpression;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.validate.SqlValidator;
 
 import javax.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /** A utility class with logic for handling the {@code CREATE TABLE ... LIKE} clause. */
 class MergeTableLikeUtil {
@@ -95,11 +90,11 @@ class MergeTableLikeUtil {
      * specific {@link FeatureOption}.
      */
     public Map<FeatureOption, MergingStrategy> computeMergingStrategies(
-            List<SqlTableLike.SqlTableLikeOption> mergingOptions) {
+            List<SqlTableLikeOption> mergingOptions) {
 
         Map<FeatureOption, MergingStrategy> result = new HashMap<>(defaultMergingStrategies);
 
-        Optional<SqlTableLike.SqlTableLikeOption> maybeAllOption =
+        Optional<SqlTableLikeOption> maybeAllOption =
                 mergingOptions.stream()
                         .filter(option -> option.getFeatureOption() == FeatureOption.ALL)
                         .findFirst();
@@ -114,7 +109,7 @@ class MergeTableLikeUtil {
                     }
                 });
 
-        for (SqlTableLike.SqlTableLikeOption mergingOption : mergingOptions) {
+        for (SqlTableLikeOption mergingOption : mergingOptions) {
             result.put(mergingOption.getFeatureOption(), mergingOption.getMergingStrategy());
         }
 
@@ -188,7 +183,7 @@ class MergeTableLikeUtil {
      * Merges the partitions part of {@code CREATE TABLE} statement.
      *
      * <p>Partitioning is a single property of a Table, thus there can be at most a single instance
-     * of partitioning. Therefore it is not possible to use {@link MergingStrategy#INCLUDING} with
+     * of partitioning. Therefore, it is not possible to use {@link MergingStrategy#INCLUDING} with
      * partitioning defined in both source and derived table.
      */
     public List<String> mergePartitions(
@@ -237,11 +232,6 @@ class MergeTableLikeUtil {
     }
 
     private static class SchemaBuilder extends SchemaBuilderUtil {
-
-        Map<String, UnresolvedColumn> columns = new LinkedHashMap<>();
-        Map<String, UnresolvedWatermarkSpec> watermarkSpecs = new HashMap<>();
-        UnresolvedPrimaryKey primaryKey = null;
-
         // Intermediate state
         Map<String, RelDataType> physicalFieldNamesToTypes = new LinkedHashMap<>();
         Map<String, RelDataType> metadataFieldNamesToTypes = new LinkedHashMap<>();
@@ -312,113 +302,35 @@ class MergeTableLikeUtil {
                         "The base table already has a primary key. You might "
                                 + "want to specify EXCLUDING CONSTRAINTS.");
             } else if (derivedPrimaryKey != null) {
-                List<String> primaryKeyColumns = new ArrayList<>();
-                for (SqlNode primaryKeyNode : derivedPrimaryKey.getColumns()) {
-                    String primaryKey = ((SqlIdentifier) primaryKeyNode).getSimple();
-                    if (!columns.containsKey(primaryKey)) {
-                        throw new ValidationException(
-                                String.format(
-                                        "Primary key column '%s' is not defined in the schema at %s",
-                                        primaryKey, primaryKeyNode.getParserPosition()));
-                    }
-                    if (!(columns.get(primaryKey) instanceof UnresolvedPhysicalColumn)) {
-                        throw new ValidationException(
-                                String.format(
-                                        "Could not create a PRIMARY KEY with column '%s' at %s.\n"
-                                                + "A PRIMARY KEY constraint must be declared on physical columns.",
-                                        primaryKey, primaryKeyNode.getParserPosition()));
-                    }
-                    primaryKeyColumns.add(primaryKey);
-                }
-                primaryKey =
-                        new UnresolvedPrimaryKey(
-                                derivedPrimaryKey
-                                        .getConstraintName()
-                                        .orElseGet(
-                                                () ->
-                                                        primaryKeyColumns.stream()
-                                                                .collect(
-                                                                        Collectors.joining(
-                                                                                "_", "PK_", ""))),
-                                primaryKeyColumns);
+                setPrimaryKey(derivedPrimaryKey);
             }
         }
 
         private void appendDerivedWatermarks(
                 Map<FeatureOption, MergingStrategy> mergingStrategies,
                 List<SqlWatermark> derivedWatermarkSpecs) {
-            for (SqlWatermark derivedWatermarkSpec : derivedWatermarkSpecs) {
-                SqlIdentifier eventTimeColumnName = derivedWatermarkSpec.getEventTimeColumnName();
+            if (mergingStrategies.get(FeatureOption.WATERMARKS) != MergingStrategy.OVERWRITING) {
+                for (SqlWatermark derivedWatermarkSpec : derivedWatermarkSpecs) {
+                    SqlIdentifier eventTimeColumnName =
+                            derivedWatermarkSpec.getEventTimeColumnName();
+                    String rowtimeAttribute = eventTimeColumnName.toString();
 
-                HashMap<String, RelDataType> nameToTypeMap = new LinkedHashMap<>();
-                nameToTypeMap.putAll(physicalFieldNamesToTypes);
-                nameToTypeMap.putAll(metadataFieldNamesToTypes);
-                nameToTypeMap.putAll(computedFieldNamesToTypes);
-
-                verifyRowtimeAttribute(mergingStrategies, eventTimeColumnName, nameToTypeMap);
-                String rowtimeAttribute = eventTimeColumnName.toString();
-
-                SqlNode expression = derivedWatermarkSpec.getWatermarkStrategy();
-
-                // this will validate and expand function identifiers.
-                SqlNode validated =
-                        sqlValidator.validateParameterizedExpression(expression, nameToTypeMap);
-
-                watermarkSpecs.put(
-                        rowtimeAttribute,
-                        new UnresolvedWatermarkSpec(
-                                rowtimeAttribute,
-                                new SqlCallExpression(escapeExpressions.apply(validated))));
-            }
-        }
-
-        private void verifyRowtimeAttribute(
-                Map<FeatureOption, MergingStrategy> mergingStrategies,
-                SqlIdentifier eventTimeColumnName,
-                Map<String, RelDataType> allFieldsTypes) {
-            String fullRowtimeExpression = eventTimeColumnName.toString();
-            boolean specAlreadyExists = watermarkSpecs.containsKey(fullRowtimeExpression);
-
-            if (specAlreadyExists
-                    && mergingStrategies.get(FeatureOption.WATERMARKS)
-                            != MergingStrategy.OVERWRITING) {
-                throw new ValidationException(
-                        String.format(
-                                "There already exists a watermark spec for column '%s' in the base table. You "
-                                        + "might want to specify EXCLUDING WATERMARKS or OVERWRITING WATERMARKS.",
-                                fullRowtimeExpression));
-            }
-
-            List<String> components = eventTimeColumnName.names;
-            if (!allFieldsTypes.containsKey(components.get(0))) {
-                throw new ValidationException(
-                        String.format(
-                                "The rowtime attribute field '%s' is not defined in the table schema, at %s\n"
-                                        + "Available fields: [%s]",
-                                fullRowtimeExpression,
-                                eventTimeColumnName.getParserPosition(),
-                                allFieldsTypes.keySet().stream()
-                                        .collect(Collectors.joining("', '", "'", "'"))));
-            }
-
-            if (components.size() > 1) {
-                RelDataType componentType = allFieldsTypes.get(components.get(0));
-                for (int i = 1; i < components.size(); i++) {
-                    RelDataTypeField field = componentType.getField(components.get(i), true, false);
-                    if (field == null) {
+                    if (watermarkSpecs.containsKey(rowtimeAttribute)) {
                         throw new ValidationException(
                                 String.format(
-                                        "The rowtime attribute field '%s' is not defined in the table schema, at %s\n"
-                                                + "Nested field '%s' was not found in a composite type: %s.",
-                                        fullRowtimeExpression,
-                                        eventTimeColumnName.getComponent(i).getParserPosition(),
-                                        components.get(i),
-                                        FlinkTypeFactory.toLogicalType(
-                                                allFieldsTypes.get(components.get(0)))));
+                                        "There already exists a watermark spec for column '%s' in the base table. You "
+                                                + "might want to specify EXCLUDING WATERMARKS or OVERWRITING WATERMARKS.",
+                                        rowtimeAttribute));
                     }
-                    componentType = field.getType();
                 }
             }
+
+            HashMap<String, RelDataType> nameToTypeMap = new LinkedHashMap<>();
+            nameToTypeMap.putAll(physicalFieldNamesToTypes);
+            nameToTypeMap.putAll(metadataFieldNamesToTypes);
+            nameToTypeMap.putAll(computedFieldNamesToTypes);
+
+            addWatermarks(derivedWatermarkSpecs, nameToTypeMap, true);
         }
 
         private void appendDerivedColumns(
@@ -472,7 +384,7 @@ class MergeTableLikeUtil {
                             sqlValidator.getValidatedNodeType(validatedExpr);
                     column =
                             toUnresolvedComputedColumn(
-                                    (SqlComputedColumn) derivedColumn, accessibleFieldNamesToTypes);
+                                    (SqlComputedColumn) derivedColumn, validatedExpr);
                     computedFieldNamesToTypes.put(name, validatedType);
                 } else if (derivedColumn instanceof SqlMetadataColumn) {
                     final SqlMetadataColumn metadataColumn = (SqlMetadataColumn) derivedColumn;
@@ -534,22 +446,6 @@ class MergeTableLikeUtil {
                     }
                 }
             }
-        }
-
-        public Schema build() {
-            Schema.Builder resultBuilder = Schema.newBuilder();
-            resultBuilder.fromColumns(new ArrayList<>(columns.values()));
-
-            for (UnresolvedWatermarkSpec watermarkSpec : watermarkSpecs.values()) {
-                resultBuilder.watermark(
-                        watermarkSpec.getColumnName(), watermarkSpec.getWatermarkExpression());
-            }
-            if (primaryKey != null) {
-                resultBuilder.primaryKeyNamed(
-                        primaryKey.getConstraintName(),
-                        primaryKey.getColumnNames().toArray(new String[0]));
-            }
-            return resultBuilder.build();
         }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SchemaBuilderUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SchemaBuilderUtil.java
@@ -22,33 +22,51 @@ import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlComputedColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlMetadataColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableColumn.SqlRegularColumn;
+import org.apache.flink.sql.parser.ddl.SqlWatermark;
+import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
+import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.Schema.UnresolvedComputedColumn;
 import org.apache.flink.table.api.Schema.UnresolvedMetadataColumn;
 import org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn;
+import org.apache.flink.table.api.Schema.UnresolvedPrimaryKey;
+import org.apache.flink.table.api.Schema.UnresolvedWatermarkSpec;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.expressions.SqlCallExpression;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.types.logical.LogicalType;
 
 import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.validate.SqlValidator;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.planner.calcite.FlinkTypeFactory.toLogicalType;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 
 /** A utility class for {@link MergeTableAsUtil} and {@link MergeTableLikeUtil} classes. */
 public class SchemaBuilderUtil {
-    protected final SqlValidator sqlValidator;
-    protected final Function<SqlNode, String> escapeExpressions;
-    protected final DataTypeFactory dataTypeFactory;
+    final SqlValidator sqlValidator;
+    final Function<SqlNode, String> escapeExpressions;
+    final DataTypeFactory dataTypeFactory;
 
-    public SchemaBuilderUtil(
+    Map<String, Schema.UnresolvedColumn> columns = new LinkedHashMap<>();
+    Map<String, UnresolvedWatermarkSpec> watermarkSpecs = new HashMap<>();
+    UnresolvedPrimaryKey primaryKey = null;
+
+    SchemaBuilderUtil(
             SqlValidator sqlValidator,
             Function<SqlNode, String> escapeExpressions,
             DataTypeFactory dataTypeFactory) {
@@ -57,8 +75,125 @@ public class SchemaBuilderUtil {
         this.dataTypeFactory = dataTypeFactory;
     }
 
+    /** Sets the primary key for the schema. */
+    void setPrimaryKey(SqlTableConstraint primaryKeyConstraint) {
+        if (primaryKey != null) {
+            throw new ValidationException(
+                    "There already exists a primary key constraint in the table.");
+        }
+
+        for (SqlNode primaryKeyNode : primaryKeyConstraint.getColumns()) {
+            String primaryKey = ((SqlIdentifier) primaryKeyNode).getSimple();
+
+            if (!columns.containsKey(primaryKey)) {
+                throw new ValidationException(
+                        String.format(
+                                "Primary key column '%s' is not defined in the schema at %s",
+                                primaryKey, primaryKeyNode.getParserPosition()));
+            }
+
+            if (!(columns.get(primaryKey) instanceof UnresolvedPhysicalColumn)) {
+                throw new ValidationException(
+                        String.format(
+                                "Could not create a PRIMARY KEY with column '%s' at %s.\n"
+                                        + "A PRIMARY KEY constraint must be declared on physical columns.",
+                                primaryKey, primaryKeyNode.getParserPosition()));
+            }
+        }
+
+        primaryKey = toUnresolvedPrimaryKey(primaryKeyConstraint);
+    }
+
+    void addWatermarks(
+            List<SqlWatermark> derivedWatermarkSpecs,
+            Map<String, RelDataType> allFieldsTypes,
+            boolean overwriteWatermark) {
+        for (SqlWatermark derivedWatermarkSpec : derivedWatermarkSpecs) {
+            SqlIdentifier eventTimeColumnName = derivedWatermarkSpec.getEventTimeColumnName();
+            String rowtimeAttribute = eventTimeColumnName.toString();
+
+            if (!overwriteWatermark && watermarkSpecs.containsKey(rowtimeAttribute)) {
+                throw new ValidationException(
+                        String.format(
+                                "There already exists a watermark on column '%s'.",
+                                rowtimeAttribute));
+            }
+
+            verifyRowtimeAttribute(derivedWatermarkSpec, allFieldsTypes);
+            watermarkSpecs.put(
+                    rowtimeAttribute,
+                    toUnresolvedWatermarkSpec(derivedWatermarkSpec, allFieldsTypes));
+        }
+    }
+
+    /**
+     * Builds and returns a {@link Schema} from the columns, watermark specs, and primary key
+     * specified in the builder.
+     */
+    public Schema build() {
+        Schema.Builder resultBuilder = Schema.newBuilder();
+        resultBuilder.fromColumns(new ArrayList<>(columns.values()));
+
+        for (UnresolvedWatermarkSpec watermarkSpec : watermarkSpecs.values()) {
+            resultBuilder.watermark(
+                    watermarkSpec.getColumnName(), watermarkSpec.getWatermarkExpression());
+        }
+
+        if (primaryKey != null) {
+            resultBuilder.primaryKeyNamed(
+                    primaryKey.getConstraintName(),
+                    primaryKey.getColumnNames().toArray(new String[0]));
+        }
+
+        return resultBuilder.build();
+    }
+
+    /**
+     * Verify the watermark rowtime attribute is part of the table schema specified in the {@code
+     * allFieldsTypes}.
+     *
+     * @param sqlWatermark The watermark with the rowtime attribute to verify.
+     * @param allFieldsTypes The table schema to verify the rowtime attribute against.
+     */
+    static void verifyRowtimeAttribute(
+            SqlWatermark sqlWatermark, Map<String, RelDataType> allFieldsTypes) {
+        SqlIdentifier eventTimeColumnName = sqlWatermark.getEventTimeColumnName();
+        String fullRowtimeExpression = eventTimeColumnName.toString();
+
+        List<String> components = eventTimeColumnName.names;
+        if (!allFieldsTypes.containsKey(components.get(0))) {
+            throw new ValidationException(
+                    String.format(
+                            "The rowtime attribute field '%s' is not defined in the table schema, at %s\n"
+                                    + "Available fields: [%s]",
+                            fullRowtimeExpression,
+                            eventTimeColumnName.getParserPosition(),
+                            allFieldsTypes.keySet().stream()
+                                    .collect(Collectors.joining("', '", "'", "'"))));
+        }
+
+        if (components.size() > 1) {
+            RelDataType componentType = allFieldsTypes.get(components.get(0));
+            for (int i = 1; i < components.size(); i++) {
+                RelDataTypeField field = componentType.getField(components.get(i), true, false);
+                if (field == null) {
+                    throw new ValidationException(
+                            String.format(
+                                    "The rowtime attribute field '%s' is not defined in the table schema, at %s\n"
+                                            + "Nested field '%s' was not found in a composite type: %s.",
+                                    fullRowtimeExpression,
+                                    eventTimeColumnName.getComponent(i).getParserPosition(),
+                                    components.get(i),
+                                    FlinkTypeFactory.toLogicalType(
+                                            allFieldsTypes.get(components.get(0)))));
+                }
+                componentType = field.getType();
+            }
+        }
+    }
+
     /** Converts a {@link SqlRegularColumn} to an {@link UnresolvedPhysicalColumn} object. */
-    public UnresolvedPhysicalColumn toUnresolvedPhysicalColumn(SqlRegularColumn column) {
+    UnresolvedPhysicalColumn toUnresolvedPhysicalColumn(SqlRegularColumn column) {
         final String name = column.getName().getSimple();
         final Optional<String> comment = getComment(column);
         final LogicalType logicalType = toLogicalType(toRelDataType(column.getType()));
@@ -68,23 +203,19 @@ public class SchemaBuilderUtil {
     }
 
     /** Converts a {@link SqlComputedColumn} to an {@link UnresolvedComputedColumn} object. */
-    public UnresolvedComputedColumn toUnresolvedComputedColumn(
-            SqlComputedColumn column, Map<String, RelDataType> accessibleFieldNamesToTypes) {
+    UnresolvedComputedColumn toUnresolvedComputedColumn(
+            SqlComputedColumn column, SqlNode validatedExpression) {
         final String name = column.getName().getSimple();
         final Optional<String> comment = getComment(column);
 
-        final SqlNode validatedExpr =
-                sqlValidator.validateParameterizedExpression(
-                        column.getExpr(), accessibleFieldNamesToTypes);
-
         return new UnresolvedComputedColumn(
                 name,
-                new SqlCallExpression(escapeExpressions.apply(validatedExpr)),
+                new SqlCallExpression(escapeExpressions.apply(validatedExpression)),
                 comment.orElse(null));
     }
 
     /** Converts a {@link SqlMetadataColumn} to an {@link UnresolvedMetadataColumn} object. */
-    public UnresolvedMetadataColumn toUnresolvedMetadataColumn(SqlMetadataColumn column) {
+    UnresolvedMetadataColumn toUnresolvedMetadataColumn(SqlMetadataColumn column) {
         final String name = column.getName().getSimple();
         final Optional<String> comment = getComment(column);
         final LogicalType logicalType = toLogicalType(toRelDataType(column.getType()));
@@ -97,19 +228,50 @@ public class SchemaBuilderUtil {
                 comment.orElse(null));
     }
 
+    /** Converts a {@link SqlWatermark} to an {@link UnresolvedWatermarkSpec} object. */
+    UnresolvedWatermarkSpec toUnresolvedWatermarkSpec(
+            SqlWatermark watermark, Map<String, RelDataType> accessibleFieldNamesToTypes) {
+        // this will validate and expand function identifiers.
+        SqlNode validated =
+                sqlValidator.validateParameterizedExpression(
+                        watermark.getWatermarkStrategy(), accessibleFieldNamesToTypes);
+
+        return new UnresolvedWatermarkSpec(
+                watermark.getEventTimeColumnName().toString(),
+                new SqlCallExpression(escapeExpressions.apply(validated)));
+    }
+
+    /** Converts a {@link SqlTableConstraint} to an {@link UnresolvedPrimaryKey} object. */
+    public UnresolvedPrimaryKey toUnresolvedPrimaryKey(SqlTableConstraint primaryKey) {
+        List<String> columnNames =
+                primaryKey.getColumns().getList().stream()
+                        .map(n -> ((SqlIdentifier) n).getSimple())
+                        .collect(Collectors.toList());
+
+        String constraintName =
+                primaryKey
+                        .getConstraintName()
+                        .orElseGet(
+                                () ->
+                                        columnNames.stream()
+                                                .collect(Collectors.joining("_", "PK_", "")));
+
+        return new UnresolvedPrimaryKey(constraintName, columnNames);
+    }
+
     /**
      * Gets the column data type of {@link UnresolvedPhysicalColumn} column and convert it to a
      * {@link LogicalType}.
      */
-    public LogicalType getLogicalType(UnresolvedPhysicalColumn column) {
+    LogicalType getLogicalType(UnresolvedPhysicalColumn column) {
         return dataTypeFactory.createDataType(column.getDataType()).getLogicalType();
     }
 
-    public Optional<String> getComment(SqlTableColumn column) {
+    Optional<String> getComment(SqlTableColumn column) {
         return column.getComment().map(c -> ((SqlLiteral) c).getValueAs(String.class));
     }
 
-    public RelDataType toRelDataType(SqlDataTypeSpec type) {
+    RelDataType toRelDataType(SqlDataTypeSpec type) {
         boolean nullable = type.getNullable() == null || type.getNullable();
         return type.deriveType(sqlValidator, nullable);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -276,6 +276,8 @@ class SqlCreateTableConverter {
         Map<String, String> mergedOptions =
                 mergeOptions(sqlCreateTable, sourceProperties, mergingStrategies);
 
+        // It is assumed only a primary key constraint may be defined in the table. The
+        // SqlCreateTableAs has validations to ensure this before the object is created.
         Optional<SqlTableConstraint> primaryKey =
                 sqlCreateTable.getFullConstraints().stream()
                         .filter(SqlTableConstraint::isPrimaryKey)


### PR DESCRIPTION
## What is the purpose of the change

Allows defining the WATERMARK and PRIMARY KEY in the CTAS statement. 

PRIMARY KEY example:
```
CREATE TABLE table_name (PRIMARY KEY (person) NOT ENFORCED)
AS SELECT person, age FROM people;
```

WATERMARK example example:
```
CREATE TABLE table_name (WATERMARK FOR ts AS ts - INTERVAL '3' SECOND)
AS SELECT f0, f1, ts FROM people;
```

## Brief change log

- Added support for WATERMARK and PRIMARY KEY syntax in CTAS

## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests to validation and converter classes
- Added integration tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs (will follow-up with another PR to update docs)
