### PR TITLE
[FLINK-35793][tests] Remove hybrid shuffle types from BatchSQLTest temporarily

### DIFF
--- a/flink-end-to-end-tests/flink-batch-sql-test/src/test/java/org/apache/flink/sql/tests/BatchSQLTest.java
+++ b/flink-end-to-end-tests/flink-batch-sql-test/src/test/java/org/apache/flink/sql/tests/BatchSQLTest.java
@@ -71,10 +71,11 @@ class BatchSQLTest {
     @ParameterizedTest
     @EnumSource(
             value = BatchShuffleMode.class,
-            names = {
-                "ALL_EXCHANGES_BLOCKING",
-                "ALL_EXCHANGES_HYBRID_FULL",
-                "ALL_EXCHANGES_HYBRID_SELECTIVE"
+            names = {"ALL_EXCHANGES_BLOCKING"
+                // Remove hybrid shuffle types to unblock CI. This have to reactive when we find the
+                // reason.
+                // "ALL_EXCHANGES_HYBRID_FULL",
+                // "ALL_EXCHANGES_HYBRID_SELECTIVE"
                 // Only above shuffle modes are supported by the adaptive batch scheduler
                 // , "ALL_EXCHANGES_PIPELINE"
             })


### PR DESCRIPTION
## What is the purpose of the change

*Remove hybrid shuffle types to unblock CI. This have to reactive when we find the reason*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
