### PR TITLE
[FLINK-35801] Fix SnapshotFileMergingCompatibilityITCase, wait for file deletion before quit

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SnapshotFileMergingCompatibilityITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SnapshotFileMergingCompatibilityITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.test.util.TestUtils;
+import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.jupiter.api.io.TempDir;
@@ -55,6 +56,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * fileMerging mode (i.e. fileMerging enabled/disabled).
  */
 public class SnapshotFileMergingCompatibilityITCase extends TestLogger {
+
+    private static final long DELETE_TIMEOUT_MILLS = 60000;
 
     public static Collection<Object[]> parameters() {
         return Arrays.asList(
@@ -150,6 +153,11 @@ public class SnapshotFileMergingCompatibilityITCase extends TestLogger {
                             true);
             assertThat(secondCheckpoint).isNotNull();
             verifyStateHandleType(secondCheckpoint, secondFileMergingSwitch);
+            verifyCheckpointExistOrWaitDeleted(
+                    firstCheckpoint,
+                    determineFileExist(
+                            restoreMode, firstFileMergingSwitch, secondFileMergingSwitch),
+                    firstFileMergingSwitch);
         } finally {
             secondCluster.after();
         }
@@ -177,6 +185,11 @@ public class SnapshotFileMergingCompatibilityITCase extends TestLogger {
                             true);
             assertThat(thirdCheckpoint).isNotNull();
             verifyStateHandleType(thirdCheckpoint, secondFileMergingSwitch);
+            verifyCheckpointExistOrWaitDeleted(
+                    secondCheckpoint,
+                    determineFileExist(
+                            restoreMode, secondFileMergingSwitch, secondFileMergingSwitch),
+                    secondFileMergingSwitch);
         } finally {
             thirdCluster.after();
         }
@@ -204,18 +217,16 @@ public class SnapshotFileMergingCompatibilityITCase extends TestLogger {
                             consecutiveCheckpoint,
                             false);
             assertThat(fourthCheckpoint).isNotNull();
+            verifyCheckpointExistOrWaitDeleted(
+                    thirdCheckpoint,
+                    determineFileExist(
+                            restoreMode, secondFileMergingSwitch, secondFileMergingSwitch),
+                    secondFileMergingSwitch);
+            verifyCheckpointExistOrWaitDeleted(
+                    fourthCheckpoint, TernaryBoolean.FALSE, secondFileMergingSwitch);
         } finally {
             fourthCluster.after();
         }
-
-        waitUntilNoJobThreads();
-        verifyCheckpointExist(
-                firstCheckpoint, restoreMode != RestoreMode.CLAIM, firstFileMergingSwitch);
-        verifyCheckpointExist(
-                secondCheckpoint, restoreMode != RestoreMode.CLAIM, secondFileMergingSwitch);
-        verifyCheckpointExist(
-                thirdCheckpoint, restoreMode != RestoreMode.CLAIM, secondFileMergingSwitch);
-        verifyCheckpointExist(fourthCheckpoint, false, secondFileMergingSwitch);
     }
 
     private void verifyStateHandleType(String checkpointPath, boolean fileMergingEnabled)
@@ -249,48 +260,68 @@ public class SnapshotFileMergingCompatibilityITCase extends TestLogger {
         assertThat(hasKeyedState).isTrue();
     }
 
-    private static void waitUntilNoJobThreads() throws InterruptedException {
-        SecurityManager securityManager = System.getSecurityManager();
-        ThreadGroup group =
-                (securityManager != null)
-                        ? securityManager.getThreadGroup()
-                        : Thread.currentThread().getThreadGroup();
-
-        boolean jobThreads = true;
-        while (jobThreads) {
-            jobThreads = false;
-            Thread[] activeThreads = new Thread[group.activeCount() * 2];
-            group.enumerate(activeThreads);
-            for (Thread thread : activeThreads) {
-                if (thread != null
-                        && thread != Thread.currentThread()
-                        && thread.getName().contains("jobmanager")) {
-                    jobThreads = true;
-                    Thread.sleep(500);
-                    break;
-                }
+    private static TernaryBoolean determineFileExist(
+            RestoreMode mode, boolean lastFileMergingEnabled, boolean thisFileMergingEnabled) {
+        if (mode == RestoreMode.CLAIM) {
+            if (lastFileMergingEnabled || thisFileMergingEnabled) {
+                // file merging will not reference files from previous jobs.
+                return TernaryBoolean.FALSE;
+            } else {
+                return TernaryBoolean.UNDEFINED;
             }
+        } else {
+            return TernaryBoolean.TRUE;
         }
     }
 
-    private void verifyCheckpointExist(
-            String checkpointPath, boolean exist, boolean fileMergingEnabled) throws IOException {
+    private static void verifyCheckpointExistOrWaitDeleted(
+            String checkpointPath, TernaryBoolean exist, boolean fileMergingEnabled)
+            throws Exception {
         org.apache.flink.core.fs.Path checkpointDir =
                 new org.apache.flink.core.fs.Path(checkpointPath);
         FileSystem fs = checkpointDir.getFileSystem();
-        assertThat(fs.exists(checkpointDir)).isEqualTo(exist);
         org.apache.flink.core.fs.Path baseDir = checkpointDir.getParent();
-        assertThat(fs.exists(baseDir)).isTrue();
         org.apache.flink.core.fs.Path sharedFile =
                 new org.apache.flink.core.fs.Path(baseDir, CHECKPOINT_SHARED_STATE_DIR);
-        assertThat(fs.exists(sharedFile)).isTrue();
-        assertThat(fs.listStatus(sharedFile) != null && fs.listStatus(sharedFile).length > 0)
-                .isEqualTo(exist);
         org.apache.flink.core.fs.Path taskOwnedFile =
                 new org.apache.flink.core.fs.Path(baseDir, CHECKPOINT_TASK_OWNED_STATE_DIR);
+        assertThat(fs.exists(baseDir)).isTrue();
+        assertThat(fs.exists(sharedFile)).isTrue();
         assertThat(fs.exists(taskOwnedFile)).isTrue();
-        // Since there is no exclusive state, we should consider fileMergingEnabled.
-        assertThat(fs.exists(taskOwnedFile) && fs.listStatus(taskOwnedFile).length > 0)
-                .isEqualTo(exist && fileMergingEnabled);
+        if (exist.equals(TernaryBoolean.TRUE)) {
+            // should exist, just check
+            assertThat(fs.exists(checkpointDir)).isTrue();
+            assertThat(fs.listStatus(sharedFile) != null && fs.listStatus(sharedFile).length > 0)
+                    .isTrue();
+            // Since there is no exclusive state, we should consider fileMergingEnabled.
+            assertThat(
+                            fs.listStatus(taskOwnedFile) != null
+                                    && fs.listStatus(taskOwnedFile).length > 0)
+                    .isEqualTo(fileMergingEnabled);
+        } else if (exist.equals(TernaryBoolean.FALSE)) {
+            // should be cleaned, since the job io threads may work slow, we wait.
+            long waited = 0L;
+            boolean fileExist = true;
+            while (fileExist) {
+                try {
+                    fileExist =
+                            (fs.exists(checkpointDir)
+                                    || (fs.listStatus(sharedFile) != null
+                                            && fs.listStatus(sharedFile).length > 0)
+                                    || (fs.listStatus(taskOwnedFile) != null
+                                            && fs.listStatus(taskOwnedFile).length > 0));
+                } catch (IOException e) {
+                    // Sometimes it may happen that the files are being deleted while we list them,
+                    // thus an IOException is raised.
+                }
+                if (fileExist) {
+                    // We wait
+                    Thread.sleep(500L);
+                    waited += 500L;
+                    // Or timeout
+                    assertThat(waited).isLessThan(DELETE_TIMEOUT_MILLS);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the unstable test `SnapshotFileMergingCompatibilityITCase`. There is a problem with the test code itself. The test verifies the cp files are cleaned as expected, which depends on an async cleaner (the job io thread). While the mini-cluster quit, the async threads may not have finished their jobs before termination.


It is better to try multiple rounds AZP to verify this fix.


## Brief change log

Only `SnapshotFileMergingCompatibilityITCase`. Make it wait for file deletion before cluster termination.

## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
