### PR TITLE
[FLINK-35804][table-planner] Fix incorrect calc merge to avoid wrong plans

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/sql2rel/RelDecorrelator.java
@@ -100,6 +100,9 @@ import org.apache.calcite.util.ReflectiveVisitor;
 import org.apache.calcite.util.Util;
 import org.apache.calcite.util.mapping.Mappings;
 import org.apache.calcite.util.trace.CalciteTrace;
+
+import org.apache.flink.table.planner.plan.rules.logical.FlinkFilterProjectTransposeRule;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
@@ -268,20 +271,20 @@ public class RelDecorrelator implements ReflectiveVisitor {
                                                         .FilterIntoJoinRuleConfig.class)
                                         .toRule())
                         .addRuleInstance(
-                                CoreRules.FILTER_PROJECT_TRANSPOSE
-                                        .config
-                                        .withRelBuilderFactory(f)
-                                        .as(FilterProjectTransposeRule.Config.class)
-                                        .withOperandFor(
-                                                Filter.class,
-                                                filter ->
-                                                        !RexUtil.containsCorrelation(
-                                                                filter.getCondition()),
-                                                Project.class,
-                                                project -> true)
-                                        .withCopyFilter(true)
-                                        .withCopyProject(true)
-                                        .toRule())
+                                FlinkFilterProjectTransposeRule.build(
+                                        CoreRules.FILTER_PROJECT_TRANSPOSE
+                                                .config
+                                                .withRelBuilderFactory(f)
+                                                .as(FilterProjectTransposeRule.Config.class)
+                                                .withOperandFor(
+                                                        Filter.class,
+                                                        filter ->
+                                                                !RexUtil.containsCorrelation(
+                                                                        filter.getCondition()),
+                                                        Project.class,
+                                                        project -> true)
+                                                .withCopyFilter(true)
+                                                .withCopyProject(true)))
                         .addRuleInstance(
                                 FilterCorrelateRule.Config.DEFAULT
                                         .withRelBuilderFactory(f)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterProjectTransposeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterProjectTransposeRule.java
@@ -39,6 +39,10 @@ public class FlinkFilterProjectTransposeRule extends FilterProjectTransposeRule 
 
     public static final RelOptRule INSTANCE = new FlinkFilterProjectTransposeRule(Config.DEFAULT);
 
+    public static FlinkFilterProjectTransposeRule build(Config config) {
+        return new FlinkFilterProjectTransposeRule(config);
+    }
+
     protected FlinkFilterProjectTransposeRule(Config config) {
         super(config);
     }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcTest.xml
@@ -72,6 +72,39 @@ Calc(select=[a], where=[>(random_udf(b), 10)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCalcMergeWithNonDeterministicExpr3">
+    <Resource name="sql">
+      <![CDATA[SELECT r FROM View2 WHERE r > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(r=[$0])
++- LogicalFilter(condition=[>($0, 10)])
+   +- LogicalProject(r=[random_udf($1)])
+      +- LogicalProject(a=[$0], b=[$1], len=[$2])
+         +- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+            :- LogicalProject(a=[$0], b=[$1], len=[$3])
+            :  +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+            :     :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+            :     +- LogicalTableFunctionScan(invocation=[length_udtf($cor0.c)], rowType=[RecordType(INTEGER EXPR$0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable_Join, source: [TestTableSource(d, e, f)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[r], where=[>(r, 10)])
++- Calc(select=[random_udf(b) AS r])
+   +- HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d], build=[right])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b])
+      :     +- Correlate(invocation=[length_udtf($cor0.c)], correlate=[table(length_udtf($cor0.c))], select=[a,b,c,EXPR$0], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, INTEGER EXPR$0)], joinType=[INNER])
+      :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- Exchange(distribution=[hash[d]])
+         +- Calc(select=[d])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable_Join, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCollationDeriveOnCalc">
     <Resource name="sql">
       <![CDATA[SELECT CAST(a AS INT), CAST(b AS VARCHAR) FROM (VALUES (3, 'c')) T(a,b)]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
@@ -72,6 +72,39 @@ Calc(select=[a], where=[>(random_udf(b), 10)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCalcMergeWithNonDeterministicExpr3">
+    <Resource name="sql">
+      <![CDATA[SELECT r FROM View2 WHERE r > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(r=[$0])
++- LogicalFilter(condition=[>($0, 10)])
+   +- LogicalProject(r=[random_udf($1)])
+      +- LogicalProject(a=[$0], b=[$1], len=[$2])
+         +- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+            :- LogicalProject(a=[$0], b=[$1], len=[$3])
+            :  +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+            :     :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+            :     +- LogicalTableFunctionScan(invocation=[length_udtf($cor0.c)], rowType=[RecordType(INTEGER EXPR$0)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable_Join, source: [TestTableSource(d, e, f)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+       <![CDATA[
+Calc(select=[r], where=[>(r, 10)])
++- Calc(select=[random_udf(b) AS r])
+   +- Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b])
+      :     +- Correlate(invocation=[length_udtf($cor0.c)], correlate=[table(length_udtf($cor0.c))], select=[a,b,c,EXPR$0], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, INTEGER EXPR$0)], joinType=[INNER])
+      :        +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- Exchange(distribution=[hash[d]])
+         +- Calc(select=[d])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable_Join, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testConjunctiveFilter">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable WHERE a < 10 AND b > 20]]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/CalcTest.scala
@@ -23,8 +23,8 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api._
 import org.apache.flink.table.planner.plan.utils.MyPojo
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.NonDeterministicUdf
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.JavaTableFunc1
 import org.apache.flink.table.planner.utils.TableTestBase
-
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.{BeforeEach, Test}
 
@@ -37,7 +37,9 @@ class CalcTest extends TableTestBase {
   @BeforeEach
   def setup(): Unit = {
     util.addTableSource[(Long, Int, String)]("MyTable", 'a, 'b, 'c)
+    util.addTableSource[(Long, Int, String)]("MyTable_Join", 'd, 'e, 'f)
     util.addTemporarySystemFunction("random_udf", new NonDeterministicUdf)
+    util.addTemporarySystemFunction("length_udtf", new JavaTableFunc1)
   }
 
   @Test
@@ -205,6 +207,21 @@ class CalcTest extends TableTestBase {
   @Test
   def testCalcMergeWithNonDeterministicExpr2(): Unit = {
     val sqlQuery = "SELECT a FROM (SELECT a, b FROM MyTable) t WHERE random_udf(b) > 10"
+    util.verifyRelPlan(sqlQuery)
+  }
+
+  @Test
+  def testCalcMergeWithNonDeterministicExpr3(): Unit = {
+    val sqlUdtfQuery = "SELECT a, b, len FROM MyTable, LATERAL TABLE (length_udtf(c)) AS T(len)"
+    val sqlView1Query = "SELECT a, b, len " +
+      s"FROM ($sqlUdtfQuery) t JOIN MyTable_Join t2 " +
+      "ON t.a = t2.d"
+    val view1 = util.tableEnv.sqlQuery(sqlView1Query)
+    util.tableEnv.createTemporaryView("View1", view1)
+    val sqlView2Query = "SELECT random_udf(b) AS r FROM View1"
+    val view2 = util.tableEnv.sqlQuery(sqlView2Query)
+    util.tableEnv.createTemporaryView("View2", view2)
+    val sqlQuery = "SELECT r FROM View2 WHERE r > 10"
     util.verifyRelPlan(sqlQuery)
   }
 }


### PR DESCRIPTION

## What is the purpose of the change

Like the same issue in [FLINK-30841](https://issues.apache.org/jira/browse/FLINK-30841).

Take one test as example:

```scala
@Test
def testCalcMergeWithNonDeterministicExpr3(): Unit =

{ val sqlUdtfQuery = "SELECT a, b, len FROM MyTable, LATERAL TABLE (length_udtf(c)) AS T(len)" val sqlView1Query = "SELECT a, b, len " + s"FROM ($sqlUdtfQuery) t JOIN MyTable_Join t2 " + "ON t.a = t2.d" val view1 = util.tableEnv.sqlQuery(sqlView1Query) util.tableEnv.createTemporaryView("View1", view1) val sqlView2Query = "SELECT random_udf(b) AS r FROM View1" val view2 = util.tableEnv.sqlQuery(sqlView2Query) util.tableEnv.createTemporaryView("View2", view2) val sqlQuery = "SELECT r FROM View2 WHERE r > 10" util.verifyRelPlan(sqlQuery) }
```

optimized plan will be wrong:

```
Calc(select=[random_udf(b) AS r])
+- Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
:- Exchange(distribution=[hash[a]])
: +- Calc(select=[a, b], where=[>(random_udf(b), 10)])
: +- Correlate(invocation=[length_udtf($cor0.c)], correlate=[table(length_udtf($cor0.c))], select=[a,b,c,EXPR$0], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, INTEGER EXPR$0)], joinType=[INNER])
: +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+- Exchange(distribution=[hash[d]])
+- Calc(select=[d])
+- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable_Join, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
```

the expected plan is:

```
Calc(select=[r], where=[>(r, 10)])
+- Calc(select=[random_udf(b) AS r])
+-Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, d], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
:- Exchange(distribution=[hash[a]])
:+-Calc(select=[a, b])
:+-Correlate(invocation=[length_udtf($cor0.c)], correlate=[table(length_udtf($cor0.c))], select=[a,b,c,EXPR$0], rowType=[RecordType(BIGINT a, INTEGER b, VARCHAR(2147483647) c, INTEGER EXPR$0)], joinType=[INNER])
:+-LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+-Exchange(distribution=[hash[d]])
+-Calc(select=[d])
+-LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(d, e, f)]]], fields=[d, e, f])
```


## Brief change log

change rule related to this problem in `RelDecorrelator` 


## Verifying this change

Add new plan test in CalcTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
