### PR TITLE
[FLINK-35803][checkpoint] Fix the wrong file reuse in cp file-merging

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/PhysicalFile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/filemerging/PhysicalFile.java
@@ -121,7 +121,7 @@ public class PhysicalFile {
         this.scope = scope;
         this.size = new AtomicLong(0);
         this.dataSize = new AtomicLong(0);
-        this.couldReuse = true;
+        this.couldReuse = owned;
         this.logicalFileRefCount = new AtomicInteger(0);
         this.isOwned = owned;
     }


### PR DESCRIPTION
## What is the purpose of the change

There is an issue of reusing wrong restored files in following cp when enabling file-merging. All the files from previous job should not be reused afterwards. This PR fixes that.


## Brief change log

 - When creating/referencing a `PhysicalFile` during recovery, mark it unable to reuse.


## Verifying this change

This change is already covered by existing IT tests, such as `ResumeCheckpointManuallyITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
