### PR TITLE
[FLINK-35678][doc] Update compatibility matrix for 1.20 release

### DIFF
--- a/docs/content.zh/docs/ops/upgrading.md
+++ b/docs/content.zh/docs/ops/upgrading.md
@@ -249,22 +249,14 @@ $ bin/flink run -s :savepointPath [:runArgs]
   <thead>
     <tr>
       <th class="text-left" style="width: 25%">创建于 \ 恢复于</th>
-      <th class="text-center">1.16.x</th>
       <th class="text-center">1.17.x</th>
       <th class="text-center">1.18.x</th>
       <th class="text-center">1.19.x</th>
+      <th class="text-center">1.20.x</th>
       <th class="text-center" style="width: 50%">限制</th>
     </tr>
   </thead>
   <tbody>
-    <tr>
-          <td class="text-center"><strong>1.7.x</strong></td>
-          <td class="text-center">O</td>
-          <td class="text-center"></td>
-          <td class="text-center"></td>
-          <td class="text-center"></td>
-          <td class="text-left"></td>
-    </tr>
     <tr>
           <td class="text-center"><strong>1.8.x</strong></td>
           <td class="text-center">O</td>
@@ -347,7 +339,7 @@ $ bin/flink run -s :savepointPath [:runArgs]
         </tr>
     <tr>
           <td class="text-center"><strong>1.17.x</strong></td>
-          <td class="text-center"></td>
+          <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
@@ -356,13 +348,21 @@ $ bin/flink run -s :savepointPath [:runArgs]
     <tr>
           <td class="text-center"><strong>1.18.x</strong></td>
           <td class="text-center"></td>
-          <td class="text-center"></td>
+          <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-left"></td>
         </tr>
     <tr>
           <td class="text-center"><strong>1.19.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-left"></td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>1.20.x</strong></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>

--- a/docs/content/docs/ops/upgrading.md
+++ b/docs/content/docs/ops/upgrading.md
@@ -283,22 +283,14 @@ Savepoints are compatible across Flink versions as indicated by the table below:
   <thead>
     <tr>
       <th class="text-left" style="width: 25%">Created with \ Resumed with</th>
-      <th class="text-center">1.16.x</th>
       <th class="text-center">1.17.x</th>
       <th class="text-center">1.18.x</th>
       <th class="text-center">1.19.x</th>
+      <th class="text-center">1.20.x</th>
       <th class="text-center" style="width: 50%">Limitations</th>
     </tr>
   </thead>
   <tbody>
-    <tr>
-          <td class="text-center"><strong>1.7.x</strong></td>
-          <td class="text-center">O</td>
-          <td class="text-center"></td>
-          <td class="text-center"></td>
-          <td class="text-center"></td>
-          <td class="text-left"></td>
-    </tr>
     <tr>
           <td class="text-center"><strong>1.8.x</strong></td>
           <td class="text-center">O</td>
@@ -381,7 +373,7 @@ Savepoints are compatible across Flink versions as indicated by the table below:
         </tr>
     <tr>
           <td class="text-center"><strong>1.17.x</strong></td>
-          <td class="text-center"></td>
+          <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
@@ -390,13 +382,21 @@ Savepoints are compatible across Flink versions as indicated by the table below:
     <tr>
           <td class="text-center"><strong>1.18.x</strong></td>
           <td class="text-center"></td>
-          <td class="text-center"></td>
+          <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-center">O</td>
           <td class="text-left"></td>
         </tr>
     <tr>
           <td class="text-center"><strong>1.19.x</strong></td>
+          <td class="text-center"></td>
+          <td class="text-center"></td>
+          <td class="text-center">O</td>
+          <td class="text-center">O</td>
+          <td class="text-left"></td>
+        </tr>
+    <tr>
+          <td class="text-center"><strong>1.20.x</strong></td>
           <td class="text-center"></td>
           <td class="text-center"></td>
           <td class="text-center"></td>


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-35678][doc] Update compatibility matrix for 1.20 release


## Brief change log

[FLINK-35678][doc] Update compatibility matrix for 1.20 release


## Verifying this change

As I know, flink 1.20 doesn't break the compatibility.

![](https://github.com/apache/flink/assets/38427477/ebfb3b4c-bbd4-417f-b729-6d93423d5b75)

