### PR TITLE
[BP-1.20][FLINK-35754][e2e] Fix SqlGatewayE2ECase.testMaterializedTableInFullMode failed due to Internal Server Error

### DIFF
--- a/docs/content.zh/docs/dev/table/materialized-table/statements.md
+++ b/docs/content.zh/docs/dev/table/materialized-table/statements.md
@@ -96,7 +96,7 @@ CREATE MATERIALIZED TABLE my_materialized_table
 如上例所示，我们为 `ds` 分区列指定了 `date-formatter` 选项。每次调度时，调度时间将转换为相应的 `ds` 分区值。例如，在 `2024-01-01 00:00:00` 的调度时间下，只有分区 `ds = '2024-01-01'` 会被刷新。
 
 <span class="label label-danger">注意</span>
-- `partition.fields.#.date-formatter` 选项仅适用于全量模式。
+- [partition.fields.#.date-formatter]({{< ref "docs/dev/table/config" >}}#partition-fields-date-formatter) 选项仅适用于全量模式。
 - [partition.fields.#.date-formatter]({{< ref "docs/dev/table/config" >}}#partition-fields-date-formatter) 中的字段必须是有效的字符串类型分区字段。
 
 ## FRESHNESS

--- a/docs/content/docs/dev/table/materialized-table/overview.md
+++ b/docs/content/docs/dev/table/materialized-table/overview.md
@@ -45,8 +45,8 @@ Data freshness is a crucial attribute of a materialized table, serving two main 
     - CONTINUOUS mode: Launches a Flink streaming job that continuously refreshes the materialized table data.
     - FULL mode: The workflow scheduler periodically triggers a Flink batch job to refresh the materialized table data.
 - **Determining the Refresh Frequency**.
-    - In CONTINUOUS mode, data freshness is converted into the `checkpoint` interval of the Flink streaming job currently.
-    - In FULL mode, data freshness is converted into the scheduling cycle of the workflow, e.g. cron expression.
+    - In CONTINUOUS mode, data freshness is converted into the `checkpoint` interval of the Flink streaming job.
+    - In FULL mode, data freshness is converted into the scheduling cycle of the workflow, e.g., a cron expression.
 
 ## Refresh Mode
 

--- a/docs/content/docs/dev/table/materialized-table/statements.md
+++ b/docs/content/docs/dev/table/materialized-table/statements.md
@@ -28,7 +28,7 @@ under the License.
 
 Flink SQL supports the following Materialized Table statements for now:
 - [CREATE MATERIALIZED TABLE](#create-materialized-table)
-- [Alter MATERIALIZED TABLE](#alter-materialized-table)
+- [ALTER MATERIALIZED TABLE](#alter-materialized-table)
 - [DROP MATERIALIZED TABLE](#drop-materialized-table)
 
 # CREATE MATERIALIZED TABLE
@@ -60,7 +60,7 @@ AS <select_statement>
 
 ## PARTITIONED BY
 
-`PARTITIONED BY` define an optional list of columns to partition the materialized table. A directory is created for each partition if this materialized table is used as a filesystem sink.
+`PARTITIONED BY` defines an optional list of columns to partition the materialized table. A directory is created for each partition if this materialized table is used as a filesystem sink.
 
 **Example:**
 
@@ -96,12 +96,12 @@ CREATE MATERIALIZED TABLE my_materialized_table
 As shown in the above example, we specified the date-formatter option for the `ds` partition column. During each scheduling, the scheduling time will be converted to the ds partition value. For example, for a scheduling time of `2024-01-01 00:00:00`, only the partition `ds = '2024-01-01'` will be refreshed.
 
 <span class="label label-danger">Note</span>
-- The `partition.fields.#.date-formatter` option only works in full mode.
+- The [partition.fields.#.date-formatter]({{< ref "docs/dev/table/config" >}}#partition-fields-date-formatter) option only works in full mode.
 - The field in the [partition.fields.#.date-formatter]({{< ref "docs/dev/table/config" >}}#partition-fields-date-formatter) must be a valid string type partition field.
 
 ## FRESHNESS
 
-`FRESHNESS` define the data freshness of a materialized table.
+`FRESHNESS` defines the data freshness of a materialized table.
 
 **FRESHNESS and Refresh Mode Relationship**
 

--- a/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/SqlGatewayE2ECase.java
+++ b/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/SqlGatewayE2ECase.java
@@ -187,7 +187,7 @@ public class SqlGatewayE2ECase extends TestLogger {
             gatewayRestClient.executeStatementWithResult("SET 'execution.runtime-mode' = 'batch'");
 
             // verify the result
-            CommonTestUtils.waitUtil(
+            CommonTestUtils.waitUntilIgnoringExceptions(
                     () -> {
                         List<RowData> result =
                                 gatewayRestClient.executeStatementWithResult(
@@ -219,7 +219,7 @@ public class SqlGatewayE2ECase extends TestLogger {
                     "ALTER MATERIALIZED TABLE my_materialized_table_in_continuous_mode RESUME");
 
             // verify the result
-            CommonTestUtils.waitUtil(
+            CommonTestUtils.waitUntilIgnoringExceptions(
                     () -> {
                         List<RowData> result =
                                 gatewayRestClient.executeStatementWithResult(
@@ -312,7 +312,7 @@ public class SqlGatewayE2ECase extends TestLogger {
 
             // verify the materialized table should auto refresh the today partition or tomorrow
             // partition
-            CommonTestUtils.waitUtil(
+            CommonTestUtils.waitUntilIgnoringExceptions(
                     () -> {
                         List<RowData> result =
                                 gatewayRestClient.executeStatementWithResult(
@@ -345,9 +345,10 @@ public class SqlGatewayE2ECase extends TestLogger {
             gatewayRestClient.executeStatementWithResult(
                     "ALTER MATERIALIZED TABLE my_materialized_table_in_full_mode RESUME");
 
-            // wait until the materialized table is updated and verify only today or tomorrow data
+            // wait until the materialized table is updated and verify only today or tomorrow
+            // data
             // should be updated
-            CommonTestUtils.waitUtil(
+            CommonTestUtils.waitUntilIgnoringExceptions(
                     () -> {
                         List<RowData> result =
                                 gatewayRestClient.executeStatementWithResult(
@@ -378,7 +379,7 @@ public class SqlGatewayE2ECase extends TestLogger {
                             + "')");
 
             // verify the materialized table that all partitions are updated
-            CommonTestUtils.waitUtil(
+            CommonTestUtils.waitUntilIgnoringExceptions(
                     () -> {
                         List<RowData> result =
                                 gatewayRestClient.executeStatementWithResult(

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/CommonTestUtils.java
@@ -19,6 +19,8 @@
 package org.apache.flink.core.testutils;
 
 import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -41,6 +43,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 /** This class contains reusable utility methods for unit tests. */
 public class CommonTestUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CommonTestUtils.class);
 
     /**
      * Creates a copy of an object via Java Serialization.
@@ -213,6 +217,35 @@ public class CommonTestUtils {
         if (!conditionResult) {
             throw new TimeoutException(errorMsg);
         }
+    }
+
+    /**
+     * Wait until the given condition is met or timeout, ignoring any exceptions thrown by the
+     * condition.
+     *
+     * @param condition the condition to wait for.
+     * @param timeout the maximum time to wait for the condition to become true.
+     * @param pause delay between condition checks.
+     * @param errorMsg the error message to include in the <code>TimeoutException</code> if the
+     *     condition was not met before timeout.
+     * @throws TimeoutException if the condition is not met before timeout.
+     * @throws InterruptedException if the thread is interrupted.
+     */
+    @SuppressWarnings("BusyWait")
+    public static void waitUntilIgnoringExceptions(
+            Supplier<Boolean> condition, Duration timeout, Duration pause, String errorMsg)
+            throws TimeoutException, InterruptedException {
+        Supplier<Boolean> safeCondition =
+                () -> {
+                    try {
+                        return condition.get();
+                    } catch (Exception ignored) {
+                        LOG.warn("Exception thrown while evaluating condition", ignored);
+                        return false;
+                    }
+                };
+
+        waitUtil(safeCondition, timeout, pause, errorMsg);
     }
 
     /**


### PR DESCRIPTION
BP https://github.com/apache/flink/pull/25029

## What is the purpose of the change

*Fix unstable testMaterializedTableInFullMode test case*


## Brief change log

  - *Fix SqlGatewayE2ECase.testMaterializedTableInFullMode failed *


## Verifying this change

*It's a test fix* 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
