### PR TITLE
[FLINK-35816][table] Non-mergeable proctime tvf window aggregate needs to fallback to group aggregate

### DIFF
--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -2275,6 +2275,620 @@ Sink(table=[default_catalog.default_database.s1], fields=[window_start, window_e
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProctimeWindowTVFWithCalcOnWindowColumnWhenCantMerge[aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, count(a)
+from
+ TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes))
+where window_start <> '123'
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[COUNT($4)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], a=[$0])
+      +- LogicalFilter(condition=[<>($7, _UTF-16LE'123')])
+         +- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+               +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, COUNT(a) AS EXPR$1])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, window_time, a], where=[<>(window_start, '123')])
+         +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+            +- Calc(select=[a, c, proctime])
+               +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                  +- Calc(select=[a, c, PROCTIME() AS proctime, rowtime])
+                     +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithCalcOnWindowColumnWhenCantMerge[aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, count(a)
+from
+ TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes))
+where window_start <> '123'
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[COUNT($4)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], a=[$0])
+      +- LogicalFilter(condition=[<>($7, _UTF-16LE'123')])
+         +- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+               +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, COUNT(a) AS EXPR$1])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, window_time, a], where=[<>(window_start, '123')])
+         +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+            +- Calc(select=[a, c, proctime])
+               +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                  +- Calc(select=[a, c, PROCTIME() AS proctime, rowtime])
+                     +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithCorrelateWhenCantMerge[aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select t.c, max(t2.x), count(t.a)
+from (
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes)) AS t
+  Left JOIN LATERAL TABLE(str_split('Jack,John', ',')) AS t2(x) ON TRUE
+)
+group by window_start, window_end, t.c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4], EXPR$2=[$5])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[MAX($4)], EXPR$2=[COUNT($5)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], EXPR$0=[$10], a=[$0])
+      +- LogicalJoin(condition=[true], joinType=[left])
+         :- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+         :  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+         :     +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         :        +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+         :           +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalTableFunctionScan(invocation=[str_split(_UTF-16LE'Jack,John', _UTF-16LE',')], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1, EXPR$2])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, MAX(EXPR$0) AS EXPR$1, COUNT(a) AS EXPR$2])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, window_time, EXPR$0, a])
+         +- Correlate(invocation=[str_split(_UTF-16LE'Jack,John', _UTF-16LE',')], correlate=[table(str_split('Jack,John',','))], select=[a,b,c,d,e,rowtime,proctime,window_start,window_end,window_time,EXPR$0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time, VARCHAR(2147483647) EXPR$0)], joinType=[LEFT])
+            +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+               +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                  +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                     +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithCorrelateWhenCantMerge[aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select t.c, max(t2.x), count(t.a)
+from (
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes)) AS t
+  Left JOIN LATERAL TABLE(str_split('Jack,John', ',')) AS t2(x) ON TRUE
+)
+group by window_start, window_end, t.c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4], EXPR$2=[$5])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[MAX($4)], EXPR$2=[COUNT($5)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], EXPR$0=[$10], a=[$0])
+      +- LogicalJoin(condition=[true], joinType=[left])
+         :- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+         :  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+         :     +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         :        +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+         :           +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalTableFunctionScan(invocation=[str_split(_UTF-16LE'Jack,John', _UTF-16LE',')], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1, EXPR$2])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, MAX(EXPR$0) AS EXPR$1, COUNT(a) AS EXPR$2])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, window_time, EXPR$0, a])
+         +- Correlate(invocation=[str_split(_UTF-16LE'Jack,John', _UTF-16LE',')], correlate=[table(str_split('Jack,John',','))], select=[a,b,c,d,e,rowtime,proctime,window_start,window_end,window_time,EXPR$0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time, VARCHAR(2147483647) EXPR$0)], joinType=[LEFT])
+            +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+               +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                  +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                     +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithDedupWhenCantMerge[aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, count(a)
+from (
+ select *, row_number() over (partition by c order by proctime desc) as rn
+ from
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes))
+)
+where rn = 1
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[COUNT($4)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], a=[$0])
+      +- LogicalFilter(condition=[=($10, 1)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rn=[ROW_NUMBER() OVER (PARTITION BY $2 ORDER BY $6 DESC NULLS LAST)])
+            +- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+                  +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, COUNT_RETRACT(a) AS EXPR$1])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, PROCTIME_MATERIALIZE(window_time) AS window_time, a])
+         +- Deduplicate(keep=[LastRow], key=[c], order=[PROCTIME])
+            +- Exchange(distribution=[hash[c]])
+               +- Calc(select=[a, c, proctime, window_start, window_end, window_time])
+                  +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                        +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                           +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithDedupWhenCantMerge[aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, count(a)
+from (
+ select *, row_number() over (partition by c order by proctime desc) as rn
+ from
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes))
+)
+where rn = 1
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[COUNT($4)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], a=[$0])
+      +- LogicalFilter(condition=[=($10, 1)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rn=[ROW_NUMBER() OVER (PARTITION BY $2 ORDER BY $6 DESC NULLS LAST)])
+            +- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+                  +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, COUNT_RETRACT(a) AS EXPR$1])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, PROCTIME_MATERIALIZE(window_time) AS window_time, a])
+         +- Deduplicate(keep=[LastRow], key=[c], order=[PROCTIME])
+            +- Exchange(distribution=[hash[c]])
+               +- Calc(select=[a, c, proctime, window_start, window_end, window_time])
+                  +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                        +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                           +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithJoinWhenCantMerge[aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select t.c, max(t2.e), count(t.a)
+from (
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes)) AS t
+  join MyTable t2 on t2.a = t.a
+)
+group by window_start, window_end, t.c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4], EXPR$2=[$5])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[MAX($4)], EXPR$2=[COUNT($5)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], e0=[$14], a=[$0])
+      +- LogicalJoin(condition=[=($10, $0)], joinType=[inner])
+         :- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+         :  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+         :     +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         :        +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+         :           +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+               +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1, EXPR$2])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, MAX(e0) AS EXPR$1, COUNT(a) AS EXPR$2])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, window_time, e AS e0, a])
+         +- Join(joinType=[InnerJoin], where=[=(a0, a)], select=[a, c, window_start, window_end, window_time, a0, e], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+            :- Exchange(distribution=[hash[a]])
+            :  +- Calc(select=[a, c, window_start, window_end, PROCTIME_MATERIALIZE(window_time) AS window_time])
+            :     +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+            :        +- Calc(select=[a, c, proctime])
+            :           +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            :              +- Calc(select=[a, c, PROCTIME() AS proctime, rowtime])
+            :                 +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, e, rowtime], metadata=[]]], fields=[a, c, e, rowtime])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, e])
+                  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                     +- Calc(select=[a, e, rowtime])
+                        +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, e, rowtime], metadata=[]]], fields=[a, c, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithJoinWhenCantMerge[aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select t.c, max(t2.e), count(t.a)
+from (
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes)) AS t
+  join MyTable t2 on t2.a = t.a
+)
+group by window_start, window_end, t.c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4], EXPR$2=[$5])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[MAX($4)], EXPR$2=[COUNT($5)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], e0=[$14], a=[$0])
+      +- LogicalJoin(condition=[=($10, $0)], joinType=[inner])
+         :- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+         :  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+         :     +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         :        +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+         :           +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+               +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1, EXPR$2])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, MAX(e0) AS EXPR$1, COUNT(a) AS EXPR$2])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, window_time, e AS e0, a])
+         +- Join(joinType=[InnerJoin], where=[=(a0, a)], select=[a, c, window_start, window_end, window_time, a0, e], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+            :- Exchange(distribution=[hash[a]])
+            :  +- Calc(select=[a, c, window_start, window_end, PROCTIME_MATERIALIZE(window_time) AS window_time])
+            :     +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+            :        +- Calc(select=[a, c, proctime])
+            :           +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            :              +- Calc(select=[a, c, PROCTIME() AS proctime, rowtime])
+            :                 +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, e, rowtime], metadata=[]]], fields=[a, c, e, rowtime])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, e])
+                  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                     +- Calc(select=[a, e, rowtime])
+                        +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, e, rowtime], metadata=[]]], fields=[a, c, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithOverAggWhenCantMerge[aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, max(c1), count(a)
+from (
+ select *, count(*) over (partition by c order by proctime desc) as c1
+ from
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes))
+)
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4], EXPR$2=[$5])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[MAX($4)], EXPR$2=[COUNT($5)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], c1=[$10], a=[$0])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], c1=[COUNT() OVER (PARTITION BY $2 ORDER BY $6 DESC NULLS LAST)])
+         +- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+               +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1, EXPR$2])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, MAX(c1) AS EXPR$1, COUNT(a) AS EXPR$2])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, PROCTIME_MATERIALIZE(window_time) AS window_time, w0$o0 AS c1, a])
+         +- OverAggregate(partitionBy=[c], orderBy=[proctime DESC], window=[ RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[a, b, c, d, e, rowtime, proctime, window_start, window_end, window_time, COUNT(*) AS w0$o0])
+            +- Exchange(distribution=[hash[c]])
+               +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+                  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                     +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                        +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithOverAggWhenCantMerge[aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, max(c1), count(a)
+from (
+ select *, count(*) over (partition by c order by proctime desc) as c1
+ from
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes))
+)
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4], EXPR$2=[$5])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[MAX($4)], EXPR$2=[COUNT($5)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], c1=[$10], a=[$0])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], c1=[COUNT() OVER (PARTITION BY $2 ORDER BY $6 DESC NULLS LAST)])
+         +- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+               +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1, EXPR$2])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, MAX(c1) AS EXPR$1, COUNT(a) AS EXPR$2])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, PROCTIME_MATERIALIZE(window_time) AS window_time, w0$o0 AS c1, a])
+         +- OverAggregate(partitionBy=[c], orderBy=[proctime DESC], window=[ RANG BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], select=[a, b, c, d, e, rowtime, proctime, window_start, window_end, window_time, COUNT(*) AS w0$o0])
+            +- Exchange(distribution=[hash[c]])
+               +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+                  +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                     +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                        +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithRankWhenCantMerge[aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, count(a)
+from (
+ select *, row_number() over (partition by c order by proctime desc) as rn
+ from
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes))
+)
+where rn = 2
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[COUNT($4)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], a=[$0])
+      +- LogicalFilter(condition=[=($10, 2)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rn=[ROW_NUMBER() OVER (PARTITION BY $2 ORDER BY $6 DESC NULLS LAST)])
+            +- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+                  +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, COUNT_RETRACT(a) AS EXPR$1])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, PROCTIME_MATERIALIZE(window_time) AS window_time, a])
+         +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=2, rankEnd=2], partitionBy=[c], orderBy=[proctime DESC], select=[a, c, proctime, window_start, window_end, window_time])
+            +- Exchange(distribution=[hash[c]])
+               +- Calc(select=[a, c, proctime, window_start, window_end, window_time])
+                  +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                        +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                           +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithRankWhenCantMerge[aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, count(a)
+from (
+ select *, row_number() over (partition by c order by proctime desc) as rn
+ from
+  TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes))
+)
+where rn = 2
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[COUNT($4)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], a=[$0])
+      +- LogicalFilter(condition=[=($10, 2)])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9], rn=[ROW_NUMBER() OVER (PARTITION BY $2 ORDER BY $6 DESC NULLS LAST)])
+            +- LogicalTableFunctionScan(invocation=[CUMULATE(DESCRIPTOR($6), 10000:INTERVAL SECOND, 300000:INTERVAL MINUTE)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+                  +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, COUNT_RETRACT(a) AS EXPR$1])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, PROCTIME_MATERIALIZE(window_time) AS window_time, a])
+         +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=2, rankEnd=2], partitionBy=[c], orderBy=[proctime DESC], select=[a, c, proctime, window_start, window_end, window_time])
+            +- Exchange(distribution=[hash[c]])
+               +- Calc(select=[a, c, proctime, window_start, window_end, window_time])
+                  +- WindowTableFunction(window=[CUMULATE(time_col=[proctime], max_size=[5 min], step=[10 s])])
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                        +- Calc(select=[a, b, c, d, e, rowtime, PROCTIME() AS proctime])
+                           +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, d, e, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithUnionWhenCantMerge[aggPhaseEnforcer=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, count(a)
+from (
+  select * from
+  TABLE(TUMBLE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds))
+  union all
+  select * from
+  TABLE(TUMBLE(table MyTable, DESCRIPTOR(proctime), interval '5' seconds))
+) t
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[COUNT($4)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], a=[$0])
+      +- LogicalUnion(all=[true])
+         :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9])
+         :  +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($6), 10000:INTERVAL SECOND)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+         :     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+         :        +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         :           +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+         :              +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9])
+            +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($6), 5000:INTERVAL SECOND)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+                  +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, COUNT(a) AS EXPR$1])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, PROCTIME_MATERIALIZE(window_time) AS window_time, a])
+         +- Union(all=[true], union=[window_start, window_end, c, window_time, a])
+            :- Calc(select=[window_start, window_end, c, window_time, a])
+            :  +- WindowTableFunction(window=[TUMBLE(time_col=[proctime], size=[10 s])])
+            :     +- Calc(select=[a, c, proctime])
+            :        +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            :           +- Calc(select=[a, c, PROCTIME() AS proctime, rowtime])
+            :              +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+            +- Calc(select=[window_start, window_end, c, window_time, a])
+               +- WindowTableFunction(window=[TUMBLE(time_col=[proctime], size=[5 s])])
+                  +- Calc(select=[a, c, proctime])
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                        +- Calc(select=[a, c, PROCTIME() AS proctime, rowtime])
+                           +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeWindowTVFWithUnionWhenCantMerge[aggPhaseEnforcer=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[
+select c, count(a)
+from (
+  select * from
+  TABLE(TUMBLE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds))
+  union all
+  select * from
+  TABLE(TUMBLE(table MyTable, DESCRIPTOR(proctime), interval '5' seconds))
+) t
+group by window_start, window_end, c, window_time
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(c=[$2], EXPR$1=[$4])
++- LogicalAggregate(group=[{0, 1, 2, 3}], EXPR$1=[COUNT($4)])
+   +- LogicalProject(window_start=[$7], window_end=[$8], c=[$2], window_time=[$9], a=[$0])
+      +- LogicalUnion(all=[true])
+         :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9])
+         :  +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($6), 10000:INTERVAL SECOND)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+         :     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+         :        +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+         :           +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+         :              +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6], window_start=[$7], window_end=[$8], window_time=[$9])
+            +- LogicalTableFunctionScan(invocation=[TUMBLE(DESCRIPTOR($6), 5000:INTERVAL SECOND)], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, DECIMAL(10, 3) d, BIGINT e, TIMESTAMP(3) *ROWTIME* rowtime, TIMESTAMP_LTZ(3) *PROCTIME* proctime, TIMESTAMP(3) window_start, TIMESTAMP(3) window_end, TIMESTAMP_LTZ(3) *PROCTIME* window_time)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[$6])
+                  +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[-($5, 1000:INTERVAL SECOND)])
+                     +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], rowtime=[$5], proctime=[PROCTIME()])
+                        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[c, EXPR$1])
++- GroupAggregate(groupBy=[window_start, window_end, c, window_time], select=[window_start, window_end, c, window_time, COUNT(a) AS EXPR$1])
+   +- Exchange(distribution=[hash[window_start, window_end, c, window_time]])
+      +- Calc(select=[window_start, window_end, c, PROCTIME_MATERIALIZE(window_time) AS window_time, a])
+         +- Union(all=[true], union=[window_start, window_end, c, window_time, a])
+            :- Calc(select=[window_start, window_end, c, window_time, a])
+            :  +- WindowTableFunction(window=[TUMBLE(time_col=[proctime], size=[10 s])])
+            :     +- Calc(select=[a, c, proctime])
+            :        +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+            :           +- Calc(select=[a, c, PROCTIME() AS proctime, rowtime])
+            :              +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+            +- Calc(select=[window_start, window_end, c, window_time, a])
+               +- WindowTableFunction(window=[TUMBLE(time_col=[proctime], size=[5 s])])
+                  +- Calc(select=[a, c, proctime])
+                     +- WatermarkAssigner(rowtime=[rowtime], watermark=[-(rowtime, 1000:INTERVAL SECOND)])
+                        +- Calc(select=[a, c, PROCTIME() AS proctime, rowtime])
+                           +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a, c, rowtime], metadata=[]]], fields=[a, c, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProctimeWindowWithFilter[aggPhaseEnforcer=ONE_PHASE]">
     <Resource name="sql">
       <![CDATA[


### PR DESCRIPTION
## What is the purpose of the change
Non-mergeable proctime tvf window aggregate needs to fallback to group aggregate, e.g.,
```sql
select c, count(a)
from
   TABLE(CUMULATE(table MyTable, DESCRIPTOR(proctime), interval '10' seconds, interval '5' minutes))
where window_start <> '123'
group by window_start, window_end, c, window_time
```
the window property in above query was materialized before aggregation, so it lost processing time attribute and cause the planner failed to pull up `StreamPhysicalWindowTableFunction` into the `StreamPhysicalWindowAggregate` to generate a valid execution plan, which goes into the attached window strategy which relies on the upstream watermark but lacks of a watermark assigner.
So, semantically when the window time attribute was materialized after window table function, the downstream aggregation should use group aggregation.

## Brief change log
* update `WindowUtil`#isValidWindowAggregate to check the invalid patterns

## Verifying this change
* added related test cases into `WindowAggregateTest`

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)