### PR TITLE
[hotfix][table] Apply uppercase for URL_ENCODE/URL_DECODE remove logging from function class

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -433,7 +433,7 @@ public final class BuiltInFunctionDefinitions {
 
     public static final BuiltInFunctionDefinition URL_DECODE =
             BuiltInFunctionDefinition.newBuilder()
-                    .name("url_decode")
+                    .name("URL_DECODE")
                     .kind(SCALAR)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING().nullable())))
@@ -443,7 +443,7 @@ public final class BuiltInFunctionDefinitions {
 
     public static final BuiltInFunctionDefinition URL_ENCODE =
             BuiltInFunctionDefinition.newBuilder()
-                    .name("url_encode")
+                    .name("URL_ENCODE")
                     .kind(SCALAR)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING().nullable())))

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -436,7 +436,7 @@ public final class BuiltInFunctionDefinitions {
                     .name("URL_DECODE")
                     .kind(SCALAR)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
-                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING().nullable())))
+                    .outputTypeStrategy(explicit(DataTypes.STRING().nullable()))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.UrlDecodeFunction")
                     .build();
@@ -446,7 +446,7 @@ public final class BuiltInFunctionDefinitions {
                     .name("URL_ENCODE")
                     .kind(SCALAR)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
-                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING().nullable())))
+                    .outputTypeStrategy(explicit(DataTypes.STRING().nullable()))
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.scalar.UrlEncodeFunction")
                     .build();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlDecodeFunction.java
@@ -23,9 +23,6 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 
 import java.io.UnsupportedEncodingException;
@@ -36,7 +33,6 @@ import java.nio.charset.StandardCharsets;
 /** Implementation of {@link BuiltInFunctionDefinitions#URL_DECODE}. */
 @Internal
 public class UrlDecodeFunction extends BuiltInScalarFunction {
-    private static final Logger LOG = LoggerFactory.getLogger(UrlDecodeFunction.class);
 
     public UrlDecodeFunction(SpecializedFunction.SpecializedContext context) {
         super(BuiltInFunctionDefinitions.URL_DECODE, context);
@@ -50,11 +46,6 @@ public class UrlDecodeFunction extends BuiltInScalarFunction {
         try {
             return StringData.fromString(URLDecoder.decode(value.toString(), charset.name()));
         } catch (UnsupportedEncodingException | RuntimeException e) {
-            LOG.error(
-                    "Failed to decode the input: {} with charset: {}, and the exception details: ",
-                    value,
-                    charset.name(),
-                    e);
             return null;
         }
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UrlEncodeFunction.java
@@ -23,9 +23,6 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.SpecializedFunction;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 
 import java.io.UnsupportedEncodingException;
@@ -36,7 +33,6 @@ import java.nio.charset.StandardCharsets;
 /** Implementation of {@link BuiltInFunctionDefinitions#URL_ENCODE}. */
 @Internal
 public class UrlEncodeFunction extends BuiltInScalarFunction {
-    private static final Logger LOG = LoggerFactory.getLogger(UrlEncodeFunction.class);
 
     public UrlEncodeFunction(SpecializedFunction.SpecializedContext context) {
         super(BuiltInFunctionDefinitions.URL_ENCODE, context);
@@ -50,11 +46,6 @@ public class UrlEncodeFunction extends BuiltInScalarFunction {
         try {
             return StringData.fromString(URLEncoder.encode(url.toString(), charset.name()));
         } catch (UnsupportedEncodingException e) {
-            LOG.error(
-                    "Failed to encode the input: {} with charset: {}, and the exception details: ",
-                    url,
-                    charset.name(),
-                    e);
             return null;
         }
     }


### PR DESCRIPTION

## What is the purpose of the change
1. Use uppercase for function names 
2. remove logging since in function classes it could lead to disk space issue while being used in streaming for huge amount of events per time unit

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (/no)
  - If yes, how is the feature documented? (not applicable )
