### PR TITLE
[FLINK-35227][rest] Remove execution-mode in ExecutionConfigInfo

### DIFF
--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -2079,8 +2079,6 @@ components:
     ExecutionConfigInfo:
       type: object
       properties:
-        execution-mode:
-          type: string
         job-parallelism:
           type: integer
           format: int32

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -355,7 +355,7 @@ class WebFrontendITCase {
                             "{\"jid\":\""
                                     + jid
                                     + "\",\"name\":\"Stoppable streaming test job\","
-                                    + "\"execution-config\":{\"execution-mode\":\"PIPELINED\",\"restart-strategy\":\"Cluster level default restart strategy\","
+                                    + "\"execution-config\":{\"restart-strategy\":\"Cluster level default restart strategy\","
                                     + "\"job-parallelism\":1,\"object-reuse-mode\":false,\"user-config\":{}}}");
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobConfigInfo.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ArchivedExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.runtime.rest.handler.job.JobConfigHandler;
-import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -169,16 +168,10 @@ public class JobConfigInfo implements ResponseBody {
     /** Nested class to encapsulate the execution configuration. */
     public static final class ExecutionConfigInfo {
 
-        @Deprecated public static final String FIELD_NAME_EXECUTION_MODE = "execution-mode";
         public static final String FIELD_NAME_RESTART_STRATEGY = "restart-strategy";
         public static final String FIELD_NAME_PARALLELISM = "job-parallelism";
         public static final String FIELD_NAME_OBJECT_REUSE_MODE = "object-reuse-mode";
         public static final String FIELD_NAME_GLOBAL_JOB_PARAMETERS = "user-config";
-
-        /** @deprecated Use {@link JobDetailsInfo#getJobType()} instead. */
-        @Deprecated
-        @JsonProperty(FIELD_NAME_EXECUTION_MODE)
-        private final String executionMode;
 
         @JsonProperty(FIELD_NAME_RESTART_STRATEGY)
         private final String restartStrategy;
@@ -194,21 +187,15 @@ public class JobConfigInfo implements ResponseBody {
 
         @JsonCreator
         public ExecutionConfigInfo(
-                @JsonProperty(FIELD_NAME_EXECUTION_MODE) String executionMode,
                 @JsonProperty(FIELD_NAME_RESTART_STRATEGY) String restartStrategy,
                 @JsonProperty(FIELD_NAME_PARALLELISM) int parallelism,
                 @JsonProperty(FIELD_NAME_OBJECT_REUSE_MODE) boolean isObjectReuse,
                 @JsonProperty(FIELD_NAME_GLOBAL_JOB_PARAMETERS)
                         Map<String, String> globalJobParameters) {
-            this.executionMode = Preconditions.checkNotNull(executionMode);
             this.restartStrategy = Preconditions.checkNotNull(restartStrategy);
             this.parallelism = parallelism;
             this.isObjectReuse = isObjectReuse;
             this.globalJobParameters = Preconditions.checkNotNull(globalJobParameters);
-        }
-
-        public String getExecutionMode() {
-            return executionMode;
         }
 
         public String getRestartStrategy() {
@@ -239,24 +226,17 @@ public class JobConfigInfo implements ResponseBody {
             ExecutionConfigInfo that = (ExecutionConfigInfo) o;
             return parallelism == that.parallelism
                     && isObjectReuse == that.isObjectReuse
-                    && Objects.equals(executionMode, that.executionMode)
                     && Objects.equals(restartStrategy, that.restartStrategy)
                     && Objects.equals(globalJobParameters, that.globalJobParameters);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(
-                    executionMode,
-                    restartStrategy,
-                    parallelism,
-                    isObjectReuse,
-                    globalJobParameters);
+            return Objects.hash(restartStrategy, parallelism, isObjectReuse, globalJobParameters);
         }
 
         public static ExecutionConfigInfo from(ArchivedExecutionConfig archivedExecutionConfig) {
             return new ExecutionConfigInfo(
-                    archivedExecutionConfig.getExecutionMode(),
                     archivedExecutionConfig.getRestartStrategyDescription(),
                     archivedExecutionConfig.getParallelism(),
                     archivedExecutionConfig.getObjectReuseEnabled(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobConfigInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobConfigInfoTest.java
@@ -43,8 +43,7 @@ class JobConfigInfoTest extends RestResponseMarshallingTestBase<JobConfigInfo> {
         globalJobParameters.put("hi", "ho");
 
         final JobConfigInfo.ExecutionConfigInfo executionConfigInfo =
-                new JobConfigInfo.ExecutionConfigInfo(
-                        "foobar", "always", 42, false, globalJobParameters);
+                new JobConfigInfo.ExecutionConfigInfo("always", 42, false, globalJobParameters);
         return new JobConfigInfo(new JobID(), "testJob", executionConfigInfo);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change


[FLINK-35227][rest] Remove execution-mode in ExecutionConfigInfo

## Brief change log

[FLINK-35227][rest] Remove execution-mode in ExecutionConfigInfo


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
