### PR TITLE
[FLINK-35095][test] Fix unstable tests in `ExecutionEnvironmentImplTest`

### DIFF
--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImplTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImplTest.java
@@ -93,8 +93,11 @@ class ExecutionEnvironmentImplTest {
         Collection<StreamNode> nodes = streamGraph.getStreamNodes();
         assertThat(nodes).hasSize(2);
         Collection<Integer> sourceIDs = streamGraph.getSourceIDs();
-        StreamNode sourceNode = nodes.iterator().next();
-        assertThat(sourceIDs).containsExactly(sourceNode.getId());
+        for (StreamNode node : nodes) {
+            if (node.getOperatorName().contains("source")) {
+                assertThat(sourceIDs).containsExactly(node.getId());
+            }
+        }
     }
 
     @Test
@@ -118,7 +121,10 @@ class ExecutionEnvironmentImplTest {
         StreamGraph streamGraph = StreamTestUtils.getStreamGraph(env);
         Collection<StreamNode> nodes = streamGraph.getStreamNodes();
         Collection<Integer> sourceIDs = streamGraph.getSourceIDs();
-        StreamNode sourceNode = nodes.iterator().next();
-        assertThat(sourceIDs).containsExactly(sourceNode.getId());
+        for (StreamNode node : nodes) {
+            if (node.getOperatorName().contains("source")) {
+                assertThat(sourceIDs).containsExactly(node.getId());
+            }
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*The returned collection of `streamGraph.getStreamNodes` is un-ordered, so we have to check every node to decide if it's the source node.*


## Brief change log

  - *Check every node to decide if it's the source node*


## Verifying this change


This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
