### PR TITLE
[FLINK-35836][fs] Fix reflection issue for s5 ITCase in JDK17

### DIFF
--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -33,6 +33,10 @@ under the License.
 	<properties>
 		<fs.s3.aws.version>1.12.319</fs.s3.aws.version>
 		<japicmp.skip>true</japicmp.skip>
+		<surefire.module.config> <!--
+			S5CmdOnMinioITCase uses ArraysAsListSerializer indirectly
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -31,6 +31,13 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<surefire.module.config> <!--
+			S5CmdOnHadoopS3FileSystemITCase uses ArraysAsListSerializer indirectly
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
+	</properties>
+
 	<dependencyManagement>
 		<dependencies>
 			<!-- Override the flink-parent dependencyManagement definition for hadoop-common to ensure

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -33,6 +33,10 @@ under the License.
 
 	<properties>
 		<presto.version>0.272</presto.version>
+		<surefire.module.config> <!--
+			S5CmdOnPrestoS3FileSystemITCase uses ArraysAsListSerializer indirectly
+			-->--add-opens=java.base/java.util=ALL-UNNAMED
+		</surefire.module.config>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## What is the purpose of the change

*In JDK17, we cannot access a final field via reflection by default. Following 2940c02c986e3d70708187091bf006806bb90dff, I have added --add-opens=java.base/java.util=ALL-UNNAMED to the module's pom.xml which including failed tests.*

