### PR TITLE
[FLINK-26232][tests][JUnit5 migration] Module:flink-avro

### DIFF
--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
@@ -28,7 +28,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.UniqueBucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.legacy.StreamingFileSink;
-import org.apache.flink.test.util.AbstractTestBaseJUnit4;
+import org.apache.flink.test.util.AbstractTestBase;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
@@ -38,19 +38,20 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.specific.SpecificDatumReader;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,13 +59,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Simple integration test case for writing bulk encoded files with the {@link StreamingFileSink}
  * with Avro.
  */
-public class AvroStreamingFileSinkITCase extends AbstractTestBaseJUnit4 {
-
-    @Rule public final Timeout timeoutPerTest = Timeout.seconds(20);
-
+public class AvroStreamingFileSinkITCase extends AbstractTestBase {
     @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
     public void testWriteAvroSpecific() throws Exception {
-        File folder = TEMPORARY_FOLDER.newFolder();
+        File folder = Files.createTempDirectory(temporaryFolder.toPath(), "junit").toFile();
 
         List<Address> data =
                 Arrays.asList(
@@ -94,8 +93,9 @@ public class AvroStreamingFileSinkITCase extends AbstractTestBaseJUnit4 {
     }
 
     @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
     public void testWriteAvroGeneric() throws Exception {
-        File folder = TEMPORARY_FOLDER.newFolder();
+        File folder = Files.createTempDirectory(temporaryFolder.toPath(), "junit").toFile();
 
         Schema schema = Address.getClassSchema();
         Collection<GenericRecord> data = new GenericTestDataCollection();
@@ -122,8 +122,9 @@ public class AvroStreamingFileSinkITCase extends AbstractTestBaseJUnit4 {
     }
 
     @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
     public void testWriteAvroReflect() throws Exception {
-        File folder = TEMPORARY_FOLDER.newFolder();
+        File folder = Files.createTempDirectory(temporaryFolder.toPath(), "junit").toFile();
 
         List<Datum> data = Arrays.asList(new Datum("a", 1), new Datum("b", 2), new Datum("c", 3));
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
@@ -27,12 +27,12 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.flink.test.util.AbstractTestBaseJUnit4;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.util.CollectionUtil;
 
 import org.apache.avro.util.Utf8;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -51,7 +51,7 @@ import static org.apache.flink.table.api.Expressions.$;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for interoperability with Avro types. */
-public class AvroTypesITCase extends AbstractTestBaseJUnit4 {
+public class AvroTypesITCase extends AbstractTestBase {
 
     private static final User USER_1 =
             User.newBuilder()


### PR DESCRIPTION
## What is the purpose of the change

*This change migrates over two leftover IT test cases from Junit 4 to 5 in the `flink-avro` module.*


## Brief change log

  - *Migrated `AvroStreamingFileSinkITCase`, `AvroTypesITCasemigrated` to Junit 5.*


## Verifying this change

This change updates existing tests. I ran successfully the test suite for the `flink-avro` module locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
