### PR TITLE
[FLINK-28984][checkpoint] Fix concurrency issue between `close` and `flushToFile` in `FsCheckpointStateOutputStream`

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -221,7 +221,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 
         private int pos;
 
-        private FSDataOutputStream outStream;
+        private volatile FSDataOutputStream outStream;
 
         private final int localStateThreshold;
 
@@ -229,7 +229,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 
         private final FileSystem fs;
 
-        private Path statePath;
+        private volatile Path statePath;
 
         private String relativeStatePath;
 
@@ -269,7 +269,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
         }
 
         @Override
-        public void write(byte[] b, int off, int len) throws IOException {
+        public synchronized void write(byte[] b, int off, int len) throws IOException {
             if (len < writeBuffer.length) {
                 // copy it into our write buffer first
                 final int remaining = writeBuffer.length - pos;
@@ -300,7 +300,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
             return pos + (outStream == null ? 0 : outStream.getPos());
         }
 
-        public void flushToFile() throws IOException {
+        public synchronized void flushToFile() throws IOException {
             if (!closed) {
                 // initialize stream if this is the first flushToFile (stream flush, not Darjeeling
                 // harvest)
@@ -345,7 +345,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
          * logs the error.
          */
         @Override
-        public void close() {
+        public synchronized void close() {
             if (!closed) {
                 closed = true;
 
@@ -374,66 +374,63 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 
         @Nullable
         @Override
-        public StreamStateHandle closeAndGetHandle() throws IOException {
+        public synchronized StreamStateHandle closeAndGetHandle() throws IOException {
             // check if there was nothing ever written
             if (outStream == null && pos == 0) {
                 return null;
             }
 
-            synchronized (this) {
-                if (!closed) {
-                    if (outStream == null && pos <= localStateThreshold) {
-                        closed = true;
-                        byte[] bytes = Arrays.copyOf(writeBuffer, pos);
-                        pos = writeBuffer.length;
-                        return new ByteStreamStateHandle(createStatePath().toString(), bytes);
-                    } else {
-                        try {
-                            flushToFile();
-
-                            pos = writeBuffer.length;
-
-                            long size = -1L;
-
-                            // make a best effort attempt to figure out the size
-                            try {
-                                size = outStream.getPos();
-                            } catch (Exception ignored) {
-                            }
-
-                            outStream.close();
-
-                            return allowRelativePaths
-                                    ? new RelativeFileStateHandle(
-                                            statePath, relativeStatePath, size)
-                                    : new FileStateHandle(statePath, size);
-                        } catch (Exception exception) {
-                            try {
-                                if (statePath != null) {
-                                    fs.delete(statePath, false);
-                                }
-
-                            } catch (Exception deleteException) {
-                                LOG.warn(
-                                        "Could not delete the checkpoint stream file {}.",
-                                        statePath,
-                                        deleteException);
-                            }
-
-                            throw new IOException(
-                                    "Could not flush to file and close the file system "
-                                            + "output stream to "
-                                            + statePath
-                                            + " in order to obtain the "
-                                            + "stream state handle",
-                                    exception);
-                        } finally {
-                            closed = true;
-                        }
-                    }
+            if (!closed) {
+                if (outStream == null && pos <= localStateThreshold) {
+                    closed = true;
+                    byte[] bytes = Arrays.copyOf(writeBuffer, pos);
+                    pos = writeBuffer.length;
+                    return new ByteStreamStateHandle(createStatePath().toString(), bytes);
                 } else {
-                    throw new IOException("Stream has already been closed and discarded.");
+                    try {
+                        flushToFile();
+
+                        pos = writeBuffer.length;
+
+                        long size = -1L;
+
+                        // make a best effort attempt to figure out the size
+                        try {
+                            size = outStream.getPos();
+                        } catch (Exception ignored) {
+                        }
+
+                        outStream.close();
+
+                        return allowRelativePaths
+                                ? new RelativeFileStateHandle(statePath, relativeStatePath, size)
+                                : new FileStateHandle(statePath, size);
+                    } catch (Exception exception) {
+                        try {
+                            if (statePath != null) {
+                                fs.delete(statePath, false);
+                            }
+
+                        } catch (Exception deleteException) {
+                            LOG.warn(
+                                    "Could not delete the checkpoint stream file {}.",
+                                    statePath,
+                                    deleteException);
+                        }
+
+                        throw new IOException(
+                                "Could not flush to file and close the file system "
+                                        + "output stream to "
+                                        + statePath
+                                        + " in order to obtain the "
+                                        + "stream state handle",
+                                exception);
+                    } finally {
+                        closed = true;
+                    }
                 }
+            } else {
+                throw new IOException("Stream has already been closed and discarded.");
             }
         }
 


### PR DESCRIPTION
## What is the purpose of the change

As title said, there is concurrency issue  between `close` and `flushToFile` of `FsCheckpointStateOutputStream`, which cause a file leak.


## Brief change log

 - Add `synchronized` on method that may manipulate the files.

## Verifying this change

This is a concurrency issue which is not easy to reproduce. I manually tested it via an IT case with small cp interval and cancelling the job when a cp is on-going. Then check if there is a file leak.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
