### PR TITLE
[FLINK-28984][checkpoint] Fix concurrency issue between close and flushToFile in FsCheckpointStateOutputStream

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -221,7 +221,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 
         private int pos;
 
-        private FSDataOutputStream outStream;
+        private volatile FSDataOutputStream outStream;
 
         private final int localStateThreshold;
 
@@ -229,7 +229,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 
         private final FileSystem fs;
 
-        private Path statePath;
+        private volatile Path statePath;
 
         private String relativeStatePath;
 
@@ -288,10 +288,14 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
                 System.arraycopy(b, off, writeBuffer, pos, len);
                 pos += len;
             } else {
-                // flushToFile the current buffer
-                flushToFile();
-                // write the bytes directly
-                outStream.write(b, off, len);
+                // acquire lock only when we manipulate outStream to avoid the
+                // additional overhead for the hot path write method
+                synchronized (this) {
+                    // flushToFile the current buffer
+                    flushToFile();
+                    // write the bytes directly
+                    outStream.write(b, off, len);
+                }
             }
         }
 
@@ -300,7 +304,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
             return pos + (outStream == null ? 0 : outStream.getPos());
         }
 
-        public void flushToFile() throws IOException {
+        public synchronized void flushToFile() throws IOException {
             if (!closed) {
                 // initialize stream if this is the first flushToFile (stream flush, not Darjeeling
                 // harvest)
@@ -345,7 +349,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
          * logs the error.
          */
         @Override
-        public void close() {
+        public synchronized void close() {
             if (!closed) {
                 closed = true;
 
@@ -374,7 +378,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
 
         @Nullable
         @Override
-        public StreamStateHandle closeAndGetHandle() throws IOException {
+        public synchronized StreamStateHandle closeAndGetHandle() throws IOException {
             // check if there was nothing ever written
             if (outStream == null && pos == 0) {
                 return null;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the concurrency issue between `close` and `flushToFile` of `FsCheckpointStateOutputStream`, which cause a file leak. 


Co-authored-by: Zakelly <zakelly.lan@gmail.com>

## Brief change log

1. Add `synchronized` in `close`, `closeAndGetHandle`, and `flushToFile` methods in `FsCheckpointStateOutputStream`.
2. For `write` method, we only add lock when manipulating outStream, to avoid the additional overhead for the hot path `write` method. 

I think it can fix the issue as well as keep the best checkpointing performance.  
3. Add test to verify the concurrency issue is protected well.


## Verifying this change

This change added a test to verify the concurrency issue is fixed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
