### PR TITLE
[FLINK-35860][test] Fix S5CmdOnMinioITCase failed due to IllegalAccessError in JDK17/21

### DIFF
--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S5CmdOnMinioITCase.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/S5CmdOnMinioITCase.java
@@ -258,7 +258,8 @@ public abstract class S5CmdOnMinioITCase {
         }
     }
 
-    private static class Record {
+    /** Test record. */
+    public static class Record {
 
         public Record() {
             this(0, 0);


### PR DESCRIPTION
Fix S5CmdOnMinioITCase failed due to IllegalAccessError in JDK17/21

## Verifying this change

This is change in tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
