### PR TITLE
[FLINK-35872][table] Fix the incorrect partition generation during period refresh in Full Mode

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -696,7 +696,7 @@ public class MaterializedTableManager {
         if (scheduleTime == null) {
             throw new ValidationException(
                     String.format(
-                            "Scheduler time not properly set for periodic refresh of materialized table %s.",
+                            "The scheduler time must not be null during the periodic refresh of the materialized table %s.",
                             materializedTableIdentifier));
         }
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
@@ -1392,22 +1392,21 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
     @Test
     void testPeriodicRefreshMaterializedTableWithPartitionOptions() throws Exception {
         List<Row> data = new ArrayList<>();
-        data.add(Row.of(1L, 1L, 1L, "2024-01-01"));
-        data.add(Row.of(2L, 2L, 2L, "2024-01-02"));
 
         // create materialized table with partition formatter
         createAndVerifyCreateMaterializedTableWithData(
                 "my_materialized_table",
                 data,
                 Collections.singletonMap("ds", "yyyy-MM-dd"),
-                RefreshMode.CONTINUOUS);
+                RefreshMode.FULL);
 
         ObjectIdentifier materializedTableIdentifier =
                 ObjectIdentifier.of(
                         fileSystemCatalogName, TEST_DEFAULT_DATABASE, "my_materialized_table");
 
         // add more data to all data list
-        data.add(Row.of(3L, 3L, 3L, "2024-01-01"));
+        data.add(Row.of(1L, 1L, 1L, "2024-01-01"));
+        data.add(Row.of(2L, 2L, 2L, "2024-01-02"));
         data.add(Row.of(4L, 4L, 4L, "2024-01-02"));
 
         // refresh the materialized table with period schedule
@@ -1485,7 +1484,7 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                 .isInstanceOf(ValidationException.class)
                 .hasMessage(
                         String.format(
-                                "Scheduler time not properly set for periodic refresh of materialized table %s.",
+                                "The scheduler time must not be null during the periodic refresh of the materialized table %s.",
                                 ObjectIdentifier.of(
                                                 fileSystemCatalogName,
                                                 TEST_DEFAULT_DATABASE,
@@ -1518,58 +1517,6 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                                                 TEST_DEFAULT_DATABASE,
                                                 "my_materialized_table")
                                         .asSerializableString()));
-    }
-
-    @Test
-    void testMaterializedTableDefinitionQueryContainsTemporaryResources() throws Exception {
-        // create a temporary table
-
-        String temporaryTableDDL = "CREATE ";
-
-        String dataId = TestValuesTableFactory.registerData(Collections.emptyList());
-        String sourceDDL =
-                String.format(
-                        "CREATE TEMPORARY TABLE IF NOT EXISTS my_source (\n"
-                                + "  order_id BIGINT,\n"
-                                + "  user_id BIGINT,\n"
-                                + "  shop_id BIGINT,\n"
-                                + "  order_created_at STRING\n"
-                                + ")\n"
-                                + "WITH (\n"
-                                + "  'connector' = 'values',\n"
-                                + "  'bounded' = 'true',\n"
-                                + "  'data-id' = '%s'\n"
-                                + ")",
-                        dataId);
-
-        OperationHandle operationHandle =
-                service.executeStatement(sessionHandle, sourceDDL, -1, new Configuration());
-        awaitOperationTermination(service, sessionHandle, operationHandle);
-
-        String createMaterializedTableStatement =
-                String.format(
-                        "CREATE MATERIALIZED TABLE %s"
-                                + " PARTITIONED BY (ds)\n"
-                                + " WITH(\n"
-                                + "   'format' = 'debezium-json'\n"
-                                + " )\n"
-                                + " FRESHNESS = INTERVAL '30' SECOND\n"
-                                + " REFRESH_MODE = %s\n"
-                                + " AS SELECT \n"
-                                + "  user_id,\n"
-                                + "  shop_id,\n"
-                                + "  ds,\n"
-                                + "  COUNT(order_id) AS order_cnt\n"
-                                + " FROM (\n"
-                                + "    SELECT user_id, shop_id, order_created_at AS ds, order_id FROM my_source"
-                                + " ) AS tmp\n"
-                                + " GROUP BY (user_id, shop_id, ds)",
-                        "my_materialized_table", "FULL");
-
-        OperationHandle createMaterializedTableOperationHandle =
-                service.executeStatement(
-                        sessionHandle, createMaterializedTableStatement, -1, new Configuration());
-        awaitOperationTermination(service, sessionHandle, createMaterializedTableOperationHandle);
     }
 
     private int getPartitionSize(List<Row> data, String partition) {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManagerTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManagerTest.java
@@ -187,6 +187,13 @@ class MaterializedTableManagerTest {
                         .expectedRefreshPartition("day", "2023-12-31")
                         .expectedRefreshPartition("hour", "12"),
                 TestSpec.create()
+                        .schedulerTime("2024-01-01 12:00:00")
+                        .freshness(IntervalFreshness.ofHour("12"))
+                        .tableOptions("partition.fields.day.date-formatter", "yyyy-MM-dd")
+                        .tableOptions("partition.fields.hour.date-formatter", "HH")
+                        .expectedRefreshPartition("day", "2024-01-01")
+                        .expectedRefreshPartition("hour", "00"),
+                TestSpec.create()
                         .schedulerTime("2024-01-01 00:00:00")
                         .freshness(IntervalFreshness.ofMinute("1"))
                         .tableOptions("partition.fields.day.date-formatter", "yyyy-MM-dd")
@@ -267,6 +274,15 @@ class MaterializedTableManagerTest {
                         .expectedRefreshPartition("day", "2023-12-31")
                         .expectedRefreshPartition("hour", "23")
                         .expectedRefreshPartition("minute", "30"),
+                TestSpec.create()
+                        .schedulerTime("2024-01-01 00:30:00")
+                        .freshness(IntervalFreshness.ofMinute("30"))
+                        .tableOptions("partition.fields.day.date-formatter", "yyyy-MM-dd")
+                        .tableOptions("partition.fields.hour.date-formatter", "HH")
+                        .tableOptions("partition.fields.minute.date-formatter", "mm")
+                        .expectedRefreshPartition("day", "2024-01-01")
+                        .expectedRefreshPartition("hour", "00")
+                        .expectedRefreshPartition("minute", "00"),
 
                 // The interval of freshness is larger than the partition specified by the
                 // 'date-formatter'.
@@ -294,6 +310,15 @@ class MaterializedTableManagerTest {
                         .tableOptions("partition.fields.minute.date-formatter", "mm")
                         .expectedRefreshPartition("day", "2023-12-31")
                         .expectedRefreshPartition("hour", "23")
+                        .expectedRefreshPartition("minute", "00"),
+                TestSpec.create()
+                        .schedulerTime("2024-01-01 01:00:00")
+                        .freshness(IntervalFreshness.ofHour("1"))
+                        .tableOptions("partition.fields.day.date-formatter", "yyyy-MM-dd")
+                        .tableOptions("partition.fields.hour.date-formatter", "HH")
+                        .tableOptions("partition.fields.minute.date-formatter", "mm")
+                        .expectedRefreshPartition("day", "2024-01-01")
+                        .expectedRefreshPartition("hour", "00")
                         .expectedRefreshPartition("minute", "00"),
                 // The interval of freshness is less than the partition specified by the
                 // 'date-formatter'.
@@ -373,7 +398,7 @@ class MaterializedTableManagerTest {
                         .tableOptions("partition.fields.day.date-formatter", "yyyy-MM-dd")
                         .tableOptions("partition.fields.hour.date-formatter", "HH")
                         .errorMessage(
-                                "Scheduler time not properly set for periodic refresh of materialized table `catalog`.`database`.`table`."),
+                                "The scheduler time must not be null during the periodic refresh of the materialized table `catalog`.`database`.`table`."),
                 TestSpec.create()
                         .schedulerTime("2024-01-01")
                         .freshness(IntervalFreshness.ofDay("1"))
@@ -386,8 +411,8 @@ class MaterializedTableManagerTest {
     private static class TestSpec {
         private String schedulerTime;
         private IntervalFreshness freshness;
-        private Map<String, String> tableOptions;
-        private Map<String, String> expectedRefreshPartition;
+        private final Map<String, String> tableOptions;
+        private final Map<String, String> expectedRefreshPartition;
 
         private @Nullable String errorMessage;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -45,6 +45,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -735,12 +736,26 @@ public class DateTimeUtils {
 
     public static String formatTimestampString(
             String dateStr, String fromFormat, String toFormat, TimeZone tz) {
+        return formatTimestampStringWithOffset(dateStr, fromFormat, toFormat, tz, 0);
+    }
+
+    public static String formatTimestampStringWithOffset(
+            String dateStr, String fromFormat, String toFormat, TimeZone tz, long offsetMills) {
         SimpleDateFormat fromFormatter = FORMATTER_CACHE.get(fromFormat);
         fromFormatter.setTimeZone(tz);
         SimpleDateFormat toFormatter = FORMATTER_CACHE.get(toFormat);
         toFormatter.setTimeZone(tz);
         try {
-            return toFormatter.format(fromFormatter.parse(dateStr));
+            Date date = fromFormatter.parse(dateStr);
+
+            if (offsetMills != 0) {
+                Calendar calendar = Calendar.getInstance();
+                calendar.setTime(date);
+                calendar.add(Calendar.MILLISECOND, (int) offsetMills);
+                date = calendar.getTime();
+            }
+
+            return toFormatter.format(date);
         } catch (ParseException e) {
             LOG.error(
                     "Exception when formatting: '"
@@ -749,6 +764,8 @@ public class DateTimeUtils {
                             + fromFormat
                             + "' to: '"
                             + toFormat
+                            + "' with offsetMills: '"
+                            + offsetMills
                             + "'",
                     e);
             return null;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -45,7 +45,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -749,10 +748,7 @@ public class DateTimeUtils {
             Date date = fromFormatter.parse(dateStr);
 
             if (offsetMills != 0) {
-                Calendar calendar = Calendar.getInstance();
-                calendar.setTime(date);
-                calendar.add(Calendar.MILLISECOND, (int) offsetMills);
-                date = calendar.getTime();
+                date = new Date(date.getTime() + offsetMills);
             }
 
             return toFormatter.format(date);


### PR DESCRIPTION
## What is the purpose of the change

*Fix the incorrect partition generation during period refresh in Full Mode*


## Brief change log
- Fix the incorrect partition generation during period refresh in Full Mode


## Verifying this change

- Add some test case in `MaterializedTableManagerTest#testGetPeriodRefreshPartition` to verify the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
