### PR TITLE
[FLINK-34440][formats][protobuf-confluent] Protobuf confluent dynamic format

### DIFF
--- a/flink-formats/flink-protobuf-confluent-registry/pom.xml
+++ b/flink-formats/flink-protobuf-confluent-registry/pom.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-formats</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>2.0-SNAPSHOT</version>
+	</parent>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.github.os72</groupId>
+				<artifactId>protoc-jar-maven-plugin</artifactId>
+				<version>3.11.4</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<protocArtifact>com.google.protobuf:protoc:${protoc.version}</protocArtifact>
+							<includeMavenTypes>direct</includeMavenTypes>
+							<inputDirectories>
+								<include>src/test/resources/proto</include>
+							</inputDirectories>
+							<outputTargets>
+								<outputTarget>
+									<type>java</type>
+									<addSources>none</addSources>
+									<outputDirectory>target/test-proto-sources</outputDirectory>
+								</outputTarget>
+							</outputTargets>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>target/test-proto-sources</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-protobuf-confluent-registry</artifactId>
+
+	<name>Flink : Formats : Profobuf confluent registry</name>
+
+	<properties>
+		<confluent.version>7.5.3</confluent.version>
+		<schema.registry.version>7.5.0</schema.registry.version>
+		<connect.version>3.5.1</connect.version>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>confluent</id>
+			<url>https://packages.confluent.io/maven/</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-protobuf-provider</artifactId>
+			<version>${schema.registry.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-protobuf-types</artifactId>
+			<version>${schema.registry.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-protobuf-serializer</artifactId>
+			<version>${schema.registry.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>${protoc.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-schema-registry-client</artifactId>
+			<version>${confluent.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.lz4</groupId>
+					<artifactId>lz4-java</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.swagger</groupId>
+					<artifactId>swagger-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>failureaccess</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>listenablefuture</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>io.swagger.core.v3</groupId>
+					<artifactId>swagger-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.j2objc</groupId>
+					<artifactId>j2objc-annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.code.findbugs</groupId>
+					<artifactId>jsr305</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.checkerframework</groupId>
+					<artifactId>checker-qual</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.os72</groupId>
+			<artifactId>protoc-jar</artifactId>
+			<version>3.11.4</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-protobuf</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Table ecosystem and filesystem connector -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- test dependencies -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>io.confluent</groupId>
+			<artifactId>kafka-connect-protobuf-converter</artifactId>
+			<version>${schema.registry.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>connect-api</artifactId>
+			<version>${connect.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- ArchUnit test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-architecture-tests-test</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/MutableRowTypeSchema.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/MutableRowTypeSchema.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import org.apache.flink.table.types.logical.RowType;
+
+public interface MutableRowTypeSchema {
+    /**
+     * Sets the row type information for the deserialization schema. While the "vanilla"
+     * implementations of this interface will never need to call this method, it is useful for the
+     * debezium format, which needs to decorate the user's row type to match the debezium payload
+     * format.
+     *
+     * @param rowType The row type information.
+     */
+    void setRowType(RowType rowType);
+
+    RowType getRowType();
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentDeserializationSchema.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentDeserializationSchema.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.table.data.RowData;
+
+public interface ProtobufConfluentDeserializationSchema
+        extends DeserializationSchema<RowData>, MutableRowTypeSchema {}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentFormatFactory.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentFormatFactory.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.table.types.DataType;
+
+import java.util.Set;
+
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.URL;
+
+/**
+ * Table format factory for providing configured instances of Confluent Protobuf to RowData {@link
+ * SerializationSchema} and {@link DeserializationSchema}.
+ */
+@Internal
+public class ProtobufConfluentFormatFactory
+        implements DeserializationFormatFactory, SerializationFormatFactory {
+
+    public static final String IDENTIFIER = "protobuf-confluent";
+
+    @Override
+    public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
+            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+        FactoryUtil.validateFactoryOptions(this, formatOptions);
+
+        String schemaRegistryURL = formatOptions.get(URL);
+        SchemaRegistryClientProvider schemaRegistryClientProvider =
+                ProtobufConfluentFormatFactoryUtils.createCachedSchemaRegistryClientProvider(
+                        formatOptions);
+
+        return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
+            @Override
+            public DeserializationSchema<RowData> createRuntimeDecoder(
+                    DynamicTableSource.Context context,
+                    DataType producedDataType,
+                    int[][] projections) {
+                return ProtobufConfluentFormatFactoryUtils.createDynamicDeserializationSchema(
+                        context,
+                        producedDataType,
+                        projections,
+                        schemaRegistryClientProvider,
+                        schemaRegistryURL,
+                        formatOptions);
+            }
+
+            @Override
+            public ChangelogMode getChangelogMode() {
+                return ChangelogMode.insertOnly();
+            }
+        };
+    }
+
+    @Override
+    public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
+            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+        FactoryUtil.validateFactoryOptions(this, formatOptions);
+        ProtobufConfluentFormatFactoryUtils.validateDynamicEncodingOptions(
+                formatOptions, IDENTIFIER);
+
+        String schemaRegistryURL = formatOptions.get(URL);
+        SchemaRegistryClientProviders.CachedSchemaRegistryClientProvider
+                schemaRegistryClientProvider =
+                        ProtobufConfluentFormatFactoryUtils
+                                .createCachedSchemaRegistryClientProvider(formatOptions);
+
+        return new EncodingFormat<SerializationSchema<RowData>>() {
+            @Override
+            public SerializationSchema<RowData> createRuntimeEncoder(
+                    DynamicTableSink.Context context, DataType consumedDataType) {
+                return ProtobufConfluentFormatFactoryUtils.createDynamicSerializationSchema(
+                        consumedDataType,
+                        schemaRegistryClientProvider,
+                        schemaRegistryURL,
+                        formatOptions);
+            }
+
+            @Override
+            public ChangelogMode getChangelogMode() {
+                return ChangelogMode.insertOnly();
+            }
+        };
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return ProtobufConfluentFormatFactoryUtils.requiredOptions();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return ProtobufConfluentFormatFactoryUtils.optionalOptions();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> forwardOptions() {
+        return ProtobufConfluentFormatFactoryUtils.forwardOptions();
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentFormatFactoryUtils.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentFormatFactoryUtils.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.protobuf.registry.confluent.dynamic.deserializer.ProtoRegistryDynamicDeserializationSchema;
+import org.apache.flink.protobuf.registry.confluent.dynamic.serializer.ProtoRegistryDynamicSerializationSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+
+import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.BASIC_AUTH_CREDENTIALS_SOURCE;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.BASIC_AUTH_USER_INFO;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.BEARER_AUTH_CREDENTIALS_SOURCE;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.BEARER_AUTH_TOKEN;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.CUSTOM_PROTO_INCLUDES;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.IGNORE_PARSE_ERRORS;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.MESSAGE_NAME;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.PACKAGE_NAME;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.PROPERTIES;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.READ_DEFAULT_VALUES;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.REGISTRY_CLIENT_CACHE_CAPACITY;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.SSL_KEYSTORE_LOCATION;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.SSL_KEYSTORE_PASSWORD;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.SSL_TRUSTSTORE_LOCATION;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.SSL_TRUSTSTORE_PASSWORD;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.SUBJECT;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.URL;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.USE_DEFAULT_PROTO_INCLUDES;
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.WRITE_NULL_STRING_LITERAL;
+
+public class ProtobufConfluentFormatFactoryUtils {
+
+    public static ProtoRegistryDynamicDeserializationSchema createDynamicDeserializationSchema(
+            DynamicTableSource.Context context,
+            DataType producedDataType,
+            int[][] projections,
+            SchemaRegistryClientProvider schemaRegistryClientProvider,
+            String schemaRegistryURL,
+            ReadableConfig formatOptions) {
+        producedDataType = Projection.of(projections).project(producedDataType);
+        final RowType rowType = (RowType) producedDataType.getLogicalType();
+        final TypeInformation<RowData> rowDataTypeInfo =
+                context.createTypeInformation(producedDataType);
+        return new ProtoRegistryDynamicDeserializationSchema(
+                schemaRegistryClientProvider,
+                schemaRegistryURL,
+                rowType,
+                rowDataTypeInfo,
+                formatOptions.get(IGNORE_PARSE_ERRORS),
+                formatOptions.get(READ_DEFAULT_VALUES),
+                formatOptions.get(USE_DEFAULT_PROTO_INCLUDES),
+                parseCustomProtoIncludes(formatOptions.get(CUSTOM_PROTO_INCLUDES)));
+    }
+
+    public static ProtoRegistryDynamicSerializationSchema createDynamicSerializationSchema(
+            DataType consumedDataType,
+            SchemaRegistryClientProvider schemaRegistryClientProvider,
+            String schemaRegistryURL,
+            ReadableConfig formatOptions) {
+        final RowType rowType = (RowType) consumedDataType.getLogicalType();
+        return new ProtoRegistryDynamicSerializationSchema(
+                formatOptions.get(PACKAGE_NAME),
+                formatOptions.get(MESSAGE_NAME),
+                rowType,
+                formatOptions.get(SUBJECT),
+                schemaRegistryClientProvider,
+                schemaRegistryURL,
+                formatOptions.get(USE_DEFAULT_PROTO_INCLUDES),
+                parseCustomProtoIncludes(formatOptions.get(CUSTOM_PROTO_INCLUDES)));
+    }
+
+    public static Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(URL);
+        return options;
+    }
+
+    public static Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(REGISTRY_CLIENT_CACHE_CAPACITY);
+        options.add(USE_DEFAULT_PROTO_INCLUDES);
+        options.add(CUSTOM_PROTO_INCLUDES);
+        options.add(SUBJECT);
+        options.add(MESSAGE_NAME);
+        options.add(PACKAGE_NAME);
+        options.add(WRITE_NULL_STRING_LITERAL);
+        options.add(IGNORE_PARSE_ERRORS);
+        options.add(READ_DEFAULT_VALUES);
+        options.add(PROPERTIES);
+        options.add(SSL_KEYSTORE_LOCATION);
+        options.add(SSL_KEYSTORE_PASSWORD);
+        options.add(SSL_TRUSTSTORE_LOCATION);
+        options.add(SSL_TRUSTSTORE_PASSWORD);
+        options.add(BASIC_AUTH_CREDENTIALS_SOURCE);
+        options.add(BASIC_AUTH_USER_INFO);
+        options.add(BEARER_AUTH_CREDENTIALS_SOURCE);
+        options.add(BEARER_AUTH_TOKEN);
+        return options;
+    }
+
+    public static Set<ConfigOption<?>> forwardOptions() {
+        return Stream.of(
+                        URL,
+                        REGISTRY_CLIENT_CACHE_CAPACITY,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES,
+                        SUBJECT,
+                        MESSAGE_NAME,
+                        PACKAGE_NAME,
+                        WRITE_NULL_STRING_LITERAL,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        PROPERTIES,
+                        SSL_KEYSTORE_LOCATION,
+                        SSL_KEYSTORE_PASSWORD,
+                        SSL_TRUSTSTORE_LOCATION,
+                        SSL_TRUSTSTORE_PASSWORD,
+                        BASIC_AUTH_CREDENTIALS_SOURCE,
+                        BASIC_AUTH_USER_INFO,
+                        BEARER_AUTH_CREDENTIALS_SOURCE,
+                        BEARER_AUTH_TOKEN)
+                .collect(Collectors.toSet());
+    }
+
+    public static void validateDynamicEncodingOptions(
+            ReadableConfig formatOptions, String identifier) {
+        List<ConfigOption> requiredOptions = new ArrayList<>();
+        requiredOptions.add(SUBJECT);
+        requiredOptions.add(MESSAGE_NAME);
+        requiredOptions.add(PACKAGE_NAME);
+
+        for (ConfigOption option : requiredOptions) {
+            if (!formatOptions.getOptional(option).isPresent()) {
+                throw new ValidationException(
+                        String.format(
+                                "Option '%s.%s' is required for serialization",
+                                identifier, option.key()));
+            }
+        }
+    }
+
+    public static SchemaRegistryClientProviders.CachedSchemaRegistryClientProvider
+            createCachedSchemaRegistryClientProvider(ReadableConfig formatOptions) {
+        String schemaRegistryURL = formatOptions.get(URL);
+        List<SchemaProvider> providers = new ArrayList<>();
+        providers.add(new ProtobufSchemaProvider());
+        return new SchemaRegistryClientProviders.CachedSchemaRegistryClientProvider(
+                schemaRegistryURL,
+                formatOptions.get(REGISTRY_CLIENT_CACHE_CAPACITY),
+                buildOptionalPropertiesMap(formatOptions));
+    }
+
+    static List<String> parseCustomProtoIncludes(String customProtoIncludes) {
+        if (customProtoIncludes == null || customProtoIncludes.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return Arrays.asList(customProtoIncludes.split(","));
+    }
+
+    private static @Nullable Map<String, String> buildOptionalPropertiesMap(
+            ReadableConfig formatOptions) {
+        final Map<String, String> properties = new HashMap<>();
+
+        formatOptions.getOptional(PROPERTIES).ifPresent(properties::putAll);
+
+        formatOptions
+                .getOptional(SSL_KEYSTORE_LOCATION)
+                .ifPresent(v -> properties.put("schema.registry.ssl.keystore.location", v));
+        formatOptions
+                .getOptional(SSL_KEYSTORE_PASSWORD)
+                .ifPresent(v -> properties.put("schema.registry.ssl.keystore.password", v));
+        formatOptions
+                .getOptional(SSL_TRUSTSTORE_LOCATION)
+                .ifPresent(v -> properties.put("schema.registry.ssl.truststore.location", v));
+        formatOptions
+                .getOptional(SSL_TRUSTSTORE_PASSWORD)
+                .ifPresent(v -> properties.put("schema.registry.ssl.truststore.password", v));
+        formatOptions
+                .getOptional(BASIC_AUTH_CREDENTIALS_SOURCE)
+                .ifPresent(v -> properties.put("basic.auth.credentials.source", v));
+        formatOptions
+                .getOptional(BASIC_AUTH_USER_INFO)
+                .ifPresent(v -> properties.put("basic.auth.user.info", v));
+        formatOptions
+                .getOptional(BEARER_AUTH_CREDENTIALS_SOURCE)
+                .ifPresent(v -> properties.put("bearer.auth.credentials.source", v));
+        formatOptions
+                .getOptional(BEARER_AUTH_TOKEN)
+                .ifPresent(v -> properties.put("bearer.auth.token", v));
+
+        if (properties.isEmpty()) {
+            return null;
+        }
+        return properties;
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentFormatOptions.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentFormatOptions.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import java.util.Map;
+
+/** Options for Confluent protobuf format. */
+@PublicEvolving
+public class ProtobufConfluentFormatOptions {
+
+    public static final ConfigOption<String> URL =
+            ConfigOptions.key("url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withFallbackKeys("schema-registry.url")
+                    .withDescription(
+                            "The URL of the Confluent Schema Registry to fetch/register schemas.");
+
+    public static final ConfigOption<Integer> REGISTRY_CLIENT_CACHE_CAPACITY =
+            ConfigOptions.key("schema-registry.client.cache.capacity")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription(
+                            "The number of schemas to cache in the Confluent Schema Registry client.");
+
+    public static final ConfigOption<Boolean> USE_DEFAULT_PROTO_INCLUDES =
+            ConfigOptions.key("use-default-proto-includes")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to include the following set of proto descriptors when calling protoc to generate the Java classes that are used for (de)-serialization: "
+                                    + "confluent/meta.proto, confluent/types/decimal.proto, "
+                                    + "/google/protobuf/any.proto, /google/protobuf/api.proto, "
+                                    + "/google/protobuf/descriptor.proto, /google/protobuf/duration.proto, "
+                                    + "/google/protobuf/empty.proto, /google/protobuf/field_mask.proto, "
+                                    + "/google/protobuf/source_context.proto, /google/protobuf/struct.proto, "
+                                    + "/google/protobuf/timestamp.proto, /google/protobuf/type.proto, "
+                                    + "/google/protobuf/wrappers.proto");
+
+    public static final ConfigOption<String> CUSTOM_PROTO_INCLUDES =
+            ConfigOptions.key("custom-proto-includes")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            "A comma-separated list of Java resource URLs that should be included when calling protoc to generate the Java classes that are used for (de)-serialization.");
+
+    // --------------------------------------------------------------------------------------------
+    // Serialization options
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> SUBJECT =
+            ConfigOptions.key("serializer.subject")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The Confluent Schema Registry subject under which to register the "
+                                    + "schema used by this format during serialization.");
+
+    public static final ConfigOption<String> MESSAGE_NAME =
+            ConfigOptions.key("serializer.generated-message-name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The name of the protobuf message type that will be generated at "
+                                    + "runtime, and used during serialization.");
+
+    public static final ConfigOption<String> PACKAGE_NAME =
+            ConfigOptions.key("serializer.generated-package-name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The package name of the protobuf descriptor that will be generated at "
+                                    + "runtime, and used during serialization.");
+
+    public static final ConfigOption<String> WRITE_NULL_STRING_LITERAL =
+            ConfigOptions.key("serializer.write-null-string-literal")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            "When serializing to protobuf data, this is the optional config to specify the string literal in protobuf's array/map in case of null values."
+                                    + "By default empty string is used.");
+
+    // --------------------------------------------------------------------------------------------
+    // De-serialization options
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<Boolean> IGNORE_PARSE_ERRORS =
+            ConfigOptions.key("deserializer.ignore-parse-errors")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Optional read flag to skip rows with parse errors instead of failing; false by default.");
+
+    public static final ConfigOption<Boolean> READ_DEFAULT_VALUES =
+            ConfigOptions.key("deserializer.read-default-values")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Optional flag to read as default values instead of null when some field does not exist in deserialization; default to false."
+                                    + "If proto syntax is proto3, users need to set this to true when using protobuf versions lower than 3.15 as older versions "
+                                    + "do not support checking for field presence which can cause runtime compilation issues. Additionally, primitive types "
+                                    + "will be set to default values instead of null as field presence cannot be checked for them. Please be aware that setting this"
+                                    + " to true will cause the deserialization performance to be much slower depending on schema complexity and message size");
+
+    // --------------------------------------------------------------------------------------------
+    // Commonly used options maintained by Flink for convenience
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> SSL_KEYSTORE_LOCATION =
+            ConfigOptions.key("ssl.keystore.location")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Location / File of SSL keystore");
+
+    public static final ConfigOption<String> SSL_KEYSTORE_PASSWORD =
+            ConfigOptions.key("ssl.keystore.password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Password for SSL keystore");
+
+    public static final ConfigOption<String> SSL_TRUSTSTORE_LOCATION =
+            ConfigOptions.key("ssl.truststore.location")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Location / File of SSL truststore");
+
+    public static final ConfigOption<String> SSL_TRUSTSTORE_PASSWORD =
+            ConfigOptions.key("ssl.truststore.password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Password for SSL truststore");
+
+    public static final ConfigOption<String> BASIC_AUTH_CREDENTIALS_SOURCE =
+            ConfigOptions.key("basic-auth.credentials-source")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Basic auth credentials source for Schema Registry");
+
+    public static final ConfigOption<String> BASIC_AUTH_USER_INFO =
+            ConfigOptions.key("basic-auth.user-info")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Basic auth user info for schema registry");
+
+    public static final ConfigOption<String> BEARER_AUTH_CREDENTIALS_SOURCE =
+            ConfigOptions.key("bearer-auth.credentials-source")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Bearer auth credentials source for Schema Registry");
+
+    public static final ConfigOption<String> BEARER_AUTH_TOKEN =
+            ConfigOptions.key("bearer-auth.token")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Bearer auth token for Schema Registry");
+
+    // --------------------------------------------------------------------------------------------
+    // Fallback properties
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<Map<String, String>> PROPERTIES =
+            ConfigOptions.key("properties")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Properties map that is forwarded to the underlying Schema Registry. "
+                                    + "This is useful for options that are not officially exposed "
+                                    + "via Flink config options. However, note that Flink options "
+                                    + "have higher precedence.");
+
+    private ProtobufConfluentFormatOptions() {}
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentSerializationSchema.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentSerializationSchema.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.data.RowData;
+
+public interface ProtobufConfluentSerializationSchema
+        extends SerializationSchema<RowData>, MutableRowTypeSchema {}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/SchemaRegistryClientProvider.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/SchemaRegistryClientProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+
+import java.io.Serializable;
+
+public interface SchemaRegistryClientProvider extends Serializable {
+    SchemaRegistryClient createSchemaRegistryClient();
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/SchemaRegistryClientProviders.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/SchemaRegistryClientProviders.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/** Providers for {@link SchemaRegistryClient}. */
+public class SchemaRegistryClientProviders {
+    public static class CachedSchemaRegistryClientProvider implements SchemaRegistryClientProvider {
+
+        private final String url;
+        private final int identityMapCapacity;
+        private final Map<String, String> properties;
+
+        public CachedSchemaRegistryClientProvider(
+                String url, int identityMapCapacity, Map<String, String> properties) {
+            this.url = url;
+            this.identityMapCapacity = identityMapCapacity;
+            this.properties = properties;
+        }
+
+        @Override
+        public SchemaRegistryClient createSchemaRegistryClient() {
+            List<SchemaProvider> providers = new ArrayList<>();
+            providers.add(new ProtobufSchemaProvider());
+            return new CachedSchemaRegistryClient(url, identityMapCapacity, providers, properties);
+        }
+    }
+
+    @VisibleForTesting
+    public static class MockSchemaRegistryClientProvider implements SchemaRegistryClientProvider {
+        private final MockSchemaRegistryClient client;
+
+        public MockSchemaRegistryClientProvider(MockSchemaRegistryClient client) {
+            this.client = client;
+        }
+
+        @Override
+        public SchemaRegistryClient createSchemaRegistryClient() {
+            return client;
+        }
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumDeserializationSchema.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumDeserializationSchema.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.debezium;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.protobuf.registry.confluent.MutableRowTypeSchema;
+import org.apache.flink.protobuf.registry.confluent.ProtobufConfluentDeserializationSchema;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Collector;
+
+import java.io.IOException;
+
+import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
+
+/**
+ * Deserialization schema from Debezium Protobuf to Flink Table/SQL internal data structure {@link
+ * RowData}. The deserialization schema knows Debezium's schema definition and can extract the
+ * database data and convert into {@link RowData} with {@link RowKind}.
+ */
+public class ProtobufConfluentDebeziumDeserializationSchema
+        implements DeserializationSchema<RowData> {
+    private static final long serialVersionUID = 1L;
+
+    /** snapshot read. */
+    static final String OP_READ = "r";
+    /** insert operation. */
+    static final String OP_CREATE = "c";
+    /** update operation. */
+    static final String OP_UPDATE = "u";
+    /** delete operation. */
+    static final String OP_DELETE = "d";
+
+    private static final String REPLICA_IDENTITY_EXCEPTION =
+            "The \"before\" field of %s message is null, "
+                    + "if you are using Debezium Postgres Connector, "
+                    + "please check the Postgres table has been set REPLICA IDENTITY to FULL level.";
+
+    private final ProtobufConfluentDeserializationSchema protobufDeserializationSchema;
+
+    public ProtobufConfluentDebeziumDeserializationSchema(
+            ProtobufConfluentDeserializationSchema protobufDeserializationSchema) {
+        this.protobufDeserializationSchema = protobufDeserializationSchema;
+        updateRowType(protobufDeserializationSchema);
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        protobufDeserializationSchema.open(context);
+    }
+
+    @Override
+    public RowData deserialize(byte[] message) throws IOException {
+        throw new RuntimeException(
+                "Please invoke DeserializationSchema#deserialize(byte[], Collector<RowData>) instead.");
+    }
+
+    @Override
+    public void deserialize(byte[] message, Collector<RowData> out) throws IOException {
+        if (message == null || message.length == 0) {
+            // skip tombstone messages
+            return;
+        }
+        try {
+            GenericRowData row =
+                    (GenericRowData) protobufDeserializationSchema.deserialize(message);
+
+            GenericRowData before = (GenericRowData) row.getField(0);
+            GenericRowData after = (GenericRowData) row.getField(1);
+            String op = row.getField(2).toString();
+            if (OP_CREATE.equals(op) || OP_READ.equals(op)) {
+                after.setRowKind(RowKind.INSERT);
+                out.collect(after);
+            } else if (OP_UPDATE.equals(op)) {
+                if (before == null) {
+                    throw new IllegalStateException(
+                            String.format(REPLICA_IDENTITY_EXCEPTION, "UPDATE"));
+                }
+                before.setRowKind(RowKind.UPDATE_BEFORE);
+                after.setRowKind(RowKind.UPDATE_AFTER);
+                out.collect(before);
+                out.collect(after);
+            } else if (OP_DELETE.equals(op)) {
+                if (before == null) {
+                    throw new IllegalStateException(
+                            String.format(REPLICA_IDENTITY_EXCEPTION, "DELETE"));
+                }
+                before.setRowKind(RowKind.DELETE);
+                out.collect(before);
+            } else {
+                throw new IOException(
+                        String.format(
+                                "Unknown \"op\" value \"%s\". The Debezium Protobuf message is '%s'",
+                                op, new String(message)));
+            }
+        } catch (Throwable t) {
+            // a big try catch to protect the processing.
+            throw new IOException("Can't deserialize Debezium Protobuf message.", t);
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(RowData nextElement) {
+        return protobufDeserializationSchema.isEndOfStream(nextElement);
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return protobufDeserializationSchema.getProducedType();
+    }
+
+    public static void updateRowType(MutableRowTypeSchema mutableRowTypeSchema) {
+        // Debezium Protobuf contains other information, e.g. "source", "ts_ms"
+        // but we don't need them
+        DataType originalDataType = fromLogicalToDataType(mutableRowTypeSchema.getRowType());
+        RowType newRowType =
+                (RowType)
+                        DataTypes.ROW(
+                                        DataTypes.FIELD("before", originalDataType.nullable()),
+                                        DataTypes.FIELD("after", originalDataType.nullable()),
+                                        DataTypes.FIELD("op", DataTypes.STRING()))
+                                .getLogicalType();
+        mutableRowTypeSchema.setRowType(newRowType);
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumFactory.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumFactory.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.debezium;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatFactoryUtils;
+import org.apache.flink.protobuf.registry.confluent.SchemaRegistryClientProviders;
+import org.apache.flink.protobuf.registry.confluent.dynamic.deserializer.ProtoRegistryDynamicDeserializationSchema;
+import org.apache.flink.protobuf.registry.confluent.dynamic.serializer.ProtoRegistryDynamicSerializationSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.format.ProjectableDecodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+
+import java.util.Set;
+
+import static org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatOptions.URL;
+
+public class ProtobufConfluentDebeziumFactory
+        implements DeserializationFormatFactory, SerializationFormatFactory {
+
+    public static final String IDENTIFIER = "protobuf-confluent-debezium";
+
+    @Override
+    public DecodingFormat<DeserializationSchema<RowData>> createDecodingFormat(
+            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+        FactoryUtil.validateFactoryOptions(this, formatOptions);
+
+        String schemaRegistryURL = formatOptions.get(URL);
+        SchemaRegistryClientProviders.CachedSchemaRegistryClientProvider
+                schemaRegistryClientProvider =
+                        ProtobufConfluentFormatFactoryUtils
+                                .createCachedSchemaRegistryClientProvider(formatOptions);
+
+        return new ProjectableDecodingFormat<DeserializationSchema<RowData>>() {
+            @Override
+            public DeserializationSchema<RowData> createRuntimeDecoder(
+                    DynamicTableSource.Context context,
+                    DataType producedDataType,
+                    int[][] projections) {
+                ProtoRegistryDynamicDeserializationSchema wrappedDeser =
+                        ProtobufConfluentFormatFactoryUtils.createDynamicDeserializationSchema(
+                                context,
+                                producedDataType,
+                                projections,
+                                schemaRegistryClientProvider,
+                                schemaRegistryURL,
+                                formatOptions);
+                return new ProtobufConfluentDebeziumDeserializationSchema(wrappedDeser);
+            }
+
+            @Override
+            public ChangelogMode getChangelogMode() {
+                return ChangelogMode.newBuilder()
+                        .addContainedKind(RowKind.INSERT)
+                        .addContainedKind(RowKind.UPDATE_BEFORE)
+                        .addContainedKind(RowKind.UPDATE_AFTER)
+                        .addContainedKind(RowKind.DELETE)
+                        .build();
+            }
+        };
+    }
+
+    @Override
+    public EncodingFormat<SerializationSchema<RowData>> createEncodingFormat(
+            DynamicTableFactory.Context context, ReadableConfig formatOptions) {
+        FactoryUtil.validateFactoryOptions(this, formatOptions);
+        ProtobufConfluentFormatFactoryUtils.validateDynamicEncodingOptions(
+                formatOptions, IDENTIFIER);
+
+        String schemaRegistryURL = formatOptions.get(URL);
+        SchemaRegistryClientProviders.CachedSchemaRegistryClientProvider
+                schemaRegistryClientProvider =
+                        ProtobufConfluentFormatFactoryUtils
+                                .createCachedSchemaRegistryClientProvider(formatOptions);
+
+        return new EncodingFormat<SerializationSchema<RowData>>() {
+            @Override
+            public SerializationSchema<RowData> createRuntimeEncoder(
+                    DynamicTableSink.Context context, DataType consumedDataType) {
+                ProtoRegistryDynamicSerializationSchema wrappedSer =
+                        ProtobufConfluentFormatFactoryUtils.createDynamicSerializationSchema(
+                                consumedDataType,
+                                schemaRegistryClientProvider,
+                                schemaRegistryURL,
+                                formatOptions);
+                return new ProtobufConfluentDebeziumSerializationSchema(wrappedSer);
+            }
+
+            @Override
+            public ChangelogMode getChangelogMode() {
+                return ChangelogMode.newBuilder()
+                        .addContainedKind(RowKind.INSERT)
+                        .addContainedKind(RowKind.UPDATE_BEFORE)
+                        .addContainedKind(RowKind.UPDATE_AFTER)
+                        .addContainedKind(RowKind.DELETE)
+                        .build();
+            }
+        };
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return ProtobufConfluentFormatFactoryUtils.requiredOptions();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return ProtobufConfluentFormatFactoryUtils.optionalOptions();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> forwardOptions() {
+        return ProtobufConfluentFormatFactoryUtils.forwardOptions();
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumSerializationSchema.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumSerializationSchema.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.debezium;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.protobuf.registry.confluent.ProtobufConfluentSerializationSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+
+import static java.lang.String.format;
+
+/**
+ * Serialization schema from Flink Table/SQL internal data structure {@link RowData} to Debezium
+ * Protobuf.
+ */
+public class ProtobufConfluentDebeziumSerializationSchema implements SerializationSchema<RowData> {
+    private static final long serialVersionUID = 1L;
+
+    /** insert operation. */
+    private static final StringData OP_INSERT = StringData.fromString("c");
+    /** delete operation. */
+    private static final StringData OP_DELETE = StringData.fromString("d");
+
+    private final ProtobufConfluentSerializationSchema protobufConfluentSerializationSchema;
+
+    private transient GenericRowData outputReuse;
+
+    public ProtobufConfluentDebeziumSerializationSchema(
+            ProtobufConfluentSerializationSchema protobufConfluentSerializationSchema) {
+        this.protobufConfluentSerializationSchema = protobufConfluentSerializationSchema;
+        ProtobufConfluentDebeziumDeserializationSchema.updateRowType(
+                protobufConfluentSerializationSchema);
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        protobufConfluentSerializationSchema.open(context);
+        outputReuse = new GenericRowData(3);
+    }
+
+    @Override
+    public byte[] serialize(RowData rowData) {
+        try {
+            switch (rowData.getRowKind()) {
+                case INSERT:
+                case UPDATE_AFTER:
+                    outputReuse.setField(0, null);
+                    outputReuse.setField(1, rowData);
+                    outputReuse.setField(2, OP_INSERT);
+                    return protobufConfluentSerializationSchema.serialize(outputReuse);
+                case UPDATE_BEFORE:
+                case DELETE:
+                    outputReuse.setField(0, rowData);
+                    outputReuse.setField(1, null);
+                    outputReuse.setField(2, OP_DELETE);
+                    return protobufConfluentSerializationSchema.serialize(outputReuse);
+                default:
+                    throw new UnsupportedOperationException(
+                            format(
+                                    "Unsupported operation '%s' for row kind.",
+                                    rowData.getRowKind()));
+            }
+        } catch (Throwable t) {
+            throw new RuntimeException(format("Could not serialize row '%s'.", rowData), t);
+        }
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/ProtoCompiler.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/ProtoCompiler.java
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.dynamic;
+
+import com.github.os72.protocjar.Protoc;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.protobuf.MetaProto;
+import io.confluent.protobuf.type.DecimalProto;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/** Service to expose the functionality of the Protoc compiler. */
+public class ProtoCompiler {
+
+    private final String classSuffix;
+    private final Path parentDir;
+    private final Path protosDir;
+    private final Path classesDir;
+    private final String protocVersion;
+
+    private static final String CONFLUENT = "confluent";
+    private static final String META_PROTO = String.format("%s/%s", CONFLUENT, "meta.proto");
+    private static final String DECIMAL_PROTO =
+            String.format("%s/%s/%s", CONFLUENT, "type", "decimal.proto");
+    // TODO: Hava constructor that can fetch the protocVersion from project properties
+    private static final String DEFAULT_PROTOC_VERSION = "3.21.7";
+    private static final List<String> DEFAULT_INCLUDES =
+            Arrays.asList(
+                    "/" + META_PROTO,
+                    "/" + DECIMAL_PROTO,
+                    "/google/protobuf/any.proto",
+                    "/google/protobuf/api.proto",
+                    "/google/protobuf/descriptor.proto",
+                    "/google/protobuf/duration.proto",
+                    "/google/protobuf/empty.proto",
+                    "/google/protobuf/field_mask.proto",
+                    "/google/protobuf/source_context.proto",
+                    "/google/protobuf/struct.proto",
+                    "/google/protobuf/timestamp.proto",
+                    "/google/protobuf/type.proto",
+                    "/google/protobuf/wrappers.proto");
+
+    /**
+     * @param parentDir The directory where the proto files and generated classes will be written to
+     * @param protocVersion The version of protoc to use
+     * @param classSuffix The suffix to append to the generated class name
+     * @param customIncludes An optional list of resource URLs to copy to the parent directory, and
+     *     include when invoking protoc
+     * @param useDefaultIncludes Whether to include the default set of proto descriptors from {@link
+     *     ProtoCompiler#DEFAULT_INCLUDES}
+     */
+    public ProtoCompiler(
+            Path parentDir,
+            String protocVersion,
+            String classSuffix,
+            boolean useDefaultIncludes,
+            String... customIncludes) {
+        this.classSuffix = classSuffix;
+        this.parentDir = parentDir;
+        this.protosDir = createChildDir(parentDir, "protos");
+        this.classesDir = createChildDir(parentDir, "classes");
+        this.protocVersion = protocVersion;
+        List<String> resolvedIncludes = new ArrayList<>();
+        if (useDefaultIncludes) {
+            resolvedIncludes.addAll(DEFAULT_INCLUDES);
+        }
+        if (customIncludes != null && customIncludes.length > 0) {
+            resolvedIncludes.addAll(Arrays.asList(customIncludes));
+        }
+        for (String include : resolvedIncludes) {
+            copyIncludedProto(include);
+        }
+    }
+
+    public ProtoCompiler(
+            String protocVersion,
+            String classSuffix,
+            boolean useDefaultIncludes,
+            String... customIncludes) {
+        this(createParentDir(), protocVersion, classSuffix, useDefaultIncludes, customIncludes);
+    }
+
+    public ProtoCompiler(boolean useDefaultIncludes, String... customIncludes) {
+        this(DEFAULT_PROTOC_VERSION, generateClassSuffix(), useDefaultIncludes, customIncludes);
+    }
+
+    public ProtoCompiler(String classSuffix, boolean useDefaultIncludes, String... customIncludes) {
+        this(DEFAULT_PROTOC_VERSION, classSuffix, useDefaultIncludes, customIncludes);
+    }
+
+    /**
+     * Given a protobuf schema this method will: 1. Write the schema to a .proto file in a temporary
+     * directory 2. Generate the Java class definition using protoc 3. Compile a Java class from the
+     * Java source file 4. Load the class into the JVM
+     *
+     * @return the Class of the generated message type
+     */
+    public Class generateMessageClass(ProtobufSchema protobufSchema, Integer schemaId) {
+        String suffixedProtoClassName = suffixedProtoClassName(protobufSchema, schemaId);
+        Path schemaFilePath = writeProto(protobufSchema, suffixedProtoClassName);
+
+        String indexedClassName = schemaFilePath.getFileName().toString().replace(".proto", "");
+        Path javaOutDir = generateJavaClassDef(schemaFilePath, indexedClassName);
+
+        String packageName = protobufSchema.rawSchema().getPackageName();
+        Path javaClassDefPath = getJavaClassDefPath(javaOutDir, packageName, indexedClassName);
+
+        String topLevelClassName = packageName + "." + indexedClassName;
+        compileJavaClass(javaClassDefPath, topLevelClassName);
+
+        String nestedClassName = topLevelClassName + "$" + getClassNameFromProto(protobufSchema);
+        return loadClass(javaOutDir, topLevelClassName, nestedClassName);
+    }
+
+    private Class loadClass(Path javaOutDir, String topLevelClassName, String nestedClassName) {
+        try {
+            URL classUrl = javaOutDir.toFile().toURI().toURL();
+            URLClassLoader classLoader =
+                    URLClassLoader.newInstance(
+                            new URL[] {classUrl}, Thread.currentThread().getContextClassLoader());
+            Thread.currentThread().setContextClassLoader(classLoader);
+            classLoader.loadClass(topLevelClassName);
+            return Class.forName(nestedClassName, true, classLoader);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load class " + nestedClassName, e);
+        }
+    }
+
+    private void compileJavaClass(Path javaClassDefPath, String topLevelClassName) {
+        // Tried using {@link PbUtils}'s existing compiler but was getting errors.
+        // Assignment conversion not possible from type "java.lang.Object" to type
+        // "com.google.protobuf.Descriptors$Descriptor"
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
+        int result = compiler.run(null, outputStream, errorStream, javaClassDefPath.toString());
+        if (result != 0) {
+            String msg =
+                    String.format(
+                            "Failed to compile class %s: err=%s; out=%s",
+                            topLevelClassName, errorStream, outputStream);
+            throw new RuntimeException(msg);
+        }
+    }
+
+    private Path getJavaClassDefPath(Path javaOutDir, String packageName, String className) {
+        if (packageName == null || packageName.isEmpty()) {
+            return javaOutDir.resolve(className + ".java");
+        } else {
+            return javaOutDir.resolve(packageName.replace(".", "/")).resolve(className + ".java");
+        }
+    }
+
+    private Path generateJavaClassDef(Path schemaFilePath, String className) {
+        Path javaOutDir = createChildDir(classesDir, className);
+        String[] args = {
+            "-I" + parentDir.toString(), // include custom types
+            "-v" + protocVersion,
+            "--java_out=" + javaOutDir.toString(),
+            "--proto_path=" + protosDir.toString(),
+            schemaFilePath.toString()
+        };
+        try {
+            int result = Protoc.runProtoc(args);
+            if (result != 0) {
+                throw new RuntimeException("Failed to run protoc for " + schemaFilePath);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to run protoc for " + schemaFilePath, e);
+        }
+        return javaOutDir;
+    }
+
+    private String suffixedProtoClassName(ProtobufSchema protobufSchema, Integer schemaId) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getClassNameFromProto(protobufSchema));
+        if (schemaId != null) {
+            sb.append("_");
+            sb.append(schemaId);
+        }
+        if (classSuffix != null) {
+            sb.append("_");
+            sb.append(classSuffix);
+        }
+        return sb.toString();
+    }
+
+    private Path writeProto(ProtobufSchema protobufSchema, String suffixedProtoClassName) {
+
+        ProtobufSchema withJavaOuterClassName =
+                setProtoOptions(protobufSchema, suffixedProtoClassName);
+        String schema = withJavaOuterClassName.rawSchema().toSchema();
+        String schemaFileName = suffixedProtoClassName + ".proto";
+        Path schemaFilePath = protosDir.resolve(schemaFileName);
+        try {
+            java.io.FileWriter myWriter = new java.io.FileWriter(schemaFilePath.toFile());
+            myWriter.write(schema);
+            myWriter.close();
+        } catch (java.io.IOException e) {
+            throw new RuntimeException("Failed to write schema to " + schemaFilePath, e);
+        }
+        return schemaFilePath;
+    }
+
+    private ProtobufSchema setProtoOptions(ProtobufSchema protobufSchema, String className) {
+        Descriptors.FileDescriptor originalDescriptor = protobufSchema.toDescriptor().getFile();
+
+        String protoPackageName = protobufSchema.rawSchema().getPackageName();
+        if (protoPackageName == null || protoPackageName.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Proto package name was null or empty in "
+                            + protobufSchema.rawSchema().toSchema());
+        }
+
+        DescriptorProtos.FileOptions newOptions =
+                DescriptorProtos.FileOptions.newBuilder()
+                        .mergeFrom(originalDescriptor.getOptions())
+                        // Without this, the generated class will be prefixed with the package name
+                        // e.g. SomePackageNameClassName
+                        .setJavaOuterClassname(className)
+                        // For deterministic compilation, we will always set java package to proto
+                        // package
+                        .setJavaPackage(protoPackageName)
+                        // Don't split the generated class into multiple files
+                        .setJavaMultipleFiles(false)
+                        .build();
+        DescriptorProtos.FileDescriptorProto.Builder newProtoBuilder =
+                originalDescriptor.toProto().toBuilder().setOptions(newOptions);
+
+        DescriptorProtos.FileDescriptorProto newProto =
+                maybeAddConfluentImports(newProtoBuilder, originalDescriptor.getDependencies());
+        try {
+            return new ProtobufSchema(
+                    Descriptors.FileDescriptor.buildFrom(
+                            newProto,
+                            originalDescriptor
+                                    .getDependencies()
+                                    .toArray(new Descriptors.FileDescriptor[0])));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set proto options.", e);
+        }
+    }
+
+    // Debezium schemas sometimes contain references to confluent message types
+    // but don't contain the necessary import statement. This can lead to
+    // protoc errors. We will add the necessary imports if they are missing.
+    private DescriptorProtos.FileDescriptorProto maybeAddConfluentImports(
+            DescriptorProtos.FileDescriptorProto.Builder newProtoBuilder,
+            List<Descriptors.FileDescriptor> originalDependencies) {
+        List<String> originalDependencyNames =
+                originalDependencies.stream()
+                        .map(
+                                dep -> {
+                                    if (dep.getPackage().isEmpty() || dep.getName().contains("/")) {
+                                        return dep.getName();
+                                    }
+                                    return String.format("%s/%s", dep.getPackage(), dep.getName());
+                                })
+                        .collect(Collectors.toList());
+
+        if (!originalDependencyNames.contains(META_PROTO)
+                && !originalDependencies.contains(MetaProto.getDescriptor())) {
+            newProtoBuilder.addDependency(META_PROTO);
+        }
+        if (!originalDependencyNames.contains(DECIMAL_PROTO)
+                && !originalDependencies.contains(DecimalProto.getDescriptor())) {
+            newProtoBuilder.addDependency(DECIMAL_PROTO);
+        }
+
+        return newProtoBuilder.build();
+    }
+
+    private String getClassNameFromProto(ProtobufSchema protobufSchema) {
+        String[] classNameParts = protobufSchema.name().split("\\.");
+        return classNameParts[classNameParts.length - 1];
+    }
+
+    private void copyIncludedProto(String includedProto) {
+        InputStream protoFileStream = ProtoCompiler.class.getResourceAsStream(includedProto);
+        if (protoFileStream == null) {
+            throw new IllegalArgumentException("Could not find the proto file: " + includedProto);
+        }
+        BufferedReader reader =
+                new BufferedReader(new InputStreamReader(protoFileStream, StandardCharsets.UTF_8));
+        String protoFileContents = reader.lines().collect(Collectors.joining("\n"));
+
+        // Create any necessary subdirectory
+        String[] resourceNameParts = includedProto.substring(1).split("/");
+        for (int i = 0; i < resourceNameParts.length - 1; i++) {
+            String childDirName = resourceNameParts[i];
+            Path currentParentDir =
+                    parentDir.resolve(
+                            String.join("/", Arrays.copyOfRange(resourceNameParts, 0, i)));
+            createChildDir(currentParentDir, childDirName);
+        }
+
+        Path protoFilePath = parentDir.resolve(includedProto.substring(1));
+        try {
+            Files.write(protoFilePath, protoFileContents.getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to write proto file to " + protoFilePath, e);
+        }
+    }
+
+    private static Path createParentDir() {
+        try {
+            return Files.createTempDirectory("protoc-");
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create temporary directory", e);
+        }
+    }
+
+    private static Path createChildDir(Path parentDir, String name) {
+        if (!Files.exists(parentDir)) {
+            throw new IllegalArgumentException("Parent directory does not exist");
+        }
+
+        Path childPath = parentDir.resolve(name);
+        if (Files.exists(childPath)) {
+            return childPath;
+        }
+
+        try {
+            return Files.createDirectory(parentDir.resolve(name));
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create child directory", e);
+        }
+    }
+
+    private static String generateClassSuffix() {
+        return UUID.randomUUID().toString().replace("-", "");
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/deserializer/ProtoRegistryDynamicDeserializationSchema.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/deserializer/ProtoRegistryDynamicDeserializationSchema.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.dynamic.deserializer;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.formats.protobuf.PbFormatConfig;
+import org.apache.flink.formats.protobuf.deserialize.ProtoToRowConverter;
+import org.apache.flink.protobuf.registry.confluent.ProtobufConfluentDeserializationSchema;
+import org.apache.flink.protobuf.registry.confluent.SchemaRegistryClientProvider;
+import org.apache.flink.protobuf.registry.confluent.dynamic.ProtoCompiler;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.google.protobuf.Message;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Deserialization schema that dynamically deserializes Confluent Protobuf messages using schemas
+ * fetched from the schema registry.
+ *
+ * <p>Use TODO ProtoRegistryStaticDeserializationSchema to deserialize messages with a fixed schema.
+ * While we expect that all messages in the input will be compatible with the row schema, it is
+ * possible that we will encounter more than one version of the schema in the input. Therefore, for
+ * a number of services used by ProtoRegistryDeserializationSchema, we need to maintain a map of
+ * schema ID -> service.
+ */
+public class ProtoRegistryDynamicDeserializationSchema
+        implements ProtobufConfluentDeserializationSchema {
+    private static final long serialVersionUID = 1L;
+
+    private RowType rowType;
+    private final TypeInformation<RowData> resultTypeInfo;
+
+    private final Map<Integer, KafkaProtobufDeserializer> kafkaProtobufDeserializers;
+    private final boolean ignoreParseErrors;
+    private final boolean readDefaultValues;
+    private final String schemaRegistryUrl;
+    private final SchemaRegistryClientProvider schemaRegistryClientProvider;
+    private final boolean useDefaultProtoIncludes;
+    private final List<String> customProtoIncludes;
+
+    private transient SchemaRegistryClient schemaRegistryClient;
+    // Since these services operate on dynamically compiled and loaded classes, we need to
+    // assume that the new worker don't have the classes loaded yet.
+    private transient Map<Integer, ProtoToRowConverter> protoToRowConverters;
+    private transient Map<Integer, Class> generatedMessageClasses;
+    private transient ProtoCompiler protoCompiler;
+
+    private static final String FAKE_TOPIC = "fake_topic";
+
+    public ProtoRegistryDynamicDeserializationSchema(
+            SchemaRegistryClientProvider schemaRegistryClientProvider,
+            String schemaRegistryUrl,
+            RowType rowType,
+            TypeInformation<RowData> resultTypeInfo,
+            boolean ignoreParseErrors,
+            boolean readDefaultValues,
+            boolean useDefaultProtoIncludes,
+            List<String> customProtoIncludes) {
+        this.rowType = rowType;
+        this.resultTypeInfo = resultTypeInfo;
+        this.ignoreParseErrors = ignoreParseErrors;
+        this.readDefaultValues = readDefaultValues;
+        this.schemaRegistryClientProvider = schemaRegistryClientProvider;
+        this.schemaRegistryUrl = schemaRegistryUrl;
+        this.kafkaProtobufDeserializers = new HashMap<>();
+        this.useDefaultProtoIncludes = useDefaultProtoIncludes;
+        this.customProtoIncludes = customProtoIncludes;
+    }
+
+    @Override
+    public RowData deserialize(byte[] message) throws IOException {
+        if (message == null || message.length == 0) {
+            return null;
+        }
+
+        int schemaId = getSchemaIdFromMessage(message);
+        ProtoToRowConverter protoToRowConverter = getOrCreateProtoConverter(schemaId);
+        KafkaProtobufDeserializer kafkaProtobufDeserializer =
+                getOrCreateKafkaProtobufDeserializer(schemaId);
+        Message protoMessage = kafkaProtobufDeserializer.deserialize(FAKE_TOPIC, message);
+
+        try {
+            return protoToRowConverter.convertProtoObjectToRow(protoMessage);
+        } catch (Exception e) {
+            if (ignoreParseErrors) {
+                return null;
+            }
+            throw new IOException("Failed to deserialize Protobuf message", e);
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(RowData nextElement) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return this.resultTypeInfo;
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        schemaRegistryClient = schemaRegistryClientProvider.createSchemaRegistryClient();
+        protoToRowConverters = new HashMap<>();
+        protoCompiler =
+                new ProtoCompiler(
+                        this.useDefaultProtoIncludes,
+                        this.customProtoIncludes.toArray(new String[0]));
+        generatedMessageClasses = new HashMap<>();
+    }
+
+    @Override
+    public void setRowType(RowType rowType) {
+        this.rowType = rowType;
+    }
+
+    @Override
+    public RowType getRowType() {
+        return this.rowType;
+    }
+
+    private int getSchemaIdFromMessage(byte[] message) {
+        InputStream inputStream = new ByteArrayInputStream(message);
+        DataInputStream dataInputStream = new DataInputStream(inputStream);
+        try {
+            if (dataInputStream.readByte() != 0) {
+                throw new RuntimeException("Unknown data format. Magic number does not match");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Could not read magic number from message", e);
+        }
+
+        try {
+            return dataInputStream.readInt();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not read schema ID from message", e);
+        }
+    }
+
+    private ProtobufSchema getProtobufSchema(int schemaId) {
+        try {
+            return (ProtobufSchema) schemaRegistryClient.getSchemaById(schemaId);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not retrieve schema from schema registry", e);
+        }
+    }
+
+    private KafkaProtobufDeserializer getOrCreateKafkaProtobufDeserializer(int schemaId) {
+        if (!kafkaProtobufDeserializers.containsKey(schemaId)) {
+            Map<String, String> config = new HashMap<>();
+            config.put("schema.registry.url", schemaRegistryUrl);
+            Class messageClass = generatedMessageClasses.get(schemaId);
+            KafkaProtobufDeserializer deserializer =
+                    new KafkaProtobufDeserializer(schemaRegistryClient, config, messageClass);
+            kafkaProtobufDeserializers.put(schemaId, deserializer);
+        }
+        return kafkaProtobufDeserializers.get(schemaId);
+    }
+
+    private ProtoToRowConverter getOrCreateProtoConverter(int schemaId) {
+        if (protoToRowConverters.containsKey(schemaId)) {
+            return protoToRowConverters.get(schemaId);
+        }
+
+        ProtobufSchema protobufSchema = getProtobufSchema(schemaId);
+        Class messageClass = protoCompiler.generateMessageClass(protobufSchema, schemaId);
+        generatedMessageClasses.put(schemaId, messageClass);
+        PbFormatConfig pbFormatConfig =
+                new PbFormatConfig(
+                        messageClass.getName(), ignoreParseErrors, readDefaultValues, null);
+        try {
+            ProtoToRowConverter protoToRowConverter =
+                    new ProtoToRowConverter(rowType, pbFormatConfig);
+            protoToRowConverters.put(schemaId, protoToRowConverter);
+            return protoToRowConverter;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create ProtoToRowConverter", e);
+        }
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/ConfluentMessageSerializer.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/ConfluentMessageSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.dynamic.serializer;
+
+import org.apache.flink.formats.protobuf.serialize.MessageSerializer;
+
+import com.google.protobuf.AbstractMessage;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+
+public class ConfluentMessageSerializer implements MessageSerializer {
+    private final KafkaProtobufSerializer kafkaProtobufSerializer;
+    private final String subjectName;
+
+    public ConfluentMessageSerializer(
+            KafkaProtobufSerializer kafkaProtobufSerializer, String subjectName) {
+        this.kafkaProtobufSerializer = kafkaProtobufSerializer;
+        this.subjectName = subjectName;
+    }
+
+    @Override
+    public byte[] serialize(AbstractMessage message) {
+        return kafkaProtobufSerializer.serialize(subjectName, message);
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/NoSuffixTopicNameStrategy.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/NoSuffixTopicNameStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.dynamic.serializer;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
+
+import java.util.Map;
+
+/**
+ * {@link io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy} implementation that
+ * treats the provided topic as the subject name without appending a "-key" or "-value" suffix.
+ */
+public class NoSuffixTopicNameStrategy implements SubjectNameStrategy {
+    @Override
+    public String subjectName(String topic, boolean isKey, ParsedSchema parsedSchema) {
+        return topic;
+    }
+
+    @Override
+    public void configure(Map<String, ?> map) {}
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/ProtoRegistryDynamicSerializationSchema.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/ProtoRegistryDynamicSerializationSchema.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.dynamic.serializer;
+
+import org.apache.flink.formats.protobuf.PbFormatConfig;
+import org.apache.flink.formats.protobuf.serialize.MessageSerializer;
+import org.apache.flink.formats.protobuf.serialize.RowToProtoConverter;
+import org.apache.flink.protobuf.registry.confluent.ProtobufConfluentSerializationSchema;
+import org.apache.flink.protobuf.registry.confluent.SchemaRegistryClientProvider;
+import org.apache.flink.protobuf.registry.confluent.dynamic.ProtoCompiler;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Serialization schema that dynamically serializes RowData into Confluent Protobuf messages and
+ * registers the schemas in the Confluent registry.
+ */
+public class ProtoRegistryDynamicSerializationSchema
+        implements ProtobufConfluentSerializationSchema {
+    private static final long serialVersionUID = 1L;
+
+    private static final String PROTOBUF_OUTER_CLASS_NAME_SUFFIX = "OuterClass";
+
+    private final String generatedPackageName;
+    private final String generatedClassName;
+    private RowType rowType;
+    private final String subjectName;
+    private final String schemaRegistryUrl;
+    private final SchemaRegistryClientProvider schemaRegistryClientProvider;
+    private final boolean useDefaultProtoIncludes;
+    private final List<String> customProtoIncludes;
+
+    private transient SchemaRegistryClient schemaRegistryClient;
+    private transient RowToProtoConverter rowToProtoConverter;
+
+    public ProtoRegistryDynamicSerializationSchema(
+            String generatedPackageName,
+            String generatedClassName,
+            RowType rowType,
+            String subjectName,
+            SchemaRegistryClientProvider schemaRegistryClientProvider,
+            String schemaRegistryUrl,
+            boolean useDefaultProtoIncludes,
+            List<String> customProtoIncludes) {
+        this.generatedPackageName = generatedPackageName;
+        this.generatedClassName = generatedClassName;
+        this.rowType = rowType;
+        this.subjectName = subjectName;
+        this.schemaRegistryClientProvider = schemaRegistryClientProvider;
+        this.schemaRegistryUrl = schemaRegistryUrl;
+        this.useDefaultProtoIncludes = useDefaultProtoIncludes;
+        this.customProtoIncludes = customProtoIncludes;
+    }
+
+    @Override
+    public byte[] serialize(RowData element) {
+        try {
+            return rowToProtoConverter.convertRowToProtoBinary(element);
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(e);
+        }
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        schemaRegistryClient = schemaRegistryClientProvider.createSchemaRegistryClient();
+        Class generatedClass = generateProtoClassForRowType();
+        KafkaProtobufSerializer kafkaProtobufSerializer = createKafkaSerializer();
+        MessageSerializer messageSerializer =
+                new ConfluentMessageSerializer(kafkaProtobufSerializer, subjectName);
+        PbFormatConfig formatConfig =
+                new PbFormatConfig(generatedClass.getName(), false, true, null);
+        rowToProtoConverter = new RowToProtoConverter(rowType, formatConfig, messageSerializer);
+    }
+
+    @Override
+    public void setRowType(RowType rowType) {
+        this.rowType = rowType;
+    }
+
+    @Override
+    public RowType getRowType() {
+        return this.rowType;
+    }
+
+    private Class generateProtoClassForRowType() throws Exception {
+        RowToProtobufSchemaConverter rowToProtobufSchemaConverter =
+                new RowToProtobufSchemaConverter(generatedPackageName, generatedClassName, rowType);
+
+        ProtobufSchema protoSchema = rowToProtobufSchemaConverter.convert();
+        ProtoCompiler protoCompiler =
+                new ProtoCompiler(
+                        PROTOBUF_OUTER_CLASS_NAME_SUFFIX,
+                        this.useDefaultProtoIncludes,
+                        this.customProtoIncludes.toArray(new String[0]));
+        return protoCompiler.generateMessageClass(protoSchema, null);
+    }
+
+    private KafkaProtobufSerializer createKafkaSerializer() {
+        Map<String, String> opts = new HashMap<>();
+        opts.put("schema.registry.url", schemaRegistryUrl);
+        opts.put("auto.register.schemas", "true");
+        opts.put("value.subject.name.strategy", NoSuffixTopicNameStrategy.class.getName());
+        boolean isKey = false;
+
+        KafkaProtobufSerializer ser = new KafkaProtobufSerializer(schemaRegistryClient);
+        ser.configure(opts, isKey);
+
+        return ser;
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/RowToProtobufSchemaConverter.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/RowToProtobufSchemaConverter.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.dynamic.serializer;
+
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Timestamp;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import org.apache.commons.text.CaseUtils;
+
+import java.util.List;
+
+/**
+ * Converts a Flink {@link RowType} to a {@link ProtobufSchema}. The generated schema can be used to
+ * serialize Flink RowData to Protobuf.
+ */
+public class RowToProtobufSchemaConverter {
+    private static final String NESTED_MESSAGE_SUFFIX = "Message";
+    private static final String MAP_ENTRY_SUFFIX = "Entry";
+
+    private final String packageName;
+    private final String className;
+    private final RowType rowType;
+
+    public RowToProtobufSchemaConverter(String packageName, String className, RowType rowType) {
+        this.packageName = packageName;
+        this.className = className;
+        this.rowType = rowType;
+    }
+
+    public ProtobufSchema convert() throws Descriptors.DescriptorValidationException {
+
+        // Create a FileDescriptorProto builder
+        DescriptorProtos.FileDescriptorProto.Builder fileDescriptorProtoBuilder =
+                DescriptorProtos.FileDescriptorProto.newBuilder();
+        fileDescriptorProtoBuilder.setName(className);
+        fileDescriptorProtoBuilder.setPackage(packageName);
+        fileDescriptorProtoBuilder.setSyntax("proto3");
+        fileDescriptorProtoBuilder.addDependency("google/protobuf/timestamp.proto");
+
+        // Create a DescriptorProto builder for the message type
+        DescriptorProtos.DescriptorProto.Builder descriptorProtoBuilder =
+                DescriptorProtos.DescriptorProto.newBuilder();
+        descriptorProtoBuilder.setName(className);
+
+        // Convert each field in RowType to a FieldDescriptorProto
+        recurseRowType(rowType, descriptorProtoBuilder);
+
+        // Add the message type to the file descriptor
+        fileDescriptorProtoBuilder.addMessageType(descriptorProtoBuilder);
+
+        // Build the FileDescriptor
+        DescriptorProtos.FileDescriptorProto fileDescriptorProto =
+                fileDescriptorProtoBuilder.build();
+        Descriptors.FileDescriptor[] dependencies =
+                new Descriptors.FileDescriptor[] {Timestamp.getDescriptor().getFile()};
+        Descriptors.FileDescriptor fileDescriptor =
+                Descriptors.FileDescriptor.buildFrom(fileDescriptorProto, dependencies);
+
+        return new ProtobufSchema(fileDescriptor);
+    }
+
+    /** Recursively traverse a RowType and convert its fields to proto message fields. */
+    private static void recurseRowType(
+            RowType rowType, DescriptorProtos.DescriptorProto.Builder currentBuilder) {
+
+        List<RowType.RowField> fields = rowType.getFields();
+        for (int i = 0; i < fields.size(); i++) {
+
+            RowType.RowField field = fields.get(i);
+            DescriptorProtos.FieldDescriptorProto.Builder fieldDescriptorProtoBuilder =
+                    DescriptorProtos.FieldDescriptorProto.newBuilder();
+            fieldDescriptorProtoBuilder.setName(field.getName());
+            fieldDescriptorProtoBuilder.setNumber(i + 1);
+
+            if (field.getType() instanceof RowType) {
+
+                String nestedTypeName =
+                        addFlinkRowTypeToDescriptor(
+                                field, (RowType) field.getType(), currentBuilder);
+                fieldDescriptorProtoBuilder.setType(Type.TYPE_MESSAGE);
+                fieldDescriptorProtoBuilder.setTypeName(nestedTypeName);
+
+            } else if (field.getType() instanceof ArrayType) {
+
+                if (((ArrayType) field.getType()).getElementType() instanceof RowType) {
+                    String nestedTypeName =
+                            addFlinkRowTypeToDescriptor(
+                                    field,
+                                    (RowType) ((ArrayType) field.getType()).getElementType(),
+                                    currentBuilder);
+                    fieldDescriptorProtoBuilder.setType(Type.TYPE_MESSAGE);
+                    fieldDescriptorProtoBuilder.setTypeName(nestedTypeName);
+                } else {
+                    addPrimitiveFlinkFieldToDescriptor(
+                            fieldDescriptorProtoBuilder,
+                            ((ArrayType) field.getType()).getElementType());
+                }
+
+                fieldDescriptorProtoBuilder.setLabel(
+                        DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED);
+
+            } else if (field.getType() instanceof MapType) {
+
+                String nestedTypeName =
+                        addFlinkMapTypeToDescriptor(
+                                field, (MapType) field.getType(), currentBuilder);
+                fieldDescriptorProtoBuilder.setType(Type.TYPE_MESSAGE);
+                fieldDescriptorProtoBuilder.setTypeName(nestedTypeName);
+                fieldDescriptorProtoBuilder.setLabel(
+                        DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED);
+
+            } else {
+                addPrimitiveFlinkFieldToDescriptor(fieldDescriptorProtoBuilder, field.getType());
+            }
+            currentBuilder.addField(fieldDescriptorProtoBuilder.build());
+        }
+    }
+
+    private static void addPrimitiveFlinkFieldToDescriptor(
+            DescriptorProtos.FieldDescriptorProto.Builder input, LogicalType rowFieldType) {
+        switch (rowFieldType.getTypeRoot()) {
+            case CHAR:
+            case VARCHAR:
+                input.setType(Type.TYPE_STRING);
+                return;
+            case BOOLEAN:
+                input.setType(Type.TYPE_BOOL);
+                return;
+            case BINARY:
+            case VARBINARY:
+                input.setType(Type.TYPE_BYTES);
+                return;
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+                input.setType(Type.TYPE_INT32);
+                return;
+            case BIGINT:
+                input.setType(Type.TYPE_INT64);
+                return;
+            case FLOAT:
+                input.setType(Type.TYPE_FLOAT);
+                return;
+            case DOUBLE:
+                input.setType(Type.TYPE_DOUBLE);
+                return;
+            default:
+                throw new IllegalArgumentException("Unsupported logical type: " + rowFieldType);
+        }
+    }
+
+    private static String addFlinkRowTypeToDescriptor(
+            RowType.RowField field,
+            RowType rowType,
+            DescriptorProtos.DescriptorProto.Builder currentBuilder) {
+
+        if (isTimestampType(rowType)) {
+            return "google.protobuf.Timestamp";
+        }
+
+        String nestedTypeName = field.getName() + NESTED_MESSAGE_SUFFIX;
+
+        DescriptorProtos.DescriptorProto.Builder newBuilder =
+                DescriptorProtos.DescriptorProto.newBuilder();
+        newBuilder.setName(nestedTypeName);
+        recurseRowType(rowType, newBuilder);
+        currentBuilder.addNestedType(newBuilder);
+        return nestedTypeName;
+    }
+
+    private static String addFlinkMapTypeToDescriptor(
+            RowType.RowField field,
+            MapType mapType,
+            DescriptorProtos.DescriptorProto.Builder currentBuilder) {
+
+        DescriptorProtos.FieldDescriptorProto.Builder keyFieldDescriptorProtoBuilder =
+                DescriptorProtos.FieldDescriptorProto.newBuilder();
+        keyFieldDescriptorProtoBuilder.setName("key");
+        keyFieldDescriptorProtoBuilder.setNumber(1);
+
+        if (mapType.getKeyType() instanceof RowType) {
+            DescriptorProtos.DescriptorProto.Builder keyMessageProtoBuilder =
+                    DescriptorProtos.DescriptorProto.newBuilder();
+            recurseRowType((RowType) mapType.getKeyType(), currentBuilder);
+            String keyTypeName = field.getName() + "Key" + NESTED_MESSAGE_SUFFIX;
+            keyMessageProtoBuilder.setName(keyTypeName);
+            currentBuilder.addNestedType(keyMessageProtoBuilder);
+
+            keyFieldDescriptorProtoBuilder.setType(Type.TYPE_MESSAGE);
+            keyFieldDescriptorProtoBuilder.setTypeName(keyTypeName);
+        } else {
+            addPrimitiveFlinkFieldToDescriptor(
+                    keyFieldDescriptorProtoBuilder, mapType.getKeyType());
+        }
+
+        DescriptorProtos.FieldDescriptorProto.Builder valueFieldDescriptorProtoBuilder =
+                DescriptorProtos.FieldDescriptorProto.newBuilder();
+        valueFieldDescriptorProtoBuilder.setName("value");
+        valueFieldDescriptorProtoBuilder.setNumber(2);
+
+        if (mapType.getValueType() instanceof RowType) {
+            DescriptorProtos.DescriptorProto.Builder valueMessageProtoBuilder =
+                    DescriptorProtos.DescriptorProto.newBuilder();
+            recurseRowType((RowType) mapType.getValueType(), valueMessageProtoBuilder);
+            String valueTypeName = field.getName() + "Value" + NESTED_MESSAGE_SUFFIX;
+            valueMessageProtoBuilder.setName(valueTypeName);
+            currentBuilder.addNestedType(valueMessageProtoBuilder);
+
+            valueFieldDescriptorProtoBuilder.setType(Type.TYPE_MESSAGE);
+            valueFieldDescriptorProtoBuilder.setTypeName(valueTypeName);
+        } else {
+            addPrimitiveFlinkFieldToDescriptor(
+                    valueFieldDescriptorProtoBuilder, mapType.getValueType());
+        }
+
+        DescriptorProtos.DescriptorProto.Builder newBuilder =
+                DescriptorProtos.DescriptorProto.newBuilder();
+
+        // This is a very obscure part of the protobuf format. If the type isn't called fieldName +
+        // "Entry",
+        // the proto compiler won't be able to parse the definition.
+        String camelCasedFieldName = CaseUtils.toCamelCase(field.getName(), true, '_');
+        String nestedTypeName = camelCasedFieldName + MAP_ENTRY_SUFFIX;
+        newBuilder.setName(nestedTypeName);
+
+        newBuilder.addField(keyFieldDescriptorProtoBuilder.build());
+        newBuilder.addField(valueFieldDescriptorProtoBuilder.build());
+        newBuilder.setOptions(
+                DescriptorProtos.MessageOptions.newBuilder().setMapEntry(true).build());
+
+        currentBuilder.addNestedType(newBuilder);
+        return nestedTypeName;
+    }
+
+    // Auto-detect rows that should be represented as proto timestamps
+    private static boolean isTimestampType(RowType rowType) {
+        return rowType.getFields().size() == 2
+                && rowType.getFields().get(0).getName().equals("seconds")
+                && rowType.getFields().get(1).getName().equals("nanos")
+                && rowType.getFields().get(0).getType().getTypeRoot().equals(LogicalTypeRoot.BIGINT)
+                && rowType.getFields()
+                        .get(1)
+                        .getType()
+                        .getTypeRoot()
+                        .equals(LogicalTypeRoot.INTEGER);
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-formats/flink-protobuf-confluent-registry/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.protobuf.registry.confluent.ProtobufConfluentFormatFactory
+org.apache.flink.protobuf.registry.confluent.debezium.ProtobufConfluentDebeziumFactory

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentFormatFactoryUtilsTest.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/ProtobufConfluentFormatFactoryUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class ProtobufConfluentFormatFactoryUtilsTest {
+
+    @Test
+    void parseCustomProtoIncludes() {
+        Assertions.assertTrue(
+                ProtobufConfluentFormatFactoryUtils.parseCustomProtoIncludes("").isEmpty());
+
+        List<String> expectedOne = new ArrayList<>();
+        expectedOne.add("a");
+        Assertions.assertEquals(
+                expectedOne, ProtobufConfluentFormatFactoryUtils.parseCustomProtoIncludes("a"));
+
+        List<String> expectedTwo = new ArrayList<>();
+        expectedTwo.add("a");
+        expectedTwo.add("b");
+        Assertions.assertEquals(
+                expectedTwo, ProtobufConfluentFormatFactoryUtils.parseCustomProtoIncludes("a,b"));
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/TestUtils.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/TestUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent;
+
+import org.apache.flink.table.types.logical.RowType;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Message;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TestUtils {
+
+    public static final String TEST_STRING = "test";
+    public static final int TEST_INT = 42;
+    public static final long TEST_LONG = 99L;
+    public static final float TEST_FLOAT = 3.14f;
+    public static final double TEST_DOUBLE = 2.71828;
+    public static final boolean TEST_BOOL = true;
+    public static final ByteString TEST_BYTES =
+            ByteString.copyFrom(new byte[] {0x01, 0x02, 0x03, 0x04});
+
+    public static final String STRING_FIELD = "string";
+    public static final String INT_FIELD = "int";
+    public static final String LONG_FIELD = "long";
+    public static final String FLOAT_FIELD = "float";
+    public static final String DOUBLE_FIELD = "double";
+    public static final String BOOL_FIELD = "bool";
+    public static final String BYTES_FIELD = "bytes";
+    public static final String NESTED_FIELD = "nested";
+    public static final String ARRAY_FIELD = "array";
+    public static final String MAP_FIELD = "map";
+    public static final String TIMESTAMP_FIELD = "ts";
+    public static final String SECONDS_FIELD = "seconds";
+    public static final String NANOS_FIELD = "nanos";
+
+    public static final String DEFAULT_PACKAGE = "org.apache.flink.formats.protobuf.proto";
+    public static final int DEFAULT_SCHEMA_ID = 1;
+    public static final String DEFAULT_CLASS_SUFFIX = "123";
+    public static final String DEFAULT_CLASS_NAME = "TestClass";
+    public static final String DUMMY_SCHEMA_REGISTRY_URL = "http://registry:8081";
+    public static final String FAKE_TOPIC = "fake-topic";
+    public static final String FAKE_SUBJECT = "fake-subject";
+    public static final boolean USE_DEFAULT_PROTO_INCLUDES = true;
+    public static final List<String> CUSTOM_PROTO_INCLUDES = new ArrayList<>();
+    public static final boolean IGNORE_PARSE_ERRORS = false;
+    public static final boolean READ_DEFAULT_VALUES = false;
+
+    public static RowType createRowType(RowType.RowField... fields) {
+        List<RowType.RowField> fieldList = new ArrayList<>();
+        fieldList.addAll(Arrays.asList(fields));
+        return new RowType(fieldList);
+    }
+
+    public static Message parseBytesToMessage(
+            byte[] bytes, SchemaRegistryClient mockSchemaRegistryClient) {
+        Map<String, String> opts = new HashMap<>();
+        opts.put("schema.registry.url", DUMMY_SCHEMA_REGISTRY_URL);
+        KafkaProtobufDeserializer deser =
+                new KafkaProtobufDeserializer(mockSchemaRegistryClient, opts);
+        return deser.deserialize(null, bytes);
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumDeserializationSchemaTest.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumDeserializationSchemaTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.debezium;
+
+import org.apache.flink.protobuf.registry.confluent.SchemaRegistryClientProviders;
+import org.apache.flink.protobuf.registry.confluent.TestUtils;
+import org.apache.flink.protobuf.registry.confluent.dynamic.deserializer.ProtoRegistryDynamicDeserializationSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Collector;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import my_table.products.DebeziumProto3;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.BOOL_FIELD;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.CUSTOM_PROTO_INCLUDES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.DUMMY_SCHEMA_REGISTRY_URL;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.FAKE_TOPIC;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.IGNORE_PARSE_ERRORS;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.LONG_FIELD;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.READ_DEFAULT_VALUES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.STRING_FIELD;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_BOOL;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_LONG;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_STRING;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.USE_DEFAULT_PROTO_INCLUDES;
+
+public class ProtobufConfluentDebeziumDeserializationSchemaTest {
+
+    private MockSchemaRegistryClient mockSchemaRegistryClient;
+    private KafkaProtobufSerializer kafkaProtobufSerializer;
+    private SimpleCollector collector;
+    private ProtobufConfluentDebeziumDeserializationSchema deser;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        mockSchemaRegistryClient = new MockSchemaRegistryClient();
+        Map<String, String> opts = new HashMap<>();
+        opts.put("schema.registry.url", DUMMY_SCHEMA_REGISTRY_URL);
+        kafkaProtobufSerializer = new KafkaProtobufSerializer(mockSchemaRegistryClient, opts);
+        collector = new SimpleCollector();
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(STRING_FIELD, new VarCharType()),
+                        new RowType.RowField(LONG_FIELD, new BigIntType()),
+                        new RowType.RowField(BOOL_FIELD, new BooleanType()));
+        ProtoRegistryDynamicDeserializationSchema wrappedDeser =
+                new ProtoRegistryDynamicDeserializationSchema(
+                        new SchemaRegistryClientProviders.MockSchemaRegistryClientProvider(
+                                mockSchemaRegistryClient),
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        rowType,
+                        null,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        deser = new ProtobufConfluentDebeziumDeserializationSchema(wrappedDeser);
+        deser.open(null);
+    }
+
+    @Test
+    public void deserializeDelete() throws Exception {
+        DebeziumProto3.Envelope.Value before =
+                DebeziumProto3.Envelope.Value.newBuilder()
+                        .setString(TEST_STRING)
+                        .setLong(TEST_LONG)
+                        .setBool(TEST_BOOL)
+                        .build();
+        DebeziumProto3.Envelope.Source source =
+                DebeziumProto3.Envelope.Source.newBuilder()
+                        .setVersion(TEST_STRING)
+                        .setConnector(TEST_STRING)
+                        .setDb(TEST_STRING)
+                        .setTable(TEST_STRING)
+                        .setTsMs(TEST_LONG)
+                        .setSnapshot(TEST_STRING)
+                        .build();
+        DebeziumProto3.Envelope envelope =
+                DebeziumProto3.Envelope.newBuilder()
+                        .setOp(ProtobufConfluentDebeziumDeserializationSchema.OP_DELETE)
+                        .setBefore(before)
+                        .setSource(source)
+                        .setTsMs(TEST_LONG)
+                        .build();
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, envelope);
+
+        deser.deserialize(inBytes, collector);
+        Assertions.assertEquals(1, collector.list.size());
+
+        RowData actual = collector.list.get(0);
+
+        Assertions.assertEquals(3, actual.getArity());
+        Assertions.assertEquals(TEST_STRING, actual.getString(0).toString());
+        Assertions.assertEquals(TEST_LONG, actual.getLong(1));
+        Assertions.assertEquals(TEST_BOOL, actual.getBoolean(2));
+        Assertions.assertEquals(RowKind.DELETE, actual.getRowKind());
+    }
+
+    @Test
+    public void deserializeUpdate() throws Exception {
+        DebeziumProto3.Envelope.Value before =
+                DebeziumProto3.Envelope.Value.newBuilder()
+                        .setString(TEST_STRING)
+                        .setLong(TEST_LONG)
+                        .setBool(TEST_BOOL)
+                        .build();
+        DebeziumProto3.Envelope.Value after =
+                DebeziumProto3.Envelope.Value.newBuilder()
+                        .setString(TEST_STRING)
+                        .setLong((TEST_LONG * 2))
+                        .setBool(false)
+                        .build();
+        DebeziumProto3.Envelope.Source source =
+                DebeziumProto3.Envelope.Source.newBuilder()
+                        .setVersion(TEST_STRING)
+                        .setConnector(TEST_STRING)
+                        .setDb(TEST_STRING)
+                        .setTable(TEST_STRING)
+                        .setTsMs(TEST_LONG)
+                        .setSnapshot(TEST_STRING)
+                        .build();
+        DebeziumProto3.Envelope envelope =
+                DebeziumProto3.Envelope.newBuilder()
+                        .setOp(ProtobufConfluentDebeziumDeserializationSchema.OP_UPDATE)
+                        .setBefore(before)
+                        .setAfter(after)
+                        .setSource(source)
+                        .setTsMs(TEST_LONG)
+                        .build();
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, envelope);
+
+        deser.deserialize(inBytes, collector);
+        Assertions.assertEquals(2, collector.list.size());
+
+        RowData deleteActual = collector.list.get(0);
+
+        Assertions.assertEquals(3, deleteActual.getArity());
+        Assertions.assertEquals(TEST_STRING, deleteActual.getString(0).toString());
+        Assertions.assertEquals(TEST_LONG, deleteActual.getLong(1));
+        Assertions.assertEquals(TEST_BOOL, deleteActual.getBoolean(2));
+        Assertions.assertEquals(RowKind.UPDATE_BEFORE, deleteActual.getRowKind());
+
+        RowData insertActual = collector.list.get(1);
+
+        Assertions.assertEquals(3, insertActual.getArity());
+        Assertions.assertEquals(TEST_STRING, insertActual.getString(0).toString());
+        Assertions.assertEquals(TEST_LONG * 2, insertActual.getLong(1));
+        Assertions.assertFalse(insertActual.getBoolean(2));
+        Assertions.assertEquals(RowKind.UPDATE_AFTER, insertActual.getRowKind());
+    }
+
+    @Test
+    public void deserializeCreate() throws Exception {
+        DebeziumProto3.Envelope.Value after =
+                DebeziumProto3.Envelope.Value.newBuilder()
+                        .setString(TEST_STRING)
+                        .setLong(TEST_LONG)
+                        .setBool(TEST_BOOL)
+                        .build();
+        DebeziumProto3.Envelope.Source source =
+                DebeziumProto3.Envelope.Source.newBuilder()
+                        .setVersion(TEST_STRING)
+                        .setConnector(TEST_STRING)
+                        .setDb(TEST_STRING)
+                        .setTable(TEST_STRING)
+                        .setTsMs(TEST_LONG)
+                        .setSnapshot(TEST_STRING)
+                        .build();
+        DebeziumProto3.Envelope envelope =
+                DebeziumProto3.Envelope.newBuilder()
+                        .setOp(ProtobufConfluentDebeziumDeserializationSchema.OP_CREATE)
+                        .setAfter(after)
+                        .setSource(source)
+                        .setTsMs(TEST_LONG)
+                        .build();
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, envelope);
+
+        deser.deserialize(inBytes, collector);
+        Assertions.assertEquals(1, collector.list.size());
+
+        RowData actual = collector.list.get(0);
+
+        Assertions.assertEquals(3, actual.getArity());
+        Assertions.assertEquals(TEST_STRING, actual.getString(0).toString());
+        Assertions.assertEquals(TEST_LONG, actual.getLong(1));
+        Assertions.assertEquals(TEST_BOOL, actual.getBoolean(2));
+        Assertions.assertEquals(RowKind.INSERT, actual.getRowKind());
+    }
+
+    private static class SimpleCollector implements Collector<RowData> {
+
+        public final List<RowData> list = new ArrayList<>();
+
+        @Override
+        public void collect(RowData record) {
+            list.add(record);
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumSerializationSchemaTest.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/debezium/ProtobufConfluentDebeziumSerializationSchemaTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.debezium;
+
+import org.apache.flink.protobuf.registry.confluent.SchemaRegistryClientProviders;
+import org.apache.flink.protobuf.registry.confluent.TestUtils;
+import org.apache.flink.protobuf.registry.confluent.dynamic.serializer.ProtoRegistryDynamicSerializationSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.RowKind;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.CUSTOM_PROTO_INCLUDES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.DUMMY_SCHEMA_REGISTRY_URL;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.FAKE_SUBJECT;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.USE_DEFAULT_PROTO_INCLUDES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.parseBytesToMessage;
+
+public class ProtobufConfluentDebeziumSerializationSchemaTest {
+
+    private MockSchemaRegistryClient mockSchemaRegistryClient;
+    private String className;
+    private ProtobufConfluentDebeziumSerializationSchema ser;
+    private GenericRowData rowData;
+    private static final String AFTER_FIELD = "after";
+    private static final String BEFORE_FIELD = "before";
+    private static final String OP_FIELD = "op";
+
+    @BeforeEach
+    public void setup() throws Exception {
+        mockSchemaRegistryClient = new MockSchemaRegistryClient();
+        className = TestUtils.DEFAULT_CLASS_NAME + UUID.randomUUID().toString().replace("-", "");
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(TestUtils.STRING_FIELD, new VarCharType()));
+        ProtoRegistryDynamicSerializationSchema wrappedSer =
+                new ProtoRegistryDynamicSerializationSchema(
+                        TestUtils.DEFAULT_PACKAGE,
+                        className,
+                        rowType,
+                        FAKE_SUBJECT,
+                        new SchemaRegistryClientProviders.MockSchemaRegistryClientProvider(
+                                mockSchemaRegistryClient),
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        ser = new ProtobufConfluentDebeziumSerializationSchema(wrappedSer);
+        ser.open(null);
+        rowData = new GenericRowData(1);
+        rowData.setField(0, StringData.fromString(TestUtils.TEST_STRING));
+    }
+
+    @Test
+    public void serializeInsert() throws Exception {
+
+        rowData.setRowKind(RowKind.INSERT);
+        runCreateTest(rowData);
+    }
+
+    @Test
+    public void serializeDelete() throws Exception {
+
+        rowData.setRowKind(RowKind.DELETE);
+        runDeleteTest(rowData);
+    }
+
+    @Test
+    public void serializeUpdateAfter() throws Exception {
+
+        rowData.setRowKind(RowKind.UPDATE_AFTER);
+        runCreateTest(rowData);
+    }
+
+    @Test
+    public void serializeUpdateBefore() throws Exception {
+
+        rowData.setRowKind(RowKind.UPDATE_BEFORE);
+        runDeleteTest(rowData);
+    }
+
+    private void runCreateTest(RowData rowData) {
+        byte[] actualBytes = ser.serialize(rowData);
+
+        Message message = parseBytesToMessage(actualBytes, mockSchemaRegistryClient);
+        Descriptors.FieldDescriptor opField =
+                message.getDescriptorForType().findFieldByName(OP_FIELD);
+        Descriptors.FieldDescriptor afterField =
+                message.getDescriptorForType().findFieldByName(AFTER_FIELD);
+        Descriptors.FieldDescriptor beforeField =
+                message.getDescriptorForType().findFieldByName(BEFORE_FIELD);
+        DynamicMessage afterMessage = (DynamicMessage) message.getField(afterField);
+        Descriptors.FieldDescriptor stringField =
+                afterMessage.getDescriptorForType().findFieldByName(TestUtils.STRING_FIELD);
+
+        Assertions.assertFalse(message.hasField(beforeField));
+        Assertions.assertEquals(TestUtils.TEST_STRING, afterMessage.getField(stringField));
+        Assertions.assertEquals(
+                ProtobufConfluentDebeziumDeserializationSchema.OP_CREATE,
+                message.getField(opField));
+    }
+
+    private void runDeleteTest(RowData rowData) {
+        byte[] actualBytes = ser.serialize(rowData);
+
+        Message message = parseBytesToMessage(actualBytes, mockSchemaRegistryClient);
+        Descriptors.FieldDescriptor opField =
+                message.getDescriptorForType().findFieldByName(OP_FIELD);
+        Descriptors.FieldDescriptor afterField =
+                message.getDescriptorForType().findFieldByName(AFTER_FIELD);
+        Descriptors.FieldDescriptor beforeField =
+                message.getDescriptorForType().findFieldByName(BEFORE_FIELD);
+        DynamicMessage beforeMessage = (DynamicMessage) message.getField(beforeField);
+        Descriptors.FieldDescriptor stringField =
+                beforeMessage.getDescriptorForType().findFieldByName(TestUtils.STRING_FIELD);
+
+        Assertions.assertFalse(message.hasField(afterField));
+        Assertions.assertEquals(TestUtils.TEST_STRING, beforeMessage.getField(stringField));
+        Assertions.assertEquals(
+                ProtobufConfluentDebeziumDeserializationSchema.OP_DELETE,
+                message.getField(opField));
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/dynamic/ProtoCompilerTest.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/dynamic/ProtoCompilerTest.java
@@ -1,0 +1,530 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.dynamic;
+
+import org.apache.flink.formats.protobuf.PbConstant;
+import org.apache.flink.formats.protobuf.proto.ConfluentTagsProto3OuterClass;
+import org.apache.flink.formats.protobuf.proto.EnumProto3OuterClass;
+import org.apache.flink.formats.protobuf.proto.FlatProto2OuterClass;
+import org.apache.flink.formats.protobuf.proto.FlatProto3OuterClass;
+import org.apache.flink.formats.protobuf.proto.MapProto3;
+import org.apache.flink.formats.protobuf.proto.MultipleFilesProto3;
+import org.apache.flink.formats.protobuf.proto.MyFancyOuterClassName;
+import org.apache.flink.formats.protobuf.proto.NestedProto3OuterClass;
+import org.apache.flink.formats.protobuf.proto.OneofProto3;
+import org.apache.flink.formats.protobuf.proto.TimestampProto3OuterClass;
+import org.apache.flink.formatzz.proto.JavaPackageProto3OuterClass;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.Timestamp;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.DEFAULT_CLASS_SUFFIX;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.DEFAULT_PACKAGE;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.DEFAULT_SCHEMA_ID;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_BOOL;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_BYTES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_DOUBLE;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_FLOAT;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_INT;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_LONG;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_STRING;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.USE_DEFAULT_PROTO_INCLUDES;
+
+public class ProtoCompilerTest {
+
+    private static final Map<String, String> TEST_STRING_MAP = new HashMap<>();
+
+    @BeforeEach
+    public void setup() {
+        TEST_STRING_MAP.put("key1", "value1");
+        TEST_STRING_MAP.put("key2", "value2");
+    }
+
+    @Test
+    public void flatProto3() throws Exception {
+        FlatProto3OuterClass.FlatProto3 in =
+                FlatProto3OuterClass.FlatProto3.newBuilder()
+                        .setString(TEST_STRING)
+                        .setInt(TEST_INT)
+                        .setLong(TEST_LONG)
+                        .setFloat(TEST_FLOAT)
+                        .setDouble(TEST_DOUBLE)
+                        .addInts(TEST_INT)
+                        .setBytes(TEST_BYTES)
+                        .setBool(TEST_BOOL)
+                        .build();
+        Class generatedClass = runCompilerTest(in, DEFAULT_SCHEMA_ID);
+        assertGeneratedClassName(in, generatedClass, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void flatProto3WithFieldsOmitted() throws Exception {
+        FlatProto3OuterClass.FlatProto3 in =
+                FlatProto3OuterClass.FlatProto3.newBuilder()
+                        .addInts(TEST_INT)
+                        .setBytes(TEST_BYTES)
+                        .setBool(TEST_BOOL)
+                        .build();
+        runCompilerTest(in, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void mapProto3() throws Exception {
+        MapProto3.Proto3Map in =
+                MapProto3.Proto3Map.newBuilder().putAllMap(TEST_STRING_MAP).build();
+        runCompilerTest(in, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void nestedProto3() throws Exception {
+        NestedProto3OuterClass.NestedProto3.Nested nested =
+                NestedProto3OuterClass.NestedProto3.Nested.newBuilder()
+                        .setFloat(TEST_FLOAT)
+                        .setDouble(TEST_DOUBLE)
+                        .build();
+
+        NestedProto3OuterClass.NestedProto3 in =
+                NestedProto3OuterClass.NestedProto3.newBuilder()
+                        .setNested(nested)
+                        .setString(TEST_STRING)
+                        .setInt(TEST_INT)
+                        .setLong(TEST_LONG)
+                        .build();
+        runCompilerTest(in, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void oneOfProto3() throws Exception {
+        OneofProto3.OneOfProto3 in =
+                OneofProto3.OneOfProto3.newBuilder().setA(TEST_INT).setB(TEST_INT).build();
+        runCompilerTest(in, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void enumProto3() throws Exception {
+        EnumProto3OuterClass.EnumProto3 in =
+                EnumProto3OuterClass.EnumProto3.newBuilder()
+                        .setInt(TEST_INT)
+                        .setCorpus(EnumProto3OuterClass.EnumProto3.Corpus.UNIVERSAL)
+                        .build();
+        runCompilerTest(in, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void timestampProto3() throws Exception {
+        TimestampProto3OuterClass.TimestampProto3 in =
+                TimestampProto3OuterClass.TimestampProto3.newBuilder()
+                        .setTs(
+                                Timestamp.newBuilder()
+                                        .setSeconds(System.currentTimeMillis() / 1000)
+                                        .build())
+                        .build();
+        runCompilerTest(in, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void javaPackageProto3() throws Exception {
+        JavaPackageProto3OuterClass.JavaPackageProto3 in =
+                JavaPackageProto3OuterClass.JavaPackageProto3.newBuilder()
+                        .setString(TEST_STRING)
+                        .setInt(TEST_INT)
+                        .setLong(TEST_LONG)
+                        .setFloat(TEST_FLOAT)
+                        .setDouble(TEST_DOUBLE)
+                        .addInts(TEST_INT)
+                        .setBytes(TEST_BYTES)
+                        .setBool(TEST_BOOL)
+                        .build();
+        Class generatedClass = runCompilerTest(in, DEFAULT_SCHEMA_ID);
+        assertGeneratedClassName(in, generatedClass, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void multipleFilesProto3() throws Exception {
+        MultipleFilesProto3.Nested nested =
+                MultipleFilesProto3.Nested.newBuilder()
+                        .setFloat(TEST_FLOAT)
+                        .setDouble(TEST_DOUBLE)
+                        .build();
+
+        MultipleFilesProto3 in =
+                MultipleFilesProto3.newBuilder().setInt(TEST_INT).setNested(nested).build();
+        Class generatedClass = runCompilerTest(in, DEFAULT_SCHEMA_ID);
+        Assertions.assertEquals(
+                "org.apache.flink.formats.protobuf.proto.MultipleFilesProto3_1_123$MultipleFilesProto3",
+                generatedClass.getName());
+    }
+
+    @Test
+    public void outerClassNameOptionProto3() throws Exception {
+        MyFancyOuterClassName.OuterClassOptionProto3 in =
+                MyFancyOuterClassName.OuterClassOptionProto3.newBuilder().setInt(TEST_INT).build();
+        Class generatedClass = runCompilerTest(in, DEFAULT_SCHEMA_ID);
+        assertGeneratedClassName(in, generatedClass, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void confluentTagsProto3() throws Exception {
+        ConfluentTagsProto3OuterClass.ConfluentTagsProto3 in =
+                ConfluentTagsProto3OuterClass.ConfluentTagsProto3.newBuilder()
+                        .setInt(TEST_INT)
+                        .build();
+        Class generatedClass = runCompilerTest(in, DEFAULT_SCHEMA_ID);
+        assertGeneratedClassName(in, generatedClass, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void confluentTagsWithMissingImportProto3() throws Exception {
+        // the schemas registered by Debezium don't always seem to have the import statement in
+        // the definition
+        String schemaStr =
+                "syntax = \"proto3\";\n"
+                        + "package org.apache.flink.formats.protobuf.proto;\n"
+                        + "\n"
+                        + "message ConfluentTagsWithMissingImportProto3 {\n"
+                        + "  int32 int = 1 [(confluent.field_meta) = {\n"
+                        + "    params: [\n"
+                        + "      {\n"
+                        + "        key: \"connect.type\",\n"
+                        + "        value: \"int16\"\n"
+                        + "      }\n"
+                        + "    ]\n"
+                        + "  }];\n"
+                        + "}";
+
+        ProtobufSchema schema = new ProtobufSchema(schemaStr);
+        ProtoCompiler protoCompiler =
+                new ProtoCompiler(DEFAULT_CLASS_SUFFIX, USE_DEFAULT_PROTO_INCLUDES);
+
+        // We just want to check that the compiler doesn't throw an exception
+        protoCompiler.generateMessageClass(schema, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void confluentTagsWithImportProto3() throws Exception {
+        // the schemas registered by Debezium don't always seem to have the import statement in
+        // the definition
+        String schemaStr =
+                "syntax = \"proto3\";\n"
+                        + "package org.apache.flink.formats.protobuf.proto;\n"
+                        + "import \"confluent/meta.proto\";\n"
+                        + "\n"
+                        + "message ConfluentTagsWithImportProto3 {\n"
+                        + "  int32 int = 1 [(confluent.field_meta) = {\n"
+                        + "    params: [\n"
+                        + "      {\n"
+                        + "        key: \"connect.type\",\n"
+                        + "        value: \"int16\"\n"
+                        + "      }\n"
+                        + "    ]\n"
+                        + "  }];\n"
+                        + "}";
+
+        ProtobufSchema schema = new ProtobufSchema(schemaStr);
+        ProtoCompiler protoCompiler =
+                new ProtoCompiler(DEFAULT_CLASS_SUFFIX, USE_DEFAULT_PROTO_INCLUDES);
+
+        // We just want to check that the compiler doesn't throw an exception
+        protoCompiler.generateMessageClass(schema, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void confluentTagsWithoutDefaultIncludesProto3() throws Exception {
+        String schemaStr =
+                "syntax = \"proto3\";\n"
+                        + "package org.apache.flink.formats.protobuf.proto;\n"
+                        + "import \"confluent/meta.proto\";\n"
+                        + "\n"
+                        + "message ConfluentTagsWithImportProto3 {\n"
+                        + "  int32 int = 1 [(confluent.field_meta) = {\n"
+                        + "    params: [\n"
+                        + "      {\n"
+                        + "        key: \"connect.type\",\n"
+                        + "        value: \"int16\"\n"
+                        + "      }\n"
+                        + "    ]\n"
+                        + "  }];\n"
+                        + "}";
+
+        ProtobufSchema schema = new ProtobufSchema(schemaStr);
+        boolean useDefaultProtoIncludes = false;
+        ProtoCompiler protoCompiler =
+                new ProtoCompiler(DEFAULT_CLASS_SUFFIX, useDefaultProtoIncludes);
+
+        Assertions.assertThrows(
+                RuntimeException.class,
+                () -> protoCompiler.generateMessageClass(schema, DEFAULT_SCHEMA_ID));
+    }
+
+    @Test
+    public void customIncludesProto3() throws Exception {
+        String schemaStr =
+                "syntax = \"proto3\";\n"
+                        + "package org.apache.flink.formats.protobuf.proto;\n"
+                        + "import \"confluent/meta.proto\";\n"
+                        + "\n"
+                        + "message ConfluentTagsWithImportProto3 {\n"
+                        + "  int32 int = 1 [(confluent.field_meta) = {\n"
+                        + "    params: [\n"
+                        + "      {\n"
+                        + "        key: \"connect.type\",\n"
+                        + "        value: \"int16\"\n"
+                        + "      }\n"
+                        + "    ]\n"
+                        + "  }];\n"
+                        + "}";
+
+        ProtobufSchema schema = new ProtobufSchema(schemaStr);
+        boolean useDefaultProtoIncludes = false;
+        String[] customProtoIncludes =
+                new String[] {
+                    "/confluent/meta.proto",
+                    "/confluent/type/decimal.proto",
+                    "/google/protobuf/descriptor.proto"
+                };
+        ProtoCompiler protoCompiler =
+                new ProtoCompiler(
+                        DEFAULT_CLASS_SUFFIX, useDefaultProtoIncludes, customProtoIncludes);
+
+        // We just want to check that the compiler doesn't throw an exception
+        protoCompiler.generateMessageClass(schema, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void optionalWithConfluentTagsProto3() throws Exception {
+        String schemaStr =
+                "syntax = \"proto3\";\n"
+                        + "package org.apache.flink.formats.protobuf.proto;\n"
+                        + "\n"
+                        + "message Envelope {\n"
+                        + "  optional Value before = 1;\n"
+                        + "\n"
+                        + "  message Value {\n"
+                        + "    int64 id = 1 [deprecated = false];\n"
+                        + "    optional int64 other_id = 2 ;\n"
+                        + "    optional int32 is_published = 13 [\n"
+                        + "      deprecated = false,\n"
+                        + "      (confluent.field_meta) = {\n"
+                        + "        params: [\n"
+                        + "          {\n"
+                        + "            key: \"connect.type\",\n"
+                        + "            value: \"int16\"\n"
+                        + "          }\n"
+                        + "        ]\n"
+                        + "      }\n"
+                        + "    ];"
+                        + "  }\n"
+                        + "}";
+
+        ProtobufSchema schema = new ProtobufSchema(schemaStr);
+        ProtoCompiler protoCompiler =
+                new ProtoCompiler(DEFAULT_CLASS_SUFFIX, USE_DEFAULT_PROTO_INCLUDES);
+
+        // We just want to check that the compiler doesn't throw an exception
+        protoCompiler.generateMessageClass(schema, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void flatProto2() throws Exception {
+        FlatProto2OuterClass.FlatProto2 in =
+                FlatProto2OuterClass.FlatProto2.newBuilder()
+                        .setString(TEST_STRING)
+                        .setInt(TEST_INT)
+                        .setLong(TEST_LONG)
+                        .setFloat(TEST_FLOAT)
+                        .setDouble(TEST_DOUBLE)
+                        .addInts(TEST_INT)
+                        .setBytes(TEST_BYTES)
+                        .setBool(TEST_BOOL)
+                        .build();
+        runCompilerTest(in, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void flatProto2WithFieldsOmitted() throws Exception {
+        FlatProto2OuterClass.FlatProto2 in =
+                FlatProto2OuterClass.FlatProto2.newBuilder()
+                        .setLong(TEST_LONG)
+                        .setFloat(TEST_FLOAT)
+                        .setDouble(TEST_DOUBLE)
+                        .addInts(TEST_INT)
+                        .setBool(TEST_BOOL)
+                        .build();
+        runCompilerTest(in, DEFAULT_SCHEMA_ID);
+    }
+
+    @Test
+    public void sameSchemaDifferentIds() throws Exception {
+        FlatProto3OuterClass.FlatProto3 in =
+                FlatProto3OuterClass.FlatProto3.newBuilder()
+                        .setString(TEST_STRING)
+                        .setInt(TEST_INT)
+                        .setLong(TEST_LONG)
+                        .setFloat(TEST_FLOAT)
+                        .setDouble(TEST_DOUBLE)
+                        .addInts(TEST_INT)
+                        .setBytes(TEST_BYTES)
+                        .setBool(TEST_BOOL)
+                        .build();
+        byte[] inBytes = in.toByteArray();
+
+        ProtobufSchema schema = new ProtobufSchema(in.getDescriptorForType());
+        ProtoCompiler protoCompiler =
+                new ProtoCompiler(DEFAULT_CLASS_SUFFIX, USE_DEFAULT_PROTO_INCLUDES);
+        Class generatedClass1 = protoCompiler.generateMessageClass(schema, 1);
+        Class generatedClass2 = protoCompiler.generateMessageClass(schema, 2);
+
+        byte[] reprocessedBytes1 = processOriginalBytesWithGeneratedClass(generatedClass1, inBytes);
+        byte[] reprocessedBytes2 = processOriginalBytesWithGeneratedClass(generatedClass2, inBytes);
+
+        Assertions.assertArrayEquals(
+                inBytes, reprocessedBytes1, "Input and output1 messages are not the same");
+        Assertions.assertArrayEquals(
+                inBytes, reprocessedBytes2, "Input and output2 messages are not the same");
+
+        assertGeneratedClassName(in, generatedClass1, 1);
+        assertGeneratedClassName(in, generatedClass2, 2);
+    }
+
+    @Test
+    public void noClassNameClashForSameSchemaOnDifferentThreads() throws Exception {
+        FlatProto3OuterClass.FlatProto3 in =
+                FlatProto3OuterClass.FlatProto3.newBuilder()
+                        .setString(TEST_STRING)
+                        .setInt(TEST_INT)
+                        .setLong(TEST_LONG)
+                        .setFloat(TEST_FLOAT)
+                        .setDouble(TEST_DOUBLE)
+                        .addInts(TEST_INT)
+                        .setBytes(TEST_BYTES)
+                        .setBool(TEST_BOOL)
+                        .build();
+        byte[] inBytes = in.toByteArray();
+        ProtobufSchema schema = new ProtobufSchema(in.getDescriptorForType());
+
+        Queue<Class> classes = new ConcurrentLinkedQueue<>();
+
+        Thread thread1 =
+                new Thread(
+                        () -> {
+                            try {
+                                ProtoCompiler protoCompiler =
+                                        new ProtoCompiler(USE_DEFAULT_PROTO_INCLUDES);
+                                Class generatedClass =
+                                        protoCompiler.generateMessageClass(
+                                                schema, DEFAULT_SCHEMA_ID);
+                                classes.add(generatedClass);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+        Thread thread2 =
+                new Thread(
+                        () -> {
+                            try {
+                                ProtoCompiler protoCompiler =
+                                        new ProtoCompiler(USE_DEFAULT_PROTO_INCLUDES);
+                                Class generatedClass =
+                                        protoCompiler.generateMessageClass(
+                                                schema, DEFAULT_SCHEMA_ID);
+                                classes.add(generatedClass);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+        thread1.start();
+        thread2.start();
+
+        thread1.join();
+        thread2.join();
+
+        Class generatedClass1 = classes.poll();
+        Class generatedClass2 = classes.poll();
+
+        byte[] reprocessedBytes1 = processOriginalBytesWithGeneratedClass(generatedClass1, inBytes);
+        byte[] reprocessedBytes2 = processOriginalBytesWithGeneratedClass(generatedClass2, inBytes);
+
+        Assertions.assertArrayEquals(
+                inBytes, reprocessedBytes1, "Input and output1 messages are not the same");
+        Assertions.assertArrayEquals(
+                inBytes, reprocessedBytes2, "Input and output2 messages are not the same");
+
+        Assertions.assertNotEquals(generatedClass1.getName(), generatedClass2.getName());
+    }
+
+    private Class runCompilerTest(Message message, int fakeSchemaId) throws Exception {
+        byte[] inBytes = message.toByteArray();
+
+        // Fixtures
+        ProtobufSchema schema = new ProtobufSchema(message.getDescriptorForType());
+        ProtoCompiler protoCompiler =
+                new ProtoCompiler(DEFAULT_CLASS_SUFFIX, USE_DEFAULT_PROTO_INCLUDES);
+
+        // Call the target method
+        Class messageClass = protoCompiler.generateMessageClass(schema, fakeSchemaId);
+
+        // Parse the original message and then serialize it back
+        byte[] outBytes = processOriginalBytesWithGeneratedClass(messageClass, inBytes);
+
+        // Check if the original and the rebuilt messages are the same
+        Assertions.assertArrayEquals(
+                inBytes, outBytes, "Input and output messages are not the same");
+        return messageClass;
+    }
+
+    private byte[] processOriginalBytesWithGeneratedClass(Class generatedClass, byte[] inBytes)
+            throws Exception {
+        Method parseFromMethod =
+                generatedClass.getMethod(PbConstant.PB_METHOD_PARSE_FROM, byte[].class);
+        Method toByteArrayMethod = generatedClass.getMethod("toByteArray");
+
+        // Parse the original message and then serialize it back
+        return (byte[]) toByteArrayMethod.invoke(parseFromMethod.invoke(null, inBytes));
+    }
+
+    public void assertGeneratedClassName(
+            Message originalMessage, Class generatedClass, int fakeSchemaId) {
+        String originalMessageClassName = originalMessage.getClass().getName();
+        String[] originalMessageClassNameParts = originalMessageClassName.split("\\$");
+        String originalMessageInnerClassName =
+                originalMessageClassNameParts[originalMessageClassNameParts.length - 1];
+        String generatedClassName = generatedClass.getName();
+        String expectedGeneratedClassName =
+                String.format(
+                        "%s.%s_%d_%s$%s",
+                        DEFAULT_PACKAGE,
+                        originalMessageInnerClassName,
+                        fakeSchemaId,
+                        DEFAULT_CLASS_SUFFIX,
+                        originalMessageInnerClassName);
+        Assertions.assertEquals(expectedGeneratedClassName, generatedClassName);
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/dynamic/deserializer/ProtoRegistryDynamicDeserializationSchemaTest.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/dynamic/deserializer/ProtoRegistryDynamicDeserializationSchemaTest.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.dynamic.deserializer;
+
+import org.apache.flink.formats.protobuf.proto.AddressAndUser;
+import org.apache.flink.formats.protobuf.proto.ConfluentDebeziumProto3;
+import org.apache.flink.formats.protobuf.proto.FlatProto3OuterClass;
+import org.apache.flink.formats.protobuf.proto.MapProto3;
+import org.apache.flink.formats.protobuf.proto.NestedProto3OuterClass;
+import org.apache.flink.formats.protobuf.proto.TimestampProto3OuterClass;
+import org.apache.flink.protobuf.registry.confluent.SchemaRegistryClientProviders;
+import org.apache.flink.protobuf.registry.confluent.TestUtils;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import io.confluent.protobuf.type.Decimal;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.CUSTOM_PROTO_INCLUDES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.DUMMY_SCHEMA_REGISTRY_URL;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.FAKE_TOPIC;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.IGNORE_PARSE_ERRORS;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.READ_DEFAULT_VALUES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_BYTES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.TEST_INT;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.USE_DEFAULT_PROTO_INCLUDES;
+
+class ProtoRegistryDynamicDeserializationSchemaTest {
+
+    private MockSchemaRegistryClient mockSchemaRegistryClient;
+    private KafkaProtobufSerializer kafkaProtobufSerializer;
+    private SchemaRegistryClientProviders.MockSchemaRegistryClientProvider
+            mockSchemaRegistryClientProvider;
+
+    @BeforeEach
+    public void setup() {
+        mockSchemaRegistryClient = new MockSchemaRegistryClient();
+        Map<String, String> opts = new HashMap<>();
+        opts.put("schema.registry.url", DUMMY_SCHEMA_REGISTRY_URL);
+        kafkaProtobufSerializer = new KafkaProtobufSerializer(mockSchemaRegistryClient, opts);
+        mockSchemaRegistryClientProvider =
+                new SchemaRegistryClientProviders.MockSchemaRegistryClientProvider(
+                        mockSchemaRegistryClient);
+    }
+
+    @Test
+    public void deserializePrimitives() throws Exception {
+        FlatProto3OuterClass.FlatProto3 in =
+                FlatProto3OuterClass.FlatProto3.newBuilder()
+                        .setString(TestUtils.TEST_STRING)
+                        .setInt(TestUtils.TEST_INT)
+                        .setLong(TestUtils.TEST_LONG)
+                        .setFloat(TestUtils.TEST_FLOAT)
+                        .setDouble(TestUtils.TEST_DOUBLE)
+                        .addInts(TestUtils.TEST_INT)
+                        .setBytes(TestUtils.TEST_BYTES)
+                        .setBool(TestUtils.TEST_BOOL)
+                        .build();
+
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, in);
+
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(TestUtils.STRING_FIELD, new VarCharType()),
+                        new RowType.RowField(TestUtils.INT_FIELD, new IntType()),
+                        new RowType.RowField(TestUtils.LONG_FIELD, new BigIntType()));
+
+        ProtoRegistryDynamicDeserializationSchema deser =
+                new ProtoRegistryDynamicDeserializationSchema(
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        rowType,
+                        null,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        deser.open(null);
+
+        RowData actual = deser.deserialize(inBytes);
+        Assertions.assertEquals(3, actual.getArity());
+        Assertions.assertEquals(TestUtils.TEST_STRING, actual.getString(0).toString());
+        Assertions.assertEquals(TestUtils.TEST_INT, actual.getInt(1));
+        Assertions.assertEquals(TestUtils.TEST_LONG, actual.getLong(2));
+    }
+
+    @Test
+    public void deserializeNestedRow() throws Exception {
+        NestedProto3OuterClass.NestedProto3 in =
+                NestedProto3OuterClass.NestedProto3.newBuilder()
+                        .setString(TestUtils.TEST_STRING)
+                        .setInt(TestUtils.TEST_INT)
+                        .setLong(TestUtils.TEST_LONG)
+                        .setNested(
+                                NestedProto3OuterClass.NestedProto3.Nested.newBuilder()
+                                        .setDouble(TestUtils.TEST_DOUBLE)
+                                        .setFloat(TestUtils.TEST_FLOAT)
+                                        .build())
+                        .build();
+
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, in);
+
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(
+                                TestUtils.NESTED_FIELD,
+                                TestUtils.createRowType(
+                                        new RowType.RowField(
+                                                TestUtils.FLOAT_FIELD, new FloatType()),
+                                        new RowType.RowField(
+                                                TestUtils.DOUBLE_FIELD, new DoubleType()))),
+                        new RowType.RowField(TestUtils.STRING_FIELD, new VarCharType()),
+                        new RowType.RowField(TestUtils.INT_FIELD, new IntType()));
+
+        ProtoRegistryDynamicDeserializationSchema deser =
+                new ProtoRegistryDynamicDeserializationSchema(
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        rowType,
+                        null,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        deser.open(null);
+
+        RowData actual = deser.deserialize(inBytes);
+        Assertions.assertEquals(3, actual.getArity());
+        Assertions.assertEquals(TestUtils.TEST_STRING, actual.getString(1).toString());
+        Assertions.assertEquals(TestUtils.TEST_INT, actual.getInt(2));
+
+        GenericRowData nestedValue = new GenericRowData(2);
+        nestedValue.setField(0, TestUtils.TEST_FLOAT);
+        nestedValue.setField(1, TestUtils.TEST_DOUBLE);
+        Assertions.assertEquals(nestedValue, actual.getRow(0, 2));
+    }
+
+    @Test
+    public void deserializeArray() throws Exception {
+        FlatProto3OuterClass.FlatProto3 in =
+                FlatProto3OuterClass.FlatProto3.newBuilder()
+                        .addInts(TestUtils.TEST_INT)
+                        .addInts(TestUtils.TEST_INT * 2)
+                        .build();
+
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, in);
+
+        RowType rowType =
+                TestUtils.createRowType(new RowType.RowField("ints", new ArrayType(new IntType())));
+
+        ProtoRegistryDynamicDeserializationSchema deser =
+                new ProtoRegistryDynamicDeserializationSchema(
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        rowType,
+                        null,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        deser.open(null);
+
+        RowData actual = deser.deserialize(inBytes);
+        Assertions.assertEquals(1, actual.getArity());
+        Assertions.assertEquals(TestUtils.TEST_INT, actual.getArray(0).getInt(0));
+        Assertions.assertEquals(TestUtils.TEST_INT * 2, actual.getArray(0).getInt(1));
+    }
+
+    @Test
+    public void deserializeMap() throws Exception {
+        MapProto3.Proto3Map in =
+                MapProto3.Proto3Map.newBuilder()
+                        .putMap(TestUtils.TEST_STRING, TestUtils.TEST_STRING)
+                        .putNested(
+                                TestUtils.TEST_STRING,
+                                MapProto3.Proto3Map.Nested.newBuilder()
+                                        .setDouble(TestUtils.TEST_DOUBLE)
+                                        .setFloat(TestUtils.TEST_FLOAT)
+                                        .build())
+                        .build();
+
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, in);
+
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(
+                                TestUtils.MAP_FIELD,
+                                new MapType(new VarCharType(), new VarCharType())),
+                        new RowType.RowField(
+                                TestUtils.NESTED_FIELD,
+                                new MapType(
+                                        new VarCharType(),
+                                        TestUtils.createRowType(
+                                                new RowType.RowField(
+                                                        TestUtils.DOUBLE_FIELD, new DoubleType()),
+                                                new RowType.RowField(
+                                                        TestUtils.FLOAT_FIELD,
+                                                        new DoubleType())))));
+
+        ProtoRegistryDynamicDeserializationSchema deser =
+                new ProtoRegistryDynamicDeserializationSchema(
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        rowType,
+                        null,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        deser.open(null);
+
+        RowData actual = deser.deserialize(inBytes);
+        Assertions.assertEquals(2, actual.getArity());
+
+        Map<BinaryStringData, BinaryStringData> expectedMap = new HashMap<>();
+        BinaryStringData binaryString = BinaryStringData.fromString(TestUtils.TEST_STRING);
+        expectedMap.put(binaryString, binaryString);
+        Assertions.assertEquals(new GenericMapData(expectedMap), actual.getMap(0));
+
+        GenericRowData nestedMapValue = new GenericRowData(2);
+        nestedMapValue.setField(0, TestUtils.TEST_DOUBLE);
+        nestedMapValue.setField(1, TestUtils.TEST_FLOAT);
+        Assertions.assertEquals(nestedMapValue, actual.getMap(1).valueArray().getRow(0, 2));
+    }
+
+    @Test
+    public void deserializeTimestamp() throws Exception {
+        TimestampProto3OuterClass.TimestampProto3 in =
+                TimestampProto3OuterClass.TimestampProto3.newBuilder()
+                        .setTs(
+                                com.google.protobuf.Timestamp.newBuilder()
+                                        .setSeconds(TestUtils.TEST_LONG)
+                                        .setNanos(TestUtils.TEST_INT)
+                                        .build())
+                        .build();
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, in);
+
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(
+                                TestUtils.TIMESTAMP_FIELD,
+                                TestUtils.createRowType(
+                                        new RowType.RowField(
+                                                TestUtils.SECONDS_FIELD, new BigIntType()),
+                                        new RowType.RowField(
+                                                TestUtils.NANOS_FIELD, new IntType()))));
+
+        ProtoRegistryDynamicDeserializationSchema deser =
+                new ProtoRegistryDynamicDeserializationSchema(
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        rowType,
+                        null,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        deser.open(null);
+
+        RowData actual = deser.deserialize(inBytes);
+        Assertions.assertEquals(1, actual.getArity());
+
+        GenericRowData timestampValue = new GenericRowData(2);
+        timestampValue.setField(0, TestUtils.TEST_LONG);
+        timestampValue.setField(1, TestUtils.TEST_INT);
+        Assertions.assertEquals(timestampValue, actual.getRow(0, 2));
+    }
+
+    @Test
+    public void deserializeConfluentDecimal() throws Exception {
+        ConfluentDebeziumProto3.DecimalProto3 in =
+                ConfluentDebeziumProto3.DecimalProto3.newBuilder()
+                        .setDecimal(
+                                Decimal.newBuilder()
+                                        .setValue(TEST_BYTES)
+                                        .setPrecision(TEST_INT * 2)
+                                        .setScale(TEST_INT)
+                                        .build())
+                        .build();
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, in);
+
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(
+                                "decimal",
+                                TestUtils.createRowType(
+                                        new RowType.RowField("value", new BinaryType()),
+                                        new RowType.RowField("precision", new IntType()),
+                                        new RowType.RowField("scale", new IntType()))));
+
+        ProtoRegistryDynamicDeserializationSchema deser =
+                new ProtoRegistryDynamicDeserializationSchema(
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        rowType,
+                        null,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        deser.open(null);
+
+        RowData actual = deser.deserialize(inBytes);
+        Assertions.assertEquals(1, actual.getArity());
+
+        GenericRowData decimalValue = new GenericRowData(3);
+        decimalValue.setField(0, TestUtils.TEST_BYTES.toByteArray());
+        decimalValue.setField(1, TestUtils.TEST_INT * 2);
+        decimalValue.setField(2, TestUtils.TEST_INT);
+        Assertions.assertEquals(decimalValue, actual.getRow(0, 3));
+    }
+
+    @Test
+    public void deserializeUsingSchemaWithReferences() throws Exception {
+
+        ProtobufSchema addressSchema =
+                new ProtobufSchema(AddressAndUser.AddressProto.getDescriptor());
+        mockSchemaRegistryClient.register("Address", addressSchema);
+
+        // Register the User schema
+        SchemaReference schemaReference = new SchemaReference("Address", "Address", null);
+        ProtobufSchema userSchema =
+                new ProtobufSchema(
+                        AddressAndUser.UserProto.getDescriptor(), Arrays.asList(schemaReference));
+        mockSchemaRegistryClient.register("User", userSchema);
+
+        Assertions.assertFalse(
+                mockSchemaRegistryClient.getLatestSchemaMetadata("User").getReferences().isEmpty(),
+                "User schema should have references");
+
+        AddressAndUser.UserProto in =
+                AddressAndUser.UserProto.newBuilder()
+                        .setName(TestUtils.TEST_STRING)
+                        .setAddress(
+                                AddressAndUser.AddressProto.newBuilder()
+                                        .setStreet(TestUtils.TEST_STRING)
+                                        .setCity(TestUtils.TEST_STRING)
+                                        .build())
+                        .build();
+
+        byte[] inBytes = kafkaProtobufSerializer.serialize(FAKE_TOPIC, in);
+
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField("name", new VarCharType()),
+                        new RowType.RowField(
+                                "address",
+                                TestUtils.createRowType(
+                                        new RowType.RowField("street", new VarCharType()),
+                                        new RowType.RowField("city", new VarCharType()))));
+        ProtoRegistryDynamicDeserializationSchema deser =
+                new ProtoRegistryDynamicDeserializationSchema(
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        rowType,
+                        null,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        deser.open(null);
+
+        RowData actual = deser.deserialize(inBytes);
+        Assertions.assertEquals(2, actual.getArity());
+        Assertions.assertEquals(TestUtils.TEST_STRING, actual.getString(0).toString());
+        Assertions.assertEquals(TestUtils.TEST_STRING, actual.getRow(1, 2).getString(0).toString());
+        Assertions.assertEquals(TestUtils.TEST_STRING, actual.getRow(1, 2).getString(1).toString());
+    }
+
+    @Test
+    public void deserializeTombstone() throws Exception {
+
+        byte[] inBytes = null;
+
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(TestUtils.STRING_FIELD, new VarCharType()));
+        ProtoRegistryDynamicDeserializationSchema deser =
+                new ProtoRegistryDynamicDeserializationSchema(
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        rowType,
+                        null,
+                        IGNORE_PARSE_ERRORS,
+                        READ_DEFAULT_VALUES,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        deser.open(null);
+
+        Assertions.assertNull(deser.deserialize(inBytes));
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/ProtoRegistryDynamicSerializationSchemaTest.java
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/java/org/apache/flink/protobuf/registry/confluent/dynamic/serializer/ProtoRegistryDynamicSerializationSchemaTest.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.protobuf.registry.confluent.dynamic.serializer;
+
+import org.apache.flink.protobuf.registry.confluent.SchemaRegistryClientProviders;
+import org.apache.flink.protobuf.registry.confluent.TestUtils;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.CUSTOM_PROTO_INCLUDES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.DUMMY_SCHEMA_REGISTRY_URL;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.FAKE_SUBJECT;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.USE_DEFAULT_PROTO_INCLUDES;
+import static org.apache.flink.protobuf.registry.confluent.TestUtils.parseBytesToMessage;
+
+public class ProtoRegistryDynamicSerializationSchemaTest {
+
+    private MockSchemaRegistryClient mockSchemaRegistryClient;
+    private String className;
+    private SchemaRegistryClientProviders.MockSchemaRegistryClientProvider
+            mockSchemaRegistryClientProvider;
+
+    @BeforeEach
+    public void setup() {
+        mockSchemaRegistryClient = new MockSchemaRegistryClient();
+        className = TestUtils.DEFAULT_CLASS_NAME + UUID.randomUUID().toString().replace("-", "");
+        mockSchemaRegistryClientProvider =
+                new SchemaRegistryClientProviders.MockSchemaRegistryClientProvider(
+                        mockSchemaRegistryClient);
+    }
+
+    @Test
+    public void serializePrimitiveTypes() throws Exception {
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(TestUtils.STRING_FIELD, new VarCharType()),
+                        new RowType.RowField(TestUtils.INT_FIELD, new IntType()),
+                        new RowType.RowField(TestUtils.LONG_FIELD, new BigIntType()),
+                        new RowType.RowField(TestUtils.FLOAT_FIELD, new FloatType()),
+                        new RowType.RowField(TestUtils.DOUBLE_FIELD, new DoubleType()),
+                        new RowType.RowField(TestUtils.BOOL_FIELD, new BooleanType()),
+                        new RowType.RowField(TestUtils.BYTES_FIELD, new BinaryType()));
+        ProtoRegistryDynamicSerializationSchema protoRegistryDynamicSerializationSchema =
+                new ProtoRegistryDynamicSerializationSchema(
+                        TestUtils.DEFAULT_PACKAGE,
+                        className,
+                        rowType,
+                        FAKE_SUBJECT,
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        protoRegistryDynamicSerializationSchema.open(null);
+
+        GenericRowData rowData = new GenericRowData(7);
+        rowData.setField(0, StringData.fromString(TestUtils.TEST_STRING));
+        rowData.setField(1, TestUtils.TEST_INT);
+        rowData.setField(2, TestUtils.TEST_LONG);
+        rowData.setField(3, TestUtils.TEST_FLOAT);
+        rowData.setField(4, TestUtils.TEST_DOUBLE);
+        rowData.setField(5, true);
+        rowData.setField(6, TestUtils.TEST_BYTES.toByteArray());
+
+        byte[] actualBytes = protoRegistryDynamicSerializationSchema.serialize(rowData);
+
+        Message message = parseBytesToMessage(actualBytes, mockSchemaRegistryClient);
+        Descriptors.FieldDescriptor stringField =
+                message.getDescriptorForType().findFieldByName(TestUtils.STRING_FIELD);
+        Descriptors.FieldDescriptor intField =
+                message.getDescriptorForType().findFieldByName(TestUtils.INT_FIELD);
+        Descriptors.FieldDescriptor longField =
+                message.getDescriptorForType().findFieldByName(TestUtils.LONG_FIELD);
+        Descriptors.FieldDescriptor floatField =
+                message.getDescriptorForType().findFieldByName(TestUtils.FLOAT_FIELD);
+        Descriptors.FieldDescriptor doubleField =
+                message.getDescriptorForType().findFieldByName(TestUtils.DOUBLE_FIELD);
+        Descriptors.FieldDescriptor boolField =
+                message.getDescriptorForType().findFieldByName(TestUtils.BOOL_FIELD);
+        Descriptors.FieldDescriptor bytesField =
+                message.getDescriptorForType().findFieldByName(TestUtils.BYTES_FIELD);
+
+        Assertions.assertEquals(TestUtils.TEST_STRING, message.getField(stringField));
+        Assertions.assertEquals(TestUtils.TEST_INT, message.getField(intField));
+        Assertions.assertEquals(TestUtils.TEST_LONG, message.getField(longField));
+        Assertions.assertEquals(TestUtils.TEST_FLOAT, message.getField(floatField));
+        Assertions.assertEquals(TestUtils.TEST_DOUBLE, message.getField(doubleField));
+        Assertions.assertEquals(true, message.getField(boolField));
+        Assertions.assertEquals(TestUtils.TEST_BYTES, message.getField(bytesField));
+    }
+
+    @Test
+    public void serializeNestedRow() throws Exception {
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(
+                                TestUtils.NESTED_FIELD,
+                                TestUtils.createRowType(
+                                        new RowType.RowField(
+                                                TestUtils.STRING_FIELD, new VarCharType()),
+                                        new RowType.RowField(TestUtils.INT_FIELD, new IntType()))));
+
+        ProtoRegistryDynamicSerializationSchema protoRegistryDynamicSerializationSchema =
+                new ProtoRegistryDynamicSerializationSchema(
+                        TestUtils.DEFAULT_PACKAGE,
+                        className,
+                        rowType,
+                        FAKE_SUBJECT,
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        protoRegistryDynamicSerializationSchema.open(null);
+
+        GenericRowData nestedRow = new GenericRowData(2);
+        nestedRow.setField(0, StringData.fromString(TestUtils.TEST_STRING));
+        nestedRow.setField(1, TestUtils.TEST_INT);
+
+        GenericRowData rowData = new GenericRowData(1);
+        rowData.setField(0, nestedRow);
+
+        byte[] actualBytes = protoRegistryDynamicSerializationSchema.serialize(rowData);
+
+        Message message = parseBytesToMessage(actualBytes, mockSchemaRegistryClient);
+        Descriptors.FieldDescriptor nestedField =
+                message.getDescriptorForType().findFieldByName(TestUtils.NESTED_FIELD);
+        DynamicMessage nestedMessage = (DynamicMessage) message.getField(nestedField);
+        Descriptors.FieldDescriptor stringField =
+                nestedMessage.getDescriptorForType().findFieldByName(TestUtils.STRING_FIELD);
+        Descriptors.FieldDescriptor intField =
+                nestedMessage.getDescriptorForType().findFieldByName(TestUtils.INT_FIELD);
+
+        Assertions.assertEquals(TestUtils.TEST_STRING, nestedMessage.getField(stringField));
+        Assertions.assertEquals(TestUtils.TEST_INT, nestedMessage.getField(intField));
+    }
+
+    @Test
+    public void serializeArray() throws Exception {
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(
+                                TestUtils.ARRAY_FIELD, new ArrayType(new VarCharType())));
+
+        ProtoRegistryDynamicSerializationSchema protoRegistryDynamicSerializationSchema =
+                new ProtoRegistryDynamicSerializationSchema(
+                        TestUtils.DEFAULT_PACKAGE,
+                        className,
+                        rowType,
+                        FAKE_SUBJECT,
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        protoRegistryDynamicSerializationSchema.open(null);
+
+        GenericRowData rowData = new GenericRowData(1);
+        StringData[] arrayData =
+                new StringData[] {StringData.fromString("a"), StringData.fromString("b")};
+        rowData.setField(0, new GenericArrayData(arrayData));
+
+        byte[] actualBytes = protoRegistryDynamicSerializationSchema.serialize(rowData);
+
+        Message message = parseBytesToMessage(actualBytes, mockSchemaRegistryClient);
+        Descriptors.FieldDescriptor arrayField =
+                message.getDescriptorForType().findFieldByName(TestUtils.ARRAY_FIELD);
+
+        Assertions.assertArrayEquals(
+                new String[] {"a", "b"}, ((List) message.getField(arrayField)).toArray());
+    }
+
+    @Test
+    public void serializeMap() throws Exception {
+        String otherMapField = "other_m_a_p"; // Exercises the camel case logic
+        String nestedMapField = "nested_map";
+
+        RowType nestedMapValueType =
+                TestUtils.createRowType(
+                        new RowType.RowField(
+                                TestUtils.ARRAY_FIELD, new ArrayType(new VarCharType())),
+                        new RowType.RowField(TestUtils.INT_FIELD, new IntType()));
+
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(
+                                TestUtils.MAP_FIELD, new MapType(new VarCharType(), new IntType())),
+                        new RowType.RowField(
+                                otherMapField, new MapType(new VarCharType(), new IntType())),
+                        new RowType.RowField(
+                                nestedMapField,
+                                new MapType(new VarCharType(), nestedMapValueType)));
+        ProtoRegistryDynamicSerializationSchema protoRegistryDynamicSerializationSchema =
+                new ProtoRegistryDynamicSerializationSchema(
+                        TestUtils.DEFAULT_PACKAGE,
+                        className,
+                        rowType,
+                        FAKE_SUBJECT,
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        protoRegistryDynamicSerializationSchema.open(null);
+
+        GenericRowData rowData = new GenericRowData(3);
+        Map<StringData, Integer> mapContent = new HashMap<>();
+        mapContent.put(StringData.fromString(TestUtils.TEST_STRING), TestUtils.TEST_INT);
+        rowData.setField(0, new GenericMapData(mapContent));
+        rowData.setField(1, new GenericMapData(mapContent));
+
+        Map<StringData, RowData> nestedMapContent = new HashMap<>();
+        GenericRowData nestedMapValue = new GenericRowData(2);
+        StringData[] arrayData =
+                new StringData[] {StringData.fromString("a"), StringData.fromString("b")};
+        nestedMapValue.setField(0, new GenericArrayData(arrayData));
+        nestedMapValue.setField(1, TestUtils.TEST_INT);
+        nestedMapContent.put(StringData.fromString(TestUtils.TEST_STRING), nestedMapValue);
+        rowData.setField(2, new GenericMapData(nestedMapContent));
+
+        byte[] actualBytes = protoRegistryDynamicSerializationSchema.serialize(rowData);
+
+        Message message = parseBytesToMessage(actualBytes, mockSchemaRegistryClient);
+
+        Descriptors.FieldDescriptor mapMessageField =
+                message.getDescriptorForType().findFieldByName(TestUtils.MAP_FIELD);
+        DynamicMessage mapMessage =
+                (DynamicMessage) ((List) message.getField(mapMessageField)).get(0);
+        Descriptors.FieldDescriptor mapKeyField =
+                mapMessage.getDescriptorForType().findFieldByName("key");
+        Descriptors.FieldDescriptor mapValueField =
+                mapMessage.getDescriptorForType().findFieldByName("value");
+
+        Assertions.assertEquals(TestUtils.TEST_STRING, mapMessage.getField(mapKeyField));
+        Assertions.assertEquals(TestUtils.TEST_INT, mapMessage.getField(mapValueField));
+
+        Descriptors.FieldDescriptor otherMapMessageField =
+                message.getDescriptorForType().findFieldByName(otherMapField);
+        DynamicMessage otherMapMessage =
+                (DynamicMessage) ((List) message.getField(otherMapMessageField)).get(0);
+        Descriptors.FieldDescriptor otherMapKeyField =
+                otherMapMessage.getDescriptorForType().findFieldByName("key");
+        Descriptors.FieldDescriptor otherMapValueField =
+                otherMapMessage.getDescriptorForType().findFieldByName("value");
+
+        Assertions.assertEquals(TestUtils.TEST_STRING, otherMapMessage.getField(otherMapKeyField));
+        Assertions.assertEquals(TestUtils.TEST_INT, otherMapMessage.getField(otherMapValueField));
+
+        Descriptors.FieldDescriptor nestedMapMessageField =
+                message.getDescriptorForType().findFieldByName(nestedMapField);
+        DynamicMessage nestedMapMessage =
+                (DynamicMessage) ((List) message.getField(nestedMapMessageField)).get(0);
+        Descriptors.FieldDescriptor nestedMapValueField =
+                nestedMapMessage.getDescriptorForType().findFieldByName("value");
+        DynamicMessage nestedMapValueMessage =
+                (DynamicMessage) nestedMapMessage.getField(nestedMapValueField);
+        Descriptors.FieldDescriptor nestedMapValueArrayField =
+                nestedMapValueField.getMessageType().findFieldByName(TestUtils.ARRAY_FIELD);
+        Descriptors.FieldDescriptor nestedMapValueIntField =
+                nestedMapValueField.getMessageType().findFieldByName(TestUtils.INT_FIELD);
+
+        Assertions.assertArrayEquals(
+                new String[] {"a", "b"},
+                ((List) nestedMapValueMessage.getField(nestedMapValueArrayField)).toArray());
+        Assertions.assertEquals(
+                TestUtils.TEST_INT, nestedMapValueMessage.getField(nestedMapValueIntField));
+    }
+
+    @Test
+    public void serializeTimestamp() throws Exception {
+        RowType rowType =
+                TestUtils.createRowType(
+                        new RowType.RowField(
+                                TestUtils.TIMESTAMP_FIELD,
+                                TestUtils.createRowType(
+                                        new RowType.RowField(
+                                                TestUtils.SECONDS_FIELD, new BigIntType()),
+                                        new RowType.RowField(
+                                                TestUtils.NANOS_FIELD, new IntType()))));
+        ProtoRegistryDynamicSerializationSchema protoRegistryDynamicSerializationSchema =
+                new ProtoRegistryDynamicSerializationSchema(
+                        TestUtils.DEFAULT_PACKAGE,
+                        className,
+                        rowType,
+                        FAKE_SUBJECT,
+                        mockSchemaRegistryClientProvider,
+                        DUMMY_SCHEMA_REGISTRY_URL,
+                        USE_DEFAULT_PROTO_INCLUDES,
+                        CUSTOM_PROTO_INCLUDES);
+        protoRegistryDynamicSerializationSchema.open(null);
+
+        GenericRowData nestedRow = new GenericRowData(2);
+        nestedRow.setField(0, TestUtils.TEST_LONG);
+        nestedRow.setField(1, TestUtils.TEST_INT);
+
+        GenericRowData rowData = new GenericRowData(1);
+        rowData.setField(0, nestedRow);
+
+        byte[] actualBytes = protoRegistryDynamicSerializationSchema.serialize(rowData);
+
+        Message message = parseBytesToMessage(actualBytes, mockSchemaRegistryClient);
+        Descriptors.FieldDescriptor tsFieldDescriptor =
+                message.getDescriptorForType().findFieldByName(TestUtils.TIMESTAMP_FIELD);
+        DynamicMessage tsMessage = (DynamicMessage) message.getField(tsFieldDescriptor);
+        Descriptors.FieldDescriptor secondsField =
+                tsMessage.getDescriptorForType().findFieldByName(TestUtils.SECONDS_FIELD);
+        Descriptors.FieldDescriptor nanosField =
+                tsMessage.getDescriptorForType().findFieldByName(TestUtils.NANOS_FIELD);
+
+        Assertions.assertEquals(TestUtils.TEST_LONG, tsMessage.getField(secondsField));
+        Assertions.assertEquals(TestUtils.TEST_INT, tsMessage.getField(nanosField));
+    }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/address_and_user.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/address_and_user.proto
@@ -1,0 +1,30 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+
+message AddressProto {
+  string street = 1;
+  string city = 2;
+}
+
+message UserProto {
+  string name = 1;
+  AddressProto address = 3;
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/confluent_debezium_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/confluent_debezium_proto3.proto
@@ -1,0 +1,26 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+
+import "confluent/type/decimal.proto";
+
+message DecimalProto3 {
+  confluent.type.Decimal decimal = 1;
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/confluent_tags_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/confluent_tags_proto3.proto
@@ -1,0 +1,33 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+
+import "confluent/meta.proto";
+
+message ConfluentTagsProto3 {
+  int32 int = 1 [(confluent.field_meta) = {
+    params: [
+      {
+        key: "connect.type",
+        value: "int16"
+      }
+    ]
+  }];
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/debezium_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/debezium_proto3.proto
@@ -1,0 +1,61 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package my_table.products;
+
+message Envelope {
+  Value before = 1;
+  Value after = 2;
+  Source source = 3;
+  string op = 4;
+  int64 ts_ms = 5;
+  int64 ts_us = 6;
+  int64 ts_ns = 7;
+  block transaction = 8;
+
+  message Value {
+    int64 long = 1;
+    string string = 2;
+    bool bool = 3;
+  }
+  message Source {
+    string version = 1;
+    string connector = 2;
+    string name = 3;
+    int64 ts_ms = 4;
+    string snapshot = 5;
+    string db = 6;
+    string sequence = 7;
+    int64 ts_us = 8;
+    int64 ts_ns = 9;
+    string table = 10;
+    int64 server_id = 11;
+    string gtid = 12;
+    string file = 13;
+    int64 pos = 14;
+    int32 row = 15;
+    int64 thread = 16;
+    string query = 17;
+  }
+  message block {
+    string id = 1;
+    int64 total_order = 2;
+    int64 data_collection_order = 3;
+  }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/enum_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/enum_proto3.proto
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+
+message EnumProto3 {
+  int32 int = 1;
+  Corpus corpus = 2;
+
+  enum Corpus {
+    UNIVERSAL = 0;
+    WEB = 1;
+  }
+}
+

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/flat_proto2.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/flat_proto2.proto
@@ -1,0 +1,31 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto2";
+package org.apache.flink.formats.protobuf.proto;
+
+message FlatProto2 {
+  optional int32 int = 1;
+  required int64 long = 2;
+  optional string string = 3;
+  required float float = 4;
+  required double double = 5;
+  required bool bool = 6;
+  repeated int32 ints = 8;
+  optional bytes bytes = 9;
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/flat_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/flat_proto3.proto
@@ -1,0 +1,31 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+
+message FlatProto3 {
+  int32 int = 1;
+  int64 long = 2;
+  string string = 3;
+  float float = 4;
+  double double = 5;
+  bool bool = 6;
+  repeated int32 ints = 8;
+  bytes bytes = 9;
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/java_package_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/java_package_proto3.proto
@@ -1,0 +1,32 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+option java_package = "org.apache.flink.formatzz.proto";
+
+message JavaPackageProto3 {
+  int32 int = 1;
+  int64 long = 2;
+  string string = 3;
+  float float = 4;
+  double double = 5;
+  bool bool = 6;
+  repeated int32 ints = 8;
+  bytes bytes = 9;
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/map_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/map_proto3.proto
@@ -1,0 +1,30 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+
+message Proto3Map {
+  map<string, string> map = 1;
+  map<string, Nested> nested = 2;
+
+  message Nested {
+    double double = 1;
+    float float = 2;
+  }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/multiple_files_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/multiple_files_proto3.proto
@@ -1,0 +1,31 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+option java_multiple_files = true;
+
+message MultipleFilesProto3 {
+  int32 int = 1;
+  Nested nested = 4;
+
+  message Nested {
+    double double = 1;
+    float float = 2;
+  }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/nested_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/nested_proto3.proto
@@ -1,0 +1,32 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+
+message NestedProto3 {
+  int32 int = 1;
+  int64 long = 2;
+  string string = 3;
+  Nested nested = 4;
+
+  message Nested {
+    double double = 1;
+    float float = 2;
+  }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/oneof_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/oneof_proto3.proto
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+
+message OneOfProto3 {
+  oneof test_oneof{
+    int32 a = 1;
+    int32 b = 2;
+  }
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/outer_class_option_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/outer_class_option_proto3.proto
@@ -1,0 +1,25 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+option java_outer_classname = "MyFancyOuterClassName";
+
+message OuterClassOptionProto3 {
+  int32 int = 1;
+}

--- a/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/timestamp_proto3.proto
+++ b/flink-formats/flink-protobuf-confluent-registry/src/test/resources/proto/timestamp_proto3.proto
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+package org.apache.flink.formats.protobuf.proto;
+import "google/protobuf/timestamp.proto";
+
+message TimestampProto3 {
+  google.protobuf.Timestamp ts = 1;
+}

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/ProtoToRowConverter.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/deserialize/ProtoToRowConverter.java
@@ -132,7 +132,11 @@ public class ProtoToRowConverter {
 
     public RowData convertProtoBinaryToRow(byte[] data) throws Exception {
         Object messageObj = parseFromMethod.invoke(null, data);
-        return (RowData) decodeMethod.invoke(null, messageObj);
+        return convertProtoObjectToRow(messageObj);
+    }
+
+    public RowData convertProtoObjectToRow(Object message) throws Exception {
+        return (RowData) decodeMethod.invoke(null, message);
     }
 
     @VisibleForTesting

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/BaseMessageSerializer.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/BaseMessageSerializer.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf.serialize;
+
+import com.google.protobuf.AbstractMessage;
+
+public class BaseMessageSerializer implements MessageSerializer {
+    @Override
+    public byte[] serialize(AbstractMessage message) {
+        return message.toByteArray();
+    }
+}

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/MessageSerializer.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/MessageSerializer.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.protobuf.serialize;
+
+import com.google.protobuf.AbstractMessage;
+
+public interface MessageSerializer {
+    byte[] serialize(AbstractMessage message);
+}

--- a/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/RowToProtoConverter.java
+++ b/flink-formats/flink-protobuf/src/main/java/org/apache/flink/formats/protobuf/serialize/RowToProtoConverter.java
@@ -53,9 +53,17 @@ public class RowToProtoConverter {
     private static final Logger LOG = LoggerFactory.getLogger(ProtoToRowConverter.class);
     private final Method encodeMethod;
     private boolean isCodeSplit = false;
+    private MessageSerializer messageSerializer;
 
     public RowToProtoConverter(RowType rowType, PbFormatConfig formatConfig)
             throws PbCodegenException {
+        this(rowType, formatConfig, new BaseMessageSerializer());
+    }
+
+    public RowToProtoConverter(
+            RowType rowType, PbFormatConfig formatConfig, MessageSerializer messageSerializer)
+            throws PbCodegenException {
+        this.messageSerializer = messageSerializer;
         try {
             Descriptors.Descriptor descriptor =
                     PbFormatUtils.getDescriptor(formatConfig.getMessageClassName());
@@ -115,7 +123,7 @@ public class RowToProtoConverter {
 
     public byte[] convertRowToProtoBinary(RowData rowData) throws Exception {
         AbstractMessage message = (AbstractMessage) encodeMethod.invoke(null, rowData);
-        return message.toByteArray();
+        return messageSerializer.serialize(message);
     }
 
     @VisibleForTesting

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -46,6 +46,7 @@ under the License.
 		<module>flink-compress</module>
 		<module>flink-csv</module>
 		<module>flink-protobuf</module>
+		<module>flink-protobuf-confluent-registry</module>
 		<module>flink-orc</module>
 		<module>flink-orc-nohive</module>
 		<module>flink-hadoop-bulk</module>


### PR DESCRIPTION
## What is the purpose of the change

- Add support for deserializing protobuf messages using the Confluent wire format and whose schemas can be fetched from Confluent Schema Registry
- Add support for serializing Flink records using the Confluent protobuf wire format

### Out of scope for this PR

- Support for using the format with user-supplied schemas and classes will be tackled in a separate PR

## Brief change log

My intention was to:
- Maintain parity with the existing flink-protobuf format's semantics in terms of the Flink -> Protobuf / Protobuf -> Flink conversions
- Maximize code reuse between flink-protobuf-confluent and flink-protobuf formats

### Deserializer

- Fetch the message's protobuf descriptor from the Confluent schema registry
- Generate a java class from the descriptor at runtime
- Deserialize `byte[]`s to the generated `protobuf.Message` type using a `io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer`
- Delegate the work of converting between a `protobuf.Message` and a `RowData` object to the existing flink-protobuf format

### Serializer

- Convert the user's `RowType` to a protobuf descriptor
- Generate a java class from the descriptor at runtime
- Delegate the `RowData` -> `AbstractMessage` conversion to the existing flink-protobuf format
- Serialize the `AbstractMessage` object using a `io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer`

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

- Added comprehensive test coverage
- Deployed to Shopify Flink clusters

### Performance

We saw a 2-4X performance boost when using this implementation over our previous in-house serdes that used `DynamicMessage` types for the conversion rather than generated Java objects.
<img width="625" alt="Old serde(2)" src="https://github.com/user-attachments/assets/30d4f9ac-6637-4559-99dc-a4e4bc613f82">

<img width="626" alt="New serde" src="https://github.com/user-attachments/assets/3ab86f1b-80ac-4b33-884f-eb4165ba6d69">

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes (com.github.os72:protoc-jar)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs to follow
