### PR TITLE
[FLINK-35885][table] Ignore advancing window processor by watermark in window agg based on proctime

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
@@ -252,6 +252,7 @@ public class StreamExecWindowRank extends ExecNodeBase<RowData>
                         .rankStart(constantRankRange.getRankStart())
                         .rankEnd(constantRankRange.getRankEnd())
                         .windowEndIndex(windowEndIndex)
+                        .isEventTime(windowing.isRowtime())
                         .build();
 
         OneInputTransformation<RowData, RowData> transform =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
@@ -252,7 +252,7 @@ public class StreamExecWindowRank extends ExecNodeBase<RowData>
                         .rankStart(constantRankRange.getRankStart())
                         .rankEnd(constantRankRange.getRankEnd())
                         .windowEndIndex(windowEndIndex)
-                        .isEventTime(windowing.isRowtime())
+                        .withEventTime(windowing.isRowtime())
                         .build();
 
         OneInputTransformation<RowData, RowData> transform =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.planner.runtime.harness
 
 import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness
 import org.apache.flink.table.api._
@@ -685,6 +686,51 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
 
     // simulate a failover after a failed task open, expect no exception happens
     testHarness1.close()
+  }
+
+  @TestTemplate
+  def testProcessingTimeWindowAggWithLargeWatermarkArrivesFirst(): Unit = {
+    val (testHarness, outputTypes) =
+      createProcessingTimeWindowOperator(TUMBLE, isCDCSource = false)
+    val assertor = new RowDataHarnessAssertor(outputTypes)
+
+    testHarness.open()
+
+    // mock a large watermark arrives before proctime
+    testHarness.processWatermark(10000L)
+
+    testHarness.setProcessingTime(1000L)
+    testHarness.processElement(insertRecord("a", 1d, "str1", null))
+    testHarness.setProcessingTime(2000L)
+    testHarness.processElement(insertRecord("a", 2d, "str2", null))
+    testHarness.setProcessingTime(3000L)
+    testHarness.processElement(insertRecord("a", 3d, "str2", null))
+
+    testHarness.setProcessingTime(6000L)
+    testHarness.processElement(insertRecord("a", 4d, "str1", null))
+
+    testHarness.setProcessingTime(50000L)
+
+    val expected = new ConcurrentLinkedQueue[Object]()
+    expected.add(new Watermark(10000L))
+    expected.add(
+      insertRecord(
+        "a",
+        3L,
+        3.0d,
+        2L,
+        localMills("1970-01-01T00:00:00"),
+        localMills("1970-01-01T00:00:05")))
+    expected.add(
+      insertRecord(
+        "a",
+        1L,
+        4.0d,
+        1L,
+        localMills("1970-01-01T00:00:05"),
+        localMills("1970-01-01T00:00:10")))
+    assertor.assertOutputEqualsSorted("result mismatch", expected, testHarness.getOutput)
+    testHarness.close()
   }
 
   private def createProcessingTimeWindowOperator(testWindow: String, isCDCSource: Boolean)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/WindowAggregateHarnessTest.scala
@@ -689,7 +689,7 @@ class WindowAggregateHarnessTest(backend: StateBackendMode, shiftTimeZone: ZoneI
   }
 
   @TestTemplate
-  def testProcessingTimeWindowAggWithLargeWatermarkArrivesFirst(): Unit = {
+  def testProcessingTimeTumbleWindowWithFutureWatermark(): Unit = {
     val (testHarness, outputTypes) =
       createProcessingTimeWindowOperator(TUMBLE, isCDCSource = false)
     val assertor = new RowDataHarnessAssertor(outputTypes)

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/WindowAggOperatorBuilder.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/WindowAggOperatorBuilder.java
@@ -153,7 +153,7 @@ public class WindowAggOperatorBuilder {
         } else {
             windowProcessor = buildUnslicingWindowProcessor();
         }
-        return new WindowAggOperator<>(windowProcessor);
+        return new WindowAggOperator<>(windowProcessor, assigner.isEventTime());
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/window/RowTimeWindowDeduplicateOperatorBuilder.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/window/RowTimeWindowDeduplicateOperatorBuilder.java
@@ -108,6 +108,6 @@ public class RowTimeWindowDeduplicateOperatorBuilder {
         final SlicingWindowProcessor<Long> windowProcessor =
                 new RowTimeWindowDeduplicateProcessor(
                         inputSerializer, bufferFactory, windowEndIndex, shiftTimeZone);
-        return new WindowAggOperator<>(windowProcessor);
+        return new WindowAggOperator<>(windowProcessor, true);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
@@ -50,7 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *   .rankStart(0)
  *   .rankEnd(100)
  *   .windowEndIndex(windowEndIndex)
- *   .isEventTime(true)
+ *   .withEventTime(true)
  *   .build();
  * </pre>
  */
@@ -118,7 +118,7 @@ public class WindowRankOperatorBuilder {
         return this;
     }
 
-    public WindowRankOperatorBuilder isEventTime(Boolean isEventTime) {
+    public WindowRankOperatorBuilder withEventTime(Boolean isEventTime) {
         this.isEventTime = isEventTime;
         return this;
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
@@ -152,6 +152,7 @@ public class WindowRankOperatorBuilder {
                         outputRankNumber,
                         windowEndIndex,
                         shiftTimeZone);
-        return new WindowAggOperator<>(windowProcessor);
+        // Processing time Window TopN is not supported yet.
+        return new WindowAggOperator<>(windowProcessor, true);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
@@ -50,6 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *   .rankStart(0)
  *   .rankEnd(100)
  *   .windowEndIndex(windowEndIndex)
+ *   .isEventTime(true)
  *   .build();
  * </pre>
  */
@@ -68,6 +69,7 @@ public class WindowRankOperatorBuilder {
     private long rankEnd = -1;
     private int windowEndIndex = -1;
     private ZoneId shiftTimeZone;
+    private Boolean isEventTime;
 
     public WindowRankOperatorBuilder inputSerializer(
             AbstractRowDataSerializer<RowData> inputSerializer) {
@@ -116,11 +118,17 @@ public class WindowRankOperatorBuilder {
         return this;
     }
 
+    public WindowRankOperatorBuilder isEventTime(Boolean isEventTime) {
+        this.isEventTime = isEventTime;
+        return this;
+    }
+
     public WindowAggOperator<RowData, ?> build() {
         checkNotNull(inputSerializer);
         checkNotNull(keySerializer);
         checkNotNull(sortKeySelector);
         checkNotNull(generatedSortKeyComparator);
+        checkNotNull(isEventTime);
         checkArgument(
                 rankStart > 0,
                 String.format("Illegal rank start %s, it should be positive!", rankStart));
@@ -153,6 +161,6 @@ public class WindowRankOperatorBuilder {
                         windowEndIndex,
                         shiftTimeZone);
         // Processing time Window TopN is not supported yet.
-        return new WindowAggOperator<>(windowProcessor, true);
+        return new WindowAggOperator<>(windowProcessor, isEventTime);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowAggOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowAggOperator.java
@@ -225,7 +225,8 @@ public final class WindowAggOperator<K, W> extends TableStreamOperator<RowData>
     @Override
     public void processWatermark(Watermark mark) throws Exception {
         if (mark.getTimestamp() > currentWatermark) {
-            // advance the window processor by timer if this window agg is based on proctime
+            // If this is a proctime window, progress should not be advanced by watermark, or it'll
+            // disturb timer-based processing
             if (isEventTime) {
                 windowProcessor.advanceProgress(mark.getTimestamp());
             }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowAggOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowAggOperator.java
@@ -103,32 +103,35 @@ public final class WindowAggOperator<K, W> extends TableStreamOperator<RowData>
     private static final String WATERMARK_LATENCY_METRIC_NAME = "watermarkLatency";
 
     /** The concrete window operator implementation. */
-    protected final WindowProcessor<W> windowProcessor;
+    private final WindowProcessor<W> windowProcessor;
+
+    private final boolean isEventTime;
 
     // ------------------------------------------------------------------------
 
     /** This is used for emitting elements with a given timestamp. */
-    protected transient TimestampedCollector<RowData> collector;
+    private transient TimestampedCollector<RowData> collector;
 
     /** The service to register timers. */
-    protected transient InternalTimerService<W> internalTimerService;
+    private transient InternalTimerService<W> internalTimerService;
 
     /** The tracked processing time triggered last time. */
-    protected transient long lastTriggeredProcessingTime;
+    private transient long lastTriggeredProcessingTime;
 
     /** The operator state to store watermark. */
-    protected transient ListState<Long> watermarkState;
+    private transient ListState<Long> watermarkState;
 
     // ------------------------------------------------------------------------
     // Metrics
     // ------------------------------------------------------------------------
 
-    protected transient Counter numLateRecordsDropped;
-    protected transient Meter lateRecordsDroppedRate;
-    protected transient Gauge<Long> watermarkLatency;
+    private transient Counter numLateRecordsDropped;
+    private transient Meter lateRecordsDroppedRate;
+    private transient Gauge<Long> watermarkLatency;
 
-    public WindowAggOperator(WindowProcessor<W> windowProcessor) {
+    public WindowAggOperator(WindowProcessor<W> windowProcessor, boolean isEventTime) {
         this.windowProcessor = windowProcessor;
+        this.isEventTime = isEventTime;
         setChainingStrategy(ChainingStrategy.ALWAYS);
     }
 
@@ -222,7 +225,10 @@ public final class WindowAggOperator<K, W> extends TableStreamOperator<RowData>
     @Override
     public void processWatermark(Watermark mark) throws Exception {
         if (mark.getTimestamp() > currentWatermark) {
-            windowProcessor.advanceProgress(mark.getTimestamp());
+            // advance the window processor by timer if this window agg is based on proctime
+            if (isEventTime) {
+                windowProcessor.advanceProgress(mark.getTimestamp());
+            }
             super.processWatermark(mark);
         } else {
             super.processWatermark(new Watermark(currentWatermark));

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
@@ -151,7 +151,7 @@ public class WindowRankOperatorTest {
                         .rankStart(1)
                         .rankEnd(2)
                         .windowEndIndex(WINDOW_END_INDEX)
-                        .isEventTime(true)
+                        .withEventTime(true)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -258,7 +258,7 @@ public class WindowRankOperatorTest {
                         .rankStart(2)
                         .rankEnd(2)
                         .windowEndIndex(WINDOW_END_INDEX)
-                        .isEventTime(true)
+                        .withEventTime(true)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -348,7 +348,7 @@ public class WindowRankOperatorTest {
                         .rankStart(1)
                         .rankEnd(2)
                         .windowEndIndex(WINDOW_END_INDEX)
-                        .isEventTime(true)
+                        .withEventTime(true)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
@@ -151,6 +151,7 @@ public class WindowRankOperatorTest {
                         .rankStart(1)
                         .rankEnd(2)
                         .windowEndIndex(WINDOW_END_INDEX)
+                        .isEventTime(true)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -257,6 +258,7 @@ public class WindowRankOperatorTest {
                         .rankStart(2)
                         .rankEnd(2)
                         .windowEndIndex(WINDOW_END_INDEX)
+                        .isEventTime(true)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -346,6 +348,7 @@ public class WindowRankOperatorTest {
                         .rankStart(1)
                         .rankEnd(2)
                         .windowEndIndex(WINDOW_END_INDEX)
+                        .isEventTime(true)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =


### PR DESCRIPTION
## What is the purpose of the change

This pr tries to ignore the advancement of the window processor caused by watermark in proctime window agg.

## Brief change log

  - *Ignore the advancement of the window processor caused by watermark in proctime window agg*
  - *Add harness test for this bugfix*


## Verifying this change

A harness test has been added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
