### PR TITLE
[FLINK-35897][Checkpoint] Cleanup completed resource when checkpoint is canceled

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategyRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/SnapshotStrategyRunner.java
@@ -99,6 +99,22 @@ public final class SnapshotStrategyRunner<T extends StateObject, SR extends Snap
                     }
 
                     @Override
+                    protected void cleanupCompletedResource(SnapshotResult<T> completedResource) {
+                        try {
+                            completedResource.discardState();
+                            LOG.debug(
+                                    "Cleanup completed resource ({}, {}) success.",
+                                    completedResource.getJobManagerOwnedSnapshot(),
+                                    completedResource.getTaskLocalSnapshot());
+                        } catch (Exception e) {
+                            LOG.warn(
+                                    "Cleanup completed resource ({}, {}) failed.",
+                                    completedResource.getJobManagerOwnedSnapshot(),
+                                    completedResource.getTaskLocalSnapshot());
+                        }
+                    }
+
+                    @Override
                     protected void logAsyncSnapshotComplete(long startTime) {
                         logCompletedInternal(
                                 LOG_ASYNC_COMPLETED_TEMPLATE, streamFactory, startTime);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotContextSynchronousImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSnapshotContextSynchronousImpl.java
@@ -236,5 +236,14 @@ public class StateSnapshotContextSynchronousImpl implements StateSnapshotContext
                 throw new IllegalStateException("Unable to cleanup a stream.", e);
             }
         }
+
+        @Override
+        protected void cleanupCompletedResource(SnapshotResult<T> completedResource) {
+            try {
+                completedResource.discardState();
+            } catch (Exception e) {
+                throw new IllegalStateException("Unable to cleanup the completed resource.", e);
+            }
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/AsyncSnapshotCallableTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/AsyncSnapshotCallableTest.java
@@ -217,6 +217,9 @@ class AsyncSnapshotCallableTest {
         }
 
         @Override
+        protected void cleanupCompletedResource(String completedResource) {}
+
+        @Override
         protected void logAsyncSnapshotComplete(long startTime) {
             invocationOrder.add(METHOD_LOG);
         }


### PR DESCRIPTION


## What is the purpose of the change

This pull request cleanup completed checkpoint resource when the job checkpoint is canceled.


## Brief change log

- When the asynchronous snapshot thread completes a checkpoint,  cleanup the completed checkpoint if it finds that the checkpoint has been canceled.

## Verifying this change

This change is already covered by existing tests, such as AsyncSnapshotCallableTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? no