### PR TITLE
[FLINK-26939][Table SQL / Planner] Add TRANSLATE supported in SQL & Table API

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -293,6 +293,13 @@ string:
   - sql: REPLACE(string1, string2, string3)
     table: STRING1.replace(STRING2, STRING3)
     description: Returns a new string which replaces all the occurrences of STRING2 with STRING3 (non-overlapping) from STRING1. E.g., 'hello world'.replace('world', 'flink') returns 'hello flink'; 'ababab'.replace('abab', 'z') returns 'zab'.
+  - sql: TRANSLATE(expr, fromStr, toStr)
+    table: expr.translate(fromStr, toStr)
+    description: |
+      Translate an expr where all characters in fromStr have been replaced with those in toStr.
+      If toStr has a shorter length than fromStr, unmatched characters are removed.
+      expr [<CHAR> | <VARCHAR>], fromStr [<CHAR> | <VARCHAR>], toStr [<CHAR> | <VARCHAR>]
+      Returns a STRING of translated expr.
   - sql: REGEXP_EXTRACT(string1, string2[, integer])
     table: STRING1.regexpExtract(STRING2[, INTEGER1])
     description: |

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -369,6 +369,13 @@ string:
       返回一个新字符串，它用 STRING3（非重叠）替换 STRING1 中所有出现的 STRING2。
       例如 `'hello world'.replace('world', 'flink')` 返回 `'hello flink'`；
       `'ababab'.replace('abab', 'z')` 返回 `'zab'`。
+  - sql: TRANSLATE(expr, fromStr, toStr)
+    table: expr.translate(fromStr, toStr)
+    description: |
+      将 expr 中所有出现在 fromStr 之中的字符替换为 toStr 中的相应字符。
+      如果 toStr 的长度短于 fromStr，则未匹配的字符将被移除。
+      expr [<CHAR> | <VARCHAR>], fromStr [<CHAR> | <VARCHAR>], toStr [<CHAR> | <VARCHAR>]
+      返回 STRING 格式的转换结果。
   - sql: REGEXP_EXTRACT(string1, string2[, integer])
     table: STRING1.regexpExtract(STRING2[, INTEGER1])
     description: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -165,6 +165,7 @@ string functions
     Expression.trim_trailing
     Expression.trim
     Expression.replace
+    Expression.translate
     Expression.char_length
     Expression.upper_case
     Expression.lower_case

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1084,6 +1084,13 @@ class Expression(Generic[T]):
         """
         return _ternary_op("replace")(self, search, replacement)
 
+    def translate(self, from_str, to_str) -> 'Expression':
+        """
+        Translate an expr where all characters in from_str have been replaced with those in to_str.
+        If to_str has a shorter length than from_str, unmatched characters are removed.
+        """
+        return _ternary_op("translate")(self, from_str, to_str)
+
     @property
     def char_length(self) -> 'Expression[int]':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -189,6 +189,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TAN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TANH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TIMES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TO_BASE64;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRANSLATE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRIM;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRUNCATE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRY_CAST;
@@ -876,6 +877,23 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType substr(InType beginIndex) {
         return toApiSpecificExpression(
                 unresolvedCall(SUBSTR, toExpr(), objectToExpression(beginIndex)));
+    }
+
+    /**
+     * Translate an {@code expr} where all characters in {@code fromStr} have been replaced with
+     * those in {@code toStr}. <br>
+     * If {@code toStr} has a shorter length than {@code fromStr}, unmatched characters are removed.
+     *
+     * @param fromStr a STRING expression
+     * @param toStr a STRING expression
+     */
+    public OutType translate(InType fromStr, InType toStr) {
+        return toApiSpecificExpression(
+                unresolvedCall(
+                        TRANSLATE,
+                        toExpr(),
+                        objectToExpression(fromStr),
+                        objectToExpression(toStr)));
     }
 
     /** Removes leading space characters from the given string. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -970,6 +970,26 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
                     .build();
 
+    // By default, Calcite parse TRANSLATE as TRANSLATE3, hence it is necessary to modify the
+    // name filed to ensure it is called correctly.
+    public static final BuiltInFunctionDefinition TRANSLATE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("TRANSLATE3")
+                    .sqlName("TRANSLATE")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Arrays.asList("expr", "fromStr", "toStr"),
+                                    Arrays.asList(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .outputTypeStrategy(
+                            nullableIfArgs(ConstantArgumentCount.to(0), explicit(STRING())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.TranslateFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition TRIM =
             BuiltInFunctionDefinition.newBuilder()
                     .name("trim")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/binary/BinaryStringDataUtil.java
@@ -964,6 +964,11 @@ public class BinaryStringDataUtil {
         }
     }
 
+    public static boolean isEmpty(BinaryStringData str) {
+        return (str.javaObject == null || str.javaObject.isEmpty())
+                && (str.binarySection == null || str.binarySection.getSizeInBytes() == 0);
+    }
+
     public static boolean isSpaceString(BinaryStringData str) {
         if (str.javaObject != null) {
             return str.javaObject.equals(" ");

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/TranslateFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/TranslateFunction.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#TRANSLATE}. */
+@Internal
+public class TranslateFunction extends BuiltInScalarFunction {
+
+    private transient String lastFrom = "";
+    private transient String lastTo = "";
+    private transient Map<Integer, String> dict;
+
+    public TranslateFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.TRANSLATE, context);
+    }
+
+    public @Nullable StringData eval(
+            @Nullable StringData expr, @Nullable StringData fromStr, @Nullable StringData toStr) {
+        if (expr == null
+                || fromStr == null
+                || BinaryStringDataUtil.isEmpty((BinaryStringData) expr)
+                || BinaryStringDataUtil.isEmpty((BinaryStringData) fromStr)) {
+            return expr;
+        }
+
+        final String source = expr.toString();
+        final String from = fromStr.toString();
+        final String to = toStr == null ? "" : toStr.toString();
+
+        if (!from.equals(lastFrom) || !to.equals(lastTo)) {
+            lastFrom = from;
+            lastTo = to;
+            dict = buildDict(from, to);
+        }
+
+        return BinaryStringData.fromString(translate(source));
+    }
+
+    private String translate(String expr) {
+        StringBuilder res = new StringBuilder();
+        for (int i = 0; i < expr.length(); ) {
+            int codePoint = expr.codePointAt(i);
+            i += Character.charCount(codePoint);
+            String ch = dict.get(codePoint);
+            if (ch == null) {
+                res.append(Character.toChars(codePoint));
+            } else {
+                res.append(ch);
+            }
+        }
+        return res.toString();
+    }
+
+    private Map<Integer, String> buildDict(String from, String to) {
+        HashMap<Integer, String> hashDict = new HashMap<>();
+
+        int i = 0;
+        int j = 0;
+        while (i < from.length()) {
+            int toCodePoint = -1;
+            if (j < to.length()) {
+                toCodePoint = to.codePointAt(j);
+                j += Character.charCount(toCodePoint);
+            }
+
+            int fromCodePoint = from.codePointAt(i);
+            i += Character.charCount(fromCodePoint);
+
+            // ignore duplicate mapping
+            if (!hashDict.containsKey(fromCodePoint)) {
+                hashDict.put(
+                        fromCodePoint,
+                        toCodePoint == -1 ? "" : String.valueOf(Character.toChars(toCodePoint)));
+            }
+        }
+
+        return hashDict;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add TRANSLATE function.
Examples:
```SQL
> SELECT TRANSLATE('AaBbCc', 'abc', '123');
 A1B2C3
```

## Brief change log

[FLINK-26939](https://issues.apache.org/jira/browse/FLINK-26939)

## Verifying this change

`StringFunctionsITCase#translateTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
