### PR TITLE
[FLINK-35902][ui] WebUI Metrics RangeError on huge parallelism

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/chart/job-overview-drawer-chart.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/chart/job-overview-drawer-chart.component.html
@@ -17,8 +17,8 @@
   -->
 
 <div class="metric-selector">
-  <span *ngIf="listOfMetricName.length === 0; else elseTemplate">No Available Metric</span>
-  <ng-template #elseTemplate>
+  <span *ngIf="listOfMetricName.length === 0">No Available Metric</span>
+  <ng-template [ngIf]="listOfMetricName.length <= countMetricBarrier" [ngIfElse]="hugeMetrics">
     Add Metric:
     <nz-select
       nzSize="small"
@@ -28,7 +28,30 @@
       (ngModelChange)="updateMetric($event)"
     >
       <nz-option
-        *ngFor="let name of listOfUnselectedMetric"
+        *ngFor="let name of listOfUnselectedMetric; trackBy: trackByName"
+        [nzLabel]="name"
+        [nzValue]="name"
+        nzCustomContent
+      >
+        <span [title]="name">{{ name }}</span>
+      </nz-option>
+    </nz-select>
+  </ng-template>
+  <ng-template #hugeMetrics>
+    Add Metric [displayed only {{ countDisplayMetric }} metrics, use search to find specific
+    metric]:
+    <br />
+    <nz-select
+      nzSize="small"
+      [ngModel]="null"
+      nzShowSearch
+      [nzPlaceHolder]="'Select Metric Name'"
+      (ngModelChange)="updateMetric($event)"
+      [nzServerSearch]="true"
+      (nzOnSearch)="onSearch($event)"
+    >
+      <nz-option
+        *ngFor="let name of listOfDisplayedMetric; trackBy: trackByName"
         [nzLabel]="name"
         [nzValue]="name"
         nzCustomContent


### PR DESCRIPTION
## What is the purpose of the change

Suggestion of a solution to the bug on WebUI related to non-displaying of metrics at large amount of operator parallelism.


## Brief change log

Changed display of metrics menu: now when the number of metrics is increased, a message will be displayed that a part metrics will be displayed in the list, but the user will be able to find the desired metric through search.


## Verifying this change

Local testing in job where operator parallelism is 1600.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
