### PR TITLE
[FLINK-35910][table] Add the built-in function BTRIM

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -274,6 +274,12 @@ string:
   - sql: RTRIM(string)
     table: STRING.rtrim()
     description: Returns a string that removes the right whitespaces from STRING. E.g., 'This is a test String. '.rtrim() returns "This is a test String.".
+  - sql: BTRIM(str[, trimStr])
+    table: str.btrim([trimStr])
+    description: |
+      Removes any leading and trailing characters within trimStr from str. trimStr is set to a space character by default.
+      str <CHAR | VARCHAR>[, trimStr <CHAR | VARCHAR>]
+      Returns a STRING representation of the trimmed str. `NULL` if any of the arguments are `NULL`.
   - sql: REPEAT(string, int)
     table: STRING.repeat(INT)
     description: Returns a string that repeats the base string integer times. E.g., REPEAT('This is a test String.', 2) returns "This is a test String.This is a test String.".

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -278,7 +278,7 @@ string:
     table: str.btrim([trimStr])
     description: |
       Removes any leading and trailing characters within trimStr from str. trimStr is set to a space character by default.
-      str <CHAR | VARCHAR>[, trimStr <CHAR | VARCHAR>]
+      str <CHAR | VARCHAR>, trimStr <CHAR | VARCHAR>
       Returns a STRING representation of the trimmed str. `NULL` if any of the arguments are `NULL`.
   - sql: REPEAT(string, int)
     table: STRING.repeat(INT)

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -277,7 +277,7 @@ string:
   - sql: BTRIM(str[, trimStr])
     table: str.btrim([trimStr])
     description: |
-      Removes any leading and trailing characters within trimStr from str. trimStr is set to a space character by default.
+      Removes any leading and trailing characters within trimStr from str. trimStr is set to whitespace by default.
       str <CHAR | VARCHAR>, trimStr <CHAR | VARCHAR>
       Returns a STRING representation of the trimmed str. `NULL` if any of the arguments are `NULL`.
   - sql: REPEAT(string, int)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -343,8 +343,8 @@ string:
   - sql: BTRIM(str[, trimStr])
     table: str.btrim([trimStr])
     description: |
-      从 str 的前缀和后缀字符中裁去 trimStr 中的字符。trimStr 默认设置为空格。      
-      str <CHAR | VARCHAR>[, trimStr <CHAR | VARCHAR>]
+      从 str 的左边和右边删除 trimStr 中的字符。trimStr 默认设置为空格。      
+      str <CHAR | VARCHAR>, trimStr <CHAR | VARCHAR>
       返回一个 STRING 格式的裁剪后的 str。如果任何参数为 `NULL`，则返回 `NULL`。
   - sql: REPEAT(string, int)
     table: STRING.repeat(INT)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -340,6 +340,12 @@ string:
     description: |
       返回从 STRING 中删除右边空格的字符串。
       例如 `'This is a test String. '.rtrim()` 返回 `'This is a test String.'`。
+  - sql: BTRIM(str[, trimStr])
+    table: str.btrim([trimStr])
+    description: |
+      从 str 的前缀和后缀字符中裁去 trimStr 中的字符。trimStr 默认设置为空格。      
+      str <CHAR | VARCHAR>[, trimStr <CHAR | VARCHAR>]
+      返回一个 STRING 格式的裁剪后的 str。如果任何参数为 `NULL`，则返回 `NULL`。
   - sql: REPEAT(string, int)
     table: STRING.repeat(INT)
     description: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -194,6 +194,7 @@ string functions
     Expression.parse_url
     Expression.ltrim
     Expression.rtrim
+    Expression.btrim
     Expression.repeat
     Expression.over
     Expression.reverse

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1322,6 +1322,16 @@ class Expression(Generic[T]):
         """
         return _unary_op("rtrim")(self)
 
+    def btrim(self, trim_str=None) -> 'Expression':
+        """
+        Removes any leading and trailing characters within trim_str from str.
+        trim_str is set to a space character by default.
+        """
+        if trim_str is None:
+            return _unary_op("btrim")(self)
+        else:
+            return _binary_op("btrim")(self, trim_str)
+
     def repeat(self, n: Union[int, 'Expression[int]']) -> 'Expression[str]':
         """
         Returns a string that repeats the base string n times.

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1325,7 +1325,7 @@ class Expression(Generic[T]):
     def btrim(self, trim_str=None) -> 'Expression':
         """
         Removes any leading and trailing characters within trim_str from str.
-        trim_str is set to a space character by default.
+        trim_str is set to whitespace by default.
         """
         if trim_str is None:
             return _unary_op("btrim")(self)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -76,6 +76,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ATAN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AVG;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.BETWEEN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.BIN;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.BTRIM;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CARDINALITY;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CAST;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CEIL;
@@ -1254,6 +1255,17 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Returns a string that removes the right whitespaces from the given string. */
     public OutType rtrim() {
         return toApiSpecificExpression(unresolvedCall(RTRIM, toExpr()));
+    }
+
+    /** Returns a string that removes the left and right whitespaces from the given string. */
+    public OutType btrim() {
+        return toApiSpecificExpression(unresolvedCall(BTRIM, toExpr()));
+    }
+
+    /** Returns a string that removes the left and right chars in trimStr from the given string. */
+    public OutType btrim(InType trimStr) {
+        return toApiSpecificExpression(
+                unresolvedCall(BTRIM, toExpr(), objectToExpression(trimStr)));
     }
 
     /** Returns a string that repeats the base string n times. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1279,6 +1279,25 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(varyingString(argument(0))))
                     .build();
 
+    public static final BuiltInFunctionDefinition BTRIM =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("BTRIM")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            Arrays.asList("str"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING))),
+                                    sequence(
+                                            Arrays.asList("str", "trimStr"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING)))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.BTrimFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition REPEAT =
             BuiltInFunctionDefinition.newBuilder()
                     .name("repeat")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -224,6 +224,11 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                                 DataTypes.STRING().notNull())
                         // normal cases
                         .testResult(
+                                lit("www.apache.org").btrim("a"),
+                                "BTRIM('www.apache.org', 'a')",
+                                "www.apache.org",
+                                DataTypes.STRING().notNull())
+                        .testResult(
                                 $("f1").btrim(),
                                 "BTRIM(f1)",
                                 "\uD83D\uDE00www.apache.org  \f",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -32,8 +32,79 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
-        return Stream.of(regexpExtractTestCases(), translateTestCases(), bTrimTestCases())
+        return Stream.of(bTrimTestCases(), regexpExtractTestCases(), translateTestCases())
                 .flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> bTrimTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.BTRIM)
+                        .onFieldsWithData(null, "  \uD83D\uDE00www.apache.org  \f   ")
+                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING())
+                        // null input
+                        .testResult($("f0").btrim(), "BTRIM(f0)", null, DataTypes.STRING())
+                        .testResult(
+                                $("f0").btrim($("f1")), "BTRIM(f0, f1)", null, DataTypes.STRING())
+                        .testResult(
+                                $("f1").btrim($("f0")), "BTRIM(f1, f0)", null, DataTypes.STRING())
+                        // special chars
+                        .testResult(
+                                $("f1").btrim(" \f\uD83D\uDE00"),
+                                "BTRIM(f1, ' \f\uD83D\uDE00')",
+                                "www.apache.org",
+                                DataTypes.STRING())
+                        .testResult(
+                                $("f1").btrim("\uD83D\uDE00 "),
+                                "BTRIM(f1, '\uD83D\uDE00 ')",
+                                "www.apache.org  \f",
+                                DataTypes.STRING())
+                        // return type
+                        .testResult(
+                                lit("  www.apache.org  ").btrim(),
+                                "BTRIM('  www.apache.org  ')",
+                                "www.apache.org",
+                                DataTypes.STRING().notNull())
+                        // normal cases
+                        .testResult(
+                                lit("www.apache.org").btrim("a"),
+                                "BTRIM('www.apache.org', 'a')",
+                                "www.apache.org",
+                                DataTypes.STRING().notNull())
+                        .testResult(
+                                $("f1").btrim(),
+                                "BTRIM(f1)",
+                                "\uD83D\uDE00www.apache.org  \f",
+                                DataTypes.STRING())
+                        .testResult(
+                                $("f1").btrim("\f"),
+                                "BTRIM(f1, '\f')",
+                                "  \uD83D\uDE00www.apache.org  \f   ",
+                                DataTypes.STRING())
+                        .testResult(
+                                $("f1").btrim($("f1")), "BTRIM(f1, f1)", "", DataTypes.STRING()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.BTRIM, "Validation Error")
+                        .onFieldsWithData(100, "123")
+                        .andDataTypes(DataTypes.INT(), DataTypes.STRING())
+                        .testTableApiValidationError(
+                                $("f0").btrim(),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "BTRIM(str <CHARACTER_STRING>)\n"
+                                        + "BTRIM(str <CHARACTER_STRING>, trimStr <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "BTRIM(f0)",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "BTRIM(str <CHARACTER_STRING>)\n"
+                                        + "BTRIM(str <CHARACTER_STRING>, trimStr <CHARACTER_STRING>)")
+                        .testTableApiValidationError(
+                                $("f1").btrim($("f0")),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "BTRIM(str <CHARACTER_STRING>)\n"
+                                        + "BTRIM(str <CHARACTER_STRING>, trimStr <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "BTRIM(f1, f0)",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "BTRIM(str <CHARACTER_STRING>)\n"
+                                        + "BTRIM(str <CHARACTER_STRING>, trimStr <CHARACTER_STRING>)"));
     }
 
     private Stream<TestSetSpec> regexpExtractTestCases() {
@@ -192,76 +263,5 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                                 "TRANSLATE(f0, '3', '5')",
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "TRANSLATE3(expr <CHARACTER_STRING>, fromStr <CHARACTER_STRING>, toStr <CHARACTER_STRING>)"));
-    }
-
-    private Stream<TestSetSpec> bTrimTestCases() {
-        return Stream.of(
-                TestSetSpec.forFunction(BuiltInFunctionDefinitions.BTRIM)
-                        .onFieldsWithData(null, "  \uD83D\uDE00www.apache.org  \f   ")
-                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING())
-                        // null input
-                        .testResult($("f0").btrim(), "BTRIM(f0)", null, DataTypes.STRING())
-                        .testResult(
-                                $("f0").btrim($("f1")), "BTRIM(f0, f1)", null, DataTypes.STRING())
-                        .testResult(
-                                $("f1").btrim($("f0")), "BTRIM(f1, f0)", null, DataTypes.STRING())
-                        // special chars
-                        .testResult(
-                                $("f1").btrim(" \f\uD83D\uDE00"),
-                                "BTRIM(f1, ' \f\uD83D\uDE00')",
-                                "www.apache.org",
-                                DataTypes.STRING())
-                        .testResult(
-                                $("f1").btrim("\uD83D\uDE00 "),
-                                "BTRIM(f1, '\uD83D\uDE00 ')",
-                                "www.apache.org  \f",
-                                DataTypes.STRING())
-                        // return type
-                        .testResult(
-                                lit("  www.apache.org  ").btrim(),
-                                "BTRIM('  www.apache.org  ')",
-                                "www.apache.org",
-                                DataTypes.STRING().notNull())
-                        // normal cases
-                        .testResult(
-                                lit("www.apache.org").btrim("a"),
-                                "BTRIM('www.apache.org', 'a')",
-                                "www.apache.org",
-                                DataTypes.STRING().notNull())
-                        .testResult(
-                                $("f1").btrim(),
-                                "BTRIM(f1)",
-                                "\uD83D\uDE00www.apache.org  \f",
-                                DataTypes.STRING())
-                        .testResult(
-                                $("f1").btrim("\f"),
-                                "BTRIM(f1, '\f')",
-                                "  \uD83D\uDE00www.apache.org  \f   ",
-                                DataTypes.STRING())
-                        .testResult(
-                                $("f1").btrim($("f1")), "BTRIM(f1, f1)", "", DataTypes.STRING()),
-                TestSetSpec.forFunction(BuiltInFunctionDefinitions.BTRIM, "Validation Error")
-                        .onFieldsWithData(100, "123")
-                        .andDataTypes(DataTypes.INT(), DataTypes.STRING())
-                        .testTableApiValidationError(
-                                $("f0").btrim(),
-                                "Invalid input arguments. Expected signatures are:\n"
-                                        + "BTRIM(str <CHARACTER_STRING>)\n"
-                                        + "BTRIM(str <CHARACTER_STRING>, trimStr <CHARACTER_STRING>)")
-                        .testSqlValidationError(
-                                "BTRIM(f0)",
-                                "Invalid input arguments. Expected signatures are:\n"
-                                        + "BTRIM(str <CHARACTER_STRING>)\n"
-                                        + "BTRIM(str <CHARACTER_STRING>, trimStr <CHARACTER_STRING>)")
-                        .testTableApiValidationError(
-                                $("f1").btrim($("f0")),
-                                "Invalid input arguments. Expected signatures are:\n"
-                                        + "BTRIM(str <CHARACTER_STRING>)\n"
-                                        + "BTRIM(str <CHARACTER_STRING>, trimStr <CHARACTER_STRING>)")
-                        .testSqlValidationError(
-                                "BTRIM(f1, f0)",
-                                "Invalid input arguments. Expected signatures are:\n"
-                                        + "BTRIM(str <CHARACTER_STRING>)\n"
-                                        + "BTRIM(str <CHARACTER_STRING>, trimStr <CHARACTER_STRING>)"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/BTrimFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/BTrimFunction.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#BTRIM}. */
+@Internal
+public class BTrimFunction extends BuiltInScalarFunction {
+
+    public BTrimFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.BTRIM, context);
+    }
+
+    public @Nullable StringData eval(@Nullable StringData str) {
+        if (str == null) {
+            return null;
+        }
+        return BinaryStringDataUtil.trim((BinaryStringData) str, BinaryStringData.fromString(" "));
+    }
+
+    public @Nullable StringData eval(@Nullable StringData str, @Nullable StringData trimStr) {
+        if (str == null || trimStr == null) {
+            return null;
+        }
+        return BinaryStringDataUtil.trim((BinaryStringData) str, (BinaryStringData) trimStr);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add BTRIM function.
Examples:
```SQL
> SELECT BTRIM('  test  ');
test
> SELECT BTRIM('test', 't');
es
```

## Brief change log

[FLINK-35910](https://issues.apache.org/jira/browse/FLINK-35910)

## Verifying this change

`StringFunctionsITCase#bTrimTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
