### PR TITLE
[FLINK-35920][table] Add the built-in function PRINTF

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -260,6 +260,18 @@ string:
   - sql: POSITION(string1 IN string2)
     table: STRING1.position(STRING2)
     description: Returns the position (start from 1) of the first occurrence of STRING1 in STRING2; returns 0 if STRING1 cannot be found in STRING2.
+  - sql: PRINTF(format[, obj]*)
+    table: format.printf(obj...)
+    description: |
+      Returns a formatted string from printf-style format string.
+      
+      The function exploits the java.util.Formatter class with Locale.US.
+      
+      null obj is formated as a string "null".
+      
+      format <CHAR | VARCHAR>, obj <ANY>
+      
+      Returns a STRING representation of the formatted string. `NULL` if format is `NULL` or invalid.
   - sql: TRIM([ BOTH | LEADING | TRAILING ] string1 FROM string2)
     table: |
       STRING1.trim(LEADING, STRING2)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -322,6 +322,18 @@ string:
   - sql: POSITION(string1 IN string2)
     table: STRING1.position(STRING2)
     description: 返回 STRING2 中第一次出现 STRING1 的位置（从 1 开始）；如果在 STRING2 中找不到 STRING1 返回 0。
+  - sql: PRINTF(format[, obj]*)
+    table: format.printf(obj...)
+    description: |
+      格式化 print-style 样式的字符串。
+      
+      函数使用 java.util.Formatter (Locale.US) 解析字符串。
+      
+      null obj 被格式化为字符串 "null"。
+      
+      strfmt <CHAR | VARCHAR>, obj <ANY>
+      
+      返回一个 STRING 格式的格式化后的字符串。如果 format 为 `NULL` 或不合法，则返回 `NULL`。
   - sql: TRIM([ BOTH | LEADING | TRAILING ] string1 FROM string2)
     table: |
       STRING1.trim(LEADING, STRING2)

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -192,6 +192,7 @@ string functions
     Expression.url_decode
     Expression.url_encode
     Expression.parse_url
+    Expression.printf
     Expression.ltrim
     Expression.rtrim
     Expression.btrim

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1310,6 +1310,20 @@ class Expression(Generic[T]):
         else:
             return _ternary_op("parseUrl")(self, part_to_extract, key)
 
+    def printf(self, *obj) -> 'Expression':
+        """
+        Returns a formatted string from printf-style format strings.
+        The function exploits the java.util.Formatter class with Locale.US.
+
+        :param obj: any expression
+        :return: a formatted string. null if format is null or invalid.
+        """
+        gateway = get_gateway()
+        ApiExpressionUtils = gateway.jvm.org.apache.flink.table.expressions.ApiExpressionUtils
+        exprs = [ApiExpressionUtils.objectToExpression(_get_java_expression(e))
+                 for e in obj]
+        return _binary_op("printf")(self, to_jarray(gateway.jvm.Object, exprs))
+
     @property
     def ltrim(self) -> 'Expression[str]':
         """

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -171,6 +171,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("strToMap(a, ';', ':')", str(expr1.str_to_map(';', ':')))
         self.assertEqual("ELT(1, a)", str(lit(1).elt(expr1)))
         self.assertEqual('ELT(3, a, b, c)', str(lit(3).elt(expr1, expr2, expr3)))
+        self.assertEqual("PRINTF('%d %s', a, b)", str(lit("%d %s").printf(expr1, expr2)))
 
         # temporal functions
         self.assertEqual('cast(a, DATE)', str(expr1.to_date))

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -156,6 +156,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PARSE_
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PLUS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.POSITION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.POWER;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PRINTF;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PROCTIME;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.RADIANS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP;
@@ -1261,6 +1262,22 @@ public abstract class BaseExpressions<InType, OutType> {
                         toExpr(),
                         objectToExpression(partToExtract),
                         objectToExpression(key)));
+    }
+
+    /**
+     * Returns a formatted string from printf-style format string. The function exploits the {@link
+     * java.util.Formatter} with Locale.US.
+     *
+     * @param obj any expression
+     * @return a formatted string. null if {@code format} is null or invalid.
+     */
+    public final OutType printf(InType... obj) {
+        Expression[] args =
+                Stream.concat(
+                                Stream.of(toExpr()),
+                                Arrays.stream(obj).map(ApiExpressionUtils::objectToExpression))
+                        .toArray(Expression[]::new);
+        return toApiSpecificExpression(unresolvedCall(PRINTF, args));
     }
 
     /** Returns a string that removes the left whitespaces from the given string. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1264,6 +1264,19 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition PRINTF =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("PRINTF")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            varyingSequence(
+                                    Arrays.asList("format", "obj"),
+                                    Arrays.asList(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING), ANY)))
+                    .outputTypeStrategy(explicit(DataTypes.STRING()))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.PrintfFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition UUID =
             BuiltInFunctionDefinition.newBuilder()
                     .name("uuid")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/PrintfFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/PrintfFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+import javax.annotation.Nullable;
+
+import java.util.Formatter;
+import java.util.Locale;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#PRINTF}. */
+@Internal
+public class PrintfFunction extends BuiltInScalarFunction {
+
+    public PrintfFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.PRINTF, context);
+    }
+
+    public @Nullable StringData eval(@Nullable StringData format, Object... obj) {
+        if (format == null) {
+            return null;
+        }
+
+        StringBuilder strBuf = new StringBuilder();
+        try (Formatter formatter = new Formatter(strBuf, Locale.US)) {
+            formatter.format(format.toString(), obj);
+        } catch (Throwable t) {
+            return null;
+        }
+
+        return BinaryStringData.fromString(strBuf.toString());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add PRINTF function.
Examples:
```SQL
> SELECT PRINTF('Hello World %d %s', 100, 'days');
 Hello World 100 days
```

## Brief change log

[FLINK-35920](https://issues.apache.org/jira/browse/FLINK-35920)

## Verifying this change

`StringFunctionsITCase#printfTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
