### PR TITLE
[FLINK-35858][State] Default namespace in async state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
@@ -50,13 +50,16 @@ public interface AsyncKeyedStateBackend extends Disposable, Closeable {
      * @param <N> the type of namespace for partitioning.
      * @param <S> The type of the public API state.
      * @param <SV> The type of the stored state value.
+     * @param defaultNamespace the default namespace for this state.
      * @param namespaceSerializer the serializer for namespace.
      * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
      * @throws Exception Exceptions may occur during initialization of the state.
      */
     @Nonnull
     <N, S extends State, SV> S createState(
-            TypeSerializer<N> namespaceSerializer, @Nonnull StateDescriptor<SV> stateDesc)
+            @Nonnull N defaultNamespace,
+            @Nonnull TypeSerializer<N> namespaceSerializer,
+            @Nonnull StateDescriptor<SV> stateDesc)
             throws Exception;
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStoreV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStoreV2.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.state.v2.MapState;
 import org.apache.flink.api.common.state.v2.ReducingState;
 import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.util.Preconditions;
 
@@ -43,7 +44,7 @@ public class DefaultKeyedStateStoreV2 implements KeyedStateStoreV2 {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
             return asyncKeyedStateBackend.createState(
-                    VoidNamespaceSerializer.INSTANCE, stateProperties);
+                    VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
         }
@@ -54,7 +55,7 @@ public class DefaultKeyedStateStoreV2 implements KeyedStateStoreV2 {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
             return asyncKeyedStateBackend.createState(
-                    VoidNamespaceSerializer.INSTANCE, stateProperties);
+                    VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
         }
@@ -66,7 +67,7 @@ public class DefaultKeyedStateStoreV2 implements KeyedStateStoreV2 {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
             return asyncKeyedStateBackend.createState(
-                    VoidNamespaceSerializer.INSTANCE, stateProperties);
+                    VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
         }
@@ -78,7 +79,7 @@ public class DefaultKeyedStateStoreV2 implements KeyedStateStoreV2 {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
             return asyncKeyedStateBackend.createState(
-                    VoidNamespaceSerializer.INSTANCE, stateProperties);
+                    VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
         }
@@ -90,7 +91,7 @@ public class DefaultKeyedStateStoreV2 implements KeyedStateStoreV2 {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
             return asyncKeyedStateBackend.createState(
-                    VoidNamespaceSerializer.INSTANCE, stateProperties);
+                    VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendTestUtils;
+import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.v2.InternalValueState;
 import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
@@ -111,7 +112,9 @@ class AsyncExecutionControllerTest {
         try {
             valueState =
                     asyncKeyedStateBackend.createState(
-                            VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+                            VoidNamespace.INSTANCE,
+                            VoidNamespaceSerializer.INSTANCE,
+                            stateDescriptor);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -131,7 +131,8 @@ public class StateBackendTestUtils {
         @Override
         @SuppressWarnings("unchecked")
         public <N, S extends org.apache.flink.api.common.state.v2.State, SV> S createState(
-                TypeSerializer<N> namespaceSerializer,
+                @Nonnull N defaultNamespace,
+                @Nonnull TypeSerializer<N> namespaceSerializer,
                 @Nonnull org.apache.flink.runtime.state.v2.StateDescriptor<SV> stateDesc) {
             return (S) innerStateSupplier.get();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/InternalKeyedStateTestBase.java
@@ -128,7 +128,8 @@ public class InternalKeyedStateTestBase {
                 @Nonnull
                 @Override
                 public <N, S extends State, SV> S createState(
-                        TypeSerializer<N> namespaceSerializer,
+                        @Nonnull N defaultNamespace,
+                        @Nonnull TypeSerializer<N> namespaceSerializer,
                         @Nonnull StateDescriptor<SV> stateDesc)
                         throws Exception {
                     return null;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -140,7 +140,9 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
     @Override
     @SuppressWarnings("unchecked")
     public <N, S extends State, SV> S createState(
-            TypeSerializer<N> namespaceSerializer, @Nonnull StateDescriptor<SV> stateDesc) {
+            @Nonnull N defaultNamespace,
+            @Nonnull TypeSerializer<N> namespaceSerializer,
+            @Nonnull StateDescriptor<SV> stateDesc) {
         Preconditions.checkNotNull(
                 stateRequestHandler,
                 "A non-null stateRequestHandler must be setup before createState");
@@ -154,6 +156,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
                             columnFamilyHandle,
                             (ValueStateDescriptor<SV>) stateDesc,
                             serializedKeyBuilder,
+                            defaultNamespace,
                             namespaceSerializer::duplicate,
                             valueSerializerView,
                             valueDeserializerView);

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.api.common.typeutils.base.VoidSerializer;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -33,6 +32,8 @@ import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.v2.InternalPartitionedState;
 import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
 import org.apache.flink.util.function.BiFunctionWithException;
@@ -96,14 +97,14 @@ public class ForStDBOperationTestBase {
         };
     }
 
-    protected ContextKey<Integer, Void> buildContextKey(int i) {
+    protected ContextKey<Integer, VoidNamespace> buildContextKey(int i) {
         int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(i, 128);
         RecordContext<Integer> recordContext =
                 new RecordContext<>(i, i, t -> {}, keyGroup, new Epoch(0));
         return new ContextKey<>(recordContext);
     }
 
-    protected ForStValueState<Integer, Void, String> buildForStValueState(String stateName)
+    protected ForStValueState<Integer, VoidNamespace, String> buildForStValueState(String stateName)
             throws Exception {
         ColumnFamilyHandle cf = createColumnFamilyHandle(stateName);
         ValueStateDescriptor<String> valueStateDescriptor =
@@ -118,7 +119,8 @@ public class ForStDBOperationTestBase {
                 cf,
                 valueStateDescriptor,
                 serializedKeyBuilder,
-                () -> VoidSerializer.INSTANCE,
+                VoidNamespace.INSTANCE,
+                () -> VoidNamespaceSerializer.INSTANCE,
                 valueSerializerView,
                 valueDeserializerView);
     }

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperationTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperationTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.VoidNamespace;
 
 import org.junit.jupiter.api.Test;
 
@@ -34,9 +35,9 @@ public class ForStGeneralMultiGetOperationTest extends ForStDBOperationTestBase 
 
     @Test
     public void testValueStateMultiGet() throws Exception {
-        ForStValueState<Integer, Void, String> valueState1 =
+        ForStValueState<Integer, VoidNamespace, String> valueState1 =
                 buildForStValueState("test-multiGet-1");
-        ForStValueState<Integer, Void, String> valueState2 =
+        ForStValueState<Integer, VoidNamespace, String> valueState2 =
                 buildForStValueState("test-multiGet-2");
         List<ForStDBGetRequest<?, ?, ?>> batchGetRequest = new ArrayList<>();
         List<Tuple2<String, TestStateFuture<String>>> resultCheckList = new ArrayList<>();
@@ -44,9 +45,9 @@ public class ForStGeneralMultiGetOperationTest extends ForStDBOperationTestBase 
         int keyNum = 1000;
         for (int i = 0; i < keyNum; i++) {
             TestStateFuture<String> future = new TestStateFuture<>();
-            ForStValueState<Integer, Void, String> table =
+            ForStValueState<Integer, VoidNamespace, String> table =
                     ((i % 2 == 0) ? valueState1 : valueState2);
-            ForStDBGetRequest<Integer, Void, String> request =
+            ForStDBGetRequest<Integer, VoidNamespace, String> request =
                     ForStDBGetRequest.of(buildContextKey(i), table, future);
             batchGetRequest.add(request);
 

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
+import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.v2.InternalKeyedState;
 
 import org.junit.jupiter.api.Test;
@@ -42,8 +43,10 @@ public class ForStStateExecutorTest extends ForStDBOperationTestBase {
     @SuppressWarnings("unchecked")
     public void testExecuteValueStateRequest() throws Exception {
         ForStStateExecutor forStStateExecutor = new ForStStateExecutor(4, db, new WriteOptions());
-        ForStValueState<Integer, Void, String> state1 = buildForStValueState("value-state-1");
-        ForStValueState<Integer, Void, String> state2 = buildForStValueState("value-state-2");
+        ForStValueState<Integer, VoidNamespace, String> state1 =
+                buildForStValueState("value-state-1");
+        ForStValueState<Integer, VoidNamespace, String> state2 =
+                buildForStValueState("value-state-2");
 
         StateRequestContainer stateRequestContainer =
                 forStStateExecutor.createStateRequestContainer();
@@ -52,7 +55,7 @@ public class ForStStateExecutorTest extends ForStDBOperationTestBase {
         // 1. Update value state: keyRange [0, keyNum)
         int keyNum = 1000;
         for (int i = 0; i < keyNum; i++) {
-            ForStValueState<Integer, Void, String> state = (i % 2 == 0 ? state1 : state2);
+            ForStValueState<Integer, VoidNamespace, String> state = (i % 2 == 0 ? state1 : state2);
             stateRequestContainer.offer(
                     buildStateRequest(state, StateRequestType.VALUE_UPDATE, i, "test-" + i, i * 2));
         }
@@ -64,14 +67,14 @@ public class ForStStateExecutorTest extends ForStDBOperationTestBase {
         // 2. Get value state: keyRange [0, keyNum)
         //    Update value state: keyRange [keyNum, keyNum + 100]
         for (int i = 0; i < keyNum; i++) {
-            ForStValueState<Integer, Void, String> state = (i % 2 == 0 ? state1 : state2);
+            ForStValueState<Integer, VoidNamespace, String> state = (i % 2 == 0 ? state1 : state2);
             StateRequest<?, ?, ?> getRequest =
                     buildStateRequest(state, StateRequestType.VALUE_GET, i, null, i * 2);
             stateRequestContainer.offer(getRequest);
             checkList.add(getRequest);
         }
         for (int i = keyNum; i < keyNum + 100; i++) {
-            ForStValueState<Integer, Void, String> state = (i % 2 == 0 ? state1 : state2);
+            ForStValueState<Integer, VoidNamespace, String> state = (i % 2 == 0 ? state1 : state2);
             stateRequestContainer.offer(
                     buildStateRequest(state, StateRequestType.VALUE_UPDATE, i, "test-" + i, i * 2));
         }
@@ -90,12 +93,12 @@ public class ForStStateExecutorTest extends ForStDBOperationTestBase {
         //    Update state with null-value : keyRange [keyNum, keyNum + 100]
         stateRequestContainer = forStStateExecutor.createStateRequestContainer();
         for (int i = keyNum - 100; i < keyNum; i++) {
-            ForStValueState<Integer, Void, String> state = (i % 2 == 0 ? state1 : state2);
+            ForStValueState<Integer, VoidNamespace, String> state = (i % 2 == 0 ? state1 : state2);
             stateRequestContainer.offer(
                     buildStateRequest(state, StateRequestType.CLEAR, i, null, i * 2));
         }
         for (int i = keyNum; i < keyNum + 100; i++) {
-            ForStValueState<Integer, Void, String> state = (i % 2 == 0 ? state1 : state2);
+            ForStValueState<Integer, VoidNamespace, String> state = (i % 2 == 0 ? state1 : state2);
             stateRequestContainer.offer(
                     buildStateRequest(state, StateRequestType.VALUE_UPDATE, i, null, i * 2));
         }
@@ -105,7 +108,7 @@ public class ForStStateExecutorTest extends ForStDBOperationTestBase {
         stateRequestContainer = forStStateExecutor.createStateRequestContainer();
         checkList.clear();
         for (int i = keyNum - 100; i < keyNum + 100; i++) {
-            ForStValueState<Integer, Void, String> state = (i % 2 == 0 ? state1 : state2);
+            ForStValueState<Integer, VoidNamespace, String> state = (i % 2 == 0 ? state1 : state2);
             StateRequest<?, ?, ?> getRequest =
                     buildStateRequest(state, StateRequestType.VALUE_GET, i, null, i * 2);
             stateRequestContainer.offer(getRequest);

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStWriteBatchOperationTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStWriteBatchOperationTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.state.forst;
 
+import org.apache.flink.runtime.state.VoidNamespace;
+
 import org.junit.jupiter.api.Test;
 import org.rocksdb.WriteOptions;
 
@@ -34,9 +36,9 @@ public class ForStWriteBatchOperationTest extends ForStDBOperationTestBase {
 
     @Test
     public void testValueStateWriteBatch() throws Exception {
-        ForStValueState<Integer, Void, String> valueState1 =
+        ForStValueState<Integer, VoidNamespace, String> valueState1 =
                 buildForStValueState("test-write-batch-1");
-        ForStValueState<Integer, Void, String> valueState2 =
+        ForStValueState<Integer, VoidNamespace, String> valueState2 =
                 buildForStValueState("test-write-batch-2");
         List<ForStDBPutRequest<?, ?, ?>> batchPutRequest = new ArrayList<>();
         int keyNum = 100;
@@ -64,7 +66,7 @@ public class ForStWriteBatchOperationTest extends ForStDBOperationTestBase {
 
     @Test
     public void testWriteBatchWithNullValue() throws Exception {
-        ForStValueState<Integer, Void, String> valueState =
+        ForStValueState<Integer, VoidNamespace, String> valueState =
                 buildForStValueState("test-write-batch");
         List<ForStDBPutRequest<?, ?, ?>> batchPutRequest = new ArrayList<>();
         // 1. write some data without null value

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -369,12 +369,14 @@ public class StreamOperatorStateHandler {
 
     /** Create new state (v2) based on new state descriptor. */
     public <N, S extends org.apache.flink.api.common.state.v2.State, T> S getOrCreateKeyedState(
+            N defaultNamespace,
             TypeSerializer<N> namespaceSerializer,
             org.apache.flink.runtime.state.v2.StateDescriptor<T> stateDescriptor)
             throws Exception {
 
         if (asyncKeyedStateBackend != null) {
-            return asyncKeyedStateBackend.createState(namespaceSerializer, stateDescriptor);
+            return asyncKeyedStateBackend.createState(
+                    defaultNamespace, namespaceSerializer, stateDescriptor);
         } else {
             throw new IllegalStateException(
                     "Cannot create partitioned state. "

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperator.java
@@ -48,6 +48,8 @@ import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.function.ThrowingConsumer;
 import org.apache.flink.util.function.ThrowingRunnable;
 
+import javax.annotation.Nonnull;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -179,9 +181,12 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
 
     /** Create new state (v2) based on new state descriptor. */
     protected <N, S extends State, T> S getOrCreateKeyedState(
-            TypeSerializer<N> namespaceSerializer, StateDescriptor<T> stateDescriptor)
+            @Nonnull N defaultNamespace,
+            @Nonnull TypeSerializer<N> namespaceSerializer,
+            @Nonnull StateDescriptor<T> stateDescriptor)
             throws Exception {
-        return stateHandler.getOrCreateKeyedState(namespaceSerializer, stateDescriptor);
+        return stateHandler.getOrCreateKeyedState(
+                defaultNamespace, namespaceSerializer, stateDescriptor);
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
@@ -45,6 +45,8 @@ import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.function.ThrowingConsumer;
 import org.apache.flink.util.function.ThrowingRunnable;
 
+import javax.annotation.Nonnull;
+
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -154,9 +156,12 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
 
     /** Create new state (v2) based on new state descriptor. */
     protected <N, S extends State, T> S getOrCreateKeyedState(
-            TypeSerializer<N> namespaceSerializer, StateDescriptor<T> stateDescriptor)
+            @Nonnull N defaultNamespace,
+            @Nonnull TypeSerializer<N> namespaceSerializer,
+            @Nonnull StateDescriptor<T> stateDescriptor)
             throws Exception {
-        return stateHandler.getOrCreateKeyedState(namespaceSerializer, stateDescriptor);
+        return stateHandler.getOrCreateKeyedState(
+                defaultNamespace, namespaceSerializer, stateDescriptor);
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -480,11 +480,12 @@ class StreamingRuntimeContextTest {
         doAnswer(
                         (Answer<Object>)
                                 invocationOnMock -> {
-                                    ref.set(invocationOnMock.getArguments()[1]);
+                                    ref.set(invocationOnMock.getArguments()[2]);
                                     return null;
                                 })
                 .when(asyncKeyedStateBackend)
                 .createState(
+                        any(),
                         any(TypeSerializer.class),
                         any(org.apache.flink.runtime.state.v2.StateDescriptor.class));
 


### PR DESCRIPTION
## What is the purpose of the change

Add default namespace in async state. Thus the namespace semantic is aligned between async state and original state apis.

## Brief change log

  - Add param of default namespace in creation method of async state
  - Forst implementation

## Verifying this change

This change is a trivial rework covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
