### PR TITLE
[FLINK-35939] Do not set empty config values via ConfigUtils#encodeCollectionToConfig

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigUtils.java
@@ -100,7 +100,9 @@ public class ConfigUtils {
                         .filter(Objects::nonNull)
                         .collect(Collectors.toCollection(ArrayList::new));
 
-        configuration.set(key, encodedOption);
+        if (!encodedOption.isEmpty()) {
+            configuration.set(key, encodedOption);
+        }
     }
 
     /**

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigUtilsTest.java
@@ -95,13 +95,13 @@ class ConfigUtilsTest {
     }
 
     @Test
-    void emptyCollectionPutsEmptyValueInConfig() {
+    void emptyCollectionPutsNothingInConfig() {
         final Configuration configurationUnderTest = new Configuration();
         ConfigUtils.encodeCollectionToConfig(
                 configurationUnderTest, TEST_OPTION, Collections.emptyList(), Object::toString);
 
         final List<String> recovered = configurationUnderTest.get(TEST_OPTION);
-        assertThat(recovered).isEmpty();
+        assertThat(recovered).isNull();
 
         final List<Integer> recoveredList =
                 ConfigUtils.decodeListFromConfig(
@@ -110,13 +110,13 @@ class ConfigUtilsTest {
     }
 
     @Test
-    void emptyArrayPutsEmptyValueInConfig() {
+    void emptyArrayPutsNothingInConfig() {
         final Configuration configurationUnderTest = new Configuration();
         ConfigUtils.encodeArrayToConfig(
                 configurationUnderTest, TEST_OPTION, new Integer[5], Object::toString);
 
         final List<String> recovered = configurationUnderTest.get(TEST_OPTION);
-        assertThat(recovered).isEmpty();
+        assertThat(recovered).isNull();
 
         final List<Integer> recoveredList =
                 ConfigUtils.decodeListFromConfig(

--- a/flink-table/flink-sql-client/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/set.q
@@ -83,14 +83,12 @@ set;
 | execution.state-recovery.ignore-unclaimed-state |     false |
 |                                execution.target |    remote |
 |                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                             pipeline.classpaths |        [] |
-|                                   pipeline.jars |        [] |
 |                                       rest.port |     $VAR_REST_PORT |
 |              sql-client.display.print-time-cost |     false |
 |                sql-client.execution.result-mode |   tableau |
 |                table.exec.legacy-cast-behaviour |  DISABLED |
 +-------------------------------------------------+-----------+
-12 rows in set
+10 rows in set
 !ok
 
 # reset the configuration
@@ -108,11 +106,9 @@ set;
 | execution.state-recovery.ignore-unclaimed-state |     false |
 |                                execution.target |    remote |
 |                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                             pipeline.classpaths |        [] |
-|                                   pipeline.jars |        [] |
 |                                       rest.port |     $VAR_REST_PORT |
 +-------------------------------------------------+-----------+
-9 rows in set
+7 rows in set
 !ok
 
 # should fail because default dialect doesn't support hive dialect
@@ -149,12 +145,10 @@ set;
 | execution.state-recovery.ignore-unclaimed-state |     false |
 |                                execution.target |    remote |
 |                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                             pipeline.classpaths |        [] |
-|                                   pipeline.jars |        [] |
 |                                       rest.port |     $VAR_REST_PORT |
 |                              sql-client.verbose |      true |
 +-------------------------------------------------+-----------+
-10 rows in set
+8 rows in set
 !ok
 
 set 'execution.attached' = 'false';
@@ -175,12 +169,10 @@ set;
 | execution.state-recovery.ignore-unclaimed-state |     false |
 |                                execution.target |    remote |
 |                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                             pipeline.classpaths |        [] |
-|                                   pipeline.jars |        [] |
 |                                       rest.port |     $VAR_REST_PORT |
 |                              sql-client.verbose |      true |
 +-------------------------------------------------+-----------+
-10 rows in set
+8 rows in set
 !ok
 
 # test reset can work with add jar
@@ -207,12 +199,10 @@ set;
 | execution.state-recovery.ignore-unclaimed-state |     false |
 |                                execution.target |    remote |
 |                          jobmanager.rpc.address | $VAR_JOBMANAGER_RPC_ADDRESS |
-|                             pipeline.classpaths |        [] |
-|                                   pipeline.jars |        [] |
 |                                       rest.port |     $VAR_REST_PORT |
 |                              sql-client.verbose |      true |
 +-------------------------------------------------+-----------+
-10 rows in set
+8 rows in set
 !ok
 
 reset;

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/set.q
@@ -36,11 +36,9 @@ set;
 | execution.state-recovery.ignore-unclaimed-state |     false |
 |                                execution.target |    remote |
 |                          jobmanager.rpc.address | localhost |
-|                             pipeline.classpaths |        [] |
-|                                   pipeline.jars |        [] |
 |                                       rest.port |     $VAR_REST_PORT |
 +-------------------------------------------------+-----------+
-9 rows in set
+7 rows in set
 !ok
 
 # set illegal value
@@ -60,9 +58,7 @@ set;
 | execution.state-recovery.ignore-unclaimed-state |     false |
 |                                execution.target |    remote |
 |                          jobmanager.rpc.address | localhost |
-|                             pipeline.classpaths |        [] |
-|                                   pipeline.jars |        [] |
 |                                       rest.port |     $VAR_REST_PORT |
 +-------------------------------------------------+-----------+
-9 rows in set
+7 rows in set
 !ok


### PR DESCRIPTION
## What is the purpose of the change

Avoid setting empty config values in `ConfigUtils#encodeCollectionToConfig`.  I think this could cause unintentional overwrites and I believe setting an empty collection as a config options in general should mean the same as if that config was not set at all.

Right now this behavior causes to have `pipeline.classpaths` and `pipeline.jars` have an empty list value by default.

## Brief change log

  - Skip setting if the encoded values are empty.
  - Adapt unit tests.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
