### PR TITLE
[FLINK-35962][table] Add REGEXP_INSTR function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -304,7 +304,14 @@ string:
       not exceed the number of the defined groups.
 
       E.g. REGEXP_EXTRACT('foothebar', 'foo(.*?)(bar)', 2)" returns "bar".
-
+  - sql: REGEXP_INSTR(str, regex)
+    table: str.regexpInStr(regex)
+    description: |
+      Returns the position of the first substring in str that matches regex.
+      Result indexes begin at 1, 0 if there is no match.
+      In case of a malformed regex the function returns an error.
+      str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>
+      Returns an INTEGER representation of matched substring index. `NULL` if any of the arguments are `NULL`.
   - sql: INITCAP(string)
     table: STRING.initCap()
     description: Returns a new form of STRING with the first character of each word converted to uppercase and the rest characters to lowercase. Here a word means a sequences of alphanumeric characters.

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -305,7 +305,7 @@ string:
 
       E.g. REGEXP_EXTRACT('foothebar', 'foo(.*?)(bar)', 2)" returns "bar".
   - sql: REGEXP_INSTR(str, regex)
-    table: str.regexpInStr(regex)
+    table: str.regexpInstr(regex)
     description: |
       Returns the position of the first substring in str that matches regex.
       Result indexes begin at 1, 0 if there is no match.

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -376,7 +376,7 @@ string:
       0 表示匹配整个正则表达式。此外，正则表达式匹配组索引不应超过定义的组数。
       例如 `REGEXP_EXTRACT('foothebar', 'foo(.*?)(bar)', 2)` 返回 `"bar"`。
   - sql: REGEXP_INSTR(str, regex)
-    table: str.regexpInStr(regex)
+    table: str.regexpInstr(regex)
     description: |
       返回 str 中第一个匹配 regex 的子字符串的索引。
       结果索引从 1 开始，如果匹配失败则返回 0。

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -375,6 +375,14 @@ string:
       将字符串 STRING1 按照 STRING2 正则表达式的规则拆分，返回指定 INTEGER1 处位置的字符串。正则表达式匹配组索引从 1 开始，
       0 表示匹配整个正则表达式。此外，正则表达式匹配组索引不应超过定义的组数。
       例如 `REGEXP_EXTRACT('foothebar', 'foo(.*?)(bar)', 2)` 返回 `"bar"`。
+  - sql: REGEXP_INSTR(str, regex)
+    table: str.regexpInStr(regex)
+    description: |
+      返回 str 中第一个匹配 regex 的子字符串的索引。
+      结果索引从 1 开始，如果匹配失败则返回 0。
+      如果正则表达式格式错误，则函数返回错误。
+      str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>
+      返回一个 INTEGER 表示匹配成功的子串索引。如果任何参数为 `NULL`，则返回 `NULL`。
   - sql: INITCAP(string)
     table: STRING.initCap()
     description: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -178,6 +178,7 @@ string functions
     Expression.regexp
     Expression.regexp_replace
     Expression.regexp_extract
+    Expression.regexp_instr
     Expression.from_base64
     Expression.to_base64
     Expression.ascii

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1211,7 +1211,7 @@ class Expression(Generic[T]):
         Result indexes begin at 1, 0 if there is no match.
         In case of a malformed regex the function returns an error.
         """
-        return _binary_op("regexpInStr")(self, regex)
+        return _binary_op("regexpInstr")(self, regex)
 
     @property
     def from_base64(self) -> 'Expression[str]':

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1205,6 +1205,14 @@ class Expression(Generic[T]):
         else:
             return _ternary_op("regexpExtract")(self, regex, extract_index)
 
+    def regexp_instr(self, regex) -> 'Expression':
+        """
+        Returns the position of the first substring in str that matches regex.
+        Result indexes begin at 1, 0 if there is no match.
+        In case of a malformed regex the function returns an error.
+        """
+        return _binary_op("regexpInStr")(self, regex)
+
     @property
     def from_base64(self) -> 'Expression[str]':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1136,7 +1136,7 @@ public abstract class BaseExpressions<InType, OutType> {
      * Result indexes begin at 1, 0 if there is no match. <br>
      * In case of a malformed {@code regex} the function returns an error.
      */
-    public OutType regexpInStr(InType regex) {
+    public OutType regexpInstr(InType regex) {
         return toApiSpecificExpression(
                 unresolvedCall(REGEXP_INSTR, toExpr(), objectToExpression(regex)));
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -156,6 +156,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PROCTI
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.RADIANS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_EXTRACT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_INSTR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_REPLACE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REPEAT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REPLACE;
@@ -1128,6 +1129,16 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType regexpExtract(InType regex) {
         return toApiSpecificExpression(
                 unresolvedCall(REGEXP_EXTRACT, toExpr(), objectToExpression(regex)));
+    }
+
+    /**
+     * Returns the position of the first substring in {@code str} that matches {@code regex}. <br>
+     * Result indexes begin at 1, 0 if there is no match. <br>
+     * In case of a malformed {@code regex} the function returns an error.
+     */
+    public OutType regexpInStr(InType regex) {
+        return toApiSpecificExpression(
+                unresolvedCall(REGEXP_INSTR, toExpr(), objectToExpression(regex)));
     }
 
     /** Returns the base string decoded with base64. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1105,6 +1105,21 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(explicit(DataTypes.STRING().nullable()))
                     .build();
 
+    public static final BuiltInFunctionDefinition REGEXP_INSTR =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("REGEXP_INSTR")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Arrays.asList("str", "regex"),
+                                    Arrays.asList(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.INT())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.RegexpInStrFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition FROM_BASE64 =
             BuiltInFunctionDefinition.newBuilder()
                     .name("fromBase64")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1117,7 +1117,7 @@ public final class BuiltInFunctionDefinitions {
                                             logical(LogicalTypeFamily.CHARACTER_STRING))))
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.INT())))
                     .runtimeClass(
-                            "org.apache.flink.table.runtime.functions.scalar.RegexpInStrFunction")
+                            "org.apache.flink.table.runtime.functions.scalar.RegexpInstrFunction")
                     .build();
 
     public static final BuiltInFunctionDefinition FROM_BASE64 =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.lit;
+
+/** Test Regexp functions correct behaviour. */
+class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
+
+    @Override
+    Stream<TestSetSpec> getTestSetSpecs() {
+        return regexpInStrTestCases();
+    }
+
+    private Stream<TestSetSpec> regexpInStrTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.REGEXP_INSTR)
+                        .onFieldsWithData(null, "abcdeabde", "100-200, 300-400")
+                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING())
+                        // null input
+                        .testResult(
+                                $("f0").regexpInStr($("f1")),
+                                "REGEXP_INSTR(f0, f1)",
+                                null,
+                                DataTypes.INT())
+                        .testResult(
+                                $("f1").regexpInStr($("f0")),
+                                "REGEXP_INSTR(f1, f0)",
+                                null,
+                                DataTypes.INT())
+                        // invalid regexp
+                        .testTableApiRuntimeError(
+                                $("f1").regexpInStr("("), FlinkRuntimeException.class)
+                        .testSqlRuntimeError("REGEXP_INSTR(f1, '(')", FlinkRuntimeException.class)
+                        // not found
+                        .testResult(
+                                $("f2").regexpInStr("[a-z]"),
+                                "REGEXP_INSTR(f2, '[a-z]')",
+                                0,
+                                DataTypes.INT())
+                        // border chars
+                        .testResult(
+                                lit("Helloworld! Hello everyone!").regexpInStr("\\bHello\\b"),
+                                "REGEXP_INSTR('Helloworld! Hello everyone!', '\\bHello\\b')",
+                                13,
+                                DataTypes.INT().notNull())
+                        .testResult(
+                                lit("Helloworld!  Hello everyone!").regexpInStr("\\bHello\\b"),
+                                "REGEXP_INSTR('Helloworld!  Hello everyone!', '\\bHello\\b')",
+                                14,
+                                DataTypes.INT().notNull())
+                        // normal cases
+                        .testResult(
+                                lit("hello world! Hello everyone!").regexpInStr("Hello"),
+                                "REGEXP_INSTR('hello world! Hello everyone!', 'Hello')",
+                                14,
+                                DataTypes.INT().notNull())
+                        .testResult(
+                                lit("a.b.c.d").regexpInStr("\\."),
+                                "REGEXP_INSTR('a.b.c.d', '\\.')",
+                                2,
+                                DataTypes.INT().notNull())
+                        .testResult(
+                                lit("abc123xyz456").regexpInStr("\\d"),
+                                "REGEXP_INSTR('abc123xyz456', '\\d')",
+                                4,
+                                DataTypes.INT().notNull()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.REGEXP_INSTR, "Validation Error")
+                        .onFieldsWithData(1024)
+                        .andDataTypes(DataTypes.INT())
+                        .testTableApiValidationError(
+                                $("f0").regexpInStr("1024"),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "REGEXP_INSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "REGEXP_INSTR(f0, '1024')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "REGEXP_INSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)"));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
@@ -32,59 +32,59 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
 
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
-        return regexpInStrTestCases();
+        return regexpInstrTestCases();
     }
 
-    private Stream<TestSetSpec> regexpInStrTestCases() {
+    private Stream<TestSetSpec> regexpInstrTestCases() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.REGEXP_INSTR)
                         .onFieldsWithData(null, "abcdeabde", "100-200, 300-400")
                         .andDataTypes(DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING())
                         // null input
                         .testResult(
-                                $("f0").regexpInStr($("f1")),
+                                $("f0").regexpInstr($("f1")),
                                 "REGEXP_INSTR(f0, f1)",
                                 null,
                                 DataTypes.INT())
                         .testResult(
-                                $("f1").regexpInStr($("f0")),
+                                $("f1").regexpInstr($("f0")),
                                 "REGEXP_INSTR(f1, f0)",
                                 null,
                                 DataTypes.INT())
                         // invalid regexp
                         .testTableApiRuntimeError(
-                                $("f1").regexpInStr("("), FlinkRuntimeException.class)
+                                $("f1").regexpInstr("("), FlinkRuntimeException.class)
                         .testSqlRuntimeError("REGEXP_INSTR(f1, '(')", FlinkRuntimeException.class)
                         // not found
                         .testResult(
-                                $("f2").regexpInStr("[a-z]"),
+                                $("f2").regexpInstr("[a-z]"),
                                 "REGEXP_INSTR(f2, '[a-z]')",
                                 0,
                                 DataTypes.INT())
                         // border chars
                         .testResult(
-                                lit("Helloworld! Hello everyone!").regexpInStr("\\bHello\\b"),
+                                lit("Helloworld! Hello everyone!").regexpInstr("\\bHello\\b"),
                                 "REGEXP_INSTR('Helloworld! Hello everyone!', '\\bHello\\b')",
                                 13,
                                 DataTypes.INT().notNull())
                         .testResult(
-                                lit("Helloworld!  Hello everyone!").regexpInStr("\\bHello\\b"),
+                                lit("Helloworld!  Hello everyone!").regexpInstr("\\bHello\\b"),
                                 "REGEXP_INSTR('Helloworld!  Hello everyone!', '\\bHello\\b')",
                                 14,
                                 DataTypes.INT().notNull())
                         // normal cases
                         .testResult(
-                                lit("hello world! Hello everyone!").regexpInStr("Hello"),
+                                lit("hello world! Hello everyone!").regexpInstr("Hello"),
                                 "REGEXP_INSTR('hello world! Hello everyone!', 'Hello')",
                                 14,
                                 DataTypes.INT().notNull())
                         .testResult(
-                                lit("a.b.c.d").regexpInStr("\\."),
+                                lit("a.b.c.d").regexpInstr("\\."),
                                 "REGEXP_INSTR('a.b.c.d', '\\.')",
                                 2,
                                 DataTypes.INT().notNull())
                         .testResult(
-                                lit("abc123xyz456").regexpInStr("\\d"),
+                                lit("abc123xyz456").regexpInstr("\\d"),
                                 "REGEXP_INSTR('abc123xyz456', '\\d')",
                                 4,
                                 DataTypes.INT().notNull()),
@@ -92,7 +92,7 @@ class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
                         .onFieldsWithData(1024)
                         .andDataTypes(DataTypes.INT())
                         .testTableApiValidationError(
-                                $("f0").regexpInStr("1024"),
+                                $("f0").regexpInstr("1024"),
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "REGEXP_INSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)")
                         .testSqlValidationError(

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpInStrFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpInStrFunction.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.utils.ThreadLocalCache;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#REGEXP_INSTR}. */
+@Internal
+public class RegexpInStrFunction extends BuiltInScalarFunction {
+
+    private static final ThreadLocalCache<String, Pattern> REGEXP_PATTERN_CACHE =
+            new ThreadLocalCache<String, Pattern>() {
+                @Override
+                public Pattern getNewInstance(String key) {
+                    return Pattern.compile(key);
+                }
+            };
+
+    public RegexpInStrFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.REGEXP_INSTR, context);
+    }
+
+    public @Nullable Integer eval(@Nullable StringData str, @Nullable StringData regex) {
+        if (str == null || regex == null) {
+            return null;
+        }
+
+        Matcher matcher;
+        try {
+            matcher = REGEXP_PATTERN_CACHE.get(regex.toString()).matcher(str.toString());
+        } catch (PatternSyntaxException e) {
+            throw new FlinkRuntimeException(e);
+        }
+
+        return matcher.find() ? matcher.start() + 1 : 0;
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpInstrFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpInstrFunction.java
@@ -33,7 +33,7 @@ import java.util.regex.PatternSyntaxException;
 
 /** Implementation of {@link BuiltInFunctionDefinitions#REGEXP_INSTR}. */
 @Internal
-public class RegexpInStrFunction extends BuiltInScalarFunction {
+public class RegexpInstrFunction extends BuiltInScalarFunction {
 
     private static final ThreadLocalCache<String, Pattern> REGEXP_PATTERN_CACHE =
             new ThreadLocalCache<String, Pattern>() {
@@ -43,7 +43,7 @@ public class RegexpInStrFunction extends BuiltInScalarFunction {
                 }
             };
 
-    public RegexpInStrFunction(SpecializedContext context) {
+    public RegexpInstrFunction(SpecializedContext context) {
         super(BuiltInFunctionDefinitions.REGEXP_INSTR, context);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Add REGEXP_INSTR function.
Examples:
```SQL
> SELECT REGEXP_INSTR('Steven Jones and Stephen Smith are the best players', 'Ste(v|ph)en');
 1
> SELECT REGEXP_INSTR('Mary had a little lamb', 'Ste(v|ph)en');
 0
```

## Brief change log

[FLINK-35962](https://issues.apache.org/jira/browse/FLINK-35962)

## Verifying this change

`RegexpFunctionsITCase#regexpInStrTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
