### PR TITLE
[FLINK-35963][table] Add REGEXP_SUBSTR function

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -304,7 +304,13 @@ string:
       not exceed the number of the defined groups.
 
       E.g. REGEXP_EXTRACT('foothebar', 'foo(.*?)(bar)', 2)" returns "bar".
-
+  - sql: REGEXP_SUBSTR(str, regex)
+    table: str.regexpSubstr(regex)
+    description: |
+      Returns the first substring in str that matches regex.
+      In case of a malformed regex the function returns an error.
+      str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>
+      Returns an STRING representation of matched substring. `NULL` if any of the arguments are `NULL` or pattern is not found.
   - sql: INITCAP(string)
     table: STRING.initCap()
     description: Returns a new form of STRING with the first character of each word converted to uppercase and the rest characters to lowercase. Here a word means a sequences of alphanumeric characters.

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -375,6 +375,13 @@ string:
       将字符串 STRING1 按照 STRING2 正则表达式的规则拆分，返回指定 INTEGER1 处位置的字符串。正则表达式匹配组索引从 1 开始，
       0 表示匹配整个正则表达式。此外，正则表达式匹配组索引不应超过定义的组数。
       例如 `REGEXP_EXTRACT('foothebar', 'foo(.*?)(bar)', 2)` 返回 `"bar"`。
+  - sql: REGEXP_INSTR(str, regex)
+    table: str.regexpInStr(regex)
+    description: |
+      返回 str 中第一个匹配 regex 的子字符串。
+      如果正则表达式格式错误，则函数返回错误。
+      str <CHAR | VARCHAR>, regex <CHAR | VARCHAR>
+      返回一个 STRING 表示匹配成功的子串。如果任何参数为 `NULL` 或匹配失败，则返回 `NULL`。
   - sql: INITCAP(string)
     table: STRING.initCap()
     description: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -178,6 +178,7 @@ string functions
     Expression.regexp
     Expression.regexp_replace
     Expression.regexp_extract
+    Expression.regexp_substr
     Expression.from_base64
     Expression.to_base64
     Expression.ascii

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1205,6 +1205,13 @@ class Expression(Generic[T]):
         else:
             return _ternary_op("regexpExtract")(self, regex, extract_index)
 
+    def regexp_substr(self, regex) -> 'Expression':
+        """
+        Returns the first substring in str that matches regex, null if pattern is not found.
+        In case of a malformed regex the function returns an error.
+        """
+        return _binary_op("regexpSubstr")(self, regex)
+
     @property
     def from_base64(self) -> 'Expression[str]':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -157,6 +157,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.RADIAN
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_EXTRACT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_REPLACE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REGEXP_SUBSTR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REPEAT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REPLACE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.REVERSE;
@@ -1128,6 +1129,16 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType regexpExtract(InType regex) {
         return toApiSpecificExpression(
                 unresolvedCall(REGEXP_EXTRACT, toExpr(), objectToExpression(regex)));
+    }
+
+    /**
+     * Returns the first substring in {@code str} that matches {@code regex}, null if pattern is not
+     * found. <br>
+     * In case of a malformed {@code regex} the function returns an error.
+     */
+    public OutType regexpSubstr(InType regex) {
+        return toApiSpecificExpression(
+                unresolvedCall(REGEXP_SUBSTR, toExpr(), objectToExpression(regex)));
     }
 
     /** Returns the base string decoded with base64. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1105,6 +1105,21 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(explicit(DataTypes.STRING().nullable()))
                     .build();
 
+    public static final BuiltInFunctionDefinition REGEXP_SUBSTR =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("REGEXP_SUBSTR")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Arrays.asList("str", "regex"),
+                                    Arrays.asList(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .outputTypeStrategy(explicit(DataTypes.STRING()))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.RegexpSubstrFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition FROM_BASE64 =
             BuiltInFunctionDefinition.newBuilder()
                     .name("fromBase64")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/RegexpFunctionsITCase.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.lit;
+
+/** Test Regexp functions correct behaviour. */
+class RegexpFunctionsITCase extends BuiltInFunctionTestBase {
+
+    @Override
+    Stream<TestSetSpec> getTestSetSpecs() {
+        return regexpSubstrTestCases();
+    }
+
+    private Stream<TestSetSpec> regexpSubstrTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.REGEXP_SUBSTR)
+                        .onFieldsWithData(null, "abcdeabde", "100-200, 300-400")
+                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING())
+                        // null input
+                        .testResult(
+                                $("f0").regexpSubstr($("f1")),
+                                "REGEXP_SUBSTR(f0, f1)",
+                                null,
+                                DataTypes.STRING())
+                        .testResult(
+                                $("f1").regexpSubstr($("f0")),
+                                "REGEXP_SUBSTR(f1, f0)",
+                                null,
+                                DataTypes.STRING())
+                        // invalid regexp
+                        .testTableApiRuntimeError(
+                                $("f1").regexpSubstr("("), FlinkRuntimeException.class)
+                        .testSqlRuntimeError("REGEXP_SUBSTR(f1, '(')", FlinkRuntimeException.class)
+                        // not found
+                        .testResult(
+                                $("f2").regexpSubstr("[a-z]"),
+                                "REGEXP_SUBSTR(f2, '[a-z]')",
+                                null,
+                                DataTypes.STRING())
+                        // border chars
+                        .testResult(
+                                lit("Helloworld! Hello everyone!").regexpSubstr("\\bHello\\b"),
+                                "REGEXP_SUBSTR('Helloworld! Hello everyone!', '\\bHello\\b')",
+                                "Hello",
+                                DataTypes.STRING())
+                        .testResult(
+                                $("f2").regexpSubstr("(\\d+)-(\\d+)$"),
+                                "REGEXP_SUBSTR(f2, '(\\d+)-(\\d+)$')",
+                                "300-400",
+                                DataTypes.STRING())
+                        // normal cases
+                        .testResult(
+                                lit("hello world! Hello everyone!").regexpSubstr("Hello"),
+                                "REGEXP_SUBSTR('hello world! Hello everyone!', 'Hello')",
+                                "Hello",
+                                DataTypes.STRING())
+                        .testResult(
+                                lit("a.b.c.d").regexpSubstr("\\."),
+                                "REGEXP_SUBSTR('a.b.c.d', '\\.')",
+                                ".",
+                                DataTypes.STRING())
+                        .testResult(
+                                lit("abc123xyz456").regexpSubstr("\\d"),
+                                "REGEXP_SUBSTR('abc123xyz456', '\\d')",
+                                "1",
+                                DataTypes.STRING()),
+                TestSetSpec.forFunction(
+                                BuiltInFunctionDefinitions.REGEXP_SUBSTR, "Validation Error")
+                        .onFieldsWithData(1024)
+                        .andDataTypes(DataTypes.INT())
+                        .testTableApiValidationError(
+                                $("f0").regexpSubstr("1024"),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "REGEXP_SUBSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "REGEXP_SUBSTR(f0, '1024')",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "REGEXP_SUBSTR(str <CHARACTER_STRING>, regex <CHARACTER_STRING>)"));
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpSubstrFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/RegexpSubstrFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.utils.ThreadLocalCache;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#REGEXP_SUBSTR}. */
+@Internal
+public class RegexpSubstrFunction extends BuiltInScalarFunction {
+
+    private static final ThreadLocalCache<String, Pattern> REGEXP_PATTERN_CACHE =
+            new ThreadLocalCache<String, Pattern>() {
+                @Override
+                public Pattern getNewInstance(String key) {
+                    return Pattern.compile(key);
+                }
+            };
+
+    public RegexpSubstrFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.REGEXP_SUBSTR, context);
+    }
+
+    public @Nullable StringData eval(@Nullable StringData str, @Nullable StringData regex) {
+        if (str == null || regex == null) {
+            return null;
+        }
+
+        Matcher matcher;
+        try {
+            matcher = REGEXP_PATTERN_CACHE.get(regex.toString()).matcher(str.toString());
+        } catch (PatternSyntaxException e) {
+            throw new FlinkRuntimeException(e);
+        }
+
+        return matcher.find() ? BinaryStringData.fromString(matcher.group(0)) : null;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add REGEXP_SUBSTR function.
Examples:
```SQL
> SELECT REGEXP_SUBSTR('Steven Jones and Stephen Smith are the best players', 'Ste(v|ph)en');
 Steven
> SELECT REGEXP_SUBSTR('Mary had a little lamb', 'Ste(v|ph)en');
 NULL
```

## Brief change log

[FLINK-35963](https://issues.apache.org/jira/browse/FLINK-35963)

## Verifying this change

`RegexpFunctionsITCase#regexpSubstrTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
