### PR TITLE
[hotfix][doc] Fix typo in checkpointing docs

### DIFF
--- a/docs/content/docs/dev/datastream/fault-tolerance/checkpointing.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/checkpointing.md
@@ -210,7 +210,7 @@ env.get_checkpoint_config().enable_unaligned_checkpoints()
 
 ### Related Config Options
 
-Some more parameters and/or defaults may be set via Flink configuration file (see [configuration]({{< ref "docs/deployment/config" >}}))` for a full guide):
+Some more parameters and/or defaults may be set via Flink configuration file (see [configuration]({{< ref "docs/deployment/config" >}}) for a full guide):
 
 {{< generated/checkpointing_configuration >}}
 


### PR DESCRIPTION
Typo here:

https://nightlies.apache.org/flink/flink-docs-release-1.19/docs/dev/datastream/fault-tolerance/checkpointing/#related-config-options

![image](https://github.com/user-attachments/assets/bb5dd007-b909-452d-8413-9a438efe18f6)
