### PR TITLE
[FLINK-35934] Add CompiledPlan annotations to BatchExecValues

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecValues.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecValues.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
+import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.data.RowData;
@@ -25,15 +26,25 @@ import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeMetadata;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecValues;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.calcite.rex.RexLiteral;
 
 import java.util.List;
 
 /** Batch {@link ExecNode} that read records from given values. */
+@ExecNodeMetadata(
+        name = "batch-exec-values",
+        version = 1,
+        producedTransformations = CommonExecValues.VALUES_TRANSFORMATION,
+        minPlanVersion = FlinkVersion.v2_0,
+        minStateVersion = FlinkVersion.v2_0)
 public class BatchExecValues extends CommonExecValues implements BatchExecNode<RowData> {
 
     public BatchExecValues(
@@ -48,6 +59,17 @@ public class BatchExecValues extends CommonExecValues implements BatchExecNode<R
                 tuples,
                 outputType,
                 description);
+    }
+
+    @JsonCreator
+    public BatchExecValues(
+            @JsonProperty(FIELD_NAME_ID) int id,
+            @JsonProperty(FIELD_NAME_TYPE) ExecNodeContext context,
+            @JsonProperty(FIELD_NAME_CONFIGURATION) ReadableConfig persistedConfig,
+            @JsonProperty(FIELD_NAME_TUPLES) List<List<RexLiteral>> tuples,
+            @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
+        super(id, context, persistedConfig, tuples, outputType, description);
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/ExecNodeMetadataUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/ExecNodeMetadataUtil.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecExchange;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecSink;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecSort;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecValues;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecAsyncCalc;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecCalc;
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecChangelogNormalize;
@@ -159,6 +160,7 @@ public final class ExecNodeMetadataUtil {
                     add(BatchExecCalc.class);
                     add(BatchExecExchange.class);
                     add(BatchExecSort.class);
+                    add(BatchExecValues.class);
                 }
             };
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/batch/ValuesBatchRestoreTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/batch/ValuesBatchRestoreTest.java
@@ -16,22 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.planner.plan.nodes.exec.stream;
+package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
-import org.apache.flink.table.test.program.SinkTestStep;
+import org.apache.flink.table.planner.plan.nodes.exec.common.ValuesTestPrograms;
+import org.apache.flink.table.planner.plan.nodes.exec.testutils.BatchRestoreTestBase;
 import org.apache.flink.table.test.program.TableTestProgram;
 
-/** {@link TableTestProgram} definitions for testing {@link StreamExecValues}. */
-public class ValuesTestPrograms {
+import java.util.Collections;
+import java.util.List;
 
-    static final TableTestProgram VALUES_TEST =
-            TableTestProgram.of("values-test", "validates values node")
-                    .setupTableSink(
-                            SinkTestStep.newBuilder("sink_t")
-                                    .addSchema("b INT", "a INT", "c VARCHAR")
-                                    .consumedValues("+I[1, 2, Hi]", "+I[3, 4, Hello]")
-                                    .build())
-                    .runSql(
-                            "INSERT INTO sink_t SELECT * FROM (VALUES (1, 2, 'Hi'), (3, 4, 'Hello'))")
-                    .build();
+/** Batch Compiled Plan tests for {@link BatchExecValues}. */
+public class ValuesBatchRestoreTest extends BatchRestoreTestBase {
+
+    public ValuesBatchRestoreTest() {
+        super(BatchExecValues.class);
+    }
+
+    @Override
+    public List<TableTestProgram> programs() {
+        return Collections.singletonList(ValuesTestPrograms.VALUES_TEST);
+    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/ValuesTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/common/ValuesTestPrograms.java
@@ -16,24 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.planner.plan.nodes.exec.stream;
+package org.apache.flink.table.planner.plan.nodes.exec.common;
 
-import org.apache.flink.table.planner.plan.nodes.exec.common.ValuesTestPrograms;
-import org.apache.flink.table.planner.plan.nodes.exec.testutils.RestoreTestBase;
+import org.apache.flink.table.test.program.SinkTestStep;
 import org.apache.flink.table.test.program.TableTestProgram;
 
-import java.util.Collections;
-import java.util.List;
+/** {@link TableTestProgram} definitions for testing {@link StreamExecValues}. */
+public class ValuesTestPrograms {
 
-/** Restore tests for {@link StreamExecValues}. */
-public class ValuesRestoreTest extends RestoreTestBase {
-
-    public ValuesRestoreTest() {
-        super(StreamExecValues.class, AfterRestoreSource.NO_RESTORE);
-    }
-
-    @Override
-    public List<TableTestProgram> programs() {
-        return Collections.singletonList(ValuesTestPrograms.VALUES_TEST);
-    }
+    public static final TableTestProgram VALUES_TEST =
+            TableTestProgram.of("values-test", "validates values node")
+                    .setupTableSink(
+                            SinkTestStep.newBuilder("sink_t")
+                                    .addSchema("b INT", "a INT", "c VARCHAR")
+                                    .consumedValues("+I[1, 2, Hi]", "+I[3, 4, Hello]")
+                                    .build())
+                    .runSql(
+                            "INSERT INTO sink_t SELECT * FROM (VALUES (1, 2, 'Hi'), (3, 4, 'Hello'))")
+                    .build();
 }

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-values_1/values-test/plan/values-test.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-values_1/values-test/plan/values-test.json
@@ -1,0 +1,80 @@
+{
+  "flinkVersion" : "2.0",
+  "nodes" : [ {
+    "id" : 1,
+    "type" : "batch-exec-values_1",
+    "tuples" : [ [ {
+      "kind" : "LITERAL",
+      "value" : 1,
+      "type" : "INT NOT NULL"
+    }, {
+      "kind" : "LITERAL",
+      "value" : 2,
+      "type" : "INT NOT NULL"
+    }, {
+      "kind" : "LITERAL",
+      "value" : "Hi",
+      "type" : "CHAR(2) NOT NULL"
+    } ], [ {
+      "kind" : "LITERAL",
+      "value" : 3,
+      "type" : "INT NOT NULL"
+    }, {
+      "kind" : "LITERAL",
+      "value" : 4,
+      "type" : "INT NOT NULL"
+    }, {
+      "kind" : "LITERAL",
+      "value" : "Hello",
+      "type" : "CHAR(5) NOT NULL"
+    } ] ],
+    "outputType" : "ROW<`EXPR$0` INT NOT NULL, `EXPR$1` INT NOT NULL, `EXPR$2` VARCHAR(5) NOT NULL>",
+    "description" : "Values(tuples=[[{ 1, 2, _UTF-16LE'Hi' }, { 3, 4, _UTF-16LE'Hello' }]], values=[EXPR$0, EXPR$1, EXPR$2])",
+    "inputProperties" : [ ]
+  }, {
+    "id" : 2,
+    "type" : "batch-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.type-length-enforcer" : "IGNORE"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`sink_t`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "b",
+              "dataType" : "INT"
+            }, {
+              "name" : "a",
+              "dataType" : "INT"
+            }, {
+              "name" : "c",
+              "dataType" : "VARCHAR(2147483647)"
+            } ],
+            "watermarkSpecs" : [ ]
+          },
+          "partitionKeys" : [ ]
+        }
+      }
+    },
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "BLOCKING",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`EXPR$0` INT NOT NULL, `EXPR$1` INT NOT NULL, `EXPR$2` VARCHAR(5) NOT NULL>",
+    "description" : "Sink(table=[default_catalog.default_database.sink_t], fields=[EXPR$0, EXPR$1, EXPR$2])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}


### PR DESCRIPTION
## What is the purpose of the change

* In addition to the annotations, implement a BatchRestoreTest for this operator.
* Moves the ValuesTestPrograms to a common package for re-use between streaming and batch. 

## Verifying this change

This change adds a BatchRestoreTest to cover the new annotations and show that the batch compiled plan can be restored and executed correctly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
