### PR TITLE
[FLINK-35964][table] Add the built-in function STARTSWITH & ENDSWITH

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -329,6 +329,18 @@ string:
       STRING1.overlay(STRING2, INT1)
       STRING1.overlay(STRING2, INT1, INT2)
     description: Returns a string that replaces INT2 (STRING2's length by default) characters of STRING1 with STRING2 from position INT1. E.g., 'xxxxxtest'.overlay('xxxx', 6) returns "xxxxxxxxx"; 'xxxxxtest'.overlay('xxxx', 6, 2) returns "xxxxxxxxxst".
+  - sql: STARTSWITH(expr, startExpr)
+    table: expr.startsWith(startExpr)
+    description: |
+      Returns whether expr starts with startExpr. If startExpr is empty, the result is true.
+      
+      expr and startExpr should have same type. 
+      
+      `expr <CHAR | VARCHAR>, startExpr <CHAR | VARCHAR>`
+      
+      `expr <BINARY | VARBINARY>, startExpr <BINARY | VARBINARY>`
+      
+      Returns a `BOOLEAN`. `NULL` if any of the arguments are `NULL`.
   - sql: SUBSTRING(string FROM integer1 [ FOR integer2 ])
     table: |
       STRING.substring(INT1)

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -341,6 +341,18 @@ string:
       `expr <BINARY | VARBINARY>, startExpr <BINARY | VARBINARY>`
       
       Returns a `BOOLEAN`. `NULL` if any of the arguments are `NULL`.
+  - sql: ENDSWITH(expr, endExpr)
+    table: expr.endsWith(endExpr)
+    description: |
+      Returns whether expr ends with endExpr. If endExpr is empty, the result is true.
+      
+      expr and endExpr should have same type. 
+      
+      `expr <CHAR | VARCHAR>, endExpr <CHAR | VARCHAR>`
+      
+      `expr <BINARY | VARBINARY>, endExpr <BINARY | VARBINARY>`
+      
+      Returns a `BOOLEAN`. `NULL` if any of the arguments are `NULL`.
   - sql: SUBSTRING(string FROM integer1 [ FOR integer2 ])
     table: |
       STRING.substring(INT1)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -398,6 +398,18 @@ string:
       将字符串 STRING1 从位置 INT1 开始替换 INT2（默认为 STRING2 的长度）个来自字符串 STRING2 的字符并返回。
       例如 `'xxxxxtest'.overlay('xxxx', 6)` 返回 `"xxxxxxxxx"`；
       `'xxxxxtest'.overlay('xxxx', 6, 2)` 返回 `"xxxxxxxxxst"`。
+  - sql: STARTSWITH(expr, startExpr)
+    table: expr.startsWith(startExpr)
+    description: |
+      判断 expr 是否以 startExpr 开头。如果 startExpr 为空，则结果为 true。
+      
+      expr 和 startExpr 应具有相同的类型。
+      
+      `expr <CHAR | VARCHAR>, startExpr <CHAR | VARCHAR>`
+      
+      `expr <BINARY | VARBINARY>, startExpr <BINARY | VARBINARY>`
+      
+      返回一个 `BOOLEAN`。如果任意参数为 `NULL`，则返回 `NULL`。
   - sql: SUBSTRING(string FROM integer1 [ FOR integer2 ])
     table: |
       STRING.substring(INT1)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -410,6 +410,18 @@ string:
       `expr <BINARY | VARBINARY>, startExpr <BINARY | VARBINARY>`
       
       返回一个 `BOOLEAN`。如果任意参数为 `NULL`，则返回 `NULL`。
+  - sql: ENDSWITH(expr, endExpr)
+    table: expr.endsWith(endExpr)
+    description: |
+      判断 expr 是否以 endExpr 结尾。如果 endExpr 为空，则结果为 true。
+      
+      expr 和 endExpr 应具有相同的类型。
+      
+      `expr <CHAR | VARCHAR>, endExpr <CHAR | VARCHAR>`
+      
+      `expr <BINARY | VARBINARY>, endExpr <BINARY | VARBINARY>`
+      
+      返回一个 `BOOLEAN`。如果任意参数为 `NULL`，则返回 `NULL`。
   - sql: SUBSTRING(string FROM integer1 [ FOR integer2 ])
     table: |
       STRING.substring(INT1)

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -160,6 +160,7 @@ string functions
 .. autosummary::
     :toctree: api/
 
+    Expression.starts_with
     Expression.substring
     Expression.substr
     Expression.trim_leading

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -161,6 +161,7 @@ string functions
     :toctree: api/
 
     Expression.starts_with
+    Expression.ends_with
     Expression.substring
     Expression.substr
     Expression.trim_leading

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1038,6 +1038,16 @@ class Expression(Generic[T]):
         """
         return _binary_op("startsWith")(self, start_expr)
 
+    def ends_with(self, end_expr) -> 'Expression':
+        """
+        Returns whether expr ends with end_expr. If end_expr is empty, the result is true.
+        expr and end_expr should have same type.
+
+        :param end_expr: A STRING or BINARY expression.
+        :return: A BOOLEAN.
+        """
+        return _binary_op("endsWith")(self, end_expr)
+
     def substring(self,
                   begin_index: Union[int, 'Expression[int]'],
                   length: Union[int, 'Expression[int]'] = None) -> 'Expression[str]':

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1028,6 +1028,16 @@ class Expression(Generic[T]):
 
     # ---------------------------- string functions ----------------------------------
 
+    def starts_with(self, start_expr) -> 'Expression':
+        """
+        Returns whether expr starts with start_expr. If start_expr is empty, the result is true.
+        expr and start_expr should have same type.
+
+        :param start_expr: A STRING or BINARY expression.
+        :return: A BOOLEAN.
+        """
+        return _binary_op("startsWith")(self, start_expr)
+
     def substring(self,
                   begin_index: Union[int, 'Expression[int]'],
                   length: Union[int, 'Expression[int]'] = None) -> 'Expression[str]':

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -172,6 +172,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("ELT(1, a)", str(lit(1).elt(expr1)))
         self.assertEqual('ELT(3, a, b, c)', str(lit(3).elt(expr1, expr2, expr3)))
         self.assertEqual("PRINTF('%d %s', a, b)", str(lit("%d %s").printf(expr1, expr2)))
+        self.assertEqual("STARTSWITH(a, b)", str(expr1.starts_with(expr2)))
 
         # regexp functions
         self.assertEqual("regexp(a, b)", str(expr1.regexp(expr2)))

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -173,6 +173,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('ELT(3, a, b, c)', str(lit(3).elt(expr1, expr2, expr3)))
         self.assertEqual("PRINTF('%d %s', a, b)", str(lit("%d %s").printf(expr1, expr2)))
         self.assertEqual("STARTSWITH(a, b)", str(expr1.starts_with(expr2)))
+        self.assertEqual("ENDSWITH(a, b)", str(expr1.ends_with(expr2)))
 
         # regexp functions
         self.assertEqual("regexp(a, b)", str(expr1.regexp(expr2)))

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -187,6 +187,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SINH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SPLIT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SPLIT_INDEX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.SQRT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STARTS_WITH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STDDEV_POP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STDDEV_SAMP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STR_TO_MAP;
@@ -849,6 +850,19 @@ public abstract class BaseExpressions<InType, OutType> {
     }
 
     // String operations
+
+    /**
+     * Returns whether {@code expr} starts with {@code startExpr}. If {@code startExpr} is empty,
+     * the result is true. <br>
+     * {@code expr} and {@code startExpr} should have same type.
+     *
+     * @param startExpr A STRING or BINARY expression.
+     * @return A BOOLEAN.
+     */
+    public OutType startsWith(InType startExpr) {
+        return toApiSpecificExpression(
+                unresolvedCall(STARTS_WITH, toExpr(), objectToExpression(startExpr)));
+    }
 
     /**
      * Creates a substring of the given string at given index for a given length.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -93,6 +93,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DISTIN
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DIVIDE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ELT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ENCODE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ENDS_WITH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXTRACT;
@@ -862,6 +863,19 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType startsWith(InType startExpr) {
         return toApiSpecificExpression(
                 unresolvedCall(STARTS_WITH, toExpr(), objectToExpression(startExpr)));
+    }
+
+    /**
+     * Returns whether {@code expr} ends with {@code endExpr}. If {@code endExpr} is empty, the
+     * result is true. <br>
+     * {@code expr} and {@code endExpr} should have same type.
+     *
+     * @param endExpr A STRING or BINARY expression.
+     * @return A BOOLEAN.
+     */
+    public OutType endsWith(InType endExpr) {
+        return toApiSpecificExpression(
+                unresolvedCall(ENDS_WITH, toExpr(), objectToExpression(endExpr)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -947,6 +947,27 @@ public final class BuiltInFunctionDefinitions {
                             "org.apache.flink.table.runtime.functions.scalar.StartsWithFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition ENDS_WITH =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ENDSWITH")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            Arrays.asList("expr", "endExpr"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING))),
+                                    sequence(
+                                            Arrays.asList("expr", "endExpr"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.BINARY_STRING),
+                                                    logical(LogicalTypeFamily.BINARY_STRING)))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.BOOLEAN())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.EndsWithFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition SUBSTRING =
             BuiltInFunctionDefinition.newBuilder()
                     .name("substring")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -926,6 +926,27 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.BOOLEAN())))
                     .build();
 
+    public static final BuiltInFunctionDefinition STARTS_WITH =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("STARTSWITH")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            Arrays.asList("expr", "startExpr"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING))),
+                                    sequence(
+                                            Arrays.asList("expr", "startExpr"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.BINARY_STRING),
+                                                    logical(LogicalTypeFamily.BINARY_STRING)))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.BOOLEAN())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.StartsWithFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition SUBSTRING =
             BuiltInFunctionDefinition.newBuilder()
                     .name("substring")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EndsWithFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EndsWithFunction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ENDS_WITH}. */
+@Internal
+public class EndsWithFunction extends BuiltInScalarFunction {
+
+    public EndsWithFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ENDS_WITH, context);
+    }
+
+    public @Nullable Boolean eval(@Nullable StringData expr, @Nullable StringData endExpr) {
+        if (expr == null || endExpr == null) {
+            return null;
+        }
+        if (BinaryStringDataUtil.isEmpty((BinaryStringData) endExpr)) {
+            return true;
+        }
+        return ((BinaryStringData) expr).endsWith((BinaryStringData) endExpr);
+    }
+
+    public @Nullable Boolean eval(@Nullable byte[] expr, @Nullable byte[] endExpr) {
+        if (expr == null || endExpr == null) {
+            return null;
+        }
+        if (endExpr.length == 0) {
+            return true;
+        }
+        return matchAtEnd(expr, endExpr);
+    }
+
+    private static boolean matchAtEnd(byte[] source, byte[] target) {
+        int start = source.length - target.length;
+        if (start < 0) {
+            return false;
+        }
+        for (int i = start; i < source.length; i++) {
+            if (source[i] != target[i - start]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/StartsWithFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/StartsWithFunction.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#STARTS_WITH}. */
+@Internal
+public class StartsWithFunction extends BuiltInScalarFunction {
+
+    public StartsWithFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.STARTS_WITH, context);
+    }
+
+    public @Nullable Boolean eval(@Nullable StringData expr, @Nullable StringData startExpr) {
+        if (expr == null || startExpr == null) {
+            return null;
+        }
+        if (BinaryStringDataUtil.isEmpty((BinaryStringData) startExpr)) {
+            return true;
+        }
+        return ((BinaryStringData) expr).startsWith((BinaryStringData) startExpr);
+    }
+
+    public @Nullable Boolean eval(@Nullable byte[] expr, @Nullable byte[] startExpr) {
+        if (expr == null || startExpr == null) {
+            return null;
+        }
+        if (startExpr.length == 0) {
+            return true;
+        }
+        return matchAtStart(expr, startExpr);
+    }
+
+    private static boolean matchAtStart(byte[] source, byte[] target) {
+        if (source.length < target.length) {
+            return false;
+        }
+        for (int i = 0; i < target.length; i++) {
+            if (source[i] != target[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the built-in function STARTSWITH & ENDSWITH.
Examples:
```SQL
> SELECT STARTSWITH('SparkSQL', 'Spark');
 TRUE
> SELECT STARTSWITH('SparkSQL', 'spark');
 FALSE

> SELECT ENDSWITH('SparkSQL', 'SQL');
 TRUE
> SELECT ENDSWITH('SparkSQL', 'sql');
 FALSE
```

## Brief change log

[FLINK-35964](https://issues.apache.org/jira/browse/FLINK-35964)
[FLINK-35965](https://issues.apache.org/jira/browse/FLINK-35965)

## Verifying this change

`StringFunctionsITCase#startsWithTestCases`
`StringFunctionsITCase#endsWithTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
