### PR TITLE
[FLINK-35965][table] Add the built-in function ENDSWITH

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -291,6 +291,18 @@ string:
       STRING1.overlay(STRING2, INT1)
       STRING1.overlay(STRING2, INT1, INT2)
     description: Returns a string that replaces INT2 (STRING2's length by default) characters of STRING1 with STRING2 from position INT1. E.g., 'xxxxxtest'.overlay('xxxx', 6) returns "xxxxxxxxx"; 'xxxxxtest'.overlay('xxxx', 6, 2) returns "xxxxxxxxxst".
+  - sql: ENDSWITH(expr, endExpr)
+    table: expr.endsWith(endExpr)
+    description: |
+      Returns if expr ends with endExpr. If endExpr is empty, the result is true.
+      
+      expr and endExpr should have same type. 
+      
+      expr <CHAR | VARCHAR>, endExpr <CHAR | VARCHAR>
+      
+      expr <BINARY | VARBINARY>, endExpr <BINARY | VARBINARY>
+      
+      Returns a BOOLEAN. `NULL` if any of the arguments are `NULL`.
   - sql: SUBSTRING(string FROM integer1 [ FOR integer2 ])
     table: |
       STRING.substring(INT1)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -364,6 +364,18 @@ string:
       将字符串 STRING1 从位置 INT1 开始替换 INT2（默认为 STRING2 的长度）个来自字符串 STRING2 的字符并返回。
       例如 `'xxxxxtest'.overlay('xxxx', 6)` 返回 `"xxxxxxxxx"`；
       `'xxxxxtest'.overlay('xxxx', 6, 2)` 返回 `"xxxxxxxxxst"`。
+  - sql: ENDSWITH(expr, endExpr)
+    table: expr.endsWith(endExpr)
+    description: |
+      判断 expr 是否以 endExpr 结尾。如果 endExpr 为空，则结果为 true。
+      
+      expr 和 endExpr 应具有相同的类型。
+      
+      expr <CHAR | VARCHAR>, endExpr <CHAR | VARCHAR>
+      
+      expr <BINARY | VARBINARY>, endExpr <BINARY | VARBINARY>
+      
+      返回一个 BOOLEAN。如果任意参数为 `NULL`，则返回 `NULL`。
   - sql: SUBSTRING(string FROM integer1 [ FOR integer2 ])
     table: |
       STRING.substring(INT1)

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -159,6 +159,7 @@ string functions
 .. autosummary::
     :toctree: api/
 
+    Expression.ends_with
     Expression.substring
     Expression.substr
     Expression.trim_leading

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1017,6 +1017,15 @@ class Expression(Generic[T]):
 
     # ---------------------------- string functions ----------------------------------
 
+    def ends_with(self, end_expr) -> 'Expression':
+        """
+        Returns if expr ends with end_expr. If end_expr is empty, the result is true.
+        expr and end_expr should have same type.
+
+        :param end_expr: a STRING or BINARY expression
+        """
+        return _binary_op("endsWith")(self, end_expr)
+
     def substring(self,
                   begin_index: Union[int, 'Expression[int]'],
                   length: Union[int, 'Expression[int]'] = None) -> 'Expression[str]':

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -171,6 +171,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("strToMap(a, ';', ':')", str(expr1.str_to_map(';', ':')))
         self.assertEqual("ELT(1, a)", str(lit(1).elt(expr1)))
         self.assertEqual('ELT(3, a, b, c)', str(lit(3).elt(expr1, expr2, expr3)))
+        self.assertEqual("ENDSWITH(a, b)", str(expr1.ends_with(expr2)))
 
         # temporal functions
         self.assertEqual('cast(a, DATE)', str(expr1.to_date))

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -93,6 +93,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DISTIN
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DIVIDE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ELT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ENCODE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ENDS_WITH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXP;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXTRACT;
@@ -832,6 +833,19 @@ public abstract class BaseExpressions<InType, OutType> {
     }
 
     // String operations
+
+    /**
+     * Returns if {@code expr} ends with {@code endExpr}. If {@code endExpr} is empty, the result is
+     * true. <br>
+     * {@code expr} and {@code endExpr} should have same type.
+     *
+     * @param endExpr a STRING or BINARY expression
+     * @return a BOOLEAN
+     */
+    public OutType endsWith(InType endExpr) {
+        return toApiSpecificExpression(
+                unresolvedCall(ENDS_WITH, toExpr(), objectToExpression(endExpr)));
+    }
 
     /**
      * Creates a substring of the given string at given index for a given length.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -926,6 +926,27 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.BOOLEAN())))
                     .build();
 
+    public static final BuiltInFunctionDefinition ENDS_WITH =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ENDSWITH")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            Arrays.asList("expr", "endExpr"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING))),
+                                    sequence(
+                                            Arrays.asList("expr", "endExpr"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.BINARY_STRING),
+                                                    logical(LogicalTypeFamily.BINARY_STRING)))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.BOOLEAN())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.EndsWithFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition SUBSTRING =
             BuiltInFunctionDefinition.newBuilder()
                     .name("substring")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -36,6 +36,7 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
         return Stream.of(
                         bTrimTestCases(),
                         eltTestCases(),
+                        endsWithTestCases(),
                         regexpExtractTestCases(),
                         translateTestCases())
                 .flatMap(s -> s);
@@ -188,6 +189,142 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                         .testSqlValidationError(
                                 "ELT(-1, 'a')",
                                 "Index must be an integer starting from '0', but was '-1'."));
+    }
+
+    private Stream<TestSetSpec> endsWithTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ENDS_WITH, "StringData")
+                        .onFieldsWithData(null, "www.apache.org", "", "in中文", "\uD83D\uDE00")
+                        .andDataTypes(
+                                DataTypes.STRING(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING(),
+                                DataTypes.STRING())
+                        // null input
+                        .testResult(
+                                $("f0").endsWith("abc"),
+                                "ENDSWITH(f0, 'abc')",
+                                null,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f1").endsWith($("f0")),
+                                "ENDSWITH(f1, f0)",
+                                null,
+                                DataTypes.BOOLEAN())
+                        // empty input
+                        .testResult(
+                                $("f2").endsWith("abc"),
+                                "ENDSWITH(f2, 'abc')",
+                                Boolean.FALSE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f1").endsWith($("f2")),
+                                "ENDSWITH(f1, f2)",
+                                Boolean.TRUE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                lit("").endsWith(""),
+                                "ENDSWITH('', '')",
+                                Boolean.TRUE,
+                                DataTypes.BOOLEAN().notNull())
+                        // normal cases
+                        .testResult(
+                                $("f1").endsWith("org"),
+                                "ENDSWITH(f1, 'org')",
+                                Boolean.TRUE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f1").endsWith("."),
+                                "ENDSWITH(f1, '.')",
+                                Boolean.FALSE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f3").endsWith("n中文"),
+                                "ENDSWITH(f3, 'n中文')",
+                                Boolean.TRUE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f3").endsWith("中"),
+                                "ENDSWITH(f3, '中')",
+                                Boolean.FALSE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f4").endsWith($("f4")),
+                                "ENDSWITH(f4, f4)",
+                                Boolean.TRUE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f4").endsWith("\uDE00"),
+                                "ENDSWITH(f4, '\uDE00')",
+                                Boolean.FALSE,
+                                DataTypes.BOOLEAN()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ENDS_WITH, "byte[]")
+                        .onFieldsWithData(
+                                null,
+                                new byte[] {1, 2, 3},
+                                new byte[0],
+                                new byte[0],
+                                new byte[] {2, 3},
+                                new byte[] {1})
+                        .andDataTypes(
+                                DataTypes.BYTES(),
+                                DataTypes.BYTES(),
+                                DataTypes.BYTES(),
+                                DataTypes.BYTES().notNull(),
+                                DataTypes.BYTES(),
+                                DataTypes.BYTES())
+                        // null input
+                        .testResult(
+                                $("f0").endsWith($("f1")),
+                                "ENDSWITH(f0, f1)",
+                                null,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f1").endsWith($("f0")),
+                                "ENDSWITH(f1, f0)",
+                                null,
+                                DataTypes.BOOLEAN())
+                        // empty input
+                        .testResult(
+                                $("f2").endsWith($("f1")),
+                                "ENDSWITH(f2, f1)",
+                                Boolean.FALSE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f1").endsWith($("f2")),
+                                "ENDSWITH(f1, f2)",
+                                Boolean.TRUE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f3").endsWith($("f3")),
+                                "ENDSWITH(f3, f3)",
+                                Boolean.TRUE,
+                                DataTypes.BOOLEAN().notNull())
+                        // normal cases
+                        .testResult(
+                                $("f1").endsWith($("f4")),
+                                "ENDSWITH(f1, f4)",
+                                Boolean.TRUE,
+                                DataTypes.BOOLEAN())
+                        .testResult(
+                                $("f1").endsWith($("f5")),
+                                "ENDSWITH(f1, f5)",
+                                Boolean.FALSE,
+                                DataTypes.BOOLEAN()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.ENDS_WITH, "Validation Error")
+                        .onFieldsWithData("12345", "123".getBytes())
+                        .andDataTypes(DataTypes.STRING(), DataTypes.BYTES())
+                        .testTableApiValidationError(
+                                $("f0").endsWith($("f1")),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ENDSWITH(expr <CHARACTER_STRING>, endExpr <CHARACTER_STRING>)\n"
+                                        + "ENDSWITH(expr <BINARY_STRING>, endExpr <BINARY_STRING>)")
+                        .testSqlValidationError(
+                                "ENDSWITH(f0, f1)",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "ENDSWITH(expr <CHARACTER_STRING>, endExpr <CHARACTER_STRING>)\n"
+                                        + "ENDSWITH(expr <BINARY_STRING>, endExpr <BINARY_STRING>)"));
     }
 
     private Stream<TestSetSpec> regexpExtractTestCases() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EndsWithFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EndsWithFunction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.data.binary.BinaryStringDataUtil;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ENDS_WITH}. */
+@Internal
+public class EndsWithFunction extends BuiltInScalarFunction {
+
+    public EndsWithFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ENDS_WITH, context);
+    }
+
+    public @Nullable Boolean eval(@Nullable StringData expr, @Nullable StringData endExpr) {
+        if (expr == null || endExpr == null) {
+            return null;
+        }
+        if (BinaryStringDataUtil.isEmpty((BinaryStringData) endExpr)) {
+            return true;
+        }
+        return ((BinaryStringData) expr).endsWith((BinaryStringData) endExpr);
+    }
+
+    public @Nullable Boolean eval(@Nullable byte[] expr, @Nullable byte[] endExpr) {
+        if (expr == null || endExpr == null) {
+            return null;
+        }
+        if (endExpr.length == 0) {
+            return true;
+        }
+        return matchAtEnd(expr, endExpr);
+    }
+
+    private static boolean matchAtEnd(byte[] source, byte[] target) {
+        int start = source.length - target.length;
+        if (start < 0) {
+            return false;
+        }
+        for (int i = start; i < source.length; i++) {
+            if (source[i] != target[i - start]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the built-in function ENDSWITH.
Examples:
```SQL
> SELECT ENDSWITH('SparkSQL', 'SQL');
 true
> SELECT ENDSWITH('SparkSQL', 'sql');
 false
```

## Brief change log

[FLINK-35965](https://issues.apache.org/jira/browse/FLINK-35965)

## Verifying this change

`StringFunctionsITCase#endsWithTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
