### PR TITLE
[FLINK-35987][table] Add the built-in function ELT

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -406,14 +406,13 @@ string:
   - sql: JSON_UNQUOTE(string)
     table: STRING.JsonUnquote()
     description: Unquotes JSON value, unescapes escaped special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't', 'u' hex hex hex hex), and returns the result as a string. If the argument is NULL, returns NULL. If the value does not start and end with double quotes or if it starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
-  - sql: ELT(index, expr...)
-    table: index.elt(expr...)
+  - sql: ELT(index, expr[, exprs]*)
+    table: index.elt(expr, exprs...)
     description: |
-      Returns the index-th expression. one expr is required at least.
-      index must be between 1 and the number of expr. Otherwise, the function returns an error.
-      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <CHAR | VARCHAR>
-      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>
-      The result has the type of the least common type of all expr. `NULL` if index or the index-th expression is `NULL`.
+      Returns the index-th expression. index must be an integer between 1 and the number of expressions.
+      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <CHAR | VARCHAR>, exprs <CHAR | VARCHAR>
+      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>, exprs <BINARY | VARBINARY>
+      The result has the type of the least common type of all expressions. `NULL` if index is `NULL` or out of range.
 
 temporal:
   - sql: DATE string

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -406,6 +406,14 @@ string:
   - sql: JSON_UNQUOTE(string)
     table: STRING.JsonUnquote()
     description: Unquotes JSON value, unescapes escaped special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't', 'u' hex hex hex hex), and returns the result as a string. If the argument is NULL, returns NULL. If the value does not start and end with double quotes or if it starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
+  - sql: ELT(index, expr...)
+    table: index.elt(expr...)
+    description: |
+      Returns the index-th expression. one expr is required at least.
+      index must be between 1 and the number of expr. Otherwise, the function returns an error.
+      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <CHAR | VARCHAR>
+      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>
+      The result has the type of the least common type of all expr. `NULL` if index or the index-th expression is `NULL`.
 
 temporal:
   - sql: DATE string

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -506,14 +506,13 @@ string:
   - sql: JSON_UNQUOTE(string)
     table: STRING.JsonUnquote()
     description: Unquotes JSON value, unescapes escaped special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't', 'u' hex hex hex hex), and returns the result as a string. If the argument is NULL, returns NULL. If the value does not start and end with double quotes or if it starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
-  - sql: ELT(index, expr...)
-    table: index.elt(expr...)
+  - sql: ELT(index, expr[, exprs]*)
+    table: index.elt(expr, exprs...)
     description: |
-      返回第 index 个表达式。表达式数量至少为 1。
-      index 必须介于 1 和 表达式数量之间。否则，函数将返回错误。
-      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <CHAR | VARCHAR>
-      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>
-      结果类型为所有 expr 的公共类型。如果 index 或第 index 个表达式为 `NULL`，则返回 `NULL`。
+      返回第 index 个表达式。index 必须是介于 1 和 表达式数量之间的整数。
+      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <CHAR | VARCHAR>, exprs <CHAR | VARCHAR>
+      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>, exprs <BINARY | VARBINARY>
+      结果类型为所有 expr 的公共类型。如果 index 为 `NULL` 或超出范围，则返回 `NULL`。
 
 temporal:
   - sql: DATE string

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -506,6 +506,14 @@ string:
   - sql: JSON_UNQUOTE(string)
     table: STRING.JsonUnquote()
     description: Unquotes JSON value, unescapes escaped special characters ('"', '\', '/', 'b', 'f', 'n', 'r', 't', 'u' hex hex hex hex), and returns the result as a string. If the argument is NULL, returns NULL. If the value does not start and end with double quotes or if it starts and ends with double quotes but is not a valid JSON string literal, the value is passed through unmodified.
+  - sql: ELT(index, expr...)
+    table: index.elt(expr...)
+    description: |
+      返回第 index 个表达式。表达式数量至少为 1。
+      index 必须介于 1 和 表达式数量之间。否则，函数将返回错误。
+      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <CHAR | VARCHAR>
+      index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>
+      结果类型为所有 expr 的公共类型。如果 index 或第 index 个表达式为 `NULL`，则返回 `NULL`。
 
 temporal:
   - sql: DATE string

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -200,6 +200,7 @@ string functions
     Expression.reverse
     Expression.split_index
     Expression.str_to_map
+    Expression.elt
 
 temporal functions
 ------------------

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1384,6 +1384,20 @@ class Expression(Generic[T]):
         else:
             return _ternary_op("strToMap")(self, list_delimiter, key_value_delimiter)
 
+    def elt(self, *expr) -> 'Expression':
+        """
+        Returns the index-th expression. one expr is required at least.
+        index must be between 1 and the number of expr. Otherwise, the function returns an error.
+
+        :param expr a STRING or BINARY expression
+        :return: result type is the least common type of all expr
+        """
+        gateway = get_gateway()
+        ApiExpressionUtils = gateway.jvm.org.apache.flink.table.expressions.ApiExpressionUtils
+        exprs = [ApiExpressionUtils.objectToExpression(_get_java_expression(e))
+                 for e in expr]
+        return _binary_op("elt")(self, to_jarray(gateway.jvm.Object, exprs))
+
     # ---------------------------- temporal functions ----------------------------------
 
     @property

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1384,19 +1384,21 @@ class Expression(Generic[T]):
         else:
             return _ternary_op("strToMap")(self, list_delimiter, key_value_delimiter)
 
-    def elt(self, *expr) -> 'Expression':
+    def elt(self, expr, *exprs) -> 'Expression':
         """
-        Returns the index-th expression. one expr is required at least.
-        index must be between 1 and the number of expr. Otherwise, the function returns an error.
+        Returns the index-th expression. null if index is null or out of range.
+        index must be an integer between 1 and the number of expressions.
 
-        :param expr a STRING or BINARY expression
-        :return: result type is the least common type of all expr
+        :param expr: a STRING or BINARY expression
+        :param exprs: a STRING or BINARY expression
+
+        :return: result type is the least common type of all expressions.
         """
         gateway = get_gateway()
         ApiExpressionUtils = gateway.jvm.org.apache.flink.table.expressions.ApiExpressionUtils
-        exprs = [ApiExpressionUtils.objectToExpression(_get_java_expression(e))
-                 for e in expr]
-        return _binary_op("elt")(self, to_jarray(gateway.jvm.Object, exprs))
+        expr_list = [ApiExpressionUtils.objectToExpression(_get_java_expression(e))
+                     for e in exprs]
+        return _ternary_op("elt")(self, expr, to_jarray(gateway.jvm.Object, expr_list))
 
     # ---------------------------- temporal functions ----------------------------------
 

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -169,6 +169,8 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("splitIndex(a, ',', 3)", str(expr1.split_index(',', 3)))
         self.assertEqual("strToMap(a)", str(expr1.str_to_map()))
         self.assertEqual("strToMap(a, ';', ':')", str(expr1.str_to_map(';', ':')))
+        self.assertEqual("ELT(1, a)", str(lit(1).elt(expr1)))
+        self.assertEqual('ELT(3, a, b, c)', str(lit(3).elt(expr1, expr2, expr3)))
 
         # temporal functions
         self.assertEqual('cast(a, DATE)', str(expr1.to_date))

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -1345,18 +1345,19 @@ public abstract class BaseExpressions<InType, OutType> {
     }
 
     /**
-     * Returns the {@code index}-th expression. one {@code expr} is required at least. <br>
-     * {@code index} must be between 1 and the number of {@code expr}. Otherwise, the function
-     * returns an error.
+     * Returns the {@code index}-th expression. {@code index} must be an integer between 1 and the
+     * number of expressions.
      *
      * @param expr a STRING or BINARY expression
-     * @return result type is the least common type of all expr
+     * @param exprs a STRING or BINARY expression
+     * @return result type is the least common type of all expressions.<br>
+     *     null if {@code index} is null or out of range.
      */
-    public OutType elt(InType... expr) {
+    public OutType elt(InType expr, InType... exprs) {
         Expression[] args =
                 Stream.concat(
-                                Stream.of(toExpr()),
-                                Arrays.stream(expr).map(ApiExpressionUtils::objectToExpression))
+                                Stream.of(toExpr(), objectToExpression(expr)),
+                                Arrays.stream(exprs).map(ApiExpressionUtils::objectToExpression))
                         .toArray(Expression[]::new);
         return toApiSpecificExpression(unresolvedCall(ELT, args));
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -91,6 +91,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DECODE
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DEGREES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DISTINCT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DIVIDE;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ELT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ENCODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EQUALS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.EXP;
@@ -1341,6 +1342,23 @@ public abstract class BaseExpressions<InType, OutType> {
                         toExpr(),
                         objectToExpression(listDelimiter),
                         objectToExpression(keyValueDelimiter)));
+    }
+
+    /**
+     * Returns the {@code index}-th expression. one {@code expr} is required at least. <br>
+     * {@code index} must be between 1 and the number of {@code expr}. Otherwise, the function
+     * returns an error.
+     *
+     * @param expr a STRING or BINARY expression
+     * @return result type is the least common type of all expr
+     */
+    public OutType elt(InType... expr) {
+        Expression[] args =
+                Stream.concat(
+                                Stream.of(toExpr()),
+                                Arrays.stream(expr).map(ApiExpressionUtils::objectToExpression))
+                        .toArray(Expression[]::new);
+        return toApiSpecificExpression(unresolvedCall(ELT, args));
     }
 
     // Temporal operations

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -90,6 +90,7 @@ import static org.apache.flink.table.types.inference.InputTypeStrategies.varying
 import static org.apache.flink.table.types.inference.InputTypeStrategies.wildcardWithCount;
 import static org.apache.flink.table.types.inference.TypeStrategies.COMMON;
 import static org.apache.flink.table.types.inference.TypeStrategies.argument;
+import static org.apache.flink.table.types.inference.TypeStrategies.commonRange;
 import static org.apache.flink.table.types.inference.TypeStrategies.explicit;
 import static org.apache.flink.table.types.inference.TypeStrategies.first;
 import static org.apache.flink.table.types.inference.TypeStrategies.forceNullable;
@@ -1385,6 +1386,28 @@ public final class BuiltInFunctionDefinitions {
                             nullableIfArgs(
                                     explicit(
                                             DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING()))))
+                    .build();
+
+    public static final BuiltInFunctionDefinition ELT =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ELT")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    varyingSequence(
+                                            Arrays.asList("index", "expr", "exprs"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.INTEGER_NUMERIC),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING))),
+                                    varyingSequence(
+                                            Arrays.asList("index", "expr", "exprs"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.INTEGER_NUMERIC),
+                                                    logical(LogicalTypeFamily.BINARY_STRING),
+                                                    logical(LogicalTypeFamily.BINARY_STRING)))))
+                    .outputTypeStrategy(nullableIfArgs(commonRange(ConstantArgumentCount.from(1))))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.EltFunction")
                     .build();
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -100,6 +100,7 @@ import static org.apache.flink.table.types.inference.TypeStrategies.nullableIfAr
 import static org.apache.flink.table.types.inference.TypeStrategies.varyingString;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.ARRAY_ELEMENT_ARG;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.ARRAY_FULLY_COMPARABLE;
+import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.INDEX;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.JSON_ARGUMENT;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.TWO_EQUALS_COMPARABLE;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.TWO_FULLY_COMPARABLE;
@@ -1393,19 +1394,28 @@ public final class BuiltInFunctionDefinitions {
                     .name("ELT")
                     .kind(SCALAR)
                     .inputTypeStrategy(
-                            or(
-                                    varyingSequence(
-                                            Arrays.asList("index", "expr", "exprs"),
-                                            Arrays.asList(
-                                                    logical(LogicalTypeFamily.INTEGER_NUMERIC),
-                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
-                                                    logical(LogicalTypeFamily.CHARACTER_STRING))),
-                                    varyingSequence(
-                                            Arrays.asList("index", "expr", "exprs"),
-                                            Arrays.asList(
-                                                    logical(LogicalTypeFamily.INTEGER_NUMERIC),
-                                                    logical(LogicalTypeFamily.BINARY_STRING),
-                                                    logical(LogicalTypeFamily.BINARY_STRING)))))
+                            compositeSequence()
+                                    .argument("index", INDEX)
+                                    .finishWithVarying(
+                                            or(
+                                                    varyingSequence(
+                                                            Arrays.asList("expr", "exprs"),
+                                                            Arrays.asList(
+                                                                    logical(
+                                                                            LogicalTypeFamily
+                                                                                    .CHARACTER_STRING),
+                                                                    logical(
+                                                                            LogicalTypeFamily
+                                                                                    .CHARACTER_STRING))),
+                                                    varyingSequence(
+                                                            Arrays.asList("expr", "exprs"),
+                                                            Arrays.asList(
+                                                                    logical(
+                                                                            LogicalTypeFamily
+                                                                                    .BINARY_STRING),
+                                                                    logical(
+                                                                            LogicalTypeFamily
+                                                                                    .BINARY_STRING))))))
                     .outputTypeStrategy(forceNullable(commonRange(ConstantArgumentCount.from(1))))
                     .runtimeClass("org.apache.flink.table.runtime.functions.scalar.EltFunction")
                     .build();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1406,7 +1406,7 @@ public final class BuiltInFunctionDefinitions {
                                                     logical(LogicalTypeFamily.INTEGER_NUMERIC),
                                                     logical(LogicalTypeFamily.BINARY_STRING),
                                                     logical(LogicalTypeFamily.BINARY_STRING)))))
-                    .outputTypeStrategy(nullableIfArgs(commonRange(ConstantArgumentCount.from(1))))
+                    .outputTypeStrategy(forceNullable(commonRange(ConstantArgumentCount.from(1))))
                     .runtimeClass("org.apache.flink.table.runtime.functions.scalar.EltFunction")
                     .build();
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/InputTypeStrategies.java
@@ -121,6 +121,16 @@ public final class InputTypeStrategies {
                 Arrays.asList(strategies), Arrays.asList(argumentNames));
     }
 
+    /**
+     * Strategy for a varying named function signature like {@code f(i INT, str STRING, num
+     * NUMERIC...)} using a sequence of {@link ArgumentTypeStrategy}s. The first n - 1 arguments
+     * must be constant. The n-th argument can occur 0, 1, or more times.
+     */
+    public static InputTypeStrategy varyingSequence(
+            List<String> argumentNames, List<ArgumentTypeStrategy> strategies) {
+        return new VaryingSequenceInputTypeStrategy(strategies, argumentNames);
+    }
+
     /** Arbitrarily often repeating sequence of argument type strategies. */
     public static InputTypeStrategy repeatingSequence(ArgumentTypeStrategy... strategies) {
         return new RepeatingSequenceInputTypeStrategy(Arrays.asList(strategies));

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategies.java
@@ -55,6 +55,11 @@ public final class TypeStrategies {
     /** Type strategy that returns a common, least restrictive type of all arguments. */
     public static final TypeStrategy COMMON = new CommonTypeStrategy();
 
+    /** Type strategy that returns a common, least restrictive type of selected arguments. */
+    public static TypeStrategy commonRange(ArgumentCount argumentRange) {
+        return new CommonTypeStrategy(argumentRange);
+    }
+
     /** Type strategy that returns a fixed {@link DataType}. */
     public static TypeStrategy explicit(DataType dataType) {
         return new ExplicitTypeStrategy(dataType);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/IndexArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/IndexArgumentTypeStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+
+import java.util.Optional;
+
+/**
+ * An {@link ArgumentTypeStrategy} that expects a {@link LogicalTypeFamily#INTEGER_NUMERIC} starting
+ * from 0.
+ */
+@Internal
+public final class IndexArgumentTypeStrategy implements ArgumentTypeStrategy {
+    @Override
+    public Optional<DataType> inferArgumentType(
+            CallContext callContext, int argumentPos, boolean throwOnFailure) {
+        final DataType indexType = callContext.getArgumentDataTypes().get(argumentPos);
+
+        if (indexType.getLogicalType().is(LogicalTypeFamily.INTEGER_NUMERIC)) {
+            if (callContext.isArgumentLiteral(argumentPos)) {
+                Optional<Number> literalVal =
+                        callContext.getArgumentValue(argumentPos, Number.class);
+                if (literalVal.isPresent() && literalVal.get().longValue() < 0) {
+                    return callContext.fail(
+                            throwOnFailure,
+                            "Index must be an integer starting from '0', but was '%s'.",
+                            literalVal.get());
+                }
+            }
+
+            return Optional.of(indexType);
+        } else {
+            return callContext.fail(throwOnFailure, "Index can only be an INTEGER NUMERIC type.");
+        }
+    }
+
+    @Override
+    public Signature.Argument getExpectedArgument(
+            FunctionDefinition functionDefinition, int argumentPos) {
+        return Signature.Argument.ofGroup(LogicalTypeFamily.INTEGER_NUMERIC);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -119,6 +119,12 @@ public final class SpecificInputTypeStrategies {
     public static final InputTypeStrategy TEMPORAL_OVERLAPS =
             new TemporalOverlapsInputTypeStrategy();
 
+    /**
+     * Argument type strategy that expects a {@link LogicalTypeFamily#INTEGER_NUMERIC} starting from
+     * 0.
+     */
+    public static final ArgumentTypeStrategy INDEX = new IndexArgumentTypeStrategy();
+
     // --------------------------------------------------------------------------------------------
     // Strategies composed of other strategies
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SubsequenceInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SubsequenceInputTypeStrategy.java
@@ -214,6 +214,19 @@ public final class SubsequenceInputTypeStrategy implements InputTypeStrategy {
             return this;
         }
 
+        /** Defines that we expect a single named argument at the next position. */
+        public SubsequenceStrategyBuilder argument(
+                String argumentName, ArgumentTypeStrategy argumentTypeStrategy) {
+            SequenceInputTypeStrategy singleArgumentStrategy =
+                    new SequenceInputTypeStrategy(
+                            Collections.singletonList(argumentTypeStrategy),
+                            Collections.singletonList(argumentName));
+            argumentsSplits.add(
+                    new ArgumentsSplit(currentPos, currentPos + 1, singleArgumentStrategy));
+            currentPos += 1;
+            return this;
+        }
+
         /**
          * Defines a common {@link InputTypeStrategy} for the next arguments. Given input strategy
          * must expect a constant number of arguments. That means that both the minimum and maximum

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/SubsequenceInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/SubsequenceInputTypeStrategyTest.java
@@ -23,12 +23,14 @@ import org.apache.flink.table.types.inference.strategies.SubsequenceInputTypeStr
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.types.inference.InputTypeStrategies.ANY;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.commonType;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.explicit;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.logical;
+import static org.apache.flink.table.types.inference.InputTypeStrategies.sequence;
 import static org.apache.flink.table.types.inference.InputTypeStrategies.varyingSequence;
 
 /** Tests for {@link SubsequenceInputTypeStrategy}. */
@@ -113,6 +115,34 @@ class SubsequenceInputTypeStrategyTest extends InputTypeStrategiesTestBase {
                                 DataTypes.DECIMAL(13, 3).notNull(),
                                 DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE().notNull(),
                                 DataTypes.SMALLINT(),
-                                DataTypes.BIGINT()));
+                                DataTypes.BIGINT()),
+                TestSpec.forStrategy(
+                                "A strategy with named argument",
+                                InputTypeStrategies.compositeSequence()
+                                        .argument("arg1", logical(LogicalTypeRoot.BOOLEAN))
+                                        .subsequence(
+                                                sequence(
+                                                        Arrays.asList("arg2", "arg3"),
+                                                        Arrays.asList(
+                                                                logical(
+                                                                        LogicalTypeFamily
+                                                                                .INTEGER_NUMERIC),
+                                                                logical(
+                                                                        LogicalTypeFamily
+                                                                                .INTEGER_NUMERIC))))
+                                        .argument(logical(LogicalTypeRoot.INTEGER))
+                                        .finish())
+                        .calledWithArgumentTypes(
+                                DataTypes.BOOLEAN(),
+                                DataTypes.SMALLINT(),
+                                DataTypes.BIGINT(),
+                                DataTypes.INT())
+                        .expectSignature(
+                                "f(arg1 <BOOLEAN>, arg2 <INTEGER_NUMERIC>, arg3 <INTEGER_NUMERIC>, <INTEGER>)")
+                        .expectArgumentTypes(
+                                DataTypes.BOOLEAN(),
+                                DataTypes.SMALLINT(),
+                                DataTypes.BIGINT(),
+                                DataTypes.INT()));
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
@@ -136,6 +136,25 @@ class TypeStrategiesTest extends TypeStrategiesTestBase {
                                 DataTypes.DECIMAL(20, 10))
                         .expectDataType(DataTypes.DECIMAL(20, 10)),
                 TypeStrategiesTestBase.TestSpec.forStrategy(
+                                "Find a common type of selected arguments",
+                                TypeStrategies.commonRange(ConstantArgumentCount.from(1)))
+                        .inputTypes(DataTypes.INT(), DataTypes.SMALLINT(), DataTypes.TINYINT())
+                        .expectDataType(DataTypes.SMALLINT()),
+                TypeStrategiesTestBase.TestSpec.forStrategy(
+                                "Find a common type of selected arguments",
+                                TypeStrategies.commonRange(ConstantArgumentCount.between(1, 2)))
+                        .inputTypes(
+                                DataTypes.VARCHAR(10),
+                                DataTypes.CHAR(3),
+                                DataTypes.VARCHAR(4),
+                                DataTypes.CHAR(7))
+                        .expectDataType(DataTypes.VARCHAR(4)),
+                TypeStrategiesTestBase.TestSpec.forStrategy(
+                                "Find a common type of selected arguments",
+                                TypeStrategies.commonRange(ConstantArgumentCount.to(1)))
+                        .inputTypes(DataTypes.TINYINT(), DataTypes.SMALLINT(), DataTypes.INT())
+                        .expectDataType(DataTypes.SMALLINT()),
+                TypeStrategiesTestBase.TestSpec.forStrategy(
                                 "Convert to varying string",
                                 varyingString(explicit(DataTypes.CHAR(12).notNull())))
                         .inputTypes(DataTypes.CHAR(12).notNull())

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -136,11 +136,6 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                         .testResult(
                                 lit(3).elt("a", "b"), "ELT(3, 'a', 'b')", null, DataTypes.CHAR(1))
                         .testResult(
-                                lit(-1).elt("ab", "b"),
-                                "ELT(-1, 'ab', 'b')",
-                                null,
-                                DataTypes.VARCHAR(2))
-                        .testResult(
                                 lit(9223372036854775807L).elt("ab", "b"),
                                 "ELT(9223372036854775807, 'ab', 'b')",
                                 null,
@@ -186,7 +181,13 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                                 "ELT(f2, 'a')",
                                 "Invalid input arguments. Expected signatures are:\n"
                                         + "ELT(index <INTEGER_NUMERIC>, expr <CHARACTER_STRING>, exprs <CHARACTER_STRING>...)\n"
-                                        + "ELT(index <INTEGER_NUMERIC>, expr <BINARY_STRING>, exprs <BINARY_STRING>...)"));
+                                        + "ELT(index <INTEGER_NUMERIC>, expr <BINARY_STRING>, exprs <BINARY_STRING>...)")
+                        .testTableApiValidationError(
+                                lit(-1).elt("a"),
+                                "Index must be an integer starting from '0', but was '-1'.")
+                        .testSqlValidationError(
+                                "ELT(-1, 'a')",
+                                "Index must be an integer starting from '0', but was '-1'."));
     }
 
     private Stream<TestSetSpec> regexpExtractTestCases() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
@@ -32,17 +32,14 @@ public class EltFunction extends BuiltInScalarFunction {
         super(BuiltInFunctionDefinitions.ELT, context);
     }
 
-    public @Nullable Object eval(@Nullable Number index, Object... expr) {
+    public @Nullable Object eval(@Nullable Number index, Object... exprs) {
         if (index == null) {
             return null;
         }
-
         long idx = index.longValue();
-        if (idx < 1 || idx > expr.length) {
-            throw new IndexOutOfBoundsException(
-                    String.format(
-                            "Index %d is out of range [1, %d]", index.longValue(), expr.length));
+        if (idx < 1 || idx > exprs.length) {
+            return null;
         }
-        return expr[(int) idx - 1];
+        return exprs[(int) index - 1];
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/EltFunction.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ELT}. */
+@Internal
+public class EltFunction extends BuiltInScalarFunction {
+
+    public EltFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ELT, context);
+    }
+
+    public @Nullable Object eval(@Nullable Number index, Object... expr) {
+        if (index == null) {
+            return null;
+        }
+
+        long idx = index.longValue();
+        if (idx < 1 || idx > expr.length) {
+            throw new IndexOutOfBoundsException(
+                    String.format(
+                            "Index %d is out of range [1, %d]", index.longValue(), expr.length));
+        }
+        return expr[(int) idx - 1];
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the built-in function ELT.
Examples:
```SQL
> SELECT ELT(1, 'scala', 'java');
 scala
```

## Brief change log

- [FLINK-35987](https://issues.apache.org/jira/browse/FLINK-35987)
- Support common type of selected arguments in CommonTypeStrategy.
- Add IndexArgumentTypeStrategy.
- Support single named argument in SubsequenceInputTypeStrategy.

## Verifying this change

- `StringFunctionsITCase#eltTestCases`
- `TypeStrategiesTest`
- `InputTypeStrategiesTest`
- `SubsequenceInputTypeStrategyTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
