### PR TITLE
[FLINK-36000][table-planner] Fix DynamicTableSink#Context's getTargetColumns should return an Optional#empty instead of int[0] for insert without column list

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -1389,8 +1389,11 @@ public class SqlNodeToOperationConversion {
     private int[][] getTargetColumnIndices(
             @Nonnull ContextResolvedTable contextResolvedTable,
             @Nullable SqlNodeList targetColumns) {
+        if (targetColumns == null) {
+            return null;
+        }
         List<String> allColumns = contextResolvedTable.getResolvedSchema().getColumnNames();
-        return Optional.ofNullable(targetColumns).orElse(SqlNodeList.EMPTY).stream()
+        return targetColumns.stream()
                 .mapToInt(c -> allColumns.indexOf(((SqlIdentifier) c).getSimple()))
                 .mapToObj(idx -> new int[] {idx})
                 .toArray(int[][]::new);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/Sink.scala
@@ -73,7 +73,7 @@ abstract class Sink(
           .getOrElse(Array.empty[Array[Int]])
           .map(_.mkString("[", ",", "]"))
           .mkString(","),
-        targetColumns != null && targetColumns.length > 0
+        targetColumns != null
       )
       .item("fields", getRowType.getFieldNames.mkString(", "))
       .itemIf("hints", RelExplainUtil.hintsToString(hints), !hints.isEmpty)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -2105,6 +2105,12 @@ public final class TestValuesTableFactory
             } else {
                 // we don't support OutputFormat for updating query in the TestValues connector
                 assertThat(runtimeSink.equals("SinkFunction")).isTrue();
+                // check the contract of the context.getTargetColumns method returns the expected
+                // empty Option or non-empty Option with a non-empty array
+                assertThat(
+                                !context.getTargetColumns().isPresent()
+                                        || context.getTargetColumns().get().length > 0)
+                        .isTrue();
                 SinkFunction<RowData> sinkFunction;
                 if (primaryKeyIndices.length > 0) {
                     // TODO FLINK-31301 currently partial-insert composite columns are not supported


### PR DESCRIPTION
## What is the purpose of the change
The interface [`Optional<int[][]> getTargetColumns()` |https://github.com/apache/flink/blob/master/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java#L192]
is expected to return an Optional#empty() for a sql statement without specifying a column list, e.g., 'insert into t1 select ...', but the current implemantation will return an int[0] in such cases, this is unexpected.

## Brief change log
- fix the return value of SqlNodeToOperationConversion's getTargetColumnIndices
- remove incorrect filter logic for Sink's explainTerm(this will expose the wrong behavior of the previous SqlNodeToOperationConversion's getTargetColumnIndices, see https://github.com/apache/flink/pull/22197/commits/323471c9ba72ed79d8242b06cec772132b063d81)
- add check in TestValuesTableFactory

## Verifying this change
The current `TableSinkTest` cover the cases

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)