### PR TITLE
[FLINK-35886][task] Fix watermark idleness timeout accounting when subtask is backpressured/blocked

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkGeneratorSupplier.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkGeneratorSupplier.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.eventtime;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.clock.RelativeClock;
 
 import java.io.Serializable;
 
@@ -39,7 +40,7 @@ public interface WatermarkGeneratorSupplier<T> extends Serializable {
 
     /**
      * Additional information available to {@link #createWatermarkGenerator(Context)}. This can be
-     * access to {@link org.apache.flink.metrics.MetricGroup MetricGroups}, for example.
+     * access to {@link MetricGroup MetricGroups}, for example.
      */
     interface Context {
 
@@ -54,5 +55,14 @@ public interface WatermarkGeneratorSupplier<T> extends Serializable {
          * @see MetricGroup
          */
         MetricGroup getMetricGroup();
+
+        /**
+         * Returns a {@link RelativeClock} that hides periods when input was not active and {@link
+         * WatermarkGenerator} could not have been executed due to execution being blocked by the
+         * runtime. For example a backpressure or watermark alignment blocking the progress.
+         *
+         * @see RelativeClock
+         */
+        RelativeClock getInputActivityClock();
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkStrategyWithIdleness.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkStrategyWithIdleness.java
@@ -42,7 +42,9 @@ final class WatermarkStrategyWithIdleness<T> implements WatermarkStrategy<T> {
     public WatermarkGenerator<T> createWatermarkGenerator(
             WatermarkGeneratorSupplier.Context context) {
         return new WatermarksWithIdleness<>(
-                baseStrategy.createWatermarkGenerator(context), idlenessTimeout);
+                baseStrategy.createWatermarkGenerator(context),
+                idlenessTimeout,
+                context.getInputActivityClock());
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarksWithIdleness.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarksWithIdleness.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.eventtime;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.RelativeClock;
 import org.apache.flink.util.clock.SystemClock;
 
 import java.time.Duration;
@@ -43,18 +44,26 @@ public class WatermarksWithIdleness<T> implements WatermarkGenerator<T> {
     private boolean isIdleNow = false;
 
     /**
+     * This is not used anymore, but it's technically part of the {@link Public} API. Please use
+     * {@link #WatermarksWithIdleness(WatermarkGenerator, Duration, RelativeClock)} instead.
+     */
+    @Deprecated
+    public WatermarksWithIdleness(WatermarkGenerator<T> watermarks, Duration idleTimeout) {
+        this(watermarks, idleTimeout, SystemClock.getInstance());
+    }
+
+    /**
      * Creates a new WatermarksWithIdleness generator to the given generator idleness detection with
      * the given timeout.
      *
      * @param watermarks The original watermark generator.
      * @param idleTimeout The timeout for the idleness detection.
+     * @param clock The clock that will be used to measure idleness period. It is expected that this
+     *     clock will hide periods when this {@link WatermarkGenerator} has been blocked from making
+     *     any progress despite availability of records on the input.
      */
-    public WatermarksWithIdleness(WatermarkGenerator<T> watermarks, Duration idleTimeout) {
-        this(watermarks, idleTimeout, SystemClock.getInstance());
-    }
-
-    @VisibleForTesting
-    WatermarksWithIdleness(WatermarkGenerator<T> watermarks, Duration idleTimeout, Clock clock) {
+    public WatermarksWithIdleness(
+            WatermarkGenerator<T> watermarks, Duration idleTimeout, RelativeClock clock) {
         checkNotNull(idleTimeout, "idleTimeout");
         checkArgument(
                 !(idleTimeout.isZero() || idleTimeout.isNegative()),
@@ -88,7 +97,7 @@ public class WatermarksWithIdleness<T> implements WatermarkGenerator<T> {
     static final class IdlenessTimer {
 
         /** The clock used to measure elapsed time. */
-        private final Clock clock;
+        private final RelativeClock clock;
 
         /** Counter to detect change. No problem if it overflows. */
         private long counter;
@@ -105,7 +114,7 @@ public class WatermarksWithIdleness<T> implements WatermarkGenerator<T> {
         /** The duration before the output is marked as idle. */
         private final long maxIdleTimeNanos;
 
-        IdlenessTimer(Clock clock, Duration idleTimeout) {
+        IdlenessTimer(RelativeClock clock, Duration idleTimeout) {
             this.clock = clock;
 
             long idleNanos;

--- a/flink-core/src/main/java/org/apache/flink/util/clock/Clock.java
+++ b/flink-core/src/main/java/org/apache/flink/util/clock/Clock.java
@@ -37,7 +37,7 @@ import org.apache.flink.annotation.PublicEvolving;
  * the system clock, so it never jumps. Relative time behaves similar to {@link System#nanoTime()}.
  */
 @PublicEvolving
-public abstract class Clock {
+public abstract class Clock implements RelativeClock {
 
     /** Gets the current absolute time, in milliseconds. */
     public abstract long absoluteTimeMillis();

--- a/flink-core/src/main/java/org/apache/flink/util/clock/RelativeClock.java
+++ b/flink-core/src/main/java/org/apache/flink/util/clock/RelativeClock.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.clock;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * A clock that gives access to relative time, similar to System#nanoTime(), however the progress of
+ * the relative time doesn't have to reflect the progress of a wall clock. Concrete classes can
+ * specify a different contract in that regard. Returned time must be monotonically increasing.
+ */
+@PublicEvolving
+public interface RelativeClock {
+    /** Gets the current relative time, in milliseconds. */
+    long relativeTimeMillis();
+
+    /** Gets the current relative time, in nanoseconds. */
+    long relativeTimeNanos();
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkStrategyTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkStrategyTest.java
@@ -20,7 +20,10 @@ package org.apache.flink.api.common.eventtime;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.ClosureCleaner;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.util.clock.RelativeClock;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.junit.jupiter.api.Test;
 
@@ -171,6 +174,16 @@ public class WatermarkStrategyTest {
     }
 
     static WatermarkGeneratorSupplier.Context generatorContext() {
-        return UnregisteredMetricsGroup::new;
+        return new WatermarkGeneratorSupplier.Context() {
+            @Override
+            public MetricGroup getMetricGroup() {
+                return new UnregisteredMetricsGroup();
+            }
+
+            @Override
+            public RelativeClock getInputActivityClock() {
+                return SystemClock.getInstance();
+            }
+        };
     }
 }

--- a/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestSourceFunction.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestSourceFunction.java
@@ -20,13 +20,17 @@ package org.apache.flink.table.toolbox;
 
 import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.util.clock.RelativeClock;
+import org.apache.flink.util.clock.SystemClock;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,7 +64,18 @@ public class TestSourceFunction implements SourceFunction<RowData> {
     @Override
     public void run(SourceContext<RowData> ctx) {
         WatermarkGenerator<RowData> generator =
-                watermarkStrategy.createWatermarkGenerator(() -> null);
+                watermarkStrategy.createWatermarkGenerator(
+                        new WatermarkGeneratorSupplier.Context() {
+                            @Override
+                            public MetricGroup getMetricGroup() {
+                                return null;
+                            }
+
+                            @Override
+                            public RelativeClock getInputActivityClock() {
+                                return SystemClock.getInstance();
+                            }
+                        });
         WatermarkOutput output = new TestWatermarkOutput(ctx);
 
         int rowDataSize = DATA.get(0).size();

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
@@ -19,6 +19,8 @@ package org.apache.flink.state.api.runtime;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.runtime.tasks.TimerService;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
 import java.util.concurrent.CompletableFuture;
@@ -33,8 +35,8 @@ public final class NeverFireProcessingTimeService implements TimerService {
     private AtomicBoolean shutdown = new AtomicBoolean(true);
 
     @Override
-    public long getCurrentProcessingTime() {
-        return System.currentTimeMillis();
+    public Clock getClock() {
+        return SystemClock.getInstance();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -312,6 +312,16 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         return mailboxSize;
     }
 
+    public void registerBackPressureListener(TimerGauge.StartStopListener backPressureListener) {
+        hardBackPressuredTimePerSecond.registerListener(backPressureListener);
+        softBackPressuredTimePerSecond.registerListener(backPressureListener);
+    }
+
+    public void unregisterBackPressureListener(TimerGauge.StartStopListener backPressureListener) {
+        hardBackPressuredTimePerSecond.unregisterListener(backPressureListener);
+        softBackPressuredTimePerSecond.unregisterListener(backPressureListener);
+    }
+
     // ============================================================================================
     // Metric Reuse
     // ============================================================================================

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -664,6 +664,11 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         }
     }
 
+    @Override
+    public void splitFinished(String splitId) {
+        splitCurrentWatermarks.remove(splitId);
+    }
+
     /**
      * Finds the splits that are beyond the current max watermark and pauses them. At the same time,
      * splits that have been paused and where the global watermark caught up are resumed.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -37,6 +37,7 @@ import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.StopMode;
 import org.apache.flink.runtime.metrics.groups.InternalSourceReaderMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.OperatorEventHandler;
@@ -52,6 +53,7 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.source.TimestampsAndWatermarks;
+import org.apache.flink.streaming.api.operators.util.PausableRelativeClock;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.DataInputStatus;
@@ -197,6 +199,12 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     private final CanEmitBatchOfRecordsChecker canEmitBatchOfRecords;
 
+    /**
+     * {@link PausableRelativeClock} tracking activity of the operator's main input. It's paused on
+     * backpressure. Note, each split output has its own independent {@link PausableRelativeClock}.
+     */
+    private transient PausableRelativeClock mainInputActivityClock;
+
     public SourceOperator(
             FunctionWithException<SourceReaderContext, SourceReader<OUT, SplitT>, Exception>
                     readerFactory,
@@ -322,6 +330,11 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     @Override
     public void open() throws Exception {
+        mainInputActivityClock = new PausableRelativeClock(getProcessingTimeService().getClock());
+        TaskIOMetricGroup taskIOMetricGroup =
+                getContainingTask().getEnvironment().getMetricGroup().getIOMetricGroup();
+        taskIOMetricGroup.registerBackPressureListener(mainInputActivityClock);
+
         initReader();
 
         // in the future when we this one is migrated to the "eager initialization" operator
@@ -332,11 +345,14 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
                             watermarkStrategy,
                             sourceMetricGroup,
                             getProcessingTimeService(),
-                            getExecutionConfig().getAutoWatermarkInterval());
+                            getExecutionConfig().getAutoWatermarkInterval(),
+                            mainInputActivityClock,
+                            getProcessingTimeService().getClock(),
+                            taskIOMetricGroup);
         } else {
             eventTimeLogic =
                     TimestampsAndWatermarks.createNoOpEventTimeLogic(
-                            watermarkStrategy, sourceMetricGroup);
+                            watermarkStrategy, sourceMetricGroup, mainInputActivityClock);
         }
 
         // restore the state if necessary.
@@ -396,6 +412,12 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
 
     @Override
     public void close() throws Exception {
+        getContainingTask()
+                .getEnvironment()
+                .getMetricGroup()
+                .getIOMetricGroup()
+                .unregisterBackPressureListener(mainInputActivityClock);
+
         if (sourceReader != null) {
             sourceReader.close();
         }
@@ -676,6 +698,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
             Collection<String> splitsToPause, Collection<String> splitsToResume) {
         try {
             sourceReader.pauseOrResumeSplits(splitsToPause, splitsToResume);
+            eventTimeLogic.pauseOrResumeSplits(splitsToPause, splitsToResume);
         } catch (UnsupportedOperationException e) {
             if (!allowUnalignedSourceSplits) {
                 throw e;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
@@ -27,6 +27,8 @@ import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ExceptionInChainedOperatorException;
 
+import java.util.Collection;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -67,6 +69,10 @@ public class NoOpTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<T
     public void emitImmediateWatermark(long wallClockTimestamp) {
         // do nothing
     }
+
+    @Override
+    public void pauseOrResumeSplits(
+            Collection<String> splitsToPause, Collection<String> splitsToResume) {}
 
     // ------------------------------------------------------------------------
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
@@ -304,6 +304,7 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
         }
 
         void releaseOutputForSplit(String splitId) {
+            watermarkUpdateListener.splitFinished(splitId);
             localOutputs.remove(splitId);
             watermarkMultiplexer.unregisterOutput(splitId);
             PausableRelativeClock inputActivityClock =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
@@ -27,16 +27,23 @@ import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkOutputMultiplexer;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.streaming.api.operators.util.PausableRelativeClock;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.RelativeClock;
 
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -53,11 +60,17 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
 
     private final WatermarkGeneratorSupplier<T> watermarksFactory;
 
-    private final WatermarkGeneratorSupplier.Context watermarksContext;
+    private final TimestampsAndWatermarksContextProvider watermarksContextProvider;
 
     private final ProcessingTimeService timeService;
 
     private final long periodicWatermarkInterval;
+
+    private final RelativeClock mainInputActivityClock;
+
+    private final Clock clock;
+
+    private final TaskIOMetricGroup taskIOMetricGroup;
 
     @Nullable private SplitLocalOutputs<T> currentPerSplitOutputs;
 
@@ -68,14 +81,20 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
     public ProgressiveTimestampsAndWatermarks(
             TimestampAssigner<T> timestampAssigner,
             WatermarkGeneratorSupplier<T> watermarksFactory,
-            WatermarkGeneratorSupplier.Context watermarksContext,
+            TimestampsAndWatermarksContextProvider watermarksContextProvider,
             ProcessingTimeService timeService,
-            Duration periodicWatermarkInterval) {
+            Duration periodicWatermarkInterval,
+            RelativeClock mainInputActivityClock,
+            Clock clock,
+            TaskIOMetricGroup taskIOMetricGroup) {
 
         this.timestampAssigner = timestampAssigner;
         this.watermarksFactory = watermarksFactory;
-        this.watermarksContext = watermarksContext;
+        this.watermarksContextProvider = watermarksContextProvider;
         this.timeService = timeService;
+        this.mainInputActivityClock = mainInputActivityClock;
+        this.clock = clock;
+        this.taskIOMetricGroup = taskIOMetricGroup;
 
         long periodicWatermarkIntervalMillis;
         try {
@@ -106,7 +125,8 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
         IdlenessManager idlenessManager = new IdlenessManager(watermarkOutput);
 
         final WatermarkGenerator<T> watermarkGenerator =
-                watermarksFactory.createWatermarkGenerator(watermarksContext);
+                watermarksFactory.createWatermarkGenerator(
+                        watermarksContextProvider.create(mainInputActivityClock));
 
         currentPerSplitOutputs =
                 new SplitLocalOutputs<>(
@@ -115,7 +135,9 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                         watermarkUpdateListener,
                         timestampAssigner,
                         watermarksFactory,
-                        watermarksContext);
+                        watermarksContextProvider,
+                        clock,
+                        taskIOMetricGroup);
 
         currentMainOutput =
                 new StreamingReaderOutput<>(
@@ -162,6 +184,12 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
         }
     }
 
+    @Override
+    public void pauseOrResumeSplits(
+            Collection<String> splitsToPause, Collection<String> splitsToResume) {
+        currentPerSplitOutputs.pauseOrResumeSplits(splitsToPause, splitsToResume);
+    }
+
     // ------------------------------------------------------------------------
 
     private static final class StreamingReaderOutput<T> extends SourceOutputWithWatermarks<T>
@@ -203,11 +231,14 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
 
         private final WatermarkOutputMultiplexer watermarkMultiplexer;
         private final Map<String, SourceOutputWithWatermarks<T>> localOutputs;
+        private final Map<String, PausableRelativeClock> inputActivityClocks = new HashMap<>();
         private final PushingAsyncDataInput.DataOutput<T> recordOutput;
         private final TimestampAssigner<T> timestampAssigner;
         private final WatermarkGeneratorSupplier<T> watermarksFactory;
-        private final WatermarkGeneratorSupplier.Context watermarkContext;
+        private final TimestampsAndWatermarksContextProvider watermarksContextProvider;
         private final WatermarkUpdateListener watermarkUpdateListener;
+        private final Clock clock;
+        private final TaskIOMetricGroup taskIOMetricGroup;
 
         private SplitLocalOutputs(
                 PushingAsyncDataInput.DataOutput<T> recordOutput,
@@ -215,13 +246,17 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                 WatermarkUpdateListener watermarkUpdateListener,
                 TimestampAssigner<T> timestampAssigner,
                 WatermarkGeneratorSupplier<T> watermarksFactory,
-                WatermarkGeneratorSupplier.Context watermarkContext) {
+                TimestampsAndWatermarksContextProvider watermarksContextProvider,
+                Clock clock,
+                TaskIOMetricGroup taskIOMetricGroup) {
 
             this.recordOutput = recordOutput;
             this.timestampAssigner = timestampAssigner;
             this.watermarksFactory = watermarksFactory;
-            this.watermarkContext = watermarkContext;
+            this.watermarksContextProvider = watermarksContextProvider;
             this.watermarkUpdateListener = watermarkUpdateListener;
+            this.clock = clock;
+            this.taskIOMetricGroup = taskIOMetricGroup;
 
             this.watermarkMultiplexer = new WatermarkOutputMultiplexer(watermarkOutput);
             this.localOutputs =
@@ -234,6 +269,7 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                 return previous;
             }
 
+            PausableRelativeClock inputActivityClock = createInputActivityClock(splitId);
             watermarkMultiplexer.registerNewOutput(
                     splitId,
                     watermark ->
@@ -243,7 +279,8 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
             final WatermarkOutput periodicOutput = watermarkMultiplexer.getDeferredOutput(splitId);
 
             final WatermarkGenerator<T> watermarks =
-                    watermarksFactory.createWatermarkGenerator(watermarkContext);
+                    watermarksFactory.createWatermarkGenerator(
+                            watermarksContextProvider.create(inputActivityClock));
 
             final SourceOutputWithWatermarks<T> localOutput =
                     SourceOutputWithWatermarks.createWithSeparateOutputs(
@@ -257,9 +294,21 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
             return localOutput;
         }
 
+        private PausableRelativeClock createInputActivityClock(String splitId) {
+            // Dedicated inputActivityClock for a particular split. It will be paused both in case
+            // of back pressure and when split is paused due to watermark alignment.
+            PausableRelativeClock inputActivityClock = new PausableRelativeClock(clock);
+            inputActivityClocks.put(splitId, inputActivityClock);
+            taskIOMetricGroup.registerBackPressureListener(inputActivityClock);
+            return inputActivityClock;
+        }
+
         void releaseOutputForSplit(String splitId) {
             localOutputs.remove(splitId);
             watermarkMultiplexer.unregisterOutput(splitId);
+            PausableRelativeClock inputActivityClock =
+                    requireNonNull(inputActivityClocks.remove(splitId));
+            taskIOMetricGroup.unregisterBackPressureListener(inputActivityClock);
         }
 
         void emitPeriodicWatermark() {
@@ -272,6 +321,16 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                 output.emitPeriodicWatermark();
             }
             watermarkMultiplexer.onPeriodicEmit();
+        }
+
+        public void pauseOrResumeSplits(
+                Collection<String> splitsToPause, Collection<String> splitsToResume) {
+            for (String splitId : splitsToPause) {
+                inputActivityClocks.get(splitId).pause();
+            }
+            for (String splitId : splitsToResume) {
+                inputActivityClocks.get(splitId).unPause();
+            }
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -62,6 +62,9 @@ public interface TimestampsAndWatermarks<T> {
 
         /** Notifies about changes to per split watermarks. */
         void updateCurrentSplitWatermark(String splitId, long watermark);
+
+        /** Notifies that split has finished. */
+        void splitFinished(String splitId);
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -24,10 +24,14 @@ import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.RelativeClock;
 
 import java.time.Duration;
+import java.util.Collection;
 
 /**
  * Basic interface for the timestamp extraction and watermark generation logic for the {@link
@@ -83,6 +87,8 @@ public interface TimestampsAndWatermarks<T> {
     /** Emit a watermark immediately. */
     void emitImmediateWatermark(long wallClockTimestamp);
 
+    void pauseOrResumeSplits(Collection<String> splitsToPause, Collection<String> splitsToResume);
+
     // ------------------------------------------------------------------------
     //  factories
     // ------------------------------------------------------------------------
@@ -91,27 +97,51 @@ public interface TimestampsAndWatermarks<T> {
             WatermarkStrategy<E> watermarkStrategy,
             MetricGroup metrics,
             ProcessingTimeService timeService,
-            long periodicWatermarkIntervalMillis) {
+            long periodicWatermarkIntervalMillis,
+            RelativeClock mainInputActivityClock,
+            Clock clock,
+            TaskIOMetricGroup taskIOMetricGroup) {
 
-        final TimestampsAndWatermarksContext context = new TimestampsAndWatermarksContext(metrics);
-        final TimestampAssigner<E> timestampAssigner =
-                watermarkStrategy.createTimestampAssigner(context);
+        TimestampsAndWatermarksContextProvider contextProvider =
+                new TimestampsAndWatermarksContextProvider(metrics);
+        TimestampAssigner<E> timestampAssigner =
+                watermarkStrategy.createTimestampAssigner(
+                        contextProvider.create(mainInputActivityClock));
 
         return new ProgressiveTimestampsAndWatermarks<>(
                 timestampAssigner,
                 watermarkStrategy,
-                context,
+                contextProvider,
                 timeService,
-                Duration.ofMillis(periodicWatermarkIntervalMillis));
+                Duration.ofMillis(periodicWatermarkIntervalMillis),
+                mainInputActivityClock,
+                clock,
+                taskIOMetricGroup);
     }
 
     static <E> TimestampsAndWatermarks<E> createNoOpEventTimeLogic(
-            WatermarkStrategy<E> watermarkStrategy, MetricGroup metrics) {
+            WatermarkStrategy<E> watermarkStrategy,
+            MetricGroup metrics,
+            RelativeClock inputActivityClock) {
 
-        final TimestampsAndWatermarksContext context = new TimestampsAndWatermarksContext(metrics);
+        final TimestampsAndWatermarksContext context =
+                new TimestampsAndWatermarksContext(metrics, inputActivityClock);
         final TimestampAssigner<E> timestampAssigner =
                 watermarkStrategy.createTimestampAssigner(context);
 
         return new NoOpTimestampsAndWatermarks<>(timestampAssigner);
+    }
+
+    @Internal
+    class TimestampsAndWatermarksContextProvider {
+        private final MetricGroup metrics;
+
+        public TimestampsAndWatermarksContextProvider(MetricGroup metrics) {
+            this.metrics = metrics;
+        }
+
+        public TimestampsAndWatermarksContext create(RelativeClock inputActivityClock) {
+            return new TimestampsAndWatermarksContext(metrics, inputActivityClock);
+        }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarksContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarksContext.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.eventtime.TimestampAssignerSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.util.clock.RelativeClock;
-import org.apache.flink.util.clock.SystemClock;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -36,9 +35,12 @@ public final class TimestampsAndWatermarksContext
         implements TimestampAssignerSupplier.Context, WatermarkGeneratorSupplier.Context {
 
     private final MetricGroup metricGroup;
+    private final RelativeClock inputActivityClock;
 
-    public TimestampsAndWatermarksContext(MetricGroup metricGroup) {
+    public TimestampsAndWatermarksContext(
+            MetricGroup metricGroup, RelativeClock inputActivityClock) {
         this.metricGroup = checkNotNull(metricGroup);
+        this.inputActivityClock = inputActivityClock;
     }
 
     @Override
@@ -48,6 +50,6 @@ public final class TimestampsAndWatermarksContext
 
     @Override
     public RelativeClock getInputActivityClock() {
-        return SystemClock.getInstance();
+        return inputActivityClock;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarksContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarksContext.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.eventtime.TimestampAssignerSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.clock.RelativeClock;
+import org.apache.flink.util.clock.SystemClock;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -42,5 +44,10 @@ public final class TimestampsAndWatermarksContext
     @Override
     public MetricGroup getMetricGroup() {
         return metricGroup;
+    }
+
+    @Override
+    public RelativeClock getInputActivityClock() {
+        return SystemClock.getInstance();
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
@@ -53,6 +53,9 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
 
                     @Override
                     public void updateCurrentSplitWatermark(String splitId, long watermark) {}
+
+                    @Override
+                    public void splitFinished(String splitId) {}
                 });
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/PausableRelativeClock.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/PausableRelativeClock.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.metrics.TimerGauge;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.RelativeClock;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link RelativeClock} whose time progress with respect to the wall clock can be paused and
+ * un-paused. It can be paused multiple times. If it is paused N times, it has to be un-paused also
+ * N times to resume progress.
+ */
+@Internal
+@ThreadSafe
+public class PausableRelativeClock implements RelativeClock, TimerGauge.StartStopListener {
+    private final Clock baseClock;
+
+    private long accumulativeBlockedNanoTime;
+    private long currentBlockedNanoTimeStart;
+    /** How many times this clock has been paused. */
+    private long pausedCounter;
+
+    public PausableRelativeClock(Clock baseClock) {
+        this.baseClock = baseClock;
+    }
+
+    @Override
+    public long relativeTimeMillis() {
+        return relativeTimeNanos() / 1_000_000;
+    }
+
+    @Override
+    public synchronized long relativeTimeNanos() {
+        long now = baseClock.relativeTimeNanos();
+        // we offset relativeTimeNanos by the time this clock has been paused.
+        return now - getBlockedTime(now);
+    }
+
+    /** @return how long this {@link PausableRelativeClock} has been paused so far. */
+    private long getBlockedTime(long now) {
+        long blockedTime = accumulativeBlockedNanoTime;
+        if (pausedCounter != 0) {
+            // If we are paused right now, add the time since when we were paused
+            blockedTime += now - currentBlockedNanoTimeStart;
+        }
+        return blockedTime;
+    }
+
+    public synchronized void pause() {
+        if (pausedCounter == 0) {
+            currentBlockedNanoTimeStart = baseClock.relativeTimeNanos();
+        }
+        pausedCounter++;
+    }
+
+    public synchronized void unPause() {
+        checkState(pausedCounter >= 1);
+        pausedCounter--;
+        if (pausedCounter == 0) {
+            accumulativeBlockedNanoTime +=
+                    baseClock.relativeTimeNanos() - currentBlockedNanoTimeStart;
+        }
+    }
+
+    @Override
+    public void markStart() {
+        pause();
+    }
+
+    @Override
+    public void markEnd() {
+        unPause();
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import java.util.concurrent.CompletableFuture;
@@ -32,6 +33,15 @@ import java.util.concurrent.TimeUnit;
  */
 public interface ProcessingTimeService
         extends org.apache.flink.api.common.operators.ProcessingTimeService {
+
+    @Override
+    default long getCurrentProcessingTime() {
+        return getClock().absoluteTimeMillis();
+    }
+
+    /** Returns {@link Clock} associated with this timer service. */
+    Clock getClock();
+
     /**
      * Registers a task to be executed repeatedly at a fixed rate.
      *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImpl.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
 import java.util.concurrent.CompletableFuture;
@@ -53,8 +54,8 @@ class ProcessingTimeServiceImpl implements ProcessingTimeService {
     }
 
     @Override
-    public long getCurrentProcessingTime() {
-        return timerService.getCurrentProcessingTime();
+    public Clock getClock() {
+        return timerService.getClock();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
 import org.slf4j.Logger;
@@ -86,8 +88,8 @@ public class SystemProcessingTimeService implements TimerService {
     }
 
     @Override
-    public long getCurrentProcessingTime() {
-        return System.currentTimeMillis();
+    public Clock getClock() {
+        return SystemClock.getInstance();
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorSplitWatermarkAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorSplitWatermarkAlignmentTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
@@ -40,6 +41,7 @@ import org.apache.flink.streaming.api.operators.source.TestingSourceOperator;
 import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.MockOutput;
 import org.apache.flink.streaming.util.MockStreamConfig;
 
@@ -49,18 +51,17 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit test for split alignment in {@link SourceOperator}. */
-class  SourceOperatorSplitWatermarkAlignmentTest {
+class SourceOperatorSplitWatermarkAlignmentTest {
 
     @Test
     void testSplitWatermarkAlignment() throws Exception {
 
-        MockSourceReader sourceReader = new MockSourceReader(WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS, false, true);
+        MockSourceReader sourceReader =
+                new MockSourceReader(WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS, false, true);
         SourceOperator<Integer, MockSourceSplit> operator =
                 new TestingSourceOperator<>(
                         sourceReader,
@@ -111,6 +112,144 @@ class  SourceOperatorSplitWatermarkAlignmentTest {
         assertThat(sourceReader.getPausedSplits()).containsExactly("0", "1");
     }
 
+    @Test
+    void testBackpressureAndIdleness() throws Exception {
+        long idleTimeout = 100;
+        MockSourceReader sourceReader =
+                new MockSourceReader(WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS, false, true);
+        TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+        SourceOperator<Integer, MockSourceSplit> operator =
+                createAndOpenSourceOperatorWithIdleness(
+                        sourceReader, processingTimeService, idleTimeout);
+
+        /**
+         * Intention behind this setup is that split0 emits a couple of records, while we keep
+         * advancing processing time and keep firing timers. Normally split1 would switch to idle
+         * first (it hasn't emitted any records), which would cause a watermark from split0 to be
+         * emitted and then WatermarkStatus.IDLE should be emitted after split0 also switches to
+         * idle. However we assert that neither watermark no idle status this doesn't happen due to
+         * the back pressure status.
+         */
+        MockSourceSplit split0 = new MockSourceSplit(0, 0, 10).addRecord(42).addRecord(44);
+        MockSourceSplit split1 = new MockSourceSplit(1, 10, 20);
+        operator.handleOperatorEvent(
+                new AddSplitEvent<>(
+                        Arrays.asList(split0, split1), new MockSourceSplitSerializer()));
+
+        CollectingDataOutput<Integer> dataOutput = new CollectingDataOutput<>();
+
+        // Output is initialised by the SourceOperator on the first emitNext invocation
+        operator.emitNext(dataOutput);
+
+        TaskIOMetricGroup taskIOMetricGroup =
+                operator.getContainingTask().getEnvironment().getMetricGroup().getIOMetricGroup();
+        taskIOMetricGroup.getHardBackPressuredTimePerSecond().markStart();
+
+        for (int i = 0; i < 10; i++) {
+            processingTimeService.advance(idleTimeout);
+            operator.emitNext(dataOutput);
+        }
+        assertThat(dataOutput.getEvents()).doesNotContain(WatermarkStatus.IDLE);
+        assertThat(dataOutput.getEvents()).doNotHave(new AnyWatermark());
+
+        taskIOMetricGroup.getHardBackPressuredTimePerSecond().markEnd();
+        taskIOMetricGroup.getSoftBackPressuredTimePerSecond().markStart();
+
+        for (int i = 0; i < 10; i++) {
+            processingTimeService.advance(idleTimeout);
+        }
+        assertThat(dataOutput.getEvents()).doesNotContain(WatermarkStatus.IDLE);
+        assertThat(dataOutput.getEvents()).doNotHave(new AnyWatermark());
+
+        taskIOMetricGroup.getSoftBackPressuredTimePerSecond().markEnd();
+
+        for (int i = 0; i < 10; i++) {
+            processingTimeService.advance(idleTimeout);
+        }
+
+        assertThat(dataOutput.getEvents()).contains(WatermarkStatus.IDLE);
+        assertThat(dataOutput.getEvents()).doNotHave(new AnyWatermark());
+    }
+
+    @Test
+    void testSplitWatermarkAlignmentAndIdleness() throws Exception {
+        long idleTimeout = 100;
+        MockSourceReader sourceReader =
+                new MockSourceReader(WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS, false, true);
+        TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
+        SourceOperator<Integer, MockSourceSplit> operator =
+                createAndOpenSourceOperatorWithIdleness(
+                        sourceReader, processingTimeService, idleTimeout);
+
+        MockSourceSplit split0 = new MockSourceSplit(0, 0, 10);
+        MockSourceSplit split1 = new MockSourceSplit(1, 10, 20);
+        int maxAllowedWatermark = 4;
+        int maxEmittedWatermark = maxAllowedWatermark + 1;
+        // the intention is that only first record from split0 gets emitted, then split0 gets
+        // blocked and record (maxEmittedWatermark + 100) is never emitted from split0
+        split0.addRecord(maxEmittedWatermark).addRecord(maxEmittedWatermark + 100);
+        split1.addRecord(3)
+                .addRecord(3)
+                .addRecord(3)
+                .addRecord(3)
+                .addRecord(3)
+                .addRecord(3)
+                .addRecord(3);
+        split1.addRecord(maxEmittedWatermark + 100);
+
+        operator.handleOperatorEvent(
+                new AddSplitEvent<>(
+                        Arrays.asList(split0, split1), new MockSourceSplitSerializer()));
+        CollectingDataOutput<Integer> dataOutput = new CollectingDataOutput<>();
+
+        operator.emitNext(dataOutput); // split0 emits first (and only) record (maxEmittedWatermark)
+
+        operator.handleOperatorEvent(
+                new WatermarkAlignmentEvent(maxAllowedWatermark)); // blocks split0
+        assertThat(sourceReader.getPausedSplits()).containsExactly("0");
+
+        while (operator.isAvailable()) {
+            // We are advancing a couple of times by (idleTimeout - 1) to make sure the active input
+            // never switches idle, while giving plenty of time for the blocked split0 to evaluate
+            // it's idle state
+            processingTimeService.advance(idleTimeout - 1);
+            operator.emitNext(dataOutput); // split1 keeps emitting records
+        }
+        // in the end, all records are emitted from split1. This shouldn't cause the watermark to
+        // get bumped above maxEmittedWatermark, as split0 shouldn't be idle and it is still
+        // blocked.
+        assertThat(sourceReader.getPausedSplits()).containsExactly("0", "1");
+        assertThat(dataOutput.getEvents()).doNotHave(new WatermarkAbove(maxEmittedWatermark));
+    }
+
+    private SourceOperator<Integer, MockSourceSplit> createAndOpenSourceOperatorWithIdleness(
+            MockSourceReader sourceReader,
+            TestProcessingTimeService processingTimeService,
+            long idleTimeout)
+            throws Exception {
+
+        SourceOperator<Integer, MockSourceSplit> operator =
+                new TestingSourceOperator<>(
+                        sourceReader,
+                        WatermarkStrategy.forGenerator(ctx -> new TestWatermarkGenerator())
+                                .withTimestampAssigner((r, l) -> r)
+                                .withWatermarkAlignment("group-1", Duration.ofMillis(1))
+                                .withIdleness(Duration.ofMillis(idleTimeout)),
+                        processingTimeService,
+                        new MockOperatorEventGateway(),
+                        1,
+                        5,
+                        true);
+        Environment env = getTestingEnvironment();
+        operator.setup(
+                new SourceOperatorStreamTask<Integer>(env),
+                new MockStreamConfig(new Configuration(), 1),
+                new MockOutput<>(new ArrayList<>()));
+        operator.initializeState(new StreamTaskStateInitializerImpl(env, new MemoryStateBackend()));
+        operator.open();
+        return operator;
+    }
+
     private Environment getTestingEnvironment() {
         return new StreamMockEnvironment(
                 new Configuration(),
@@ -137,6 +276,33 @@ class  SourceOperatorSplitWatermarkAlignmentTest {
         @Override
         public void onPeriodicEmit(WatermarkOutput output) {
             output.emitWatermark(new Watermark(maxWatermark));
+        }
+    }
+
+    /** Condition checking if there is no watermark above a certain value among StreamElements. */
+    public static class WatermarkAbove extends Condition<Object> {
+        public WatermarkAbove(int maxEmittedWatermark) {
+            super(
+                    event -> {
+                        if (!(event
+                                instanceof org.apache.flink.streaming.api.watermark.Watermark)) {
+                            return false;
+                        }
+                        org.apache.flink.streaming.api.watermark.Watermark w =
+                                (org.apache.flink.streaming.api.watermark.Watermark) event;
+                        return w.getTimestamp() > maxEmittedWatermark;
+                    },
+                    "watermark value of greater than %d",
+                    maxEmittedWatermark);
+        }
+    }
+
+    /** Condition checking if there is any watermark among StreamElements. */
+    public static class AnyWatermark extends Condition<Object> {
+        public AnyWatermark() {
+            super(
+                    event -> event instanceof org.apache.flink.streaming.api.watermark.Watermark,
+                    "any watermark");
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/util/PausableRelativeClockTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/util/PausableRelativeClockTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.util;
+
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PausableRelativeClockTest {
+    private static final long TIME_STEP = 14;
+
+    @Test
+    void simpleTest() {
+        ManualClock baseClock = new ManualClock();
+        PausableRelativeClock relativeClock = new PausableRelativeClock(baseClock);
+
+        long startMillis = relativeClock.relativeTimeMillis();
+        long startNanos = relativeClock.relativeTimeNanos();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP));
+        long endNanos = relativeClock.relativeTimeNanos();
+        long endMillis = relativeClock.relativeTimeMillis();
+
+        long durationNanos = endNanos - startNanos;
+        long durationMillis = endMillis - startMillis;
+
+        assertThat((durationNanos) / 1_000_000).isEqualTo(TIME_STEP);
+        assertThat(durationMillis).isEqualTo(TIME_STEP);
+    }
+
+    @Test
+    void pausedTest() throws Exception {
+        ManualClock baseClock = new ManualClock();
+        PausableRelativeClock relativeClock = new PausableRelativeClock(baseClock);
+
+        long startMillis = relativeClock.relativeTimeMillis();
+        long startNanos = relativeClock.relativeTimeNanos();
+
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP));
+        relativeClock.pause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP)); // doesn't count
+        relativeClock.pause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP)); // doesn't count
+        relativeClock.unPause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP)); // doesn't count
+        relativeClock.unPause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP));
+        relativeClock.pause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP)); // doesn't count
+        // leave the clock blocked
+
+        long endNanos = relativeClock.relativeTimeNanos();
+        long endMillis = relativeClock.relativeTimeMillis();
+
+        long durationNanos = endNanos - startNanos;
+        long durationMillis = endMillis - startMillis;
+
+        assertThat((durationNanos) / 1_000_000).isEqualTo(TIME_STEP * 2);
+        assertThat(durationMillis).isEqualTo(TIME_STEP * 2);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -459,9 +459,7 @@ class MultipleInputStreamTaskTest {
             int numRecords3 = 2;
             // add source splits before processing any elements, so the MockSourceReader does not
             // end prematurely
-            for (int x = 0; x < numRecords2; x++) {
-                addSourceRecords(testHarness, 1, 42);
-            }
+            addSourceRecords(testHarness, 1, 42, 43, 44);
             for (int x = 0; x < numRecords1; x++) {
                 testHarness.processElement(new StreamRecord<>("hello"), 0, 0);
             }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -776,6 +776,10 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
         return factory;
     }
 
+    public void advanceTime(long delta) throws Exception {
+        processingTimeService.advance(delta);
+    }
+
     public void setProcessingTime(long time) throws Exception {
         processingTimeService.setCurrentTime(time);
     }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
@@ -31,9 +31,10 @@ import org.apache.flink.table.runtime.generated.WatermarkGenerator
 import org.apache.flink.table.types.logical.{IntType, TimestampType}
 import org.apache.flink.table.utils.CatalogManagerMocks
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
+import org.apache.flink.util.clock.{RelativeClock, SystemClock}
 
-import org.junit.jupiter.api.{Test, TestTemplate}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.lang.{Integer => JInt, Long => JLong}
@@ -167,6 +168,8 @@ class WatermarkGeneratorCodeGenTest(useDefinedConstructor: Boolean) {
       val newReferences = generated.getReferences :+
         new WatermarkGeneratorSupplier.Context {
           override def getMetricGroup: MetricGroup = null
+
+          override def getInputActivityClock: RelativeClock = SystemClock.getInstance()
         }
       generated.newInstance(Thread.currentThread().getContextClassLoader, newReferences)
     } else {


### PR DESCRIPTION
## What is the purpose of the change

https://cwiki.apache.org/confluence/x/oQvOEg

This fixes a problem with idleness being incorrectly detected if subtasks/splits are backpressured or blocked due to watermark alignment.

## Brief change log

Please check individual commit messages.

## Verifying this change

This adds a couple of new test cases that are failing without this fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
