### PR TITLE
[FLINK-35993][table] Add the built-in function UNHEX

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -238,6 +238,13 @@ arithmetic:
       NUMERIC.hex()
       STRING.hex()
     description: Returns a string representation of an integer NUMERIC value or a STRING in hex format. Returns NULL if the argument is NULL. E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", a string "hello,world" leads to "68656C6C6F2C776F726C64".
+  - sql: UNHEX(expr)
+    table: expr.unhex()
+    description: |
+      Converts hexadecimal string expr to BINARY.
+      If the length of expr is odd, the first character is discarded and the result is left padded with a null byte. 
+      expr <CHAR | VARCHAR>
+      Returns a BINARY. `NULL` if expr is `NULL` or expr contains non-hex characters.
   - sql: TRUNCATE(numeric1, integer2)
     table: NUMERIC1.truncate(INTEGER2)
     description: Returns a numeric of truncated to integer2 decimal places. Returns NULL if numeric1 or integer2 is NULL. If integer2 is 0, the result has no decimal point or fractional part. integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero. This function can also pass in only one numeric1 parameter and not set integer2 to use. If integer2 is not set, the function truncates as if integer2 were 0. E.g. 42.324.truncate(2) to 42.32. and 42.324.truncate() to 42.0.

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -296,6 +296,13 @@ arithmetic:
     description: |
       以十六进制格式返回整数 numeric 或字符串 string 的字符串表示。如果参数为 `NULL`，则返回 `NULL`。
       例如数字 20 返回“14”，数字 100 返回“64”，字符串“hello,world” 返回“68656C6C6F2C776F726C64”。
+  - sql: UNHEX(expr)
+    table: expr.unhex()
+    description: |
+      将十六进制字符串 expr 转换为 BINARY。
+      如果 expr 的长度为奇数，则会舍弃第一个字符，并在结果开头补充一个空字节。
+      expr <CHAR | VARCHAR>
+      返回一个 BINARY。如果 expr 为 `NULL` 或包含非十六进制字符，则返回 `NULL`。
   - sql: TRUNCATE(numeric1, integer2)
     table: NUMERIC1.truncate(INTEGER2)
     description: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -149,6 +149,7 @@ arithmetic functions
     Expression.end
     Expression.bin
     Expression.hex
+    Expression.unhex
     Expression.truncate
 
 string functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1004,6 +1004,17 @@ class Expression(Generic[T]):
         """
         return _unary_op("hex")(self)
 
+    @property
+    def unhex(self) -> 'Expression':
+        """
+        Converts hexadecimal string expr to BINARY.
+        If the length of expr is odd, the first character is discarded
+        and the result is left padded with a null byte.
+
+        :return: a BINARY. null if expr is null or expr contains non-hex characters.
+        """
+        return _unary_op("unhex")(self)
+
     def truncate(self, n: Union[int, 'Expression[int]'] = 0) -> 'Expression[T]':
         """
         Returns a number of truncated to n decimal places.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -194,6 +194,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRANSL
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRIM;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRUNCATE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRY_CAST;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.UNHEX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.UPPER;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.URL_DECODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.URL_ENCODE;
@@ -812,6 +813,17 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType hex() {
         return toApiSpecificExpression(unresolvedCall(HEX, toExpr()));
+    }
+
+    /**
+     * Converts hexadecimal string {@code expr} to BINARY. If the length of {@code expr} is odd, the
+     * first character is discarded and the result is left padded with a null byte.
+     *
+     * @return a BINARY. <br>
+     *     null if expr is null or expr contains non-hex characters.
+     */
+    public OutType unhex() {
+        return toApiSpecificExpression(unresolvedCall(UNHEX, toExpr()));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryStringData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryStringData.java
@@ -710,6 +710,43 @@ public final class BinaryStringData extends LazyBinaryFormat<String> implements 
         return fromString(toString().toLowerCase());
     }
 
+    /**
+     * Converts a string representing hexadecimal values into an array of bytes of those same
+     * values. The returned array will be half the length of the string, as it takes two characters
+     * to represent any given byte.
+     *
+     * <p>Inspired from <a
+     * href="https://github.com/apache/commons-codec/blob/master/src/main/java/org/apache/commons/codec/binary/Hex.java">...</a>.
+     *
+     * @return A byte array to contain the binary data decoded. <br>
+     *     If original bytes length is odd, the first byte is discarded and the result is left
+     *     padded with a null byte. <br>
+     *     If original bytes contains non-hex bytes the result is null.
+     */
+    public byte[] unhex() {
+        final int len = getSizeInBytes();
+        final byte[] out = new byte[len + 1 >> 1];
+
+        int i = len - 2;
+        int j = out.length - 1;
+        while (i >= 0) {
+            int l = Character.digit(byteAt(i), 16) << 4;
+            int r = Character.digit(byteAt(i + 1), 16);
+            if (l == -16 || r == -1) {
+                return null;
+            }
+            i -= 2;
+            out[j--] = (byte) ((l | r) & 0xFF);
+        }
+
+        // length is odd and first byte is invalid
+        if (i == -1 && Character.digit(byteAt(0), 16) == -1) {
+            return null;
+        }
+
+        return out;
+    }
+
     // ------------------------------------------------------------------------------------------
     // Internal methods on BinaryStringData
     // ------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1856,6 +1856,19 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition UNHEX =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("UNHEX")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Collections.singletonList("expr"),
+                                    Collections.singletonList(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .outputTypeStrategy(explicit(DataTypes.BYTES()))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.UnhexFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition TRUNCATE =
             BuiltInFunctionDefinition.newBuilder()
                     .name("truncate")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
@@ -34,6 +34,19 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
+                        plusTestCases(),
+                        minusTestCases(),
+                        divideTestCases(),
+                        timesTestCases(),
+                        modTestCases(),
+                        roundTestCases(),
+                        truncateTestCases(),
+                        unhexTestCases())
+                .flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> plusTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.PLUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
@@ -48,7 +61,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").plus($("f0")),
                                 "f0 + f0",
                                 new BigDecimal("3028712640000"),
-                                DataTypes.DECIMAL(20, 0).notNull()),
+                                DataTypes.DECIMAL(20, 0).notNull()));
+    }
+
+    private Stream<TestSetSpec> minusTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.MINUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0))
@@ -63,7 +80,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").minus($("f0")),
                                 "f0 - f0",
                                 new BigDecimal("0"),
-                                DataTypes.DECIMAL(20, 0)),
+                                DataTypes.DECIMAL(20, 0)));
+    }
+
+    private Stream<TestSetSpec> divideTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.DIVIDE)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
@@ -78,7 +99,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").dividedBy($("f0")),
                                 "f0 / f0",
                                 new BigDecimal("1.0000000000000000000"),
-                                DataTypes.DECIMAL(38, 19).notNull()),
+                                DataTypes.DECIMAL(38, 19).notNull()));
+    }
+
+    private Stream<TestSetSpec> timesTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.TIMES)
                         .onFieldsWithData(new BigDecimal("1514356320000"), Duration.ofSeconds(2), 2)
                         .andDataTypes(
@@ -110,7 +135,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                                                         DataTypes.SECOND(3)))),
                                 "f2 * interval '3' second(3)",
                                 Duration.ofSeconds(6),
-                                DataTypes.INTERVAL(DataTypes.SECOND(3))),
+                                DataTypes.INTERVAL(DataTypes.SECOND(3))));
+    }
+
+    private Stream<TestSetSpec> modTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.MOD)
                         .onFieldsWithData(new BigDecimal("1514356320000"), 44L, 3)
                         .andDataTypes(DataTypes.DECIMAL(19, 0), DataTypes.BIGINT(), DataTypes.INT())
@@ -123,7 +152,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                         // DECIMAL(19, 0) % INT(10, 0) => INT(10, 0)
                         .testResult($("f0").mod(6), "MOD(f0, 6)", 0, DataTypes.INT())
                         // BIGINT(19, 0) % INT(10, 0) => INT(10, 0)
-                        .testResult($("f1").mod($("f2")), "MOD(f1, f2)", 2, DataTypes.INT()),
+                        .testResult($("f1").mod($("f2")), "MOD(f1, f2)", 2, DataTypes.INT()));
+    }
+
+    private Stream<TestSetSpec> roundTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ROUND)
                         .onFieldsWithData(new BigDecimal("12345.12345"))
                         // ROUND(DECIMAL(10, 5) NOT NULL, 2) => DECIMAL(8, 2) NOT NULL
@@ -131,7 +164,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").round(2),
                                 "ROUND(f0, 2)",
                                 new BigDecimal("12345.12"),
-                                DataTypes.DECIMAL(8, 2).notNull()),
+                                DataTypes.DECIMAL(8, 2).notNull()));
+    }
+
+    private Stream<TestSetSpec> truncateTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.TRUNCATE)
                         .onFieldsWithData(new BigDecimal("123.456"))
                         // TRUNCATE(DECIMAL(6, 3) NOT NULL, 2) => DECIMAL(6, 2) NOT NULL
@@ -140,5 +177,53 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 "TRUNCATE(f0, 2)",
                                 new BigDecimal("123.45"),
                                 DataTypes.DECIMAL(6, 2).notNull()));
+    }
+
+    private Stream<TestSetSpec> unhexTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.UNHEX)
+                        .onFieldsWithData((String) null)
+                        .andDataTypes(DataTypes.STRING())
+                        // null input
+                        .testResult($("f0").unhex(), "UNHEX(f0)", null, DataTypes.BYTES())
+                        // empty string
+                        .testResult(lit("").unhex(), "UNHEX('')", new byte[0], DataTypes.BYTES())
+                        // invalid hex string
+                        .testResult(
+                                lit("1").unhex(), "UNHEX('1')", new byte[] {0}, DataTypes.BYTES())
+                        .testResult(
+                                lit("146").unhex(),
+                                "UNHEX('146')",
+                                new byte[] {0, 0x46},
+                                DataTypes.BYTES())
+                        .testResult(lit("z").unhex(), "UNHEX('z')", null, DataTypes.BYTES())
+                        .testResult(lit("-1").unhex(), "UNHEX('-1')", null, DataTypes.BYTES())
+                        // normal cases
+                        .testResult(
+                                lit("466C696E6B").unhex(),
+                                "UNHEX('466C696E6B')",
+                                new byte[] {0x46, 0x6c, 0x69, 0x6E, 0x6B},
+                                DataTypes.BYTES())
+                        .testResult(
+                                lit("4D7953514C").unhex(),
+                                "UNHEX('4D7953514C')",
+                                new byte[] {0x4D, 0x79, 0x53, 0x51, 0x4C},
+                                DataTypes.BYTES())
+                        .testResult(
+                                lit("\uD83D\uDE00").unhex(),
+                                "UNHEX('\uD83D\uDE00')",
+                                null,
+                                DataTypes.BYTES()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.UNHEX, "Validation Error")
+                        .onFieldsWithData(1)
+                        .andDataTypes(DataTypes.INT())
+                        .testTableApiValidationError(
+                                $("f0").unhex(),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "UNHEX(expr <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "UNHEX(f0)",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "UNHEX(expr <CHARACTER_STRING>)"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UnhexFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UnhexFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#UNHEX}. */
+@Internal
+public class UnhexFunction extends BuiltInScalarFunction {
+
+    public UnhexFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.UNHEX, context);
+    }
+
+    public @Nullable byte[] eval(@Nullable StringData expr) {
+        if (expr == null) {
+            return null;
+        }
+        return ((BinaryStringData) expr).unhex();
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryStringDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/BinaryStringDataTest.java
@@ -870,4 +870,18 @@ public class BinaryStringDataTest {
         assertThat(isEmpty(BinaryStringData.fromBytes("中文".getBytes()))).isEqualTo(false);
         assertThat(isEmpty(new BinaryStringData())).isEqualTo(true);
     }
+
+    @Test
+    public void testUnhex() {
+        assertThat(fromString("").unhex()).isEqualTo(new byte[0]);
+        assertThat(fromString("1").unhex()).isEqualTo(new byte[] {0});
+        assertThat(fromString("146").unhex()).isEqualTo(new byte[] {0, 0x46});
+        assertThat(fromString("z").unhex()).isEqualTo(null);
+        assertThat(fromString("-1").unhex()).isEqualTo(null);
+        assertThat(fromString("466C696E6B").unhex())
+                .isEqualTo(new byte[] {0x46, 0x6C, 0x69, 0x6E, 0x6B});
+        assertThat(fromString("4D7953514C").unhex())
+                .isEqualTo(new byte[] {0x4D, 0x79, 0x53, 0x51, 0x4C});
+        assertThat(fromString("\uD83D\uDE00").unhex()).isEqualTo(null);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add the built-in function UNHEX.
Examples:
```SQL
> SELECT DECODE(UNHEX('466C696E6B'), 'UTF-8');
Flink
```

## Brief change log

- [FLINK-35993](https://issues.apache.org/jira/browse/FLINK-35993)
- Add unhex in BinaryStringData

## Verifying this change

- `MathFunctionsITCase#unhexTestCases`
- `BinaryStringDataTest#testUnhex`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
