### PR TITLE
[FLINK-35993][table] Add the built-in function UNHEX

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -242,8 +242,11 @@ arithmetic:
     table: expr.unhex()
     description: |
       Converts hexadecimal string expr to BINARY.
+      
       If the length of expr is odd, the first character is discarded and the result is left padded with a null byte. 
+      
       expr <CHAR | VARCHAR>
+      
       Returns a BINARY. `NULL` if expr is `NULL` or expr contains non-hex characters.
   - sql: TRUNCATE(numeric1, integer2)
     table: NUMERIC1.truncate(INTEGER2)
@@ -285,7 +288,9 @@ string:
     table: str.btrim([trimStr])
     description: |
       Removes any leading and trailing characters within trimStr from str. trimStr is set to whitespace by default.
+      
       str <CHAR | VARCHAR>, trimStr <CHAR | VARCHAR>
+      
       Returns a STRING representation of the trimmed str. `NULL` if any of the arguments are `NULL`.
   - sql: REPEAT(string, int)
     table: STRING.repeat(INT)
@@ -310,8 +315,11 @@ string:
     table: expr.translate(fromStr, toStr)
     description: |
       Translate an expr where all characters in fromStr have been replaced with those in toStr.
+      
       If toStr has a shorter length than fromStr, unmatched characters are removed.
-      expr [<CHAR> | <VARCHAR>], fromStr [<CHAR> | <VARCHAR>], toStr [<CHAR> | <VARCHAR>]
+      
+      expr <CHAR | VARCHAR>, fromStr <CHAR | VARCHAR>, toStr <CHAR | VARCHAR>
+      
       Returns a STRING of translated expr.
   - sql: REGEXP_EXTRACT(string1, string2[, integer])
     table: STRING1.regexpExtract(STRING2[, INTEGER1])
@@ -417,8 +425,11 @@ string:
     table: index.elt(expr, exprs...)
     description: |
       Returns the index-th expression. index must be an integer between 1 and the number of expressions.
+      
       index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <CHAR | VARCHAR>, exprs <CHAR | VARCHAR>
+      
       index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>, exprs <BINARY | VARBINARY>
+      
       The result has the type of the least common type of all expressions. `NULL` if index is `NULL` or out of range.
 
 temporal:

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -238,6 +238,13 @@ arithmetic:
       NUMERIC.hex()
       STRING.hex()
     description: Returns a string representation of an integer NUMERIC value or a STRING in hex format. Returns NULL if the argument is NULL. E.g. a numeric 20 leads to "14", a numeric 100 leads to "64", a string "hello,world" leads to "68656C6C6F2C776F726C64".
+  - sql: UNHEX(expr)
+    table: expr.unhex()
+    description: |
+      Converts hexadecimal string expr to BINARY.
+      If the length of expr is odd, the first character is discarded and the result is left padded with a null byte. 
+      expr <CHAR | VARCHAR>
+      Returns a BINARY. `NULL` if expr is `NULL` or expr contains non-hex characters.
   - sql: TRUNCATE(numeric1, integer2)
     table: NUMERIC1.truncate(INTEGER2)
     description: Returns a numeric of truncated to integer2 decimal places. Returns NULL if numeric1 or integer2 is NULL. If integer2 is 0, the result has no decimal point or fractional part. integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero. This function can also pass in only one numeric1 parameter and not set integer2 to use. If integer2 is not set, the function truncates as if integer2 were 0. E.g. 42.324.truncate(2) to 42.32. and 42.324.truncate() to 42.0.

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -300,8 +300,11 @@ arithmetic:
     table: expr.unhex()
     description: |
       将十六进制字符串 expr 转换为 BINARY。
+      
       如果 expr 的长度为奇数，则会舍弃第一个字符，并在结果开头补充一个空字节。
+      
       expr <CHAR | VARCHAR>
+      
       返回一个 BINARY。如果 expr 为 `NULL` 或包含非十六进制字符，则返回 `NULL`。
   - sql: TRUNCATE(numeric1, integer2)
     table: NUMERIC1.truncate(INTEGER2)
@@ -350,8 +353,10 @@ string:
   - sql: BTRIM(str[, trimStr])
     table: str.btrim([trimStr])
     description: |
-      从 str 的左边和右边删除 trimStr 中的字符。trimStr 默认设置为空格。      
+      从 str 的左边和右边删除 trimStr 中的字符。trimStr 默认设置为空格。
+      
       str <CHAR | VARCHAR>, trimStr <CHAR | VARCHAR>
+      
       返回一个 STRING 格式的裁剪后的 str。如果任何参数为 `NULL`，则返回 `NULL`。
   - sql: REPEAT(string, int)
     table: STRING.repeat(INT)
@@ -386,8 +391,11 @@ string:
     table: expr.translate(fromStr, toStr)
     description: |
       将 expr 中所有出现在 fromStr 之中的字符替换为 toStr 中的相应字符。
+      
       如果 toStr 的长度短于 fromStr，则未匹配的字符将被移除。
-      expr [<CHAR> | <VARCHAR>], fromStr [<CHAR> | <VARCHAR>], toStr [<CHAR> | <VARCHAR>]
+      
+      expr <CHAR | VARCHAR>, fromStr <CHAR | VARCHAR>, toStr <CHAR | VARCHAR>
+      
       返回 STRING 格式的转换结果。
   - sql: REGEXP_EXTRACT(string1, string2[, integer])
     table: STRING1.regexpExtract(STRING2[, INTEGER1])
@@ -517,8 +525,11 @@ string:
     table: index.elt(expr, exprs...)
     description: |
       返回第 index 个表达式。index 必须是介于 1 和 表达式数量之间的整数。
+      
       index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <CHAR | VARCHAR>, exprs <CHAR | VARCHAR>
+      
       index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>, exprs <BINARY | VARBINARY>
+      
       结果类型为所有 expr 的公共类型。如果 index 为 `NULL` 或超出范围，则返回 `NULL`。
 
 temporal:

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -296,6 +296,13 @@ arithmetic:
     description: |
       以十六进制格式返回整数 numeric 或字符串 string 的字符串表示。如果参数为 `NULL`，则返回 `NULL`。
       例如数字 20 返回“14”，数字 100 返回“64”，字符串“hello,world” 返回“68656C6C6F2C776F726C64”。
+  - sql: UNHEX(expr)
+    table: expr.unhex()
+    description: |
+      将十六进制字符串 expr 转换为 BINARY。
+      如果 expr 的长度为奇数，则会舍弃第一个字符，并在结果开头补充一个空字节。
+      expr <CHAR | VARCHAR>
+      返回一个 BINARY。如果 expr 为 `NULL` 或包含非十六进制字符，则返回 `NULL`。
   - sql: TRUNCATE(numeric1, integer2)
     table: NUMERIC1.truncate(INTEGER2)
     description: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -149,6 +149,7 @@ arithmetic functions
     Expression.end
     Expression.bin
     Expression.hex
+    Expression.unhex
     Expression.truncate
 
 string functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1006,6 +1006,17 @@ class Expression(Generic[T]):
         """
         return _unary_op("hex")(self)
 
+    @property
+    def unhex(self) -> 'Expression':
+        """
+        Converts hexadecimal string expr to BINARY.
+        If the length of expr is odd, the first character is discarded
+        and the result is left padded with a null byte.
+
+        :return: a BINARY. null if expr is null or expr contains non-hex characters.
+        """
+        return _unary_op("unhex")(self)
+
     def truncate(self, n: Union[int, 'Expression[int]'] = 0) -> 'Expression[T]':
         """
         Returns a number of truncated to n decimal places.

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -124,6 +124,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('end(a)', str(expr1.end))
         self.assertEqual('bin(a)', str(expr1.bin))
         self.assertEqual('hex(a)', str(expr1.hex))
+        self.assertEqual("UNHEX(a)", str(expr1.unhex))
         self.assertEqual('truncate(a, 3)', str(expr1.truncate(3)))
 
         # string functions

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -197,6 +197,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRANSL
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRIM;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRUNCATE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.TRY_CAST;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.UNHEX;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.UPPER;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.URL_DECODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.URL_ENCODE;
@@ -815,6 +816,17 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType hex() {
         return toApiSpecificExpression(unresolvedCall(HEX, toExpr()));
+    }
+
+    /**
+     * Converts hexadecimal string {@code expr} to BINARY. If the length of {@code expr} is odd, the
+     * first character is discarded and the result is left padded with a null byte.
+     *
+     * @return a BINARY. <br>
+     *     null if expr is null or expr contains non-hex characters.
+     */
+    public OutType unhex() {
+        return toApiSpecificExpression(unresolvedCall(UNHEX, toExpr()));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1907,6 +1907,19 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition UNHEX =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("UNHEX")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Collections.singletonList("expr"),
+                                    Collections.singletonList(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .outputTypeStrategy(explicit(DataTypes.BYTES()))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.UnhexFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition TRUNCATE =
             BuiltInFunctionDefinition.newBuilder()
                     .name("truncate")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
@@ -189,6 +189,44 @@ public abstract class EncodingUtils {
 
     /**
      * Converts an array of characters representing hexadecimal values into an array of bytes of
+     * those same values. E.g. {@code unhex("12".getBytes())} returns {@code new byte[]{0x12}}.
+     *
+     * <p>The returned array will be half the length of the passed array, as it takes two characters
+     * to represent any given byte. If the input array has an odd length, the first byte is handled
+     * separately and set to 0.
+     *
+     * <p>Unlike {@link #decodeHex(String)}, this method does not throw an exception for odd-length
+     * inputs or invalid characters. Instead, it returns null if invalid characters are encountered.
+     *
+     * @param bytes An array of characters containing hexadecimal digits.
+     * @return A byte array containing the binary data decoded from the supplied char array, or null
+     *     if the input contains invalid hexadecimal characters.
+     */
+    public static byte[] unhex(final byte[] bytes) {
+        final byte[] out = new byte[(bytes.length + 1) >> 1];
+
+        int i = bytes.length - 2;
+        int j = out.length - 1;
+        while (i >= 0) {
+            int l = Character.digit(bytes[i], 16);
+            int r = Character.digit(bytes[i + 1], 16);
+            if (l == -1 || r == -1) {
+                return null;
+            }
+            i -= 2;
+            out[j--] = (byte) (((l << 4) | r) & 0xFF);
+        }
+
+        // length is odd and first byte is invalid
+        if (i == -1 && Character.digit(bytes[0], 16) == -1) {
+            return null;
+        }
+
+        return out;
+    }
+
+    /**
+     * Converts an array of characters representing hexadecimal values into an array of bytes of
      * those same values. The returned array will be half the length of the passed array, as it
      * takes two characters to represent any given byte. An exception is thrown if the passed char
      * array has an odd number of elements.

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/EncodingUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/EncodingUtilsTest.java
@@ -61,6 +61,22 @@ class EncodingUtilsTest {
         assertThat(EncodingUtils.repeat("we", 3)).isEqualTo("wewewe");
     }
 
+    @Test
+    void testUnhex() {
+        assertThat(EncodingUtils.unhex("".getBytes())).isEqualTo(new byte[0]);
+        assertThat(EncodingUtils.unhex("1".getBytes())).isEqualTo(new byte[] {0});
+        assertThat(EncodingUtils.unhex("146".getBytes())).isEqualTo(new byte[] {0, 0x46});
+        assertThat(EncodingUtils.unhex("z".getBytes())).isEqualTo(null);
+        assertThat(EncodingUtils.unhex("1-".getBytes())).isEqualTo(null);
+        assertThat(EncodingUtils.unhex("466C696E6B".getBytes()))
+                .isEqualTo(new byte[] {0x46, 0x6c, 0x69, 0x6E, 0x6B});
+        assertThat(EncodingUtils.unhex("4D7953514C".getBytes()))
+                .isEqualTo(new byte[] {0x4D, 0x79, 0x53, 0x51, 0x4C});
+        assertThat(EncodingUtils.unhex("\uD83D\uDE00".getBytes())).isEqualTo(null);
+        assertThat(EncodingUtils.unhex(EncodingUtils.hex("\uD83D\uDE00").getBytes()))
+                .isEqualTo("\uD83D\uDE00".getBytes());
+    }
+
     // --------------------------------------------------------------------------------------------
 
     private static class MyPojo implements Serializable {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MathFunctionsITCase.java
@@ -34,6 +34,19 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
+                        plusTestCases(),
+                        minusTestCases(),
+                        divideTestCases(),
+                        timesTestCases(),
+                        modTestCases(),
+                        roundTestCases(),
+                        truncateTestCases(),
+                        unhexTestCases())
+                .flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> plusTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.PLUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
@@ -48,7 +61,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").plus($("f0")),
                                 "f0 + f0",
                                 new BigDecimal("3028712640000"),
-                                DataTypes.DECIMAL(20, 0).notNull()),
+                                DataTypes.DECIMAL(20, 0).notNull()));
+    }
+
+    private Stream<TestSetSpec> minusTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.MINUS)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0))
@@ -63,7 +80,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").minus($("f0")),
                                 "f0 - f0",
                                 new BigDecimal("0"),
-                                DataTypes.DECIMAL(20, 0)),
+                                DataTypes.DECIMAL(20, 0)));
+    }
+
+    private Stream<TestSetSpec> divideTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.DIVIDE)
                         .onFieldsWithData(new BigDecimal("1514356320000"))
                         .andDataTypes(DataTypes.DECIMAL(19, 0).notNull())
@@ -78,7 +99,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").dividedBy($("f0")),
                                 "f0 / f0",
                                 new BigDecimal("1.0000000000000000000"),
-                                DataTypes.DECIMAL(38, 19).notNull()),
+                                DataTypes.DECIMAL(38, 19).notNull()));
+    }
+
+    private Stream<TestSetSpec> timesTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.TIMES)
                         .onFieldsWithData(new BigDecimal("1514356320000"), Duration.ofSeconds(2), 2)
                         .andDataTypes(
@@ -110,7 +135,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                                                         DataTypes.SECOND(3)))),
                                 "f2 * interval '3' second(3)",
                                 Duration.ofSeconds(6),
-                                DataTypes.INTERVAL(DataTypes.SECOND(3))),
+                                DataTypes.INTERVAL(DataTypes.SECOND(3))));
+    }
+
+    private Stream<TestSetSpec> modTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.MOD)
                         .onFieldsWithData(new BigDecimal("1514356320000"), 44L, 3)
                         .andDataTypes(DataTypes.DECIMAL(19, 0), DataTypes.BIGINT(), DataTypes.INT())
@@ -123,7 +152,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                         // DECIMAL(19, 0) % INT(10, 0) => INT(10, 0)
                         .testResult($("f0").mod(6), "MOD(f0, 6)", 0, DataTypes.INT())
                         // BIGINT(19, 0) % INT(10, 0) => INT(10, 0)
-                        .testResult($("f1").mod($("f2")), "MOD(f1, f2)", 2, DataTypes.INT()),
+                        .testResult($("f1").mod($("f2")), "MOD(f1, f2)", 2, DataTypes.INT()));
+    }
+
+    private Stream<TestSetSpec> roundTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.ROUND)
                         .onFieldsWithData(new BigDecimal("12345.12345"))
                         // ROUND(DECIMAL(10, 5) NOT NULL, 2) => DECIMAL(8, 2) NOT NULL
@@ -131,7 +164,11 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 $("f0").round(2),
                                 "ROUND(f0, 2)",
                                 new BigDecimal("12345.12"),
-                                DataTypes.DECIMAL(8, 2).notNull()),
+                                DataTypes.DECIMAL(8, 2).notNull()));
+    }
+
+    private Stream<TestSetSpec> truncateTestCases() {
+        return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.TRUNCATE)
                         .onFieldsWithData(new BigDecimal("123.456"))
                         // TRUNCATE(DECIMAL(6, 3) NOT NULL, 2) => DECIMAL(6, 2) NOT NULL
@@ -140,5 +177,58 @@ class MathFunctionsITCase extends BuiltInFunctionTestBase {
                                 "TRUNCATE(f0, 2)",
                                 new BigDecimal("123.45"),
                                 DataTypes.DECIMAL(6, 2).notNull()));
+    }
+
+    private Stream<TestSetSpec> unhexTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.UNHEX)
+                        .onFieldsWithData((String) null)
+                        .andDataTypes(DataTypes.STRING())
+                        // null input
+                        .testResult($("f0").unhex(), "UNHEX(f0)", null, DataTypes.BYTES())
+                        // empty string
+                        .testResult(lit("").unhex(), "UNHEX('')", new byte[0], DataTypes.BYTES())
+                        // invalid hex string
+                        .testResult(
+                                lit("1").unhex(), "UNHEX('1')", new byte[] {0}, DataTypes.BYTES())
+                        .testResult(
+                                lit("146").unhex(),
+                                "UNHEX('146')",
+                                new byte[] {0, 0x46},
+                                DataTypes.BYTES())
+                        .testResult(lit("z").unhex(), "UNHEX('z')", null, DataTypes.BYTES())
+                        .testResult(lit("1-").unhex(), "UNHEX('1-')", null, DataTypes.BYTES())
+                        // normal cases
+                        .testResult(
+                                lit("466C696E6B").unhex(),
+                                "UNHEX('466C696E6B')",
+                                new byte[] {0x46, 0x6c, 0x69, 0x6E, 0x6B},
+                                DataTypes.BYTES())
+                        .testResult(
+                                lit("4D7953514C").unhex(),
+                                "UNHEX('4D7953514C')",
+                                new byte[] {0x4D, 0x79, 0x53, 0x51, 0x4C},
+                                DataTypes.BYTES())
+                        .testResult(
+                                lit("\uD83D\uDE00").unhex(),
+                                "UNHEX('\uD83D\uDE00')",
+                                null,
+                                DataTypes.BYTES())
+                        .testResult(
+                                lit("\uD83D\uDE00").hex().unhex(),
+                                "UNHEX(HEX('\uD83D\uDE00'))",
+                                "\uD83D\uDE00".getBytes(),
+                                DataTypes.BYTES()),
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.UNHEX, "Validation Error")
+                        .onFieldsWithData(1)
+                        .andDataTypes(DataTypes.INT())
+                        .testTableApiValidationError(
+                                $("f0").unhex(),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "UNHEX(expr <CHARACTER_STRING>)")
+                        .testSqlValidationError(
+                                "UNHEX(f0)",
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "UNHEX(expr <CHARACTER_STRING>)"));
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UnhexFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/UnhexFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.utils.EncodingUtils;
+
+import javax.annotation.Nullable;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#UNHEX}. */
+@Internal
+public class UnhexFunction extends BuiltInScalarFunction {
+
+    public UnhexFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.UNHEX, context);
+    }
+
+    public @Nullable byte[] eval(@Nullable StringData expr) {
+        if (expr == null) {
+            return null;
+        }
+        return EncodingUtils.unhex(expr.toBytes());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the built-in function UNHEX.
Examples:
```SQL
> SELECT DECODE(UNHEX('466C696E6B'), 'UTF-8');
Flink
```

## Brief change log

[FLINK-35993](https://issues.apache.org/jira/browse/FLINK-35993)

## Verifying this change

`MathFunctionsITCase#unhexTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
