### PR TITLE
[BP-1.19][FLINK-35974][e2e] Use docker compose v2 for E2E tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -21,7 +21,6 @@ set -o pipefail
 source "$(dirname "$0")"/common.sh
 
 docker --version
-docker-compose --version
 
 function containers_health_check() {
   local container_names=${@:1}

--- a/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
@@ -42,14 +42,14 @@ function cluster_shutdown {
   if [ ${TRAPPED_EXIT_CODE} != 0 ];then
       debug_copy_and_show_logs
   fi
-  docker-compose -f "${END_TO_END_DIR}/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml" down
+  docker compose -f "${END_TO_END_DIR}/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml" down
   rm "${FLINK_TARBALL_DIR}/${FLINK_TARBALL}"
 }
 on_exit cluster_shutdown
 
 function start_hadoop_cluster() {
     echo "Starting Hadoop cluster"
-    docker-compose -f "${END_TO_END_DIR}/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml" up -d
+    docker compose -f "${END_TO_END_DIR}/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml" up -d
 
     # Wait for kerberos to be set up
     local start_time
@@ -103,7 +103,7 @@ function build_image() {
     ln "${cache_path}" "${END_TO_END_DIR}/test-scripts/docker-hadoop-secure-cluster/hadoop/hadoop.tar.gz"
 
     echo "Building Hadoop Docker container"
-    docker-compose -f "${END_TO_END_DIR}/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml" build
+    docker compose -f "${END_TO_END_DIR}/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml" build
 }
 
 function start_hadoop_cluster_and_prepare_flink() {

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/README.md
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/README.md
@@ -25,8 +25,8 @@ Run image
 ```
 cd flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster
 wget -O hadoop/hadoop.tar.gz https://archive.apache.org/dist/hadoop/common/hadoop-2.10.2/hadoop-2.10.2.tar.gz
-docker-compose build
-docker-compose up
+docker compose build
+docker compose up
 ```
 
 Usage
@@ -56,7 +56,7 @@ Known issues
 ### Unable to obtain Kerberos password
 
 #### Error
-docker-compose up fails for the first time with the error
+docker compose up fails for the first time with the error
 
 ```
 Login failure for nn/hadoop.docker.com@EXAMPLE.COM from keytab /etc/security/keytabs/nn.service.keytab: javax.security.auth.login.LoginException: Unable to obtain password from user
@@ -64,7 +64,7 @@ Login failure for nn/hadoop.docker.com@EXAMPLE.COM from keytab /etc/security/key
 
 #### Solution
 
-Stop the containers with `docker-compose down` and start again with `docker-compose up -d`.
+Stop the containers with `docker compose down` and start again with `docker compose up -d`.
 
 ### Java Keystore
 

--- a/flink-end-to-end-tests/test-scripts/test_docker_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_docker_embedded_job.sh
@@ -61,9 +61,9 @@ if ! retry_times $DOCKER_IMAGE_BUILD_RETRIES ${BUILD_BACKOFF_TIME} "build_image 
 fi
 
 export USER_LIB=${FLINK_DIR}/examples/batch
-docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.test.yml up --force-recreate --abort-on-container-exit --exit-code-from job-cluster &> /dev/null
-docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.test.yml logs job-cluster > $FLINK_LOG_DIR/jobmanager.log
-docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.test.yml logs taskmanager > $FLINK_LOG_DIR/taskmanager.log
-docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.test.yml rm -f
+docker compose -f ${DOCKER_SCRIPTS}/docker-compose.test.yml up --force-recreate --abort-on-container-exit --exit-code-from job-cluster &> /dev/null
+docker compose -f ${DOCKER_SCRIPTS}/docker-compose.test.yml logs job-cluster > $FLINK_LOG_DIR/jobmanager.log
+docker compose -f ${DOCKER_SCRIPTS}/docker-compose.test.yml logs taskmanager > $FLINK_LOG_DIR/taskmanager.log
+docker compose -f ${DOCKER_SCRIPTS}/docker-compose.test.yml rm -f
 
 check_result_hash "WordCount" $OUTPUT_VOLUME/docker_wc_out "${RESULT_HASH}"

--- a/flink-end-to-end-tests/test-scripts/test_nat.sh
+++ b/flink-end-to-end-tests/test-scripts/test_nat.sh
@@ -64,10 +64,10 @@ fi
 popd
 
 export USER_LIB=${FLINK_DIR}/examples/batch
-docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml up --force-recreate --abort-on-container-exit --exit-code-from job-cluster &> /dev/null
-docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml logs job-cluster > $FLINK_LOG_DIR/jobmanager.log
-docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml logs taskmanager1 > $FLINK_LOG_DIR/taskmanager1.log
-docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml logs taskmanager2 > $FLINK_LOG_DIR/taskmanager2.log
-docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml rm -f
+docker compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml up --force-recreate --abort-on-container-exit --exit-code-from job-cluster &> /dev/null
+docker compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml logs job-cluster > $FLINK_LOG_DIR/jobmanager.log
+docker compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml logs taskmanager1 > $FLINK_LOG_DIR/taskmanager1.log
+docker compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml logs taskmanager2 > $FLINK_LOG_DIR/taskmanager2.log
+docker compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml rm -f
 
 check_result_hash "WordCount" ${OUTPUT_VOLUME}/${OUTPUT_PREFIX}/ "${RESULT_HASH}"


### PR DESCRIPTION
Backport [FLINK-35974](https://issues.apache.org/jira/browse/FLINK-35974) to 1.19.