### PR TITLE
[FLINK-35885][table] Prohibit advancing the progress of processing time window through watermark

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
@@ -252,6 +252,7 @@ public class StreamExecWindowRank extends ExecNodeBase<RowData>
                         .rankStart(constantRankRange.getRankStart())
                         .rankEnd(constantRankRange.getRankEnd())
                         .windowEndIndex(windowEndIndex)
+                        .withEventTime(windowing.isRowtime())
                         .build();
 
         OneInputTransformation<RowData, RowData> transform =

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/WindowAggOperatorBuilder.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/WindowAggOperatorBuilder.java
@@ -153,7 +153,7 @@ public class WindowAggOperatorBuilder {
         } else {
             windowProcessor = buildUnslicingWindowProcessor();
         }
-        return new WindowAggOperator<>(windowProcessor);
+        return new WindowAggOperator<>(windowProcessor, assigner.isEventTime());
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/window/RowTimeWindowDeduplicateOperatorBuilder.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/window/RowTimeWindowDeduplicateOperatorBuilder.java
@@ -108,6 +108,6 @@ public class RowTimeWindowDeduplicateOperatorBuilder {
         final SlicingWindowProcessor<Long> windowProcessor =
                 new RowTimeWindowDeduplicateProcessor(
                         inputSerializer, bufferFactory, windowEndIndex, shiftTimeZone);
-        return new WindowAggOperator<>(windowProcessor);
+        return new WindowAggOperator<>(windowProcessor, true);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorBuilder.java
@@ -50,6 +50,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *   .rankStart(0)
  *   .rankEnd(100)
  *   .windowEndIndex(windowEndIndex)
+ *   .withEventTime(true)
  *   .build();
  * </pre>
  */
@@ -68,6 +69,7 @@ public class WindowRankOperatorBuilder {
     private long rankEnd = -1;
     private int windowEndIndex = -1;
     private ZoneId shiftTimeZone;
+    private Boolean isEventTime;
 
     public WindowRankOperatorBuilder inputSerializer(
             AbstractRowDataSerializer<RowData> inputSerializer) {
@@ -116,11 +118,17 @@ public class WindowRankOperatorBuilder {
         return this;
     }
 
+    public WindowRankOperatorBuilder withEventTime(Boolean isEventTime) {
+        this.isEventTime = isEventTime;
+        return this;
+    }
+
     public WindowAggOperator<RowData, ?> build() {
         checkNotNull(inputSerializer);
         checkNotNull(keySerializer);
         checkNotNull(sortKeySelector);
         checkNotNull(generatedSortKeyComparator);
+        checkNotNull(isEventTime);
         checkArgument(
                 rankStart > 0,
                 String.format("Illegal rank start %s, it should be positive!", rankStart));
@@ -152,6 +160,7 @@ public class WindowRankOperatorBuilder {
                         outputRankNumber,
                         windowEndIndex,
                         shiftTimeZone);
-        return new WindowAggOperator<>(windowProcessor);
+        // Processing time Window TopN is not supported yet.
+        return new WindowAggOperator<>(windowProcessor, isEventTime);
     }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/window/WindowRankOperatorTest.java
@@ -151,6 +151,7 @@ public class WindowRankOperatorTest {
                         .rankStart(1)
                         .rankEnd(2)
                         .windowEndIndex(WINDOW_END_INDEX)
+                        .withEventTime(true)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -257,6 +258,7 @@ public class WindowRankOperatorTest {
                         .rankStart(2)
                         .rankEnd(2)
                         .windowEndIndex(WINDOW_END_INDEX)
+                        .withEventTime(true)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
@@ -346,6 +348,7 @@ public class WindowRankOperatorTest {
                         .rankStart(1)
                         .rankEnd(2)
                         .windowEndIndex(WINDOW_END_INDEX)
+                        .withEventTime(true)
                         .build();
 
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =


### PR DESCRIPTION
## What is the purpose of the change

*BP https://github.com/apache/flink/pull/25119 to 1.19*


## Brief change log

 - Ignore the advancement of the window processor caused by watermark in proctime window agg
 - Add harness test for this bugfix

## Verifying this change

A harness test has been added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
