### PR TITLE
[FLINK-36008][Documentation] Script and guidance to preview connector docs contributions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,23 @@ externally hosted documentation. The reference will look like `integrate_connect
 
 Replace <connector_name> with the name of your connector, e.g., `elasticsearch` for `flink-connector-elasticsearch`.
 
+### Include external documentation hosted on forks
+
+The configuration above works for connectors already merged in `apache/flinl-connector-<connector-name>` repos.
+When contributing to a Flink's connector, the documentation is hosted in a fork of one of these repos.
+
+To preview any connector docs changes not yet merged follow these steps:
+
+1. (If necessary) Push the latest changes to the connector docs to the forked repo, in a branch
+
+2. In the Flink repository, edit the `docs/setup_docs.sh` file and add a reference to your forked repo. The reference will look like `integrate_connector_fork_docs <fork_owner> <connector_name> <branch_or_tag>`. If you are working on an existing connector, replace the  original `integrate_connector_docs <connector_name>...` reference of the same connector with the reference to your fork. If you are working on a new connector not yet released, append the new reference after all other existing connectors.
+
+Replace <fork_owner> with the owner of the fork, <connector_name> with the name of your connector (e.g., `prometheus` for `flink-connector-prometheus`), and <branch_or_tag> with the name of the branch or tag containing your changes.
+
+
+When you run `docs/setup_docs.sh`, the <branch_or_tag> of the `https://github.com/<fork_owner>/flink-connector-<connector_name>` is cloned into the Flink docs.
+
+
 ## Generate configuration tables
 
 Configuration descriptions are auto generated from code. To trigger the generation, you need to run a command in the project root (see [Configuration documentation](https://github.com/apache/flink/blob/master/flink-docs/README.md#configuration-documentation).)

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -35,6 +35,21 @@ function integrate_connector_docs {
   rsync -a flink-connector-${connector}/docs/* "${theme_dir}/"
 }
 
+# Integrate connector docs from a fork repo
+function integrate_connector_fork_docs {
+  local connector fork_owner ref 
+  fork_owner=$1  
+  connector=$2
+  ref=$3
+
+  git clone --single-branch --branch ${ref} https://github.com/${fork_owner}/flink-connector-${connector}
+  theme_dir="../themes/connectors"
+  mkdir -p "${theme_dir}"
+
+  rsync -a flink-connector-${connector}/docs/* "${theme_dir}/"
+}
+
+
 
 SKIP_INTEGRATE_CONNECTOR_DOCS=false
 for arg in "$@"; do


### PR DESCRIPTION
## What is the purpose of the change

* Improving the contributors' experience when modifying docs of an existing connector or developing docs of a new connector.


## Brief change log

* Add a function to `docs/setup_docs.sh` script that can be used to import a fork of a connector repo
* Add instructions to `docs/README.md` about generating docs locally to preview your connector's docs contribution

TL;DR

To generate the docs site locally including the docs of the connector you are working on (while your changes are still in a fork, and not yet merged into the main connector repo) you need to edit the `setup_docs.sh` pointing to your form, and then you can generate the site.

I added a function in `setup_docs.sh` that you can use for this. The original `integrate_connector_docs` function only works with merged connectors. I preferred not to touch it.

## Verifying this change

The change can be verified generating the docs site, locally, following the new additional instructions in `docs/README.md`:

1. Have Hugo installed
2. Have a fork of a connector repo
3. Push any docs change to a branch/tag
4. Modify `docs/setup_docs.sh` replacing the existing `integrate_connector_docs ...` with `integrate_connector_fork_docs <fork-owner> <connector-name> <branch-name>` (e.g. `integrate_connector_fork_docs nicusX prometheus FLINK-33137-docs`)
5. Run `setup_docs.sh` and then `build_docs.sh` normally
6. Verify the changes in your fork are visible


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? not applicable
