### PR TITLE
[FLINK-36021][network] Delegating the responsibility for compression to every tier

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredResultPartitionFactory.java
@@ -131,7 +131,8 @@ public class TieredResultPartitionFactory {
                                 tierShuffleDescriptors,
                                 fileChannelManager,
                                 batchShuffleReadBufferPool,
-                                batchShuffleReadIOExecutor);
+                                batchShuffleReadIOExecutor,
+                                bufferCompressor);
 
         // Create producer client.
         TieredStorageProducerClient tieredStorageProducerClient =
@@ -199,7 +200,8 @@ public class TieredResultPartitionFactory {
                     List<TierShuffleDescriptor> tierShuffleDescriptors,
                     FileChannelManager fileChannelManager,
                     BatchShuffleReadBufferPool batchShuffleReadBufferPool,
-                    ScheduledExecutorService batchShuffleReadIOExecutor) {
+                    ScheduledExecutorService batchShuffleReadIOExecutor,
+                    @Nullable BufferCompressor bufferCompressor) {
 
         List<TierProducerAgent> tierProducerAgents = new ArrayList<>();
         List<TieredStorageMemorySpec> tieredStorageMemorySpecs = new ArrayList<>();
@@ -238,7 +240,8 @@ public class TieredResultPartitionFactory {
                             Collections.singletonList(tierShuffleDescriptors.get(index)),
                             Math.max(
                                     2 * batchShuffleReadBufferPool.getNumBuffersPerRequest(),
-                                    numberOfSubpartitions));
+                                    numberOfSubpartitions),
+                            bufferCompressor);
             tierProducerAgents.add(producerAgent);
             tieredStorageMemorySpecs.add(tierFactory.getProducerAgentMemorySpec());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierFactory.java
@@ -20,12 +20,15 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerSpec;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageMemoryManager;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageMemorySpec;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageResourceRegistry;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -61,7 +64,8 @@ public interface TierFactory {
             BatchShuffleReadBufferPool bufferPool,
             ScheduledExecutorService ioExecutor,
             List<TierShuffleDescriptor> shuffleDescriptors,
-            int maxRequestedBuffer);
+            int maxRequestedBuffer,
+            @Nullable BufferCompressor bufferCompressor);
 
     /** Creates the consumer-side agent of a Tier. */
     TierConsumerAgent createConsumerAgent(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.disk;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.ProducerMergedPartitionFile;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.ProducerMergedPartitionFileIndex;
@@ -37,6 +38,8 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMast
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierShuffleDescriptor;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
+
+import javax.annotation.Nullable;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -106,7 +109,8 @@ public class DiskTierFactory implements TierFactory {
             BatchShuffleReadBufferPool bufferPool,
             ScheduledExecutorService ioExecutor,
             List<TierShuffleDescriptor> shuffleDescriptors,
-            int maxRequestedBuffers) {
+            int maxRequestedBuffers,
+            @Nullable BufferCompressor bufferCompressor) {
         checkState(bufferSizeBytes > 0);
 
         ProducerMergedPartitionFileIndex partitionFileIndex =
@@ -139,7 +143,8 @@ public class DiskTierFactory implements TierFactory {
                 bufferPool,
                 ioExecutor,
                 maxRequestedBuffers,
-                DEFAULT_DISK_TIER_BUFFER_REQUEST_TIMEOUT);
+                DEFAULT_DISK_TIER_BUFFER_REQUEST_TIMEOUT,
+                bufferCompressor);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.memory;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage.TieredStorageConsumerSpec;
@@ -33,6 +34,8 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMast
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierShuffleDescriptor;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -91,7 +94,8 @@ public class MemoryTierFactory implements TierFactory {
             BatchShuffleReadBufferPool bufferPool,
             ScheduledExecutorService ioExecutor,
             List<TierShuffleDescriptor> shuffleDescriptors,
-            int maxRequestedBuffers) {
+            int maxRequestedBuffers,
+            @Nullable BufferCompressor bufferCompressor) {
         checkState(bufferSizeBytes > 0);
 
         return new MemoryTierProducerAgent(
@@ -103,7 +107,8 @@ public class MemoryTierFactory implements TierFactory {
                 isBroadcastOnly,
                 memoryManager,
                 nettyService,
-                resourceRegistry);
+                resourceRegistry,
+                bufferCompressor);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteTierFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteTierFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.remote;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileReader;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.file.PartitionFileWriter;
@@ -36,6 +37,8 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMast
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierShuffleDescriptor;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -101,7 +104,8 @@ public class RemoteTierFactory implements TierFactory {
             BatchShuffleReadBufferPool bufferPool,
             ScheduledExecutorService ioExecutor,
             List<TierShuffleDescriptor> shuffleDescriptors,
-            int maxRequestedBuffers) {
+            int maxRequestedBuffers,
+            @Nullable BufferCompressor bufferCompressor) {
         checkState(bufferSizeBytes > 0);
         checkNotNull(remoteStoragePath);
 
@@ -115,7 +119,8 @@ public class RemoteTierFactory implements TierFactory {
                 isBroadcastOnly,
                 partitionFileWriter,
                 storageMemoryManager,
-                resourceRegistry);
+                resourceRegistry,
+                bufferCompressor);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TestingTierFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TestingTierFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.hybrid.tiered.storage;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStoragePartitionId;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.netty.TieredStorageNettyService;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierConsumerAgent;
@@ -27,6 +28,8 @@ import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierFact
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierMasterAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierProducerAgent;
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.tier.TierShuffleDescriptor;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -115,7 +118,8 @@ public class TestingTierFactory implements TierFactory {
             BatchShuffleReadBufferPool bufferPool,
             ScheduledExecutorService ioExecutor,
             List<TierShuffleDescriptor> shuffleDescriptors,
-            int maxRequestedBuffers) {
+            int maxRequestedBuffers,
+            @Nullable BufferCompressor bufferCompressor) {
         return tierProducerAgentSupplier.get();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierProducerAgentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/disk/DiskTierProducerAgentTest.java
@@ -229,6 +229,7 @@ public class DiskTierProducerAgentTest {
                 new BatchShuffleReadBufferPool(1, 1),
                 new ManuallyTriggeredScheduledExecutorService(),
                 0,
-                Duration.ofMinutes(5));
+                Duration.ofMinutes(5),
+                null);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierProducerAgentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/memory/MemoryTierProducerAgentTest.java
@@ -121,7 +121,8 @@ class MemoryTierProducerAgentTest {
                         false,
                         memoryManager,
                         nettyService,
-                        new TieredStorageResourceRegistry())) {
+                        new TieredStorageResourceRegistry(),
+                        null)) {
             memoryTierProducerAgent.connectionEstablished(
                     SUBPARTITION_ID, new TestingNettyConnectionWriter.Builder().build());
             assertThat(memoryTierProducerAgent.tryStartNewSegment(SUBPARTITION_ID, 0, 0)).isFalse();
@@ -220,6 +221,7 @@ class MemoryTierProducerAgentTest {
                 isBroadcastOnly,
                 memoryManager,
                 nettyService,
-                resourceRegistry);
+                resourceRegistry,
+                null);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*Delegating the responsibility for compression to every tier, gives us more room to optimize.*


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
