### PR TITLE
[FLINK-35935][table] Fix RTAS not supporting LIMIT

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlReplaceTableAsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlReplaceTableAsConverter.java
@@ -49,10 +49,10 @@ public class SqlReplaceTableAsConverter implements SqlNodeConverter<SqlReplaceTa
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
         SqlNode asQuerySqlNode = sqlReplaceTableAs.getAsQuery();
-        context.getSqlValidator().validate(asQuerySqlNode);
+        SqlNode validated = context.getSqlValidator().validate(asQuerySqlNode);
         QueryOperation query =
                 new PlannerQueryOperation(
-                        context.toRelRoot(asQuerySqlNode).project(),
+                        context.toRelRoot(validated).project(),
                         () -> context.toQuotedSqlString(asQuerySqlNode));
 
         // get table comment

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlRTASNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlRTASNodeToOperationConverterTest.java
@@ -67,6 +67,16 @@ public class SqlRTASNodeToOperationConverterTest extends SqlNodeToOperationConve
         testCommonReplaceTableAs(sql, tableName, null);
     }
 
+    @Test
+    public void testCreateOrReplaceTableASWithLimit() {
+        String tableName = "create_or_replace_table";
+        String sql =
+                "CREATE OR REPLACE TABLE "
+                        + tableName
+                        + " WITH ('k1' = 'v1', 'k2' = 'v2') as (SELECT * FROM t1 LIMIT 5)";
+        testCommonReplaceTableAs(sql, tableName, null);
+    }
+
     private void testCommonReplaceTableAs(
             String sql, String tableName, @Nullable String tableComment) {
         ObjectIdentifier expectedIdentifier = ObjectIdentifier.of("builtin", "default", tableName);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/RTASITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/RTASITCase.java
@@ -79,12 +79,11 @@ class RTASITCase extends BatchTestBase {
     }
 
     @Test
-    void testReplaceTableASWithLimit() throws Exception {
-        env().setParallelism(1);
+    void testReplaceTableASWithSortLimit() throws Exception {
         tEnv().executeSql(
                         "REPLACE TABLE target WITH ('connector' = 'values',"
                                 + " 'bounded' = 'true')"
-                                + " AS (SELECT * FROM source LIMIT 2)")
+                                + " AS (SELECT * FROM source order by `a` LIMIT 2)")
                 .await();
 
         // verify written rows

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/RTASITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/RTASITCase.java
@@ -79,6 +79,29 @@ class RTASITCase extends BatchTestBase {
     }
 
     @Test
+    void testReplaceTableASWithLimit() throws Exception {
+        env().setParallelism(1);
+        tEnv().executeSql(
+                        "REPLACE TABLE target WITH ('connector' = 'values',"
+                                + " 'bounded' = 'true')"
+                                + " AS (SELECT * FROM source LIMIT 2)")
+                .await();
+
+        // verify written rows
+        assertThat(TestValuesTableFactory.getResultsAsStrings("target").toString())
+                .isEqualTo("[+I[1, 1, Hi], +I[2, 2, Hello]]");
+
+        // verify the table after replacing
+        CatalogTable expectCatalogTable =
+                getExpectCatalogTable(
+                        new String[] {"a", "b", "c"},
+                        new AbstractDataType[] {
+                            DataTypes.INT(), DataTypes.BIGINT(), DataTypes.STRING()
+                        });
+        verifyCatalogTable(expectCatalogTable, getCatalogTable("target"));
+    }
+
+    @Test
     void testReplaceTableASWithTableNotExist() {
         assertThatThrownBy(() -> tEnv().executeSql("REPLACE TABLE t AS SELECT * FROM source"))
                 .isInstanceOf(TableException.class)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
@@ -28,12 +28,13 @@ import org.apache.flink.table.planner.runtime.utils.TestData.smallData3
 import org.apache.flink.table.planner.utils.TableTestUtil
 
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.{BeforeEach, Test}
 
 class TableSinkITCase extends BatchTestBase {
 
-  @Test
-  def testTableHints(): Unit = {
+  @BeforeEach
+  override def before(): Unit = {
+    super.before()
     val dataId = TestValuesTableFactory.registerData(smallData3)
     tEnv.executeSql(s"""
                        |CREATE TABLE MyTable (
@@ -46,7 +47,10 @@ class TableSinkITCase extends BatchTestBase {
                        |  'data-id' = '$dataId'
                        |)
        """.stripMargin)
+  }
 
+  @Test
+  def testTableHints(): Unit = {
     val resultPath = createTempFolder().getAbsolutePath
     tEnv.executeSql(s"""
                        |CREATE TABLE MySink (
@@ -89,19 +93,6 @@ class TableSinkITCase extends BatchTestBase {
 
   @Test
   def testCreateTableAsSelect(): Unit = {
-    val dataId = TestValuesTableFactory.registerData(smallData3)
-    tEnv.executeSql(s"""
-                       |CREATE TABLE MyTable (
-                       |  `a` INT,
-                       |  `b` BIGINT,
-                       |  `c` STRING
-                       |) WITH (
-                       |  'connector' = 'values',
-                       |  'bounded' = 'true',
-                       |  'data-id' = '$dataId'
-                       |)
-       """.stripMargin)
-
     val resultPath = createTempFolder().getAbsolutePath
     tEnv
       .executeSql(s"""
@@ -137,21 +128,28 @@ class TableSinkITCase extends BatchTestBase {
   }
 
   @Test
+  def testCreateTableAsSelectWithLimit(): Unit = {
+    env.setParallelism(1)
+    val resultPath = createTempFolder().getAbsolutePath
+    tEnv
+      .executeSql(s"""
+                     |CREATE TABLE MyCtasTable
+                     | WITH (
+                     |  'connector' = 'filesystem',
+                     |  'format' = 'testcsv',
+                     |  'path' = '$resultPath'
+                     |) AS
+                     | (SELECT * FROM MyTable LIMIT 2)
+       """.stripMargin)
+      .await()
+    val expected = Seq("1,1,Hi", "2,2,Hello")
+    val result = TableTestUtil.readFromFile(resultPath)
+    assertThat(result.sorted).isEqualTo(expected.sorted)
+  }
+
+  @Test
   def testCreateTableAsSelectWithoutOptions(): Unit = {
     // TODO CTAS supports ManagedTable
-    val dataId = TestValuesTableFactory.registerData(smallData3)
-    tEnv.executeSql(s"""
-                       |CREATE TABLE MyTable (
-                       |  `a` INT,
-                       |  `b` BIGINT,
-                       |  `c` STRING
-                       |) WITH (
-                       |  'connector' = 'values',
-                       |  'bounded' = 'true',
-                       |  'data-id' = '$dataId'
-                       |)
-       """.stripMargin)
-
     assertThatThrownBy(
       () =>
         tEnv

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
@@ -128,8 +128,7 @@ class TableSinkITCase extends BatchTestBase {
   }
 
   @Test
-  def testCreateTableAsSelectWithLimit(): Unit = {
-    env.setParallelism(1)
+  def testCreateTableAsSelectWithSortLimit(): Unit = {
     val resultPath = createTempFolder().getAbsolutePath
     tEnv
       .executeSql(s"""
@@ -139,7 +138,7 @@ class TableSinkITCase extends BatchTestBase {
                      |  'format' = 'testcsv',
                      |  'path' = '$resultPath'
                      |) AS
-                     | (SELECT * FROM MyTable LIMIT 2)
+                     | (SELECT * FROM MyTable order by `a` LIMIT 2)
        """.stripMargin)
       .await()
     val expected = Seq("1,1,Hi", "2,2,Hello")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -300,20 +300,19 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
   }
 
   @TestTemplate
-  def testCreateTableAsSelectWithLimit(): Unit = {
-    env.setParallelism(1)
+  def testCreateTableAsSelectWithSortLimit(): Unit = {
     tEnv
       .executeSql("""
                     |CREATE TABLE MyCtasTable
                     | WITH (
                     |   'connector' = 'values',
-                    |   'sink-insert-only' = 'true'
+                    |   'sink-insert-only' = 'false'
                     |) AS
                     |  (SELECT
                     |    `person`,
                     |    `votes`
                     |  FROM
-                    |    src LIMIT 2)
+                    |    src order by `votes` LIMIT 2)
                     |""".stripMargin)
       .await()
     val actual = TestValuesTableFactory.getResultsAsStrings("MyCtasTable")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -300,6 +300,31 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
   }
 
   @TestTemplate
+  def testCreateTableAsSelectWithLimit(): Unit = {
+    env.setParallelism(1)
+    tEnv
+      .executeSql("""
+                    |CREATE TABLE MyCtasTable
+                    | WITH (
+                    |   'connector' = 'values',
+                    |   'sink-insert-only' = 'true'
+                    |) AS
+                    |  (SELECT
+                    |    `person`,
+                    |    `votes`
+                    |  FROM
+                    |    src LIMIT 2)
+                    |""".stripMargin)
+      .await()
+    val actual = TestValuesTableFactory.getResultsAsStrings("MyCtasTable")
+    val expected = List(
+      "+I[jason, 1]",
+      "+I[jason, 1]"
+    )
+    assertThat(actual.sorted).isEqualTo(expected.sorted)
+  }
+
+  @TestTemplate
   def testCreateTableAsSelectWithoutOptions(): Unit = {
     // TODO: CTAS supports ManagedTable
     // If the connector option is not specified, Flink will creates a Managed table.


### PR DESCRIPTION
## What is the purpose of the change

*When using `SqlReplaceTableAsConverter` to convert SqlNode,  `SqlReplaceTableAsConverter` wrongly used the original query `asQuerySqlNode`. Actually it should use the validated SqlNode.*


## Brief change log

  - *Use validated SqlNode when converting RTAS*
  - *Add full tests*

## Verifying this change

Many tests (including UT and IT) have been added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
