### PR TITLE
[FLINK-36026][table] Options from `OPTIONS` hint should be present in compile plan

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -263,6 +263,9 @@ ij_java_variable_annotation_wrap = normal
 ij_java_wrap_first_method_in_call_chain = true
 # ij_java_wrap_long_lines = false
 
+[*.out]
+insert_final_newline = false
+
 [*.xml]
 indent_style = tab
 indent_size = 4

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.java
@@ -107,19 +107,19 @@ public final class CatalogSourceTable extends FlinkPreparingTableBase {
 
         // finalize catalog table with option hints
         final Map<String, String> hintedOptions = FlinkHints.getHintedOptions(hints);
-        final ContextResolvedTable catalogTable =
+        final ContextResolvedTable contextTableWithHints =
                 computeContextResolvedTable(context, hintedOptions);
 
         // create table source
         final DynamicTableSource tableSource =
-                createDynamicTableSource(context, catalogTable.getResolvedTable());
+                createDynamicTableSource(context, contextTableWithHints.getResolvedTable());
 
         // prepare table source and convert to RelNode
         return DynamicSourceUtils.convertSourceToRel(
                 !schemaTable.isStreamingMode(),
                 context.getTableConfig(),
                 relBuilder,
-                schemaTable.getContextResolvedTable(),
+                contextTableWithHints,
                 schemaTable.getStatistic(),
                 hints,
                 tableSource);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
@@ -83,14 +83,25 @@ class CompiledPlanITCase extends JsonPlanTestBase {
                 tableEnv.compilePlanSql("INSERT INTO MySink SELECT * FROM MyTable");
         String expected = TableTestUtil.readFromResource("/jsonplan/testGetJsonPlan.out");
         assertThat(
-                        TableTestUtil.replaceExecNodeId(
-                                TableTestUtil.replaceFlinkVersion(
-                                        TableTestUtil.getFormattedJson(
-                                                compiledPlan.asJsonString()))))
+                        getPreparedToCompareCompiledPlan(
+                                TableTestUtil.getFormattedJson(compiledPlan.asJsonString())))
                 .isEqualTo(
-                        TableTestUtil.replaceExecNodeId(
-                                TableTestUtil.replaceFlinkVersion(
-                                        TableTestUtil.getFormattedJson(expected))));
+                        getPreparedToCompareCompiledPlan(TableTestUtil.getFormattedJson(expected)));
+    }
+
+    @Test
+    void testSourceTableWithHints() {
+        CompiledPlan compiledPlan =
+                tableEnv.compilePlanSql(
+                        "INSERT INTO MySink SELECT * FROM MyTable"
+                                // OPTIONS hints here do not play any significant role
+                                // we just have to be sure that these options are present in
+                                // compiled plan
+                                + " /*+ OPTIONS('bounded'='true', 'scan.parallelism'='2') */");
+
+        String expected = TableTestUtil.readFromResource("/jsonplan/testGetJsonPlanWithHints.out");
+        assertThat(getPreparedToCompareCompiledPlan(compiledPlan.asJsonString()))
+                .isEqualTo(expected);
     }
 
     @Test
@@ -416,5 +427,9 @@ class CompiledPlanITCase extends JsonPlanTestBase {
     private File createSourceSinkTables() throws IOException {
         createTestCsvSourceTable("src", DATA, COLUMNS_DEFINITION);
         return createTestCsvSinkTable("sink", COLUMNS_DEFINITION);
+    }
+
+    private String getPreparedToCompareCompiledPlan(final String planAsString) {
+        return TableTestUtil.replaceExecNodeId(TableTestUtil.replaceFlinkVersion(planAsString));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/CompiledPlanITCase.java
@@ -82,11 +82,8 @@ class CompiledPlanITCase extends JsonPlanTestBase {
         CompiledPlan compiledPlan =
                 tableEnv.compilePlanSql("INSERT INTO MySink SELECT * FROM MyTable");
         String expected = TableTestUtil.readFromResource("/jsonplan/testGetJsonPlan.out");
-        assertThat(
-                        getPreparedToCompareCompiledPlan(
-                                TableTestUtil.getFormattedJson(compiledPlan.asJsonString())))
-                .isEqualTo(
-                        getPreparedToCompareCompiledPlan(TableTestUtil.getFormattedJson(expected)));
+        assertThat(getPreparedToCompareCompiledPlan(compiledPlan.asJsonString()))
+                .isEqualTo(getPreparedToCompareCompiledPlan(expected));
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/StatementSetImplTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/internal/StatementSetImplTest.java
@@ -26,8 +26,6 @@ import org.apache.flink.table.planner.utils.TableTestUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link StatementSetImpl}. */
@@ -43,7 +41,7 @@ class StatementSetImplTest {
     }
 
     @Test
-    void testGetJsonPlan() throws IOException {
+    void testGetJsonPlan() {
         String srcTableDdl =
                 "CREATE TABLE MyTable (\n"
                         + "  a bigint,\n"
@@ -67,15 +65,8 @@ class StatementSetImplTest {
         StatementSet stmtSet = tableEnv.createStatementSet();
         stmtSet.addInsertSql("INSERT INTO MySink SELECT * FROM MyTable");
         String jsonPlan = stmtSet.compilePlan().asJsonString();
-        String actual = TableTestUtil.readFromResource("/jsonplan/testGetJsonPlan.out");
-        assertThat(
-                        TableTestUtil.getFormattedJson(
-                                TableTestUtil.replaceExecNodeId(
-                                        TableTestUtil.getFormattedJson(actual))))
-                .isEqualTo(
-                        TableTestUtil.getFormattedJson(
-                                TableTestUtil.replaceExecNodeId(
-                                        TableTestUtil.replaceFlinkVersion(
-                                                TableTestUtil.getFormattedJson(jsonPlan)))));
+        String expected = TableTestUtil.readFromResource("/jsonplan/testGetJsonPlan.out");
+        assertThat(TableTestUtil.replaceFlinkVersion(TableTestUtil.replaceExecNodeId(jsonPlan)))
+                .isEqualTo(TableTestUtil.replaceExecNodeId(expected));
     }
 }

--- a/flink-table/flink-table-planner/src/test/resources/jsonplan/testGetJsonPlan.out
+++ b/flink-table/flink-table-planner/src/test/resources/jsonplan/testGetJsonPlan.out
@@ -1,105 +1,88 @@
 {
-  "flinkVersion": "",
-  "nodes": [
-    {
-      "id": 1,
-      "type": "stream-exec-table-source-scan_1",
-      "scanTableSource": {
-        "table": {
-          "identifier": "`default_catalog`.`default_database`.`MyTable`",
-          "resolvedTable": {
-            "schema": {
-              "columns": [
-                {
-                  "name": "a",
-                  "dataType": "BIGINT"
-                },
-                {
-                  "name": "b",
-                  "dataType": "INT"
-                },
-                {
-                  "name": "c",
-                  "dataType": "VARCHAR(2147483647)"
-                }
-              ],
-              "watermarkSpecs": []
-            },
-            "partitionKeys": [],
-            "options": {
-              "bounded": "false",
-              "connector": "values"
-            }
-          }
-        }
-      },
-      "outputType": "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
-      "description": "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
-      "inputProperties": []
-    },
-    {
-      "id": 2,
-      "type": "stream-exec-sink_1",
-      "configuration":{
-        "table.exec.sink.keyed-shuffle":"AUTO",
-        "table.exec.sink.not-null-enforcer":"ERROR",
-        "table.exec.sink.rowtime-inserter" : "ENABLED",
-        "table.exec.sink.type-length-enforcer":"IGNORE",
-        "table.exec.sink.upsert-materialize":"AUTO"
-      },
-      "dynamicTableSink": {
-        "table": {
-          "identifier": "`default_catalog`.`default_database`.`MySink`",
-          "resolvedTable": {
-            "schema": {
-              "columns": [
-                {
-                  "name": "a",
-                  "dataType": "BIGINT"
-                },
-                {
-                  "name": "b",
-                  "dataType": "INT"
-                },
-                {
-                  "name": "c",
-                  "dataType": "VARCHAR(2147483647)"
-                }
-              ],
-              "watermarkSpecs": []
-            },
-            "partitionKeys": [],
-            "options": {
-              "connector": "values",
-              "table-sink-class": "DEFAULT"
-            }
-          }
-        }
-      },
-      "inputChangelogMode": [
-        "INSERT"
-      ],
-      "inputProperties": [
-        {
-          "requiredDistribution": {
-            "type": "UNKNOWN"
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "id" : 1,
+    "type" : "stream-exec-table-source-scan_1",
+    "scanTableSource" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`MyTable`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "a",
+              "dataType" : "BIGINT"
+            }, {
+              "name" : "b",
+              "dataType" : "INT"
+            }, {
+              "name" : "c",
+              "dataType" : "VARCHAR(2147483647)"
+            } ],
+            "watermarkSpecs" : [ ]
           },
-          "damBehavior": "PIPELINED",
-          "priority": 0
+          "partitionKeys" : [ ],
+          "options" : {
+            "bounded" : "false",
+            "connector" : "values"
+          }
         }
-      ],
-      "outputType": "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
-      "description": "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
-    }
-  ],
-  "edges": [
-    {
-      "source": 1,
-      "target": 2,
-      "shuffle": {
-        "type": "FORWARD"
+      }
+    },
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])",
+    "inputProperties" : [ ]
+  }, {
+    "id" : 2,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "a",
+              "dataType" : "BIGINT"
+            }, {
+              "name" : "b",
+              "dataType" : "INT"
+            }, {
+              "name" : "c",
+              "dataType" : "VARCHAR(2147483647)"
+            } ],
+            "watermarkSpecs" : [ ]
+          },
+          "partitionKeys" : [ ],
+          "options" : {
+            "connector" : "values",
+            "table-sink-class" : "DEFAULT"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
       },
-      "shuffleMode": "PIPELINED"
-    }
-  ]
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
 }

--- a/flink-table/flink-table-planner/src/test/resources/jsonplan/testGetJsonPlanWithHints.out
+++ b/flink-table/flink-table-planner/src/test/resources/jsonplan/testGetJsonPlanWithHints.out
@@ -1,7 +1,7 @@
 {
-  "flinkVersion": "",
+  "flinkVersion" : "",
   "nodes" : [ {
-    "id": 0,
+    "id" : 0,
     "type" : "stream-exec-table-source-scan_1",
     "scanTableSource" : {
       "table" : {
@@ -33,7 +33,7 @@
     "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], hints=[[[OPTIONS options:{scan.parallelism=2, bounded=true}]]])",
     "inputProperties" : [ ]
   }, {
-    "id": 0,
+    "id" : 0,
     "type" : "stream-exec-sink_1",
     "configuration" : {
       "table.exec.sink.keyed-shuffle" : "AUTO",
@@ -79,8 +79,8 @@
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
   } ],
   "edges" : [ {
-    "source": 0,
-    "target": 0,
+    "source" : 0,
+    "target" : 0,
     "shuffle" : {
       "type" : "FORWARD"
     },

--- a/flink-table/flink-table-planner/src/test/resources/jsonplan/testGetJsonPlanWithHints.out
+++ b/flink-table/flink-table-planner/src/test/resources/jsonplan/testGetJsonPlanWithHints.out
@@ -1,0 +1,89 @@
+{
+  "flinkVersion": "",
+  "nodes" : [ {
+    "id": 0,
+    "type" : "stream-exec-table-source-scan_1",
+    "scanTableSource" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`MyTable`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "a",
+              "dataType" : "BIGINT"
+            }, {
+              "name" : "b",
+              "dataType" : "INT"
+            }, {
+              "name" : "c",
+              "dataType" : "VARCHAR(2147483647)"
+            } ],
+            "watermarkSpecs" : [ ]
+          },
+          "partitionKeys" : [ ],
+          "options" : {
+            "bounded" : "true",
+            "connector" : "values",
+            "scan.parallelism" : "2"
+          }
+        }
+      }
+    },
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], hints=[[[OPTIONS options:{scan.parallelism=2, bounded=true}]]])",
+    "inputProperties" : [ ]
+  }, {
+    "id": 0,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.rowtime-inserter" : "ENABLED",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`MySink`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "a",
+              "dataType" : "BIGINT"
+            }, {
+              "name" : "b",
+              "dataType" : "INT"
+            }, {
+              "name" : "c",
+              "dataType" : "VARCHAR(2147483647)"
+            } ],
+            "watermarkSpecs" : [ ]
+          },
+          "partitionKeys" : [ ],
+          "options" : {
+            "connector" : "values",
+            "table-sink-class" : "DEFAULT"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT" ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",
+    "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b, c])"
+  } ],
+  "edges" : [ {
+    "source": 0,
+    "target": 0,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -1816,14 +1816,14 @@ object TableTestUtil {
 
   /** ExecNode {id} is ignored, because id keeps incrementing in test class. */
   def replaceExecNodeId(s: String): String = {
-    s.replaceAll("\"id\"\\s*:\\s*\\d+", "\"id\": 0")
-      .replaceAll("\"source\"\\s*:\\s*\\d+", "\"source\": 0")
-      .replaceAll("\"target\"\\s*:\\s*\\d+", "\"target\": 0")
+    s.replaceAll("\"id\"\\s*:\\s*\\d+", "\"id\" : 0")
+      .replaceAll("\"source\"\\s*:\\s*\\d+", "\"source\" : 0")
+      .replaceAll("\"target\"\\s*:\\s*\\d+", "\"target\" : 0")
   }
 
   /** Ignore flink version value. */
   def replaceFlinkVersion(s: String): String = {
-    s.replaceAll("\"flinkVersion\"\\s*:\\s*\"[\\w.-]*\"", "\"flinkVersion\": \"\"")
+    s.replaceAll("\"flinkVersion\"\\s*:\\s*\"[\\w.-]*\"", "\"flinkVersion\" : \"\"")
   }
 
   /** Ignore exec node in operator name and description. */


### PR DESCRIPTION


## What is the purpose of the change

Options from OPTIONS hint should be present in options section of compiled plan, not only in description

## Brief change log

ContextResolvedTable with merged hints should be used for that

## Verifying this 
There are 2 tests: 
StatementSetImplTest.java
and CompiledPlanITCase.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (yes )

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
