### PR TITLE
[FLINK-36029] Add @Nullable Annotation to ValueState's Value Method Return Type

### DIFF
--- a/flink-core-api/src/main/java/org/apache/flink/api/common/state/ValueState.java
+++ b/flink-core-api/src/main/java/org/apache/flink/api/common/state/ValueState.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.common.state;
 
 import org.apache.flink.annotation.PublicEvolving;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 
 /**
@@ -51,6 +53,7 @@ public interface ValueState<T> extends State {
      * @return The state value corresponding to the current input.
      * @throws IOException Thrown if the system cannot access the state.
      */
+    @Nullable
     T value() throws IOException;
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

The `ValueState#value` description says that null can be returned, but the method does not have the `@Nullable` annotation.

So it seems reasonable to add the `@Nullable` annotation to make it easier for the IDE to find the NPE.


## Brief change log
 - added `@javax.annotation.Nullable` annotation on `ValueState#value`

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
