### PR TITLE
[FLINK-36004] Deep copy the BinaryArrayData in ArrayDataSerializer#copy while using custom ArrayData

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -40,9 +40,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CyclicBarrier;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -170,22 +168,29 @@ public abstract class SerializerTestBase<T> {
 
         T[] testData = getData();
 
-        Map<T, Void> originalData = new IdentityHashMap<>();
-        Map<T, Void> copiedData = new IdentityHashMap<>();
-
         for (T datum : testData) {
-            originalData.put(datum, null);
             T copy = serializer.copy(datum);
             checkToString(copy);
             deepEquals("Copied element is not equal to the original element.", datum, copy);
-            copiedData.put(copy, null);
+        }
+    }
+
+    @Test
+    void testCopyIndependently() {
+        TypeSerializer<T> serializer = getSerializer();
+        T[] originalData = getData();
+        List<T> copiedData = new ArrayList<>(originalData.length);
+
+        for (T datum : originalData) {
+            T copy = serializer.copy(datum, serializer.createInstance());
+            copiedData.add(copy);
         }
 
-        // ensure that all copied data is not reused
-        // Note: Some data may be reused before `copy` but may not be reused
-        // afterward, such as strings in the constant pool. See more at
-        // SimpleVersionedSerializerTypeSerializerProxy.
-        assertThat(copiedData.size()).isGreaterThanOrEqualTo(originalData.size());
+        for (int i = 0; i < originalData.length; i++) {
+            T original = originalData[i];
+            T copied = copiedData.get(i);
+            deepEquals("Copied element is not equal to the original element.", original, copied);
+        }
     }
 
     @Test
@@ -440,7 +445,7 @@ public abstract class SerializerTestBase<T> {
 
     // --------------------------------------------------------------------------------------------
 
-    private void deepEquals(String message, T should, T is) {
+    protected void deepEquals(String message, T should, T is) {
         assertThat(is)
                 .as(message)
                 .matches(CustomEqualityMatcher.deeplyEquals(should).withChecker(checker));

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ArrayDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ArrayDataSerializer.java
@@ -89,7 +89,7 @@ public class ArrayDataSerializer extends TypeSerializer<ArrayData> {
         } else if (from instanceof BinaryArrayData) {
             return ((BinaryArrayData) from).copy();
         } else {
-            return toBinaryArray(from);
+            return toBinaryArray(from).copy();
         }
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
@@ -106,6 +106,7 @@ public class MapDataSerializer extends TypeSerializer<MapData> {
         if (from instanceof BinaryMapData) {
             return ((BinaryMapData) from).copy();
         } else {
+            // the returned value has been copied
             return toBinaryMap(from);
         }
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/ArrayDataSerializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/ArrayDataSerializerTest.java
@@ -90,6 +90,7 @@ class ArrayDataSerializerTest extends SerializerTestBase<ArrayData> {
             createArray("11", "lele", "haa", "ke"),
             createColumnarArray("11", "lele", "haa", "ke"),
             createCustomTypeArray("11", "lele", "haa", "ke"),
+            createCustomTypeArray("111", "lelele", "haaa", "kee")
         };
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/MapDataSerializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/MapDataSerializerTest.java
@@ -84,9 +84,12 @@ public class MapDataSerializerTest extends SerializerTestBase<MapData> {
     protected MapData[] getTestData() {
         Map<Object, Object> first = new HashMap<>();
         first.put(1, StringData.fromString(""));
+        Map<Object, Object> second = new HashMap<>();
+        second.put(2, StringData.fromString(""));
         return new MapData[] {
             new GenericMapData(first),
             new CustomMapData(first),
+            new CustomMapData(second),
             BinaryMapData.valueOf(
                     createArray(1, 2), ArrayDataSerializerTest.createArray("11", "haa")),
             BinaryMapData.valueOf(


### PR DESCRIPTION
## What is the purpose of the change

*The method `copy` in Flink’s `ArrayDataSerializer` does not return the expected copied data for the custom `ArrayData`, but instead reuses its internal data. This pr tries to fix it.*


## Brief change log

  - *copy the result in ArrayDataSerializer#copy while using custom ArrayData*
  - *add tests*

## Verifying this change

Tests are added to verify this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
