### PR TITLE
[FLINK-36050][table] Support enhanced `SHOW VIEW` syntax

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -913,10 +913,17 @@ SHOW PROCEDURES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] (LIKE | I
 ## SHOW VIEWS
 
 ```sql
-SHOW VIEWS
+SHOW VIEWS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE <sql_like_pattern> ]
 ```
 
-展示当前 catalog 和当前 database 中所有的视图。
+Show all views for an optionally specified database. If no database is specified then the views are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
+
+**LIKE**
+Show all views with given view name and optional `LIKE` clause, whose name is whether similar to the `<sql_like_pattern>`.
+
+The syntax of sql pattern in `LIKE` clause is the same as that of `MySQL` dialect.
+* `%` matches any number of characters, even zero characters, `\%` matches one `%` character.
+* `_` matches exactly one character, `\_` matches one `_` character.
 
 ## SHOW CREATE VIEW
 

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -923,10 +923,17 @@ The same behavior as `LIKE` but the SQL pattern is case-insensitive.
 ## SHOW VIEWS
 
 ```sql
-SHOW VIEWS
+SHOW VIEWS [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE <sql_like_pattern> ]
 ```
 
-Show all views in the current catalog and the current database.
+Show all views for an optionally specified database. If no database is specified then the views are returned from the current database. Additionally, the output of this statement may be filtered by an optional matching pattern.
+
+**LIKE**
+Show all views with given view name and optional `LIKE` clause, whose name is whether similar to the `<sql_like_pattern>`.
+
+The syntax of sql pattern in `LIKE` clause is the same as that of `MySQL` dialect.
+* `%` matches any number of characters, even zero characters, `\%` matches one `%` character.
+* `_` matches exactly one character, `\_` matches one `_` character.
 
 ## SHOW CREATE VIEW
 

--- a/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/catalog_database.q
@@ -802,7 +802,7 @@ show tables;
 !ok
 
 # ==========================================================================
-# test enhanced show tables
+# test enhanced show tables and views
 # ==========================================================================
 
 create catalog catalog1 with ('type'='generic_in_memory');
@@ -829,6 +829,10 @@ create view catalog1.db1.v_person as select * from catalog1.db1.person;
 [INFO] Execute statement succeeded.
 !info
 
+create view catalog1.db1.v_address comment 'view comment' as select * from catalog1.db1.address;
+[INFO] Execute statement succeeded.
+!info
+
 show tables from catalog1.db1;
 +------------+
 | table name |
@@ -836,9 +840,20 @@ show tables from catalog1.db1;
 |    address |
 |        dim |
 |     person |
+|  v_address |
 |   v_person |
 +------------+
-4 rows in set
+5 rows in set
+!ok
+
+show views from catalog1.db1;
++-----------+
+| view name |
++-----------+
+| v_address |
+|  v_person |
++-----------+
+2 rows in set
 !ok
 
 show tables from catalog1.db1 like '%person%';
@@ -851,14 +866,33 @@ show tables from catalog1.db1 like '%person%';
 2 rows in set
 !ok
 
+show views from catalog1.db1 like '%person%';
++-----------+
+| view name |
++-----------+
+|  v_person |
++-----------+
+1 row in set
+!ok
+
 show tables in catalog1.db1 not like '%person%';
 +------------+
 | table name |
 +------------+
 |    address |
 |        dim |
+|  v_address |
 +------------+
-2 rows in set
+3 rows in set
+!ok
+
+show views in catalog1.db1 not like '%person%';
++-----------+
+| view name |
++-----------+
+| v_address |
++-----------+
+1 row in set
 !ok
 
 use catalog catalog1;
@@ -871,5 +905,14 @@ show tables from db1 like 'p_r%';
 +------------+
 |     person |
 +------------+
+1 row in set
+!ok
+
+show views from db1 like '%p_r%';
++-----------+
+| view name |
++-----------+
+|  v_person |
++-----------+
 1 row in set
 !ok

--- a/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql/catalog_database.q
@@ -928,7 +928,7 @@ show tables;
 !ok
 
 # ==========================================================================
-# test enhanced show tables
+# test enhanced show tables and views
 # ==========================================================================
 
 create catalog catalog1 with ('type'='generic_in_memory');
@@ -991,6 +991,16 @@ create view catalog1.db1.v_person as select * from catalog1.db1.person;
 1 row in set
 !ok
 
+create view catalog1.db1.v_address comment 'view comment' as select * from catalog1.db1.address;
+!output
++--------+
+| result |
++--------+
+|     OK |
++--------+
+1 row in set
+!ok
+
 show tables from catalog1.db1;
 !output
 +------------+
@@ -999,9 +1009,21 @@ show tables from catalog1.db1;
 |    address |
 |        dim |
 |     person |
+|  v_address |
 |   v_person |
 +------------+
-4 rows in set
+5 rows in set
+!ok
+
+show views from catalog1.db1;
+!output
++-----------+
+| view name |
++-----------+
+| v_address |
+|  v_person |
++-----------+
+2 rows in set
 !ok
 
 show tables from catalog1.db1 like '%person%';
@@ -1015,6 +1037,16 @@ show tables from catalog1.db1 like '%person%';
 2 rows in set
 !ok
 
+show views from catalog1.db1 like '%person%';
+!output
++-----------+
+| view name |
++-----------+
+|  v_person |
++-----------+
+1 row in set
+!ok
+
 show tables in catalog1.db1 not like '%person%';
 !output
 +------------+
@@ -1022,8 +1054,19 @@ show tables in catalog1.db1 not like '%person%';
 +------------+
 |    address |
 |        dim |
+|  v_address |
 +------------+
-2 rows in set
+3 rows in set
+!ok
+
+show views in catalog1.db1 not like '%person%';
+!output
++-----------+
+| view name |
++-----------+
+| v_address |
++-----------+
+1 row in set
 !ok
 
 use catalog catalog1;
@@ -1043,5 +1086,15 @@ show tables from db1 like 'p_r%';
 +------------+
 |     person |
 +------------+
+1 row in set
+!ok
+
+show views from db1 like '%p_r%';
+!output
++-----------+
+| view name |
++-----------+
+|  v_person |
++-----------+
 1 row in set
 !ok

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
@@ -101,10 +101,8 @@ public class SqlShowTables extends SqlCall {
                 : Collections.singletonList(databaseName);
     }
 
-    public String[] fullDatabaseName() {
-        return Objects.isNull(this.databaseName)
-                ? new String[] {}
-                : databaseName.names.toArray(new String[0]);
+    public List<String> fullDatabaseName() {
+        return Objects.isNull(this.databaseName) ? Collections.emptyList() : databaseName.names;
     }
 
     @Override
@@ -116,11 +114,8 @@ public class SqlShowTables extends SqlCall {
             databaseName.unparse(writer, leftPrec, rightPrec);
         }
         if (isWithLike()) {
-            if (isNotLike()) {
-                writer.keyword(String.format("NOT LIKE '%s'", getLikeSqlPattern()));
-            } else {
-                writer.keyword(String.format("LIKE '%s'", getLikeSqlPattern()));
-            }
+            final String prefix = isNotLike() ? "NOT " : "";
+            writer.keyword(String.format("%sLIKE '%s'", prefix, getLikeSqlPattern()));
         }
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowViews.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowViews.java
@@ -19,6 +19,8 @@
 package org.apache.flink.sql.parser.dql;
 
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
@@ -28,6 +30,9 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
 
 /** SHOW VIEWS sql call. */
 public class SqlShowViews extends SqlCall {
@@ -35,8 +40,53 @@ public class SqlShowViews extends SqlCall {
     public static final SqlSpecialOperator OPERATOR =
             new SqlSpecialOperator("SHOW VIEWS", SqlKind.OTHER);
 
+    protected final String preposition;
+    protected final SqlIdentifier databaseName;
+    protected final boolean notLike;
+    protected final SqlCharStringLiteral likeLiteral;
+
     public SqlShowViews(SqlParserPos pos) {
         super(pos);
+        this.preposition = null;
+        this.databaseName = null;
+        this.notLike = false;
+        this.likeLiteral = null;
+    }
+
+    public SqlShowViews(
+            SqlParserPos pos,
+            String preposition,
+            SqlIdentifier databaseName,
+            boolean notLike,
+            SqlCharStringLiteral likeLiteral) {
+        super(pos);
+        this.preposition = preposition;
+        this.databaseName =
+                preposition != null
+                        ? requireNonNull(databaseName, "Database must not be null")
+                        : null;
+        this.notLike = notLike;
+        this.likeLiteral = likeLiteral;
+    }
+
+    public String getLikeSqlPattern() {
+        return likeLiteral == null ? null : likeLiteral.getValueAs(String.class);
+    }
+
+    public boolean isNotLike() {
+        return notLike;
+    }
+
+    public SqlCharStringLiteral getLikeLiteral() {
+        return likeLiteral;
+    }
+
+    public boolean isWithLike() {
+        return Objects.nonNull(likeLiteral);
+    }
+
+    public String getPreposition() {
+        return preposition;
     }
 
     @Override
@@ -46,11 +96,27 @@ public class SqlShowViews extends SqlCall {
 
     @Override
     public List<SqlNode> getOperandList() {
-        return Collections.EMPTY_LIST;
+        return databaseName == null
+                ? Collections.emptyList()
+                : Collections.singletonList(databaseName);
+    }
+
+    public List<String> fullDatabaseName() {
+        return databaseName == null ? Collections.emptyList() : databaseName.names;
     }
 
     @Override
     public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-        writer.keyword("SHOW VIEWS");
+        if (preposition == null) {
+            writer.keyword("SHOW VIEWS");
+        } else if (databaseName != null) {
+            writer.keyword("SHOW VIEWS " + preposition);
+            databaseName.unparse(writer, leftPrec, rightPrec);
+        }
+
+        if (isWithLike()) {
+            final String prefix = isNotLike() ? "NOT " : "";
+            writer.keyword(String.format("%sLIKE '%s'", prefix, getLikeSqlPattern()));
+        }
     }
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -2301,6 +2301,38 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     @Test
     void testShowViews() {
         sql("show views").ok("SHOW VIEWS");
+        sql("show views not like '%'").ok("SHOW VIEWS NOT LIKE '%'");
+
+        sql("show views from db1").ok("SHOW VIEWS FROM `DB1`");
+        sql("show views in db1").ok("SHOW VIEWS IN `DB1`");
+
+        sql("show views from catalog1.db1").ok("SHOW VIEWS FROM `CATALOG1`.`DB1`");
+        sql("show views in catalog1.db1").ok("SHOW VIEWS IN `CATALOG1`.`DB1`");
+
+        sql("show views from db1 like '%'").ok("SHOW VIEWS FROM `DB1` LIKE '%'");
+        sql("show views in db1 like '%'").ok("SHOW VIEWS IN `DB1` LIKE '%'");
+
+        sql("show views from catalog1.db1 like '%'")
+                .ok("SHOW VIEWS FROM `CATALOG1`.`DB1` LIKE '%'");
+        sql("show views in catalog1.db1 like '%'").ok("SHOW VIEWS IN `CATALOG1`.`DB1` LIKE '%'");
+
+        sql("show views from db1 not like '%'").ok("SHOW VIEWS FROM `DB1` NOT LIKE '%'");
+        sql("show views in db1 not like '%'").ok("SHOW VIEWS IN `DB1` NOT LIKE '%'");
+
+        sql("show views from catalog1.db1 not like '%'")
+                .ok("SHOW VIEWS FROM `CATALOG1`.`DB1` NOT LIKE '%'");
+        sql("show views in catalog1.db1 not like '%'")
+                .ok("SHOW VIEWS IN `CATALOG1`.`DB1` NOT LIKE '%'");
+
+        sql("show views ^db1^").fails("(?s).*Encountered \"db1\" at line 1, column 12.\n.*");
+        sql("show views ^catalog1^.db1")
+                .fails("(?s).*Encountered \"catalog1\" at line 1, column 12.\n.*");
+
+        sql("show views ^search^ db1")
+                .fails("(?s).*Encountered \"search\" at line 1, column 12.\n.*");
+
+        sql("show views from db1 ^likes^ '%t'")
+                .fails("(?s).*Encountered \"likes\" at line 1, column 21.\n.*");
     }
 
     @Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
@@ -106,11 +106,8 @@ public class ShowTablesOperation implements ShowOperation {
             builder.append(String.format(" %s %s.%s", preposition, catalogName, databaseName));
         }
         if (this.useLike) {
-            if (notLike) {
-                builder.append(String.format(" %s LIKE %s", "NOT", likePattern));
-            } else {
-                builder.append(String.format(" LIKE %s", likePattern));
-            }
+            final String prefix = notLike ? "NOT " : "";
+            builder.append(String.format(" %sLIKE '%s'", prefix, likePattern));
         }
         return builder.toString();
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -939,19 +939,19 @@ public class SqlNodeToOperationConversion {
                     sqlShowTables.isWithLike(),
                     sqlShowTables.isNotLike());
         }
-        String[] fullDatabaseName = sqlShowTables.fullDatabaseName();
-        if (fullDatabaseName.length > 2) {
+        List<String> fullDatabaseName = sqlShowTables.fullDatabaseName();
+        if (fullDatabaseName.size() > 2) {
             throw new ValidationException(
                     String.format(
                             "show tables from/in identifier [ %s ] format error",
                             String.join(".", fullDatabaseName)));
         }
         String catalogName =
-                (fullDatabaseName.length == 1)
+                (fullDatabaseName.size() == 1)
                         ? catalogManager.getCurrentCatalog()
-                        : fullDatabaseName[0];
+                        : fullDatabaseName.get(0);
         String databaseName =
-                (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
+                (fullDatabaseName.size() == 1) ? fullDatabaseName.get(0) : fullDatabaseName.get(1);
         return new ShowTablesOperation(
                 catalogName,
                 databaseName,
@@ -1002,7 +1002,32 @@ public class SqlNodeToOperationConversion {
 
     /** Convert SHOW VIEWS statement. */
     private Operation convertShowViews(SqlShowViews sqlShowViews) {
-        return new ShowViewsOperation();
+        if (sqlShowViews.getPreposition() == null) {
+            return new ShowViewsOperation(
+                    sqlShowViews.getLikeSqlPattern(),
+                    sqlShowViews.isWithLike(),
+                    sqlShowViews.isNotLike());
+        }
+        List<String> fullDatabaseName = sqlShowViews.fullDatabaseName();
+        if (fullDatabaseName.size() > 2) {
+            throw new ValidationException(
+                    String.format(
+                            "show views from/in identifier [ %s ] format error",
+                            String.join(".", fullDatabaseName)));
+        }
+        String catalogName =
+                (fullDatabaseName.size() == 1)
+                        ? catalogManager.getCurrentCatalog()
+                        : fullDatabaseName.get(0);
+        String databaseName =
+                (fullDatabaseName.size() == 1) ? fullDatabaseName.get(0) : fullDatabaseName.get(1);
+        return new ShowViewsOperation(
+                catalogName,
+                databaseName,
+                sqlShowViews.getLikeSqlPattern(),
+                sqlShowViews.isWithLike(),
+                sqlShowViews.isNotLike(),
+                sqlShowViews.getPreposition());
     }
 
     /** Convert RICH EXPLAIN statement. */

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlOtherOperationConverterTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.operations.ShowModulesOperation;
 import org.apache.flink.table.operations.ShowPartitionsOperation;
 import org.apache.flink.table.operations.ShowProceduresOperation;
 import org.apache.flink.table.operations.ShowTablesOperation;
+import org.apache.flink.table.operations.ShowViewsOperation;
 import org.apache.flink.table.operations.UnloadModuleOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
@@ -210,6 +211,34 @@ public class SqlOtherOperationConverterTest extends SqlNodeToOperationConversion
 
         final String sql3 = "SHOW TABLES";
         showTablesOperation = (ShowTablesOperation) parse(sql3);
+        assertThat(showTablesOperation.getCatalogName()).isNull();
+        assertThat(showTablesOperation.getDatabaseName()).isNull();
+        assertThat(showTablesOperation.getPreposition()).isNull();
+    }
+
+    @Test
+    void testShowViews() {
+        final String sql = "SHOW VIEWS from cat1.db1 not like 't%'";
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(ShowViewsOperation.class);
+
+        ShowViewsOperation showTablesOperation = (ShowViewsOperation) operation;
+        assertThat(showTablesOperation.getCatalogName()).isEqualTo("cat1");
+        assertThat(showTablesOperation.getDatabaseName()).isEqualTo("db1");
+        assertThat(showTablesOperation.getPreposition()).isEqualTo("FROM");
+        assertThat(showTablesOperation.isUseLike()).isTrue();
+        assertThat(showTablesOperation.isNotLike()).isTrue();
+
+        final String sql2 = "SHOW VIEWS in db2";
+        showTablesOperation = (ShowViewsOperation) parse(sql2);
+        assertThat(showTablesOperation.getCatalogName()).isEqualTo("builtin");
+        assertThat(showTablesOperation.getDatabaseName()).isEqualTo("db2");
+        assertThat(showTablesOperation.getPreposition()).isEqualTo("IN");
+        assertThat(showTablesOperation.isUseLike()).isFalse();
+        assertThat(showTablesOperation.isNotLike()).isFalse();
+
+        final String sql3 = "SHOW VIEWS";
+        showTablesOperation = (ShowViewsOperation) parse(sql3);
         assertThat(showTablesOperation.getCatalogName()).isNull();
         assertThat(showTablesOperation.getDatabaseName()).isNull();
         assertThat(showTablesOperation.getPreposition()).isNull();


### PR DESCRIPTION
## What is the purpose of the change

Support enhanced `SHOW VIEWS` syntax like `SHOW VIEWS FROM catalog1.db1 LIKE 't%'`

in a way similar to existing `SHOW TABLES` syntax 

## Brief change log
parser was extended


## Verifying this change
catalog_database.q in sql client and sql gateway
+ a number of unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (docs )
