### PR TITLE
[FLINK-35935][table-planner] Fix RTAS not supporting LIMIT

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlReplaceTableAsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlReplaceTableAsConverter.java
@@ -49,10 +49,10 @@ public class SqlReplaceTableAsConverter implements SqlNodeConverter<SqlReplaceTa
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
         SqlNode asQuerySqlNode = sqlReplaceTableAs.getAsQuery();
-        context.getSqlValidator().validate(asQuerySqlNode);
+        SqlNode validated = context.getSqlValidator().validate(asQuerySqlNode);
         QueryOperation query =
                 new PlannerQueryOperation(
-                        context.toRelRoot(asQuerySqlNode).project(),
+                        context.toRelRoot(validated).project(),
                         () -> context.toQuotedSqlString(asQuerySqlNode));
 
         // get table comment

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlRTASNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlRTASNodeToOperationConverterTest.java
@@ -67,6 +67,16 @@ public class SqlRTASNodeToOperationConverterTest extends SqlNodeToOperationConve
         testCommonReplaceTableAs(sql, tableName, null);
     }
 
+    @Test
+    public void testCreateOrReplaceTableASWithLimit() {
+        String tableName = "create_or_replace_table";
+        String sql =
+                "CREATE OR REPLACE TABLE "
+                        + tableName
+                        + " WITH ('k1' = 'v1', 'k2' = 'v2') as (SELECT * FROM t1 LIMIT 5)";
+        testCommonReplaceTableAs(sql, tableName, null);
+    }
+
     private void testCommonReplaceTableAs(
             String sql, String tableName, @Nullable String tableComment) {
         ObjectIdentifier expectedIdentifier = ObjectIdentifier.of("builtin", "default", tableName);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/RTASITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/RTASITCase.java
@@ -109,6 +109,30 @@ class RTASITCase extends StreamingTestBase {
     }
 
     @Test
+    void testCreateOrReplaceTableASWithSortLimit() throws Exception {
+        tEnv().executeSql(
+                        "CREATE OR REPLACE TABLE target WITH ('connector' = 'values',"
+                                + " 'sink-insert-only' = 'false')"
+                                + " AS (SELECT a, c FROM source order by `a` LIMIT 2)")
+                .await();
+
+        // verify written rows
+        assertThat(TestValuesTableFactory.getResultsAsStrings("target").toString())
+                .isEqualTo("[+I[1, Hi], +I[2, Hello]]");
+
+        // verify the table after replacing
+        Map<String, String> expectedOptions = new HashMap<>();
+        expectedOptions.put("connector", "values");
+        expectedOptions.put("sink-insert-only", "false");
+        CatalogTable expectCatalogTable =
+                getExpectCatalogTable(
+                        new String[] {"a", "c"},
+                        new AbstractDataType[] {DataTypes.INT(), DataTypes.STRING()},
+                        expectedOptions);
+        verifyCatalogTable(expectCatalogTable, getCatalogTable("target"));
+    }
+
+    @Test
     void testCreateOrReplaceTableASWithTableNotExist() throws Exception {
         tEnv().executeSql(
                         "CREATE OR REPLACE TABLE not_exist_target WITH ('connector' = 'values',"
@@ -130,11 +154,16 @@ class RTASITCase extends StreamingTestBase {
 
     private CatalogTable getExpectCatalogTable(
             String[] cols, AbstractDataType<?>[] fieldDataTypes) {
+        return getExpectCatalogTable(cols, fieldDataTypes, getDefaultTargetTableOptions());
+    }
+
+    private CatalogTable getExpectCatalogTable(
+            String[] cols, AbstractDataType<?>[] fieldDataTypes, Map<String, String> tableOptions) {
         return CatalogTable.of(
                 Schema.newBuilder().fromFields(cols, fieldDataTypes).build(),
                 null,
                 Collections.emptyList(),
-                getDefaultTargetTableOptions());
+                tableOptions);
     }
 
     private Map<String, String> getDefaultTargetTableOptions() {


### PR DESCRIPTION
## What is the purpose of the change

BP for https://github.com/apache/flink/pull/25185.

*When using `SqlReplaceTableAsConverter` to convert SqlNode,  `SqlReplaceTableAsConverter` wrongly used the original query `asQuerySqlNode`. Actually it should use the validated SqlNode.*


## Brief change log

  - *Use validated SqlNode when converting RTAS*
  - *Add full tests*

## Verifying this change

Many tests (including UT and IT) have been added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
