### PR TITLE
[hotfix] [API/DataStream]: Ensure the proper triggering functionality of ContinuousProcessingTimeTrigger

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
@@ -129,7 +129,6 @@ public class ContinuousProcessingTimeTrigger<W extends Window> extends Trigger<O
      *
      * @param interval The time interval at which to fire.
      * @param <W> The type of {@link Window Windows} on which this trigger can operate.
-     *
      * @deprecated Use {@link #of(Duration)}
      */
     @Deprecated

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/windowing/triggers/ContinuousProcessingTimeTrigger.java
@@ -76,7 +76,11 @@ public class ContinuousProcessingTimeTrigger<W extends Window> extends Trigger<O
 
         if (fireTimestampState.get().equals(time)) {
             fireTimestampState.clear();
-            registerNextFireTimestamp(time == window.maxTimestamp() ? time + 1 : time, window, ctx, fireTimestampState);
+            registerNextFireTimestamp(
+                    time == window.maxTimestamp() ? time + 1 : time,
+                    window,
+                    ctx,
+                    fireTimestampState);
             return TriggerResult.FIRE;
         }
         return TriggerResult.CONTINUE;
@@ -155,8 +159,10 @@ public class ContinuousProcessingTimeTrigger<W extends Window> extends Trigger<O
     private void registerNextFireTimestamp(
             long time, W window, TriggerContext ctx, ReducingState<Long> fireTimestampState)
             throws Exception {
-        long nextFireTimestamp = time > window.maxTimestamp() ?
-                time + interval : Math.min(time + interval, window.maxTimestamp());
+        long nextFireTimestamp =
+                time > window.maxTimestamp()
+                        ? time + interval
+                        : Math.min(time + interval, window.maxTimestamp());
         fireTimestampState.add(nextFireTimestamp);
         ctx.registerProcessingTimeTimer(nextFireTimestamp);
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ContinuousProcessingTimeTriggerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/ContinuousProcessingTimeTriggerTest.java
@@ -226,6 +226,7 @@ class ContinuousProcessingTimeTriggerTest {
         testHarness.processElement(3, 12);
         // Fire window [10, 20), value is 3.
         testHarness.getProcessingTimeService().setCurrentTime(15);
+        expectedOutput.add(new StreamRecord<>(new WindowedInteger(new TimeWindow(0, 10), 9), 9));
         expectedOutput.add(new StreamRecord<>(new WindowedInteger(new TimeWindow(10, 20), 3), 19));
         TestHarnessUtil.assertOutputEquals(
                 "Output mismatch", expectedOutput, testHarness.getOutput());


### PR DESCRIPTION
### **What is the purpose of the change**

This pull request fixes an issue in ContinuousProcessingTimeTrigger that triggered logic failure when processingtime lasted longer than the maximum window time

### **Brief change log**

When “time == window.maxTimestamp()”, increment the time parameter in registerNextFireTimestamp by one based on its original value, keeping it unchanged otherwise.

In registerNextFireTimestamp, when time is greater than window.maxTimestamp(), use time + interval as the next trigger value, otherwise, maintain the original logic.

For example, when processing historical data in the following way, the computation can be guaranteed to trigger every five seconds as expected, without failing to trigger or falling into a loop of continuous triggering:
`datastream
    .window(TumblingEventTimeWindows.of(Time.days(1), Time.hours(-8)))
    .trigger(ContinuousProcessingTimeTriggerCustomer.of(Time.seconds(5)))`


### **Verifying this change**

This change  has been validated with business data and is correct.

### **Does this pull request potentially affect one of the following parts:**

Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @Public(Evolving): no
The serializers: no
The runtime per-record code paths (performance sensitive): no
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
The S3 file system connector: no
### **Documentation**

Does this pull request introduce a new feature? no