### PR TITLE
[FLINK-36025][table] Add the built-in function TO_NUMBER

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -279,7 +279,7 @@ string:
       
       null obj is formated as a string "null".
       
-      format <CHAR | VARCHAR>, obj <ANY>
+      `format <CHAR | VARCHAR>, obj <ANY>`
       
       Returns a STRING representation of the formatted string. `NULL` if format is `NULL` or invalid.
   - sql: TRIM([ BOTH | LEADING | TRAILING ] string1 FROM string2)
@@ -457,6 +457,33 @@ string:
       index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>, exprs <BINARY | VARBINARY>
       
       The result has the type of the least common type of all expressions. `NULL` if index is `NULL` or out of range.
+  - sql: TO_NUMBER(expr, format)
+    table: expr.toNumber(expr, format)
+    description: |
+      Cast string expr to `DECIMAL` using formatting format.
+      
+      Ordering of tokens in format: [ MI | S ] [ L | $ ] [ 0 | 9 | G | , ]* [ D | . ] [ 0 | 9 ]* [ MI | S | PR]
+      
+      (1) 0 or 9: 
+      Specifies an expected digit between 0 and 9. 
+      For consecutive digits, leading 0 to the left of the decimal points indicates that expr must have exactly number of digits as in format, leading 9 indicates that expr may omit these digits.
+      Digits to the right of the decimal indicate the most digits expr may have to the right of the decimal point than format specifies.
+      (2) . or D: 
+      Specifies the position of the decimal point. expr does not need to include a decimal point.
+      (3) , or G: 
+      Specifies the position of the grouping (thousands) separator. 
+      There must be a 0 or 9 to the left and right of each grouping separator. expr must match the grouping separator relevant to the size of the number.
+      (4) L or $: 
+      Specifies the location of the $ currency sign. This character may only be specified once.
+      (5) S or MI:
+      Specifies the position of an optional + or - sign for S, and - only for MI. This directive may be specified only once.
+      (6) PR: 
+      Only allowed at the end of the format string. Specifies that expr indicates a negative number with wrapping angled brackets (<1> is -1).
+      
+      `expr <CHAR | VARCHAR>, format <CHAR | VARCHAR> & <LITERAL NOT NULL>`
+      
+      Returns a `DECIMAL(p, s)` where p is the total number of digits (0 or 9) and s is the number of digits after the decimal point, or 0 if there is none. 
+      `NULL` if format is invalid or expr mismatches format.
 
 temporal:
   - sql: DATE string

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -341,7 +341,7 @@ string:
       
       null obj 被格式化为字符串 "null"。
       
-      strfmt <CHAR | VARCHAR>, obj <ANY>
+      `strfmt <CHAR | VARCHAR>, obj <ANY>`
       
       返回一个 STRING 格式的格式化后的字符串。如果 format 为 `NULL` 或不合法，则返回 `NULL`。
   - sql: TRIM([ BOTH | LEADING | TRAILING ] string1 FROM string2)
@@ -553,6 +553,34 @@ string:
       index <TINYINT | SMALLINT | INTEGER | BIGINT>, expr <BINARY | VARBINARY>, exprs <BINARY | VARBINARY>
       
       结果类型为所有 expr 的公共类型。如果 index 为 `NULL` 或超出范围，则返回 `NULL`。
+  - sql: TO_NUMBER(expr, format)
+    table: expr.toNumber(expr, format)
+    description: |
+      将字符串 expr 根据格式规范 format 转换为 `DECIMAL` 类型。
+  
+      格式规范标准：[ MI | S ] [ L | $ ] [ 0 | 9 | G | , ]* [ D | . ] [ 0 | 9 ]* [ MI | S | PR]
+  
+      (1) 0 或 9：
+      指定期望的 0 到 9 之间的数字。对于连续的数字，小数点左侧的前导 0 表示 expr 必须具有与格式中相同数量的数字，而前导 9 则表示 expr 可以省略这些数字。
+      小数点右侧的数字表示 expr 小数点右侧可能比格式指定的还要多的位数。
+      (2) . 或 D：
+      指定小数点的位置。expr 不一定包含小数点。只能使用一次。
+      (3) , 或 G：
+      指定千位分隔符的位置。
+      每个分隔符的左右两侧都必须有 0 或 9。expr 必须匹配与数字大小相关的分组分隔符。
+      (4) L 或 $：
+      指定货币符号 $ 的位置。只能使用一次。
+      (5) S 或 MI：
+      指定可选的正负号位置，S 允许 + 或 -，而 MI 仅允许 -。只能使用一次。
+      (6) PR：
+      仅允许出现在格式字符串的末尾。指定 expr 使用尖括号包裹来表示负数（如 <1> 代表 -1）。
+      
+      `expr <CHAR | VARCHAR>, format <CHAR | VARCHAR> & <LITERAL NOT NULL>`
+      
+      返回一个 `DECIMAL(p, s)`，其中 p 是总位数（包括 0 或 9），s 是小数点后的位数，如果没有小数点则为 0。
+      如果 format 无效或 expr 与格式不匹配，则返回 `NULL`。
+
+
 
 temporal:
   - sql: DATE string

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -203,6 +203,7 @@ string functions
     Expression.split_index
     Expression.str_to_map
     Expression.elt
+    Expression.to_number
 
 temporal functions
 ------------------

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1431,6 +1431,37 @@ class Expression(Generic[T]):
                      for e in exprs]
         return _ternary_op("elt")(self, expr, to_jarray(gateway.jvm.Object, expr_list))
 
+    def to_number(self, number_format) -> 'Expression':
+        """
+        Cast STRING to DECIMAL using formatting number_format.
+
+        Ordering of tokens in number_format: [ MI | S ] [ L | $ ] [ 0 | 9 | G | , ]* [ D | . ]
+        [ 0 | 9 ]* [ MI | S | PR]
+
+        (1) 0 or 9: Specifies an expected digit between 0 and 9. For consecutive digits, leading
+        0 to the left of the decimal points indicates that expr must have exactly the number of
+        digits as in number_format, leading 9 indicates that expr may omit these digits. Digits to
+        the right of the decimal indicate the most digits expr may have to the right of the decimal
+        point than number_format specifies. (2) . or D: Specifies the position of the decimal point.
+        expr does not need to include a decimal point. (3) , or G: Specifies the position of the
+        grouping (thousands) separator. There must be a 0 or 9 to the left and right of each
+        grouping separator. expr must match the grouping separator relevant to the size of the
+        number. (4) L or $: Specifies the location of the $ currency sign. This character may only
+        be specified once. (5) S or MI: Specifies the position of an optional + or - sign for S,
+        and - only for MI. This directive may be specified only once. (6) PR: Only allowed at the
+        end of the number_format string. Specifies that expr indicates a negative number with
+        wrapping angled brackets (<1> is -1).
+
+        For the returned DECIMAL(p, s), p is the total number of digits (0 or 9) and s is the number
+        of digits after the decimal point, or 0 if there is none. null if number_format is invalid
+        or expr mismatches number_format.
+
+
+        :param number_format: A STRING literal, specifying the expected format of expr.
+        :return: A DECIMAL(p, s).
+        """
+        return _binary_op("toNumber")(self, number_format)
+
     # ---------------------------- temporal functions ----------------------------------
 
     @property

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -175,6 +175,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("ELT(1, a)", str(lit(1).elt(expr1)))
         self.assertEqual('ELT(3, a, b, c)', str(lit(3).elt(expr1, expr2, expr3)))
         self.assertEqual("PRINTF('%d %s', a, b)", str(lit("%d %s").printf(expr1, expr2)))
+        self.assertEqual("TO_NUMBER(a, b)", str(expr1.to_number(expr2)))
 
         # temporal functions
         self.assertEqual('cast(a, DATE)', str(expr1.to_date))

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1433,6 +1433,22 @@ public final class BuiltInFunctionDefinitions {
                     .runtimeClass("org.apache.flink.table.runtime.functions.scalar.EltFunction")
                     .build();
 
+    public static final BuiltInFunctionDefinition TO_NUMBER =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("TO_NUMBER")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Arrays.asList("expr", "format"),
+                                    Arrays.asList(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            and(
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING),
+                                                    LITERAL))))
+                    .outputTypeStrategy(SpecificTypeStrategies.TO_NUMBER)
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.ToNumberFunction")
+                    .build();
     // --------------------------------------------------------------------------------------------
     // Math functions
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -109,6 +109,9 @@ public final class SpecificTypeStrategies {
     /** See {@link ToTimestampLtzTypeStrategy}. */
     public static final TypeStrategy TO_TIMESTAMP_LTZ = new ToTimestampLtzTypeStrategy();
 
+    /** See {@link ToNumberTypeStrategy}. */
+    public static final TypeStrategy TO_NUMBER = new ToNumberTypeStrategy();
+
     /** Type strategy specific for {@link BuiltInFunctionDefinitions#MAP_KEYS}. */
     public static final TypeStrategy MAP_KEYS =
             callContext ->

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToNumberTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ToNumberTypeStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategy;
+import org.apache.flink.table.utils.NumberParser;
+
+import java.util.Optional;
+
+/**
+ * Type strategy of {@link org.apache.flink.table.functions.BuiltInFunctionDefinitions#TO_NUMBER}.
+ *
+ * <p>Infer output type from the format string, return Optional.empty() if type is invalid.
+ */
+@Internal
+public class ToNumberTypeStrategy implements TypeStrategy {
+
+    @Override
+    public Optional<DataType> inferType(CallContext callContext) {
+        if (callContext.isArgumentLiteral(1)) {
+            final String format = callContext.getArgumentValue(1, String.class).get();
+
+            Optional<NumberParser> parser = NumberParser.of(format);
+            if (parser.isPresent()) {
+                return parser.get().getOutputType();
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/NumberParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/NumberParser.java
@@ -1,0 +1,548 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * This class represents a parser to implement the built-in function TO_NUMBER. Inspired from
+ * ToNumberParser in Spark, but returns null instead of throwing an exception for invalid cases.
+ *
+ * <p>It works by consuming an input string and a format string. This class accepts the format
+ * string for construction, and proceeds to iterate through the format string to generate a sequence
+ * of tokens. Then, when the function is called with an input string, this class steps through the
+ * sequence of tokens and compares them against the input string, returning a {@link DecimalData}
+ * object if they match (or null otherwise).
+ */
+public final class NumberParser {
+
+    private static final char ANGLE_BRACKET_CLOSE = '>';
+    private static final char ANGLE_BRACKET_OPEN = '<';
+    private static final char COMMA_LETTER = 'G';
+    private static final char COMMA_SIGN = ',';
+    private static final char DOLLAR_LETTER = 'L';
+    private static final char DOLLAR_SIGN = '$';
+    private static final char MINUS_SIGN = '-';
+    private static final char NINE_DIGIT = '9';
+    private static final char OPTIONAL_PLUS_OR_MINUS_LETTER = 'S';
+    private static final char PLUS_SIGN = '+';
+    private static final char POINT_LETTER = 'D';
+    private static final char POINT_SIGN = '.';
+    private static final char ZERO_DIGIT = '0';
+
+    // OPTIONAL_MINUS_STRING = "MI"
+    private static final char OPTIONAL_MINUS_STRING_START = 'M';
+    private static final char OPTIONAL_MINUS_STRING_END = 'I';
+
+    // WRAPPING_ANGLE_BRACKETS_TO_NEGATIVE_NUMBER = "PR"
+    private static final char WRAPPING_ANGLE_BRACKETS_TO_NEGATIVE_NUMBER_START = 'P';
+    private static final char WRAPPING_ANGLE_BRACKETS_TO_NEGATIVE_NUMBER_END = 'R';
+
+    // This enum class represents one or more characters that we expect to be present in the input
+    // string based on the format string.
+    private enum Token {
+        // Represents exactly 'num' digits (0-9).
+        EXACTLY_AS_MANY_DIGITS,
+        // Represents at most 'num' digits (0-9).
+        AT_MOST_AS_MANY_DIGITS,
+        // See DigitGroup.
+        DIGIT_GROUP,
+        // Represents a decimal point (.).
+        DECIMAL_POINT,
+        // Represents a thousand separator (,).
+        THOUSANDS_SEPARATOR,
+        // Represents a dollar sign ($).
+        DOLLAR_SIGN,
+        // Represents an optional plus sign (+) or minus sign (-).
+        OPTIONAL_PLUS_OR_MINUS_SIGN,
+        // Represents an optional minus sign (-).
+        OPTIONAL_MINUS_SIGN,
+        // Represents an opening angle bracket (<).
+        OPENING_ANGLE_BRACKET,
+        // Represents a closing angle bracket (>).
+        CLOSING_ANGLE_BRACKET,
+        // Represents any unrecognized character other than the above.
+        INVALID_UNRECOGNIZED_CHARACTER
+    }
+
+    // Consecutive digits and thousands separators are combined into a Token.DIGIT_GROUP, this class
+    // is an extension for detailed tokens and digit lengths inside.
+    private static class DigitGroup {
+
+        // Token.EXACTLY_AS_MANY_DIGITS & Token.AT_MOST_AS_MANY_DIGITS & Token.THOUSANDS_SEPARATOR
+        private final List<Token> tokens;
+
+        // digit lengths for Token.EXACTLY_AS_MANY_DIGITS & Token.AT_MOST_AS_MANY_DIGITS
+        // NOTE: tokens.size() and sizes.size() may differ due to Token.THOUSANDS_SEPARATOR
+        private final List<Integer> sizes;
+
+        public DigitGroup(List<Token> tokens, List<Integer> sizes) {
+            this.tokens = new ArrayList<>(tokens);
+            this.sizes = new ArrayList<>(sizes);
+        }
+    }
+
+    // ------------------------------------------------
+
+    private final List<Token> formatTokens;
+    private final List<DigitGroup> digitGroups;
+
+    private int precision;
+    private int scale;
+
+    private final StringBuilder parsedBeforeDecimalPoint;
+    private final StringBuilder parsedAfterDecimalPoint;
+
+    // ------------------------------------------------
+
+    private NumberParser(final String format) {
+        formatTokens = new ArrayList<>();
+        digitGroups = new ArrayList<>();
+        parsedBeforeDecimalPoint = new StringBuilder(precision);
+        parsedAfterDecimalPoint = new StringBuilder(scale);
+        parseFormat(format);
+    }
+
+    public static Optional<NumberParser> of(final String numberFormat) {
+        NumberParser parser = new NumberParser(numberFormat);
+        // return Optional.empty() for invalid format string
+        return parser.isValidFormat() ? Optional.of(parser) : Optional.empty();
+    }
+
+    private void parseFormat(final String format) {
+        List<Token> tokens = new ArrayList<>();
+        List<Integer> digitGroupSizes = new ArrayList<>();
+
+        int len = format.length();
+        boolean reachedDecimalPoint = false;
+
+        for (int i = 0, prevI; i < len; ) {
+            char charValue = format.charAt(i);
+            switch (charValue) {
+                case ZERO_DIGIT:
+                    // consecutive digits with a leading 0
+                    prevI = i++;
+                    while (i < len
+                            && (format.charAt(i) == ZERO_DIGIT || format.charAt(i) == NINE_DIGIT)) {
+                        i++;
+                    }
+                    tokens.add(
+                            reachedDecimalPoint
+                                    ? Token.AT_MOST_AS_MANY_DIGITS
+                                    : Token.EXACTLY_AS_MANY_DIGITS);
+                    digitGroupSizes.add(i - prevI);
+                    precision += i - prevI;
+                    if (reachedDecimalPoint) {
+                        scale += i - prevI;
+                    }
+                    break;
+                case NINE_DIGIT:
+                    // consecutive digits with a leading 9
+                    prevI = i++;
+                    while (i < len
+                            && (format.charAt(i) == ZERO_DIGIT || format.charAt(i) == NINE_DIGIT)) {
+                        i++;
+                    }
+                    tokens.add(Token.AT_MOST_AS_MANY_DIGITS);
+                    digitGroupSizes.add(i - prevI);
+                    precision += i - prevI;
+                    if (reachedDecimalPoint) {
+                        scale += i - prevI;
+                    }
+                    break;
+                case POINT_SIGN:
+                case POINT_LETTER:
+                    tokens.add(Token.DECIMAL_POINT);
+                    reachedDecimalPoint = true;
+                    i++;
+                    break;
+                case COMMA_SIGN:
+                case COMMA_LETTER:
+                    tokens.add(Token.THOUSANDS_SEPARATOR);
+                    i++;
+                    break;
+                case DOLLAR_SIGN:
+                case DOLLAR_LETTER:
+                    tokens.add(Token.DOLLAR_SIGN);
+                    i++;
+                    break;
+                case OPTIONAL_PLUS_OR_MINUS_LETTER:
+                    tokens.add(Token.OPTIONAL_PLUS_OR_MINUS_SIGN);
+                    i++;
+                    break;
+                case OPTIONAL_MINUS_STRING_START:
+                    if (i < len - 1 && format.charAt(i + 1) == OPTIONAL_MINUS_STRING_END) {
+                        tokens.add(Token.OPTIONAL_MINUS_SIGN);
+                        i += 2;
+                        continue;
+                    }
+                    // fall through to default
+                case WRAPPING_ANGLE_BRACKETS_TO_NEGATIVE_NUMBER_START:
+                    if (i < len - 1
+                            && format.charAt(i + 1)
+                                    == WRAPPING_ANGLE_BRACKETS_TO_NEGATIVE_NUMBER_END) {
+                        tokens.add(0, Token.OPENING_ANGLE_BRACKET);
+                        tokens.add(Token.CLOSING_ANGLE_BRACKET);
+                        i += 2;
+                        continue;
+                    }
+                    // fall through to default
+                default:
+                    tokens.add(Token.INVALID_UNRECOGNIZED_CHARACTER);
+                    i++;
+                    break;
+            }
+        }
+        combineIntoDigitGroup(tokens, digitGroupSizes);
+    }
+
+    private void combineIntoDigitGroup(
+            final List<Token> tokens, final List<Integer> digitGroupSizes) {
+        List<Token> currentGroup = new ArrayList<>();
+        List<Integer> currentSize = new ArrayList<>();
+
+        for (int i = 0, j = 0; i < tokens.size(); i++) {
+            Token token = tokens.get(i);
+            if (token == Token.AT_MOST_AS_MANY_DIGITS || token == Token.EXACTLY_AS_MANY_DIGITS) {
+                currentGroup.add(token);
+                currentSize.add(digitGroupSizes.get(j++));
+            } else if (token == Token.THOUSANDS_SEPARATOR) {
+                currentGroup.add(token);
+            } else {
+                if (!currentGroup.isEmpty()) {
+                    formatTokens.add(Token.DIGIT_GROUP);
+                    digitGroups.add(new DigitGroup(currentGroup, currentSize));
+                    currentGroup.clear();
+                    currentSize.clear();
+                }
+                formatTokens.add(token);
+            }
+        }
+
+        if (!currentGroup.isEmpty()) {
+            // handle the last group if it exists
+            formatTokens.add(Token.DIGIT_GROUP);
+            digitGroups.add(new DigitGroup(currentGroup, currentSize));
+        }
+    }
+
+    private boolean isValidFormat() {
+        // Make sure the format string contains at least one digit.
+        if (digitGroups.isEmpty()) {
+            return false;
+        }
+
+        return !hasInvalidThousandsSeparator()
+                && !hasProhibitedDuplicateToken()
+                && !hasDisorderedToken();
+    }
+
+    private boolean hasInvalidThousandsSeparator() {
+        int firstDecimalPointIndex = formatTokens.indexOf(Token.DECIMAL_POINT);
+        int digitGroupsCountBeforeDecimalPoint =
+                firstDecimalPointIndex == -1
+                        ? digitGroups.size()
+                        : (int)
+                                formatTokens.subList(0, firstDecimalPointIndex).stream()
+                                        .filter(token -> token == Token.DIGIT_GROUP)
+                                        .count();
+
+        // Make sure any thousands separators in the format string have digits before and after.
+        for (DigitGroup dg : digitGroups.subList(0, digitGroupsCountBeforeDecimalPoint)) {
+            boolean hasInvalidThousandSeparatorsBeforeDecimal =
+                    IntStream.range(0, dg.tokens.size())
+                            .filter(index -> dg.tokens.get(index) == Token.THOUSANDS_SEPARATOR)
+                            .anyMatch(
+                                    index ->
+                                            (index == 0
+                                                    || index == dg.tokens.size() - 1
+                                                    || dg.tokens.get(index + 1)
+                                                            == Token.THOUSANDS_SEPARATOR));
+            if (hasInvalidThousandSeparatorsBeforeDecimal) {
+                return true;
+            }
+        }
+
+        // Make sure that thousands separators do not appear after the decimal point, if any.
+        return digitGroups.subList(digitGroupsCountBeforeDecimalPoint, digitGroups.size()).stream()
+                .anyMatch(dg -> dg.tokens.contains(Token.THOUSANDS_SEPARATOR));
+    }
+
+    private boolean hasProhibitedDuplicateToken() {
+        // Make sure that the format string does not contain any prohibited duplicate tokens.
+        List<Token> prohibitedDuplicates =
+                Arrays.asList(
+                        Token.DECIMAL_POINT,
+                        Token.OPTIONAL_PLUS_OR_MINUS_SIGN,
+                        Token.DOLLAR_SIGN,
+                        Token.OPTIONAL_MINUS_SIGN,
+                        Token.CLOSING_ANGLE_BRACKET);
+        return formatTokens.stream()
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+                .entrySet()
+                .stream()
+                .anyMatch(
+                        entry ->
+                                prohibitedDuplicates.contains(entry.getKey())
+                                        && entry.getValue() > 1);
+    }
+
+    private boolean hasDisorderedToken() {
+        // Ordering of tokens:
+        // [ MI | S ]
+        // [ L | $ ]
+        // [ 0 | 9 | G | , ]*
+        // [ D | . ]
+        // [ 0 | 9 ]*
+        // [ MI | S | PR]
+        List<List<Token>> allowedFormatTokens =
+                Arrays.asList(
+                        Arrays.asList(Token.OPENING_ANGLE_BRACKET),
+                        Arrays.asList(Token.OPTIONAL_MINUS_SIGN, Token.OPTIONAL_PLUS_OR_MINUS_SIGN),
+                        Arrays.asList(Token.DOLLAR_SIGN),
+                        Arrays.asList(Token.DIGIT_GROUP),
+                        Arrays.asList(Token.DECIMAL_POINT),
+                        Arrays.asList(Token.DIGIT_GROUP),
+                        Arrays.asList(
+                                Token.OPTIONAL_MINUS_SIGN,
+                                Token.OPTIONAL_PLUS_OR_MINUS_SIGN,
+                                Token.CLOSING_ANGLE_BRACKET));
+
+        int formatTokenIndex = 0;
+        for (List<Token> allowed : allowedFormatTokens) {
+            if (formatTokenIndex < formatTokens.size()
+                    && allowed.contains(formatTokens.get(formatTokenIndex))) {
+                formatTokenIndex++;
+            }
+        }
+        return formatTokenIndex != formatTokens.size();
+    }
+
+    public Optional<DataType> getOutputType() {
+        try {
+            return Optional.of(DataTypes.DECIMAL(precision, scale));
+        } catch (Throwable t) {
+            return Optional.empty();
+        }
+    }
+
+    public DecimalData parse(StringData expr) {
+        String str = expr.toString();
+        int strLength = str.length();
+
+        if (strLength == 0) {
+            return null;
+        }
+
+        parsedBeforeDecimalPoint.setLength(0);
+        parsedAfterDecimalPoint.setLength(0);
+        boolean reachedDecimalPoint = false;
+        boolean unmatchedOpeningAngleBracket = false;
+        boolean negateResult = false;
+        int strIndex = 0;
+        int formatIndex = 0;
+        int digitGroupIndex = 0;
+
+        while (formatIndex < formatTokens.size()) {
+            Token token = formatTokens.get(formatIndex);
+            Character ch = (strIndex < strLength) ? str.charAt(strIndex) : null;
+
+            switch (token) {
+                case DIGIT_GROUP:
+                    if (ch == null && !reachedDecimalPoint) {
+                        return null;
+                    }
+                    strIndex =
+                            parseDigitGroup(
+                                    digitGroups.get(digitGroupIndex),
+                                    str,
+                                    strIndex,
+                                    reachedDecimalPoint);
+                    if (strIndex == -1) {
+                        return null;
+                    }
+                    digitGroupIndex++;
+                    break;
+                case DECIMAL_POINT:
+                    // optional
+                    reachedDecimalPoint = true;
+                    if (ch != null && ch.equals(POINT_SIGN)) {
+                        strIndex++;
+                    }
+                    break;
+                case DOLLAR_SIGN:
+                    // essential
+                    if (ch != null && ch.equals(DOLLAR_SIGN)) {
+                        strIndex++;
+                    } else {
+                        return null;
+                    }
+                    break;
+                case OPTIONAL_PLUS_OR_MINUS_SIGN:
+                    if (ch != null) {
+                        if (ch.equals(PLUS_SIGN)) {
+                            strIndex++;
+                        } else if (ch.equals(MINUS_SIGN)) {
+                            negateResult = !negateResult;
+                            strIndex++;
+                        }
+                    }
+                    break;
+                case OPTIONAL_MINUS_SIGN:
+                    if (ch != null && ch.equals(MINUS_SIGN)) {
+                        negateResult = !negateResult;
+                        strIndex++;
+                    }
+                    break;
+                case OPENING_ANGLE_BRACKET:
+                    // ch is null only if str is empty since OPENING_ANGLE_BRACKET will only appears
+                    // at the beginning of formatTokens.
+                    if (ch.equals(ANGLE_BRACKET_OPEN)) {
+                        unmatchedOpeningAngleBracket = true;
+                        strIndex++;
+                    }
+                    break;
+                case CLOSING_ANGLE_BRACKET:
+                    // optional
+                    if (ch != null && ch.equals(ANGLE_BRACKET_CLOSE)) {
+                        if (!unmatchedOpeningAngleBracket) {
+                            return null;
+                        }
+                        unmatchedOpeningAngleBracket = false;
+                        negateResult = !negateResult;
+                        strIndex++;
+                    }
+                    break;
+            }
+            formatIndex++;
+        }
+
+        if (strIndex < strLength || unmatchedOpeningAngleBracket) {
+            return null;
+        }
+
+        return parseResultToDecimalValue(negateResult);
+    }
+
+    private int parseDigitGroup(
+            DigitGroup digitGroup, String str, int strIndex, boolean reachedDecimalPoint) {
+        int strLength = str.length();
+
+        int parsedDigitsNumInCurrentGroup = 0;
+        List<Integer> parsedDigitGroupSizes = new ArrayList<>();
+        for (; strIndex < strLength; strIndex++) {
+            char character = str.charAt(strIndex);
+            if (Character.isDigit(character)) {
+                parsedDigitsNumInCurrentGroup++;
+                // Append each group of input digits to the appropriate
+                // before/parsedAfterDecimalPoint
+                // StringBuilder for later use in constructing the result Decimal value.
+                if (reachedDecimalPoint) {
+                    parsedAfterDecimalPoint.append(character);
+                } else {
+                    parsedBeforeDecimalPoint.append(character);
+                }
+            } else if (character == COMMA_SIGN) {
+                parsedDigitGroupSizes.add(parsedDigitsNumInCurrentGroup);
+                parsedDigitsNumInCurrentGroup = 0;
+            } else if (!Character.isWhitespace(character)) {
+                // Ignore whitespace and keep advancing through the input string.
+                parsedDigitGroupSizes.add(parsedDigitsNumInCurrentGroup);
+                break;
+            }
+        }
+
+        if (strIndex == strLength) {
+            // handle the last group if it exists
+            parsedDigitGroupSizes.add(parsedDigitsNumInCurrentGroup);
+        }
+
+        return isActualDigitsAsExpected(parsedDigitGroupSizes, digitGroup) ? strIndex : -1;
+    }
+
+    private boolean isActualDigitsAsExpected(
+            List<Integer> actualDigitsSizes, DigitGroup expectedDigitGroup) {
+        if (actualDigitsSizes.size() > expectedDigitGroup.sizes.size()) {
+            return false;
+        }
+
+        // Traverse from the end so that leading Token.AT_MOST_AS_MANY_DIGITS can be omitted.
+        int actualIndexDiff = actualDigitsSizes.size() - expectedDigitGroup.tokens.size();
+        int expectedIndexDiff = expectedDigitGroup.sizes.size() - expectedDigitGroup.tokens.size();
+        for (int tokenIndex = expectedDigitGroup.tokens.size() - 1; tokenIndex >= 0; tokenIndex--) {
+            Token expectedToken = expectedDigitGroup.tokens.get(tokenIndex);
+            if (expectedToken == Token.THOUSANDS_SEPARATOR) {
+                actualIndexDiff++;
+                expectedIndexDiff++;
+                continue;
+            }
+
+            int actualSize =
+                    (tokenIndex + actualIndexDiff >= 0)
+                            ? actualDigitsSizes.get(tokenIndex + actualIndexDiff)
+                            : 0;
+            int expectedSize = expectedDigitGroup.sizes.get(tokenIndex + expectedIndexDiff);
+
+            if (expectedToken == Token.EXACTLY_AS_MANY_DIGITS && actualSize != expectedSize) {
+                return false;
+            } else if (expectedToken == Token.AT_MOST_AS_MANY_DIGITS && actualSize > expectedSize) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private DecimalData parseResultToDecimalValue(boolean negateResult) {
+        // Append zeros to parsedAfterDecimalPoint to match the scale defined by the format string.
+        for (int i = scale - parsedAfterDecimalPoint.length(); i > 0; i--) {
+            parsedAfterDecimalPoint.append('0');
+        }
+
+        // Construct the full decimal string, including optional negative sign and decimal point.
+        String numStr =
+                (negateResult ? "-" : "")
+                        + parsedBeforeDecimalPoint
+                        + (scale == 0 ? "" : ".")
+                        + parsedAfterDecimalPoint;
+
+        java.math.BigDecimal javaDecimal = new java.math.BigDecimal(numStr);
+
+        // Determine how to construct the final Decimal object based on its size.
+        // DecimalData.MAX_LONG_DIGITS = 18
+        if (precision <= 18) {
+            // Use long value if possible.
+            return DecimalData.fromUnscaledLong(
+                    javaDecimal.unscaledValue().longValue(), precision, scale);
+        } else {
+            // Use BigInteger for larger values.
+            return DecimalData.fromBigDecimal(javaDecimal, precision, scale);
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/NumberParser.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/NumberParser.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.utils;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.StringData;
@@ -41,6 +42,7 @@ import java.util.stream.IntStream;
  * sequence of tokens and compares them against the input string, returning a {@link DecimalData}
  * object if they match (or null otherwise).
  */
+@Internal
 public final class NumberParser {
 
     private static final char ANGLE_BRACKET_CLOSE = '>';

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/NumberParserTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/NumberParserTest.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link NumberParser}. */
+class NumberParserTest {
+
+    @Test
+    void testOfInvalidFormat() {
+        // without digits
+        assertThat(NumberParser.of("")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("$")).isEqualTo(Optional.empty());
+
+        // invalid thousands separator
+        assertThat(NumberParser.of("000,000,.")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of(",000")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("L,000")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000,,000")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000.000,000")).isEqualTo(Optional.empty());
+
+        // prohibited duplicate tokens
+        assertThat(NumberParser.of("000.0D00")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("S000000S")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("$000,000L")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("MI000,000MI")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000,000PRPR")).isEqualTo(Optional.empty());
+
+        // disordering
+        assertThat(NumberParser.of("$MI000")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("$S000")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000$")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("PR000,000")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000S.00")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000MI.00")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000PR.00")).isEqualTo(Optional.empty());
+
+        // conflicted tokens
+        assertThat(NumberParser.of("MIS000")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000PRS")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000MIPR")).isEqualTo(Optional.empty());
+
+        // invalid token
+        assertThat(NumberParser.of("000B")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000E")).isEqualTo(Optional.empty());
+
+        // incomplete token of "MI" & "PR"
+        assertThat(NumberParser.of("000P")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000PPR")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("M000")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("ML000")).isEqualTo(Optional.empty());
+        assertThat(NumberParser.of("000M")).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    void testGetOutputType() {
+        // invalid type
+        assertThat(
+                        NumberParser.of("0999999999,0999999999,0999999999,0999999999")
+                                .get()
+                                .getOutputType())
+                .isEqualTo(Optional.empty());
+
+        // valid type
+        assertThat(NumberParser.of("S$999,099G999.90PR").get().getOutputType().get())
+                .isEqualTo(DataTypes.DECIMAL(11, 2));
+        assertThat(NumberParser.of("999999PR").get().getOutputType().get())
+                .isEqualTo(DataTypes.DECIMAL(6, 0));
+        assertThat(NumberParser.of("99D99").get().getOutputType().get())
+                .isEqualTo(DataTypes.DECIMAL(4, 2));
+        assertThat(NumberParser.of("L999.99").get().getOutputType().get())
+                .isEqualTo(DataTypes.DECIMAL(5, 2));
+        assertThat(NumberParser.of(".99").get().getOutputType().get())
+                .isEqualTo(DataTypes.DECIMAL(2, 2));
+        assertThat(NumberParser.of("L999D").get().getOutputType().get())
+                .isEqualTo(DataTypes.DECIMAL(3, 0));
+    }
+
+    @Test
+    void testParseMismatching() {
+        // empty input
+        assertThat(NumberParser.of("$000").get().parse(BinaryStringData.fromString("")))
+                .isEqualTo(null);
+
+        // DIGIT_GROUP
+        // null character
+        assertThat(NumberParser.of("L999").get().parse(BinaryStringData.fromString("$")))
+                .isEqualTo(null);
+        // invalid character
+        assertThat(NumberParser.of("000").get().parse(BinaryStringData.fromString("$12")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("0D0").get().parse(BinaryStringData.fromString("1D2")))
+                .isEqualTo(null);
+        // DigitGroup size mismatch
+        assertThat(NumberParser.of("900").get().parse(BinaryStringData.fromString("1234")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("900").get().parse(BinaryStringData.fromString("123,456")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("0,9").get().parse(BinaryStringData.fromString("12")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("09").get().parse(BinaryStringData.fromString("1")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("099,099").get().parse(BinaryStringData.fromString("123")))
+                .isEqualTo(null);
+
+        // DECIMAL_POINT
+        assertThat(NumberParser.of("900.00").get().parse(BinaryStringData.fromString("12-")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("900").get().parse(BinaryStringData.fromString("12.")))
+                .isEqualTo(null);
+
+        // DOLLAR_SIGN
+        assertThat(NumberParser.of("L999.99").get().parse(BinaryStringData.fromString("123.45")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("SL999.99").get().parse(BinaryStringData.fromString("-")))
+                .isEqualTo(null);
+
+        // OPTIONAL_PLUS_OR_MINUS_SIGN
+        assertThat(NumberParser.of("SL999.99").get().parse(BinaryStringData.fromString("123.45")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("999.99S").get().parse(BinaryStringData.fromString("1.2$")))
+                .isEqualTo(null);
+
+        // OPTIONAL_MINUS_SIGN
+        assertThat(NumberParser.of("MIL999.99").get().parse(BinaryStringData.fromString("1.2")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("999.99MI").get().parse(BinaryStringData.fromString("1.2$")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("999.99MI").get().parse(BinaryStringData.fromString("1.2+")))
+                .isEqualTo(null);
+
+        // ANGLE_BRACKET
+        assertThat(
+                        NumberParser.of("999.99PR")
+                                .get()
+                                .parse(BinaryStringData.fromString("<<123.45>>")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("999.99PR").get().parse(BinaryStringData.fromString("123.45>")))
+                .isEqualTo(null);
+        assertThat(NumberParser.of("999.99PR").get().parse(BinaryStringData.fromString("<123.45")))
+                .isEqualTo(null);
+
+        // not enough token
+        assertThat(NumberParser.of("000").get().parse(BinaryStringData.fromString("123.45")))
+                .isEqualTo(null);
+    }
+
+    @Test
+    void testParseMatching() {
+        // DIGIT_GROUP
+        // white space
+        assertThat(
+                        NumberParser.of("099.099")
+                                .get()
+                                .parse(BinaryStringData.fromString("1 2  3.4\n5\f6")))
+                .isEqualTo(DecimalData.fromUnscaledLong(123456L, 6, 3));
+        assertThat(NumberParser.of("900.99").get().parse(BinaryStringData.fromString("123 ")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12300L, 5, 2));
+        assertThat(NumberParser.of("9099").get().parse(BinaryStringData.fromString("  123 ")))
+                .isEqualTo(DecimalData.fromUnscaledLong(123L, 4, 0));
+        // AT_MOST_AS_MANY_DIGITS
+        assertThat(NumberParser.of("999.999").get().parse(BinaryStringData.fromString("123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(123450L, 6, 3));
+        assertThat(
+                        NumberParser.of("999,999.999")
+                                .get()
+                                .parse(BinaryStringData.fromString("123.456")))
+                .isEqualTo(DecimalData.fromUnscaledLong(123456L, 9, 3));
+        assertThat(NumberParser.of("900,099").get().parse(BinaryStringData.fromString("123")))
+                .isEqualTo(DecimalData.fromUnscaledLong(123L, 6, 0));
+        assertThat(NumberParser.of("999.99").get().parse(BinaryStringData.fromString("12")))
+                .isEqualTo(DecimalData.fromUnscaledLong(1200L, 5, 2));
+
+        // DECIMAL_POINT
+        assertThat(NumberParser.of("900.90").get().parse(BinaryStringData.fromString(".1")))
+                .isEqualTo(DecimalData.fromUnscaledLong(10L, 2, 2));
+        assertThat(NumberParser.of("099.").get().parse(BinaryStringData.fromString("123")))
+                .isEqualTo(DecimalData.fromUnscaledLong(123L, 3, 0));
+        assertThat(NumberParser.of("099.99").get().parse(BinaryStringData.fromString("123.")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12300L, 5, 2));
+
+        // DOLLAR_SIGN
+        assertThat(NumberParser.of("L999.99").get().parse(BinaryStringData.fromString("$123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345L, 5, 2));
+
+        // OPTIONAL_PLUS_OR_MINUS_SIGN
+        assertThat(NumberParser.of("S999.99").get().parse(BinaryStringData.fromString("-123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(-12345L, 5, 2));
+        assertThat(NumberParser.of("999.99S").get().parse(BinaryStringData.fromString("123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345L, 5, 2));
+        assertThat(NumberParser.of("S999.99").get().parse(BinaryStringData.fromString("123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345L, 5, 2));
+        assertThat(NumberParser.of("S999.99").get().parse(BinaryStringData.fromString("+123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345L, 5, 2));
+
+        // OPTIONAL_MINUS_SIGN
+        assertThat(NumberParser.of("MI999.99").get().parse(BinaryStringData.fromString("-123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(-12345L, 5, 2));
+        assertThat(NumberParser.of("MI999.99").get().parse(BinaryStringData.fromString("123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345L, 5, 2));
+        assertThat(NumberParser.of("999.99MI").get().parse(BinaryStringData.fromString("123.45-")))
+                .isEqualTo(DecimalData.fromUnscaledLong(-12345L, 5, 2));
+        assertThat(NumberParser.of("999.99MI").get().parse(BinaryStringData.fromString("123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345L, 5, 2));
+
+        // ANGLE_BRACKET
+        assertThat(NumberParser.of("999.99PR").get().parse(BinaryStringData.fromString("<123.45>")))
+                .isEqualTo(DecimalData.fromUnscaledLong(-12345L, 5, 2));
+        assertThat(NumberParser.of("999.99PR").get().parse(BinaryStringData.fromString("123.45")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345L, 5, 2));
+    }
+
+    @Test
+    void testParseResultToDecimalValue() {
+        // append zeros
+        assertThat(
+                        NumberParser.of("S$999,099G999.90PR")
+                                .get()
+                                .parse(BinaryStringData.fromString("<-$123,456,789.0>")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345678900L, 11, 2));
+        assertThat(
+                        NumberParser.of("S$999,099G999.00PR")
+                                .get()
+                                .parse(BinaryStringData.fromString("<-$123,456,789>")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345678900L, 11, 2));
+
+        // multiple minus sign
+        assertThat(
+                        NumberParser.of("S999,000.99PR")
+                                .get()
+                                .parse(BinaryStringData.fromString("<-123,456.78>")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345678L, 8, 2));
+        assertThat(
+                        NumberParser.of("S999,000.99MI")
+                                .get()
+                                .parse(BinaryStringData.fromString("-123,456.78-")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345678L, 8, 2));
+        assertThat(
+                        NumberParser.of("MI999,000.99PR")
+                                .get()
+                                .parse(BinaryStringData.fromString("<-123,456.78>")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345678L, 8, 2));
+
+        // fromUnscaledLong
+        assertThat(
+                        NumberParser.of("999,000.99")
+                                .get()
+                                .parse(BinaryStringData.fromString("123,456.78")))
+                .isEqualTo(DecimalData.fromUnscaledLong(12345678L, 8, 2));
+
+        // fromBigDecimal
+        assertThat(
+                        NumberParser.of("999,999,999,999,999,999,999")
+                                .get()
+                                .parse(BinaryStringData.fromString("123,456,789,123,456,789,123")))
+                .isEqualTo(
+                        DecimalData.fromBigDecimal(new BigDecimal("123456789123456789123"), 21, 0));
+        assertThat(
+                        NumberParser.of("0999999999,0999999999,0999999999,0999999999")
+                                .get()
+                                .parse(
+                                        BinaryStringData.fromString(
+                                                "9999999999,0999999999,0999999999,0999999999")))
+                .isEqualTo(
+                        DecimalData.fromBigDecimal(
+                                new BigDecimal("9999999999099999999909999999990999999999"), 40, 0));
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ToNumberFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ToNumberFunction.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.utils.NumberParser;
+import org.apache.flink.table.utils.ThreadLocalCache;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#TO_NUMBER}. */
+@Internal
+public class ToNumberFunction extends BuiltInScalarFunction {
+
+    private static final ThreadLocalCache<String, Optional<NumberParser>> NUMBER_PARSER_CACHE =
+            new ThreadLocalCache<String, Optional<NumberParser>>() {
+                @Override
+                public Optional<NumberParser> getNewInstance(String key) {
+                    return NumberParser.of(key);
+                }
+            };
+
+    public ToNumberFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.TO_NUMBER, context);
+    }
+
+    public @Nullable DecimalData eval(@Nullable StringData expr, StringData format) {
+        if (expr == null) {
+            return null;
+        }
+        Optional<NumberParser> parser = NUMBER_PARSER_CACHE.get(format.toString());
+        return parser.map(numberParser -> numberParser.parse(expr)).orElse(null);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the built-in function TO_NUMBER.
Examples:
```SQL
-- The format expects:
--  * an optional sign at the beginning,
--  * followed by a dollar sign,
--  * followed by a number between 3 and 6 digits long,
--  * thousands separators,
--  * up to two dight beyond the decimal point.
> SELECT TO_NUMBER('-$12,345.67', 'S$999,099.99');
 -12345.67

-- Plus is optional, and so are fractional digits.
> SELECT TO_NUMBER('$345', 'S$999,099.99');
 345.00

-- The format requires at least three digits.
> SELECT TO_NUMBER('$45', 'S$999,099.99');
 NULL

-- The format requires at least three digits
> SELECT TO_NUMBER('$045', 'S$999,099.99');
 45.00

-- Using brackets to denote negative values
> SELECT TO_NUMBER('<1234>', '999999PR');
 -1234
```

## Brief change log

- [FLINK-36025](https://issues.apache.org/jira/browse/FLINK-36025)
- Add `ToNumberTypeStrategy`
- Add `NumberParser`
- Fix doc issue of function PRINTF

## Verifying this change

- `StringFunctionsITCase#toNumberTestCases`
- `TypeStrategiesTest#testData`
- `NumberParserTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
