### PR TITLE
[hotfix][API/DataStream] Log the right syncDurationMillis time

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -760,6 +760,8 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
             checkpointStorage.clearCacheFor(checkpointId);
         }
 
+        checkpointMetrics.setSyncDurationMillis((System.nanoTime() - started) / 1_000_000);
+
         LOG.debug(
                 "{} - finished synchronous part of checkpoint {}. Alignment duration: {} ms, snapshot duration {} ms, is unaligned checkpoint : {}",
                 taskName,
@@ -768,7 +770,6 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
                 checkpointMetrics.getSyncDurationMillis(),
                 checkpointOptions.isUnalignedCheckpoint());
 
-        checkpointMetrics.setSyncDurationMillis((System.nanoTime() - started) / 1_000_000);
         return true;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*Fix the wrong log info for the var syncDurationMillis.*


## Brief change log

  - *Move the set function before the log so that the var syncDurationMillis is set.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
