### PR TITLE
(1.19 backport) [FLINK-35886][task] Fix watermark idleness timeout accounting when subtask is backpressured/blocked

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkGeneratorSupplier.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkGeneratorSupplier.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.common.eventtime;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.clock.RelativeClock;
 
 import java.io.Serializable;
 
@@ -39,7 +40,7 @@ public interface WatermarkGeneratorSupplier<T> extends Serializable {
 
     /**
      * Additional information available to {@link #createWatermarkGenerator(Context)}. This can be
-     * access to {@link org.apache.flink.metrics.MetricGroup MetricGroups}, for example.
+     * access to {@link MetricGroup MetricGroups}, for example.
      */
     interface Context {
 
@@ -54,5 +55,14 @@ public interface WatermarkGeneratorSupplier<T> extends Serializable {
          * @see MetricGroup
          */
         MetricGroup getMetricGroup();
+
+        /**
+         * Returns a {@link RelativeClock} that hides periods when input was not active and {@link
+         * WatermarkGenerator} could not have been executed due to execution being blocked by the
+         * runtime. For example a backpressure or watermark alignment blocking the progress.
+         *
+         * @see RelativeClock
+         */
+        RelativeClock getInputActivityClock();
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkStrategyWithIdleness.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkStrategyWithIdleness.java
@@ -42,7 +42,9 @@ final class WatermarkStrategyWithIdleness<T> implements WatermarkStrategy<T> {
     public WatermarkGenerator<T> createWatermarkGenerator(
             WatermarkGeneratorSupplier.Context context) {
         return new WatermarksWithIdleness<>(
-                baseStrategy.createWatermarkGenerator(context), idlenessTimeout);
+                baseStrategy.createWatermarkGenerator(context),
+                idlenessTimeout,
+                context.getInputActivityClock());
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarksWithIdleness.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarksWithIdleness.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.eventtime;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.RelativeClock;
 import org.apache.flink.util.clock.SystemClock;
 
 import java.time.Duration;
@@ -43,18 +44,26 @@ public class WatermarksWithIdleness<T> implements WatermarkGenerator<T> {
     private boolean isIdleNow = false;
 
     /**
+     * This is not used anymore, but it's technically part of the {@link Public} API. Please use
+     * {@link #WatermarksWithIdleness(WatermarkGenerator, Duration, RelativeClock)} instead.
+     */
+    @Deprecated
+    public WatermarksWithIdleness(WatermarkGenerator<T> watermarks, Duration idleTimeout) {
+        this(watermarks, idleTimeout, SystemClock.getInstance());
+    }
+
+    /**
      * Creates a new WatermarksWithIdleness generator to the given generator idleness detection with
      * the given timeout.
      *
      * @param watermarks The original watermark generator.
      * @param idleTimeout The timeout for the idleness detection.
+     * @param clock The clock that will be used to measure idleness period. It is expected that this
+     *     clock will hide periods when this {@link WatermarkGenerator} has been blocked from making
+     *     any progress despite availability of records on the input.
      */
-    public WatermarksWithIdleness(WatermarkGenerator<T> watermarks, Duration idleTimeout) {
-        this(watermarks, idleTimeout, SystemClock.getInstance());
-    }
-
-    @VisibleForTesting
-    WatermarksWithIdleness(WatermarkGenerator<T> watermarks, Duration idleTimeout, Clock clock) {
+    public WatermarksWithIdleness(
+            WatermarkGenerator<T> watermarks, Duration idleTimeout, RelativeClock clock) {
         checkNotNull(idleTimeout, "idleTimeout");
         checkArgument(
                 !(idleTimeout.isZero() || idleTimeout.isNegative()),
@@ -88,7 +97,7 @@ public class WatermarksWithIdleness<T> implements WatermarkGenerator<T> {
     static final class IdlenessTimer {
 
         /** The clock used to measure elapsed time. */
-        private final Clock clock;
+        private final RelativeClock clock;
 
         /** Counter to detect change. No problem if it overflows. */
         private long counter;
@@ -105,7 +114,7 @@ public class WatermarksWithIdleness<T> implements WatermarkGenerator<T> {
         /** The duration before the output is marked as idle. */
         private final long maxIdleTimeNanos;
 
-        IdlenessTimer(Clock clock, Duration idleTimeout) {
+        IdlenessTimer(RelativeClock clock, Duration idleTimeout) {
             this.clock = clock;
 
             long idleNanos;

--- a/flink-core/src/main/java/org/apache/flink/util/clock/Clock.java
+++ b/flink-core/src/main/java/org/apache/flink/util/clock/Clock.java
@@ -37,7 +37,7 @@ import org.apache.flink.annotation.PublicEvolving;
  * the system clock, so it never jumps. Relative time behaves similar to {@link System#nanoTime()}.
  */
 @PublicEvolving
-public abstract class Clock {
+public abstract class Clock implements RelativeClock {
 
     /** Gets the current absolute time, in milliseconds. */
     public abstract long absoluteTimeMillis();

--- a/flink-core/src/main/java/org/apache/flink/util/clock/RelativeClock.java
+++ b/flink-core/src/main/java/org/apache/flink/util/clock/RelativeClock.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.clock;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * A clock that gives access to relative time, similar to System#nanoTime(), however the progress of
+ * the relative time doesn't have to reflect the progress of a wall clock. Concrete classes can
+ * specify a different contract in that regard. Returned time must be monotonically increasing.
+ */
+@PublicEvolving
+public interface RelativeClock {
+    /** Gets the current relative time, in milliseconds. */
+    long relativeTimeMillis();
+
+    /** Gets the current relative time, in nanoseconds. */
+    long relativeTimeNanos();
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkStrategyTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkStrategyTest.java
@@ -20,18 +20,15 @@ package org.apache.flink.api.common.eventtime;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.ClosureCleaner;
-import org.apache.flink.metrics.CharacterFilter;
-import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.Gauge;
-import org.apache.flink.metrics.Histogram;
-import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.util.clock.RelativeClock;
+import org.apache.flink.util.clock.SystemClock;
 
 import org.junit.Test;
 
 import java.io.Serializable;
 import java.time.Duration;
-import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -188,82 +185,20 @@ public class WatermarkStrategyTest {
     }
 
     static TimestampAssignerSupplier.Context assignerContext() {
-        return new TimestampAssignerSupplier.Context() {
-            @Override
-            public MetricGroup getMetricGroup() {
-                return new DummyMetricGroup();
-            }
-        };
+        return UnregisteredMetricsGroup::new;
     }
 
     static WatermarkGeneratorSupplier.Context generatorContext() {
         return new WatermarkGeneratorSupplier.Context() {
             @Override
             public MetricGroup getMetricGroup() {
-                return new DummyMetricGroup();
+                return new UnregisteredMetricsGroup();
+            }
+
+            @Override
+            public RelativeClock getInputActivityClock() {
+                return SystemClock.getInstance();
             }
         };
-    }
-
-    /**
-     * A dummy {@link MetricGroup} to be used when a group is required as an argument but not
-     * actually used.
-     */
-    public static class DummyMetricGroup implements MetricGroup {
-
-        @Override
-        public Counter counter(String name) {
-            return null;
-        }
-
-        @Override
-        public <C extends Counter> C counter(String name, C counter) {
-            return null;
-        }
-
-        @Override
-        public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
-            return null;
-        }
-
-        @Override
-        public <H extends Histogram> H histogram(String name, H histogram) {
-            return null;
-        }
-
-        @Override
-        public <M extends Meter> M meter(String name, M meter) {
-            return null;
-        }
-
-        @Override
-        public MetricGroup addGroup(String name) {
-            return null;
-        }
-
-        @Override
-        public MetricGroup addGroup(String key, String value) {
-            return null;
-        }
-
-        @Override
-        public String[] getScopeComponents() {
-            return new String[0];
-        }
-
-        @Override
-        public Map<String, String> getAllVariables() {
-            return null;
-        }
-
-        @Override
-        public String getMetricIdentifier(String metricName) {
-            return null;
-        }
-
-        @Override
-        public String getMetricIdentifier(String metricName, CharacterFilter filter) {
-            return null;
-        }
     }
 }

--- a/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestSourceFunction.java
+++ b/flink-end-to-end-tests/flink-sql-client-test/src/main/java/org/apache/flink/table/toolbox/TestSourceFunction.java
@@ -20,13 +20,17 @@ package org.apache.flink.table.toolbox;
 
 import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.util.clock.RelativeClock;
+import org.apache.flink.util.clock.SystemClock;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,7 +64,18 @@ public class TestSourceFunction implements SourceFunction<RowData> {
     @Override
     public void run(SourceContext<RowData> ctx) {
         WatermarkGenerator<RowData> generator =
-                watermarkStrategy.createWatermarkGenerator(() -> null);
+                watermarkStrategy.createWatermarkGenerator(
+                        new WatermarkGeneratorSupplier.Context() {
+                            @Override
+                            public MetricGroup getMetricGroup() {
+                                return null;
+                            }
+
+                            @Override
+                            public RelativeClock getInputActivityClock() {
+                                return SystemClock.getInstance();
+                            }
+                        });
         WatermarkOutput output = new TestWatermarkOutput(ctx);
 
         int rowDataSize = DATA.get(0).size();

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/NeverFireProcessingTimeService.java
@@ -19,6 +19,8 @@ package org.apache.flink.state.api.runtime;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.runtime.tasks.TimerService;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
 import java.util.concurrent.CompletableFuture;
@@ -33,8 +35,8 @@ public final class NeverFireProcessingTimeService implements TimerService {
     private AtomicBoolean shutdown = new AtomicBoolean(true);
 
     @Override
-    public long getCurrentProcessingTime() {
-        return System.currentTimeMillis();
+    public Clock getClock() {
+        return SystemClock.getInstance();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -302,6 +302,16 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         return mailboxSize;
     }
 
+    public void registerBackPressureListener(TimerGauge.StartStopListener backPressureListener) {
+        hardBackPressuredTimePerSecond.registerListener(backPressureListener);
+        softBackPressuredTimePerSecond.registerListener(backPressureListener);
+    }
+
+    public void unregisterBackPressureListener(TimerGauge.StartStopListener backPressureListener) {
+        hardBackPressuredTimePerSecond.unregisterListener(backPressureListener);
+        softBackPressuredTimePerSecond.unregisterListener(backPressureListener);
+    }
+
     // ============================================================================================
     // Metric Reuse
     // ============================================================================================

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.eventtime.WatermarkStrategyTest.DummyMetricGroup;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphCheckpointPlanCalculatorContext;
@@ -500,7 +500,7 @@ class CheckpointCoordinatorMasterHooksTest {
                         new ExecutionGraphCheckpointPlanCalculatorContext(graph),
                         graph.getVerticesTopologically(),
                         false),
-                new CheckpointStatsTracker(1, new DummyMetricGroup(), new JobID()));
+                new CheckpointStatsTracker(1, new UnregisteredMetricsGroup(), new JobID()));
     }
 
     private static <T> T mockGeneric(Class<?> clazz) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -19,11 +19,11 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.eventtime.WatermarkStrategyTest.DummyMetricGroup;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
@@ -781,7 +781,7 @@ public class CheckpointCoordinatorTestingUtils {
         private boolean allowCheckpointsAfterTasksFinished;
 
         private CheckpointStatsTracker checkpointStatsTracker =
-                new CheckpointStatsTracker(1, new DummyMetricGroup(), new JobID());
+                new CheckpointStatsTracker(1, new UnregisteredMetricsGroup(), new JobID());
 
         private BiFunction<
                         Set<ExecutionJobVertex>,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -663,6 +663,11 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         }
     }
 
+    @Override
+    public void splitFinished(String splitId) {
+        splitCurrentWatermarks.remove(splitId);
+    }
+
     /**
      * Finds the splits that are beyond the current max watermark and pauses them. At the same time,
      * splits that have been paused and where the global watermark caught up are resumed.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/NoOpTimestampsAndWatermarks.java
@@ -27,6 +27,8 @@ import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ExceptionInChainedOperatorException;
 
+import java.util.Collection;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -67,6 +69,10 @@ public class NoOpTimestampsAndWatermarks<T> implements TimestampsAndWatermarks<T
     public void emitImmediateWatermark(long wallClockTimestamp) {
         // do nothing
     }
+
+    @Override
+    public void pauseOrResumeSplits(
+            Collection<String> splitsToPause, Collection<String> splitsToResume) {}
 
     // ------------------------------------------------------------------------
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
@@ -304,6 +304,7 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
         }
 
         void releaseOutputForSplit(String splitId) {
+            watermarkUpdateListener.splitFinished(splitId);
             localOutputs.remove(splitId);
             watermarkMultiplexer.unregisterOutput(splitId);
             PausableRelativeClock inputActivityClock =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/ProgressiveTimestampsAndWatermarks.java
@@ -27,16 +27,23 @@ import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkOutputMultiplexer;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.streaming.api.operators.util.PausableRelativeClock;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.RelativeClock;
 
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 
+import static java.util.Objects.requireNonNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -53,11 +60,17 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
 
     private final WatermarkGeneratorSupplier<T> watermarksFactory;
 
-    private final WatermarkGeneratorSupplier.Context watermarksContext;
+    private final TimestampsAndWatermarksContextProvider watermarksContextProvider;
 
     private final ProcessingTimeService timeService;
 
     private final long periodicWatermarkInterval;
+
+    private final RelativeClock mainInputActivityClock;
+
+    private final Clock clock;
+
+    private final TaskIOMetricGroup taskIOMetricGroup;
 
     @Nullable private SplitLocalOutputs<T> currentPerSplitOutputs;
 
@@ -68,14 +81,20 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
     public ProgressiveTimestampsAndWatermarks(
             TimestampAssigner<T> timestampAssigner,
             WatermarkGeneratorSupplier<T> watermarksFactory,
-            WatermarkGeneratorSupplier.Context watermarksContext,
+            TimestampsAndWatermarksContextProvider watermarksContextProvider,
             ProcessingTimeService timeService,
-            Duration periodicWatermarkInterval) {
+            Duration periodicWatermarkInterval,
+            RelativeClock mainInputActivityClock,
+            Clock clock,
+            TaskIOMetricGroup taskIOMetricGroup) {
 
         this.timestampAssigner = timestampAssigner;
         this.watermarksFactory = watermarksFactory;
-        this.watermarksContext = watermarksContext;
+        this.watermarksContextProvider = watermarksContextProvider;
         this.timeService = timeService;
+        this.mainInputActivityClock = mainInputActivityClock;
+        this.clock = clock;
+        this.taskIOMetricGroup = taskIOMetricGroup;
 
         long periodicWatermarkIntervalMillis;
         try {
@@ -106,7 +125,8 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
         IdlenessManager idlenessManager = new IdlenessManager(watermarkOutput);
 
         final WatermarkGenerator<T> watermarkGenerator =
-                watermarksFactory.createWatermarkGenerator(watermarksContext);
+                watermarksFactory.createWatermarkGenerator(
+                        watermarksContextProvider.create(mainInputActivityClock));
 
         currentPerSplitOutputs =
                 new SplitLocalOutputs<>(
@@ -115,7 +135,9 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                         watermarkUpdateListener,
                         timestampAssigner,
                         watermarksFactory,
-                        watermarksContext);
+                        watermarksContextProvider,
+                        clock,
+                        taskIOMetricGroup);
 
         currentMainOutput =
                 new StreamingReaderOutput<>(
@@ -162,6 +184,12 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
         }
     }
 
+    @Override
+    public void pauseOrResumeSplits(
+            Collection<String> splitsToPause, Collection<String> splitsToResume) {
+        currentPerSplitOutputs.pauseOrResumeSplits(splitsToPause, splitsToResume);
+    }
+
     // ------------------------------------------------------------------------
 
     private static final class StreamingReaderOutput<T> extends SourceOutputWithWatermarks<T>
@@ -203,11 +231,14 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
 
         private final WatermarkOutputMultiplexer watermarkMultiplexer;
         private final Map<String, SourceOutputWithWatermarks<T>> localOutputs;
+        private final Map<String, PausableRelativeClock> inputActivityClocks = new HashMap<>();
         private final PushingAsyncDataInput.DataOutput<T> recordOutput;
         private final TimestampAssigner<T> timestampAssigner;
         private final WatermarkGeneratorSupplier<T> watermarksFactory;
-        private final WatermarkGeneratorSupplier.Context watermarkContext;
+        private final TimestampsAndWatermarksContextProvider watermarksContextProvider;
         private final WatermarkUpdateListener watermarkUpdateListener;
+        private final Clock clock;
+        private final TaskIOMetricGroup taskIOMetricGroup;
 
         private SplitLocalOutputs(
                 PushingAsyncDataInput.DataOutput<T> recordOutput,
@@ -215,13 +246,17 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                 WatermarkUpdateListener watermarkUpdateListener,
                 TimestampAssigner<T> timestampAssigner,
                 WatermarkGeneratorSupplier<T> watermarksFactory,
-                WatermarkGeneratorSupplier.Context watermarkContext) {
+                TimestampsAndWatermarksContextProvider watermarksContextProvider,
+                Clock clock,
+                TaskIOMetricGroup taskIOMetricGroup) {
 
             this.recordOutput = recordOutput;
             this.timestampAssigner = timestampAssigner;
             this.watermarksFactory = watermarksFactory;
-            this.watermarkContext = watermarkContext;
+            this.watermarksContextProvider = watermarksContextProvider;
             this.watermarkUpdateListener = watermarkUpdateListener;
+            this.clock = clock;
+            this.taskIOMetricGroup = taskIOMetricGroup;
 
             this.watermarkMultiplexer = new WatermarkOutputMultiplexer(watermarkOutput);
             this.localOutputs =
@@ -234,6 +269,7 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                 return previous;
             }
 
+            PausableRelativeClock inputActivityClock = createInputActivityClock(splitId);
             watermarkMultiplexer.registerNewOutput(
                     splitId,
                     watermark ->
@@ -243,7 +279,8 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
             final WatermarkOutput periodicOutput = watermarkMultiplexer.getDeferredOutput(splitId);
 
             final WatermarkGenerator<T> watermarks =
-                    watermarksFactory.createWatermarkGenerator(watermarkContext);
+                    watermarksFactory.createWatermarkGenerator(
+                            watermarksContextProvider.create(inputActivityClock));
 
             final SourceOutputWithWatermarks<T> localOutput =
                     SourceOutputWithWatermarks.createWithSeparateOutputs(
@@ -257,9 +294,21 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
             return localOutput;
         }
 
+        private PausableRelativeClock createInputActivityClock(String splitId) {
+            // Dedicated inputActivityClock for a particular split. It will be paused both in case
+            // of back pressure and when split is paused due to watermark alignment.
+            PausableRelativeClock inputActivityClock = new PausableRelativeClock(clock);
+            inputActivityClocks.put(splitId, inputActivityClock);
+            taskIOMetricGroup.registerBackPressureListener(inputActivityClock);
+            return inputActivityClock;
+        }
+
         void releaseOutputForSplit(String splitId) {
             localOutputs.remove(splitId);
             watermarkMultiplexer.unregisterOutput(splitId);
+            PausableRelativeClock inputActivityClock =
+                    requireNonNull(inputActivityClocks.remove(splitId));
+            taskIOMetricGroup.unregisterBackPressureListener(inputActivityClock);
         }
 
         void emitPeriodicWatermark() {
@@ -272,6 +321,16 @@ public class ProgressiveTimestampsAndWatermarks<T> implements TimestampsAndWater
                 output.emitPeriodicWatermark();
             }
             watermarkMultiplexer.onPeriodicEmit();
+        }
+
+        public void pauseOrResumeSplits(
+                Collection<String> splitsToPause, Collection<String> splitsToResume) {
+            for (String splitId : splitsToPause) {
+                inputActivityClocks.get(splitId).pause();
+            }
+            for (String splitId : splitsToResume) {
+                inputActivityClocks.get(splitId).unPause();
+            }
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -24,10 +24,14 @@ import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.RelativeClock;
 
 import java.time.Duration;
+import java.util.Collection;
 
 /**
  * Basic interface for the timestamp extraction and watermark generation logic for the {@link
@@ -83,6 +87,8 @@ public interface TimestampsAndWatermarks<T> {
     /** Emit a watermark immediately. */
     void emitImmediateWatermark(long wallClockTimestamp);
 
+    void pauseOrResumeSplits(Collection<String> splitsToPause, Collection<String> splitsToResume);
+
     // ------------------------------------------------------------------------
     //  factories
     // ------------------------------------------------------------------------
@@ -91,27 +97,52 @@ public interface TimestampsAndWatermarks<T> {
             WatermarkStrategy<E> watermarkStrategy,
             MetricGroup metrics,
             ProcessingTimeService timeService,
-            long periodicWatermarkIntervalMillis) {
+            long periodicWatermarkIntervalMillis,
+            RelativeClock mainInputActivityClock,
+            Clock clock,
+            TaskIOMetricGroup taskIOMetricGroup) {
 
-        final TimestampsAndWatermarksContext context = new TimestampsAndWatermarksContext(metrics);
-        final TimestampAssigner<E> timestampAssigner =
-                watermarkStrategy.createTimestampAssigner(context);
+        TimestampsAndWatermarksContextProvider contextProvider =
+                new TimestampsAndWatermarksContextProvider(metrics);
+        TimestampAssigner<E> timestampAssigner =
+                watermarkStrategy.createTimestampAssigner(
+                        contextProvider.create(mainInputActivityClock));
 
         return new ProgressiveTimestampsAndWatermarks<>(
                 timestampAssigner,
                 watermarkStrategy,
-                context,
+                contextProvider,
                 timeService,
-                Duration.ofMillis(periodicWatermarkIntervalMillis));
+                Duration.ofMillis(periodicWatermarkIntervalMillis),
+                mainInputActivityClock,
+                clock,
+                taskIOMetricGroup);
     }
 
     static <E> TimestampsAndWatermarks<E> createNoOpEventTimeLogic(
-            WatermarkStrategy<E> watermarkStrategy, MetricGroup metrics) {
+            WatermarkStrategy<E> watermarkStrategy,
+            MetricGroup metrics,
+            RelativeClock inputActivityClock) {
 
-        final TimestampsAndWatermarksContext context = new TimestampsAndWatermarksContext(metrics);
+        final TimestampsAndWatermarksContext context =
+                new TimestampsAndWatermarksContext(metrics, inputActivityClock);
         final TimestampAssigner<E> timestampAssigner =
                 watermarkStrategy.createTimestampAssigner(context);
 
         return new NoOpTimestampsAndWatermarks<>(timestampAssigner);
+    }
+
+    /** Helper class to construct {@link TimestampsAndWatermarksContext}. */
+    @Internal
+    class TimestampsAndWatermarksContextProvider {
+        private final MetricGroup metrics;
+
+        public TimestampsAndWatermarksContextProvider(MetricGroup metrics) {
+            this.metrics = metrics;
+        }
+
+        public TimestampsAndWatermarksContext create(RelativeClock inputActivityClock) {
+            return new TimestampsAndWatermarksContext(metrics, inputActivityClock);
+        }
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -62,6 +62,9 @@ public interface TimestampsAndWatermarks<T> {
 
         /** Notifies about changes to per split watermarks. */
         void updateCurrentSplitWatermark(String splitId, long watermark);
+
+        /** Notifies that split has finished. */
+        void splitFinished(String splitId);
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarksContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarksContext.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.eventtime.TimestampAssignerSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.util.clock.RelativeClock;
-import org.apache.flink.util.clock.SystemClock;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -36,9 +35,12 @@ public final class TimestampsAndWatermarksContext
         implements TimestampAssignerSupplier.Context, WatermarkGeneratorSupplier.Context {
 
     private final MetricGroup metricGroup;
+    private final RelativeClock inputActivityClock;
 
-    public TimestampsAndWatermarksContext(MetricGroup metricGroup) {
+    public TimestampsAndWatermarksContext(
+            MetricGroup metricGroup, RelativeClock inputActivityClock) {
         this.metricGroup = checkNotNull(metricGroup);
+        this.inputActivityClock = inputActivityClock;
     }
 
     @Override
@@ -48,6 +50,6 @@ public final class TimestampsAndWatermarksContext
 
     @Override
     public RelativeClock getInputActivityClock() {
-        return SystemClock.getInstance();
+        return inputActivityClock;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarksContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarksContext.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.eventtime.TimestampAssignerSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.clock.RelativeClock;
+import org.apache.flink.util.clock.SystemClock;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -42,5 +44,10 @@ public final class TimestampsAndWatermarksContext
     @Override
     public MetricGroup getMetricGroup() {
         return metricGroup;
+    }
+
+    @Override
+    public RelativeClock getInputActivityClock() {
+        return SystemClock.getInstance();
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
@@ -53,6 +53,9 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
 
                     @Override
                     public void updateCurrentSplitWatermark(String splitId, long watermark) {}
+
+                    @Override
+                    public void splitFinished(String splitId) {}
                 });
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/PausableRelativeClock.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/util/PausableRelativeClock.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.metrics.TimerGauge;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.RelativeClock;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link RelativeClock} whose time progress with respect to the wall clock can be paused and
+ * un-paused. It can be paused multiple times. If it is paused N times, it has to be un-paused also
+ * N times to resume progress.
+ */
+@Internal
+@ThreadSafe
+public class PausableRelativeClock implements RelativeClock, TimerGauge.StartStopListener {
+    private final Clock baseClock;
+
+    private long accumulativeBlockedNanoTime;
+    private long currentBlockedNanoTimeStart;
+    /** How many times this clock has been paused. */
+    private long pausedCounter;
+
+    public PausableRelativeClock(Clock baseClock) {
+        this.baseClock = baseClock;
+    }
+
+    @Override
+    public long relativeTimeMillis() {
+        return relativeTimeNanos() / 1_000_000;
+    }
+
+    @Override
+    public synchronized long relativeTimeNanos() {
+        long now = baseClock.relativeTimeNanos();
+        // we offset relativeTimeNanos by the time this clock has been paused.
+        return now - getBlockedTime(now);
+    }
+
+    /** @return how long this {@link PausableRelativeClock} has been paused so far. */
+    private long getBlockedTime(long now) {
+        long blockedTime = accumulativeBlockedNanoTime;
+        if (pausedCounter != 0) {
+            // If we are paused right now, add the time since when we were paused
+            blockedTime += now - currentBlockedNanoTimeStart;
+        }
+        return blockedTime;
+    }
+
+    public synchronized void pause() {
+        if (pausedCounter == 0) {
+            currentBlockedNanoTimeStart = baseClock.relativeTimeNanos();
+        }
+        pausedCounter++;
+    }
+
+    public synchronized void unPause() {
+        checkState(pausedCounter >= 1);
+        pausedCounter--;
+        if (pausedCounter == 0) {
+            accumulativeBlockedNanoTime +=
+                    baseClock.relativeTimeNanos() - currentBlockedNanoTimeStart;
+        }
+    }
+
+    @Override
+    public void markStart() {
+        pause();
+    }
+
+    @Override
+    public void markEnd() {
+        unPause();
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeService.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.runtime.tasks;
 
+import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import java.util.concurrent.CompletableFuture;
@@ -32,6 +33,15 @@ import java.util.concurrent.TimeUnit;
  */
 public interface ProcessingTimeService
         extends org.apache.flink.api.common.operators.ProcessingTimeService {
+
+    @Override
+    default long getCurrentProcessingTime() {
+        return getClock().absoluteTimeMillis();
+    }
+
+    /** Returns {@link Clock} associated with this timer service. */
+    Clock getClock();
+
     /**
      * Registers a task to be executed repeatedly at a fixed rate.
      *

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/ProcessingTimeServiceImpl.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.clock.Clock;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
 import java.util.concurrent.CompletableFuture;
@@ -53,8 +54,8 @@ class ProcessingTimeServiceImpl implements ProcessingTimeService {
     }
 
     @Override
-    public long getCurrentProcessingTime() {
-        return timerService.getCurrentProcessingTime();
+    public Clock getClock() {
+        return timerService.getClock();
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SystemProcessingTimeService.java
@@ -20,6 +20,8 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.concurrent.NeverCompleteFuture;
 
 import org.slf4j.Logger;
@@ -86,8 +88,8 @@ public class SystemProcessingTimeService implements TimerService {
     }
 
     @Override
-    public long getCurrentProcessingTime() {
-        return System.currentTimeMillis();
+    public Clock getClock() {
+        return SystemClock.getInstance();
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorSplitWatermarkAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorSplitWatermarkAlignmentTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.eventtime.WatermarkGenerator;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.mocks.MockSourceReader;
+import org.apache.flink.api.connector.source.mocks.MockSourceReader.WaitingForSplits;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.configuration.Configuration;
@@ -42,46 +43,27 @@ import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.util.MockOutput;
 import org.apache.flink.streaming.util.MockStreamConfig;
 
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit test for split alignment in {@link SourceOperator}. */
-public class SourceOperatorSplitWatermarkAlignmentTest {
-    public static final WatermarkGenerator<Integer> WATERMARK_GENERATOR =
-            new WatermarkGenerator<Integer>() {
-
-                private long maxWatermark = Long.MIN_VALUE;
-
-                @Override
-                public void onEvent(Integer event, long eventTimestamp, WatermarkOutput output) {
-                    if (eventTimestamp > maxWatermark) {
-                        this.maxWatermark = eventTimestamp;
-                        output.emitWatermark(new Watermark(maxWatermark));
-                    }
-                }
-
-                @Override
-                public void onPeriodicEmit(WatermarkOutput output) {
-                    output.emitWatermark(new Watermark(maxWatermark));
-                }
-            };
+class SourceOperatorSplitWatermarkAlignmentTest {
 
     @Test
     public void testSplitWatermarkAlignment() throws Exception {
 
-        final SplitAligningSourceReader sourceReader = new SplitAligningSourceReader();
+        MockSourceReader sourceReader =
+                new MockSourceReader(WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS, false, true);
         SourceOperator<Integer, MockSourceSplit> operator =
                 new TestingSourceOperator<>(
                         sourceReader,
-                        WatermarkStrategy.forGenerator(ctx -> WATERMARK_GENERATOR)
+                        WatermarkStrategy.forGenerator(ctx -> new TestWatermarkGenerator())
                                 .withTimestampAssigner((r, l) -> r)
                                 .withWatermarkAlignment("group-1", Duration.ofMillis(1)),
                         new TestProcessingTimeService(),
@@ -97,8 +79,8 @@ public class SourceOperatorSplitWatermarkAlignmentTest {
         operator.initializeState(new StreamTaskStateInitializerImpl(env, new MemoryStateBackend()));
 
         operator.open();
-        final MockSourceSplit split1 = new MockSourceSplit(0, 0, 10);
-        final MockSourceSplit split2 = new MockSourceSplit(1, 10, 20);
+        MockSourceSplit split1 = new MockSourceSplit(0, 0, 10);
+        MockSourceSplit split2 = new MockSourceSplit(1, 10, 20);
         split1.addRecord(5);
         split1.addRecord(11);
         split2.addRecord(3);
@@ -107,25 +89,25 @@ public class SourceOperatorSplitWatermarkAlignmentTest {
         operator.handleOperatorEvent(
                 new AddSplitEvent<>(
                         Arrays.asList(split1, split2), new MockSourceSplitSerializer()));
-        final CollectingDataOutput<Integer> dataOutput = new CollectingDataOutput<>();
+        CollectingDataOutput<Integer> dataOutput = new CollectingDataOutput<>();
 
         operator.emitNext(dataOutput); // split 1 emits 5
 
         operator.handleOperatorEvent(
                 new WatermarkAlignmentEvent(4)); // pause by coordinator message
-        assertThat(sourceReader.pausedSplits).containsExactly("0");
+        assertThat(sourceReader.getPausedSplits()).containsExactly("0");
 
         operator.handleOperatorEvent(new WatermarkAlignmentEvent(5));
-        assertThat(sourceReader.pausedSplits).isEmpty();
+        assertThat(sourceReader.getPausedSplits()).isEmpty();
 
         operator.emitNext(dataOutput); // split 1 emits 11
         operator.emitNext(dataOutput); // split 2 emits 3
 
-        assertThat(sourceReader.pausedSplits).containsExactly("0");
+        assertThat(sourceReader.getPausedSplits()).containsExactly("0");
 
         operator.emitNext(dataOutput); // split 2 emits 6
 
-        assertThat(sourceReader.pausedSplits).containsExactly("0", "1");
+        assertThat(sourceReader.getPausedSplits()).containsExactly("0", "1");
     }
 
     private Environment getTestingEnvironment() {
@@ -139,17 +121,21 @@ public class SourceOperatorSplitWatermarkAlignmentTest {
                 new TestTaskStateManager());
     }
 
-    private static class SplitAligningSourceReader extends MockSourceReader {
-        Set<String> pausedSplits = new HashSet<>();
+    private static class TestWatermarkGenerator implements WatermarkGenerator<Integer> {
 
-        public SplitAligningSourceReader() {
-            super(WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS, false, true);
+        private long maxWatermark = Long.MIN_VALUE;
+
+        @Override
+        public void onEvent(Integer event, long eventTimestamp, WatermarkOutput output) {
+            if (eventTimestamp > maxWatermark) {
+                this.maxWatermark = eventTimestamp;
+                output.emitWatermark(new Watermark(maxWatermark));
+            }
         }
 
-        public void pauseOrResumeSplits(
-                Collection<String> splitsToPause, Collection<String> splitsToResume) {
-            pausedSplits.removeAll(splitsToResume);
-            pausedSplits.addAll(splitsToPause);
+        @Override
+        public void onPeriodicEmit(WatermarkOutput output) {
+            output.emitWatermark(new Watermark(maxWatermark));
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/util/PausableRelativeClockTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/util/PausableRelativeClockTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.util;
+
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PausableRelativeClockTest {
+    private static final long TIME_STEP = 14;
+
+    @Test
+    void simpleTest() {
+        ManualClock baseClock = new ManualClock();
+        PausableRelativeClock relativeClock = new PausableRelativeClock(baseClock);
+
+        long startMillis = relativeClock.relativeTimeMillis();
+        long startNanos = relativeClock.relativeTimeNanos();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP));
+        long endNanos = relativeClock.relativeTimeNanos();
+        long endMillis = relativeClock.relativeTimeMillis();
+
+        long durationNanos = endNanos - startNanos;
+        long durationMillis = endMillis - startMillis;
+
+        assertThat((durationNanos) / 1_000_000).isEqualTo(TIME_STEP);
+        assertThat(durationMillis).isEqualTo(TIME_STEP);
+    }
+
+    @Test
+    void pausedTest() throws Exception {
+        ManualClock baseClock = new ManualClock();
+        PausableRelativeClock relativeClock = new PausableRelativeClock(baseClock);
+
+        long startMillis = relativeClock.relativeTimeMillis();
+        long startNanos = relativeClock.relativeTimeNanos();
+
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP));
+        relativeClock.pause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP)); // doesn't count
+        relativeClock.pause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP)); // doesn't count
+        relativeClock.unPause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP)); // doesn't count
+        relativeClock.unPause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP));
+        relativeClock.pause();
+        baseClock.advanceTime(Duration.ofMillis(TIME_STEP)); // doesn't count
+        // leave the clock blocked
+
+        long endNanos = relativeClock.relativeTimeNanos();
+        long endMillis = relativeClock.relativeTimeMillis();
+
+        long durationNanos = endNanos - startNanos;
+        long durationMillis = endMillis - startMillis;
+
+        assertThat((durationNanos) / 1_000_000).isEqualTo(TIME_STEP * 2);
+        assertThat(durationMillis).isEqualTo(TIME_STEP * 2);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -465,9 +465,7 @@ public class MultipleInputStreamTaskTest {
             int numRecords3 = 2;
             // add source splits before processing any elements, so the MockSourceReader does not
             // end prematurely
-            for (int x = 0; x < numRecords2; x++) {
-                addSourceRecords(testHarness, 1, 42);
-            }
+            addSourceRecords(testHarness, 1, 42, 43, 44);
             for (int x = 0; x < numRecords1; x++) {
                 testHarness.processElement(new StreamRecord<>("hello"), 0, 0);
             }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -762,6 +762,10 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
         return factory;
     }
 
+    public void advanceTime(long delta) throws Exception {
+        processingTimeService.advance(delta);
+    }
+
     public void setProcessingTime(long time) throws Exception {
         processingTimeService.setCurrentTime(time);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.factories;
 
 import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier;
 import org.apache.flink.api.common.eventtime.WatermarkOutput;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.io.RichOutputFormat;
@@ -30,6 +31,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
@@ -54,6 +56,8 @@ import org.apache.flink.test.util.SuccessException;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.types.RowUtils;
+import org.apache.flink.util.clock.RelativeClock;
+import org.apache.flink.util.clock.SystemClock;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -247,7 +251,18 @@ final class TestValuesRuntimeFunctions {
             ByteArrayInputStream bais = new ByteArrayInputStream(elementsSerialized);
             final DataInputView input = new DataInputViewStreamWrapper(bais);
             WatermarkGenerator<RowData> generator =
-                    watermarkStrategy.createWatermarkGenerator(() -> null);
+                    watermarkStrategy.createWatermarkGenerator(
+                            new WatermarkGeneratorSupplier.Context() {
+                                @Override
+                                public MetricGroup getMetricGroup() {
+                                    return null;
+                                }
+
+                                @Override
+                                public RelativeClock getInputActivityClock() {
+                                    return SystemClock.getInstance();
+                                }
+                            });
             WatermarkOutput output = new TestValuesWatermarkOutput(ctx);
             final Object lock = ctx.getCheckpointLock();
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
@@ -31,9 +31,10 @@ import org.apache.flink.table.runtime.generated.WatermarkGenerator
 import org.apache.flink.table.types.logical.{IntType, TimestampType}
 import org.apache.flink.table.utils.CatalogManagerMocks
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
+import org.apache.flink.util.clock.{RelativeClock, SystemClock}
 
-import org.junit.jupiter.api.{Test, TestTemplate}
 import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.lang.{Integer => JInt, Long => JLong}
@@ -167,6 +168,8 @@ class WatermarkGeneratorCodeGenTest(useDefinedConstructor: Boolean) {
       val newReferences = generated.getReferences :+
         new WatermarkGeneratorSupplier.Context {
           override def getMetricGroup: MetricGroup = null
+
+          override def getInputActivityClock: RelativeClock = SystemClock.getInstance()
         }
       generated.newInstance(Thread.currentThread().getContextClassLoader, newReferences)
     } else {

--- a/pom.xml
+++ b/pom.xml
@@ -2355,6 +2355,10 @@ under the License.
 								<exclude>@org.apache.flink.annotation.Experimental</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
 								<!-- MARKER: start exclusions; these will be wiped by tools/releasing/update_japicmp_configuration.sh -->
+								<!-- New method has been added to the interface, but this interface shouldn't be implemented by users, only used/called, so this doesn't break API compatibility. -->
+								<exclude>org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier$Context</exclude>
+								<!-- Base interface has been extracted from the existing Clock class. This interface shouldn't affect user code. -->
+								<exclude>org.apache.flink.util.clock.Clock</exclude>
 								<!-- MARKER: end exclusions -->
 							</excludes>
 							<accessModifier>public</accessModifier>


### PR DESCRIPTION
this is a backport of https://github.com/apache/flink/pull/25167