### PR TITLE
[FLINK-36126] Qualification of current catalog and current database should happen during execution, not parsing

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCall.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowCall.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+/** Abstract class for SHOW sql call. */
 public abstract class SqlShowCall extends SqlCall {
     private final String preposition;
     private final SqlIdentifier sqlIdentifier;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/AbstractShowOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/AbstractShowOperation.java
@@ -38,9 +38,9 @@ import static org.apache.flink.table.api.internal.TableResultUtils.buildStringAr
  */
 @Internal
 public abstract class AbstractShowOperation implements ShowOperation {
-    private final @Nullable String catalogName;
-    private final @Nullable String preposition;
-    private final @Nullable ShowLikeOperator likeOp;
+    protected final @Nullable String catalogName;
+    protected final @Nullable String preposition;
+    protected final @Nullable ShowLikeOperator likeOp;
 
     public AbstractShowOperation(
             @Nullable String catalogName,
@@ -56,18 +56,6 @@ public abstract class AbstractShowOperation implements ShowOperation {
     protected abstract String getOperationName();
 
     protected abstract String getColumnName();
-
-    public String getCatalogName() {
-        return catalogName;
-    }
-
-    public ShowLikeOperator getLikeOp() {
-        return likeOp;
-    }
-
-    public String getPreposition() {
-        return preposition;
-    }
 
     @Override
     public TableResultInternal execute(Context ctx) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/AbstractShowOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/AbstractShowOperation.java
@@ -38,12 +38,14 @@ import static org.apache.flink.table.api.internal.TableResultUtils.buildStringAr
  */
 @Internal
 public abstract class AbstractShowOperation implements ShowOperation {
-    protected final String catalogName;
-    protected final @Nullable String preposition;
-    protected final @Nullable ShowLikeOperator likeOp;
+    private final @Nullable String catalogName;
+    private final @Nullable String preposition;
+    private final @Nullable ShowLikeOperator likeOp;
 
     public AbstractShowOperation(
-            String catalogName, @Nullable String preposition, @Nullable ShowLikeOperator likeOp) {
+            @Nullable String catalogName,
+            @Nullable String preposition,
+            @Nullable ShowLikeOperator likeOp) {
         this.catalogName = catalogName;
         this.preposition = preposition;
         this.likeOp = likeOp;
@@ -54,6 +56,18 @@ public abstract class AbstractShowOperation implements ShowOperation {
     protected abstract String getOperationName();
 
     protected abstract String getColumnName();
+
+    public String getCatalogName() {
+        return catalogName;
+    }
+
+    public ShowLikeOperator getLikeOp() {
+        return likeOp;
+    }
+
+    public String getPreposition() {
+        return preposition;
+    }
 
     @Override
     public TableResultInternal execute(Context ctx) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowColumnsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowColumnsOperation.java
@@ -83,7 +83,6 @@ public class ShowColumnsOperation extends AbstractShowOperation {
 
         ResolvedSchema schema = result.get().getResolvedSchema();
         Object[][] rows = generateTableColumnsRows(schema);
-        ShowLikeOperator likeOp = getLikeOp();
         if (likeOp != null) {
             rows =
                     Arrays.stream(rows)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowColumnsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowColumnsOperation.java
@@ -83,6 +83,7 @@ public class ShowColumnsOperation extends AbstractShowOperation {
 
         ResolvedSchema schema = result.get().getResolvedSchema();
         Object[][] rows = generateTableColumnsRows(schema);
+        ShowLikeOperator likeOp = getLikeOp();
         if (likeOp != null) {
             rows =
                     Arrays.stream(rows)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowDatabasesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowDatabasesOperation.java
@@ -38,22 +38,25 @@ import java.util.Collection;
 public class ShowDatabasesOperation extends AbstractShowOperation {
 
     public ShowDatabasesOperation(
-            String catalogName, @Nullable String preposition, @Nullable ShowLikeOperator likeOp) {
+            @Nullable String catalogName,
+            @Nullable String preposition,
+            @Nullable ShowLikeOperator likeOp) {
         super(catalogName, preposition, likeOp);
     }
 
-    public ShowDatabasesOperation(String catalogName, ShowLikeOperator likeOp) {
+    public ShowDatabasesOperation(@Nullable String catalogName, @Nullable ShowLikeOperator likeOp) {
         this(catalogName, null, likeOp);
     }
 
-    public ShowDatabasesOperation(String catalogName) {
+    public ShowDatabasesOperation(@Nullable String catalogName) {
         this(catalogName, null, null);
     }
 
     @Override
     protected Collection<String> retrieveDataForTableResult(Context ctx) {
         final CatalogManager catalogManager = ctx.getCatalogManager();
-        return catalogManager.getCatalogOrThrowException(catalogName).listDatabases();
+        final String qualifiedCatalogName = catalogManager.qualifyCatalog(getCatalogName());
+        return catalogManager.getCatalogOrThrowException(qualifiedCatalogName).listDatabases();
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowDatabasesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowDatabasesOperation.java
@@ -55,7 +55,7 @@ public class ShowDatabasesOperation extends AbstractShowOperation {
     @Override
     protected Collection<String> retrieveDataForTableResult(Context ctx) {
         final CatalogManager catalogManager = ctx.getCatalogManager();
-        final String qualifiedCatalogName = catalogManager.qualifyCatalog(getCatalogName());
+        final String qualifiedCatalogName = catalogManager.qualifyCatalog(catalogName);
         return catalogManager.getCatalogOrThrowException(qualifiedCatalogName).listDatabases();
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
@@ -57,7 +57,7 @@ public class ShowFunctionsOperation extends AbstractShowOperation {
     private final FunctionScope functionScope;
     private final @Nullable String databaseName;
 
-    public ShowFunctionsOperation(String catalogName, String databaseName) {
+    public ShowFunctionsOperation(@Nullable String catalogName, @Nullable String databaseName) {
         // "SHOW FUNCTIONS" default is ALL scope
         this(FunctionScope.ALL, catalogName, databaseName, null);
     }
@@ -73,8 +73,8 @@ public class ShowFunctionsOperation extends AbstractShowOperation {
     public ShowFunctionsOperation(
             FunctionScope functionScope,
             @Nullable String preposition,
-            String catalogName,
-            String databaseName,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             @Nullable ShowLikeOperator likeOp) {
         super(catalogName, preposition, likeOp);
         this.functionScope = functionScope;
@@ -83,6 +83,8 @@ public class ShowFunctionsOperation extends AbstractShowOperation {
 
     @Override
     protected Collection<String> retrieveDataForTableResult(Context ctx) {
+        final String preposition = getPreposition();
+        final String catalogName = getCatalogName();
         switch (functionScope) {
             case USER:
                 if (preposition == null) {
@@ -103,6 +105,14 @@ public class ShowFunctionsOperation extends AbstractShowOperation {
                         String.format(
                                 "SHOW FUNCTIONS with %s scope is not supported.", databaseName));
         }
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public FunctionScope getFunctionScope() {
+        return functionScope;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
@@ -83,8 +83,6 @@ public class ShowFunctionsOperation extends AbstractShowOperation {
 
     @Override
     protected Collection<String> retrieveDataForTableResult(Context ctx) {
-        final String preposition = getPreposition();
-        final String catalogName = getCatalogName();
         switch (functionScope) {
             case USER:
                 if (preposition == null) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowFunctionsOperation.java
@@ -105,14 +105,6 @@ public class ShowFunctionsOperation extends AbstractShowOperation {
         }
     }
 
-    public String getDatabaseName() {
-        return databaseName;
-    }
-
-    public FunctionScope getFunctionScope() {
-        return functionScope;
-    }
-
     @Override
     protected String getOperationName() {
         return functionScope == FunctionScope.ALL ? "SHOW FUNCTIONS" : "SHOW USER FUNCTIONS";

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowProceduresOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowProceduresOperation.java
@@ -62,10 +62,10 @@ public class ShowProceduresOperation extends AbstractShowOperation {
     @Override
     protected Collection<String> retrieveDataForTableResult(Context ctx) {
         final CatalogManager catalogManager = ctx.getCatalogManager();
-        final String qualifiedCatalogName = catalogManager.qualifyCatalog(getCatalogName());
+        final String qualifiedCatalogName = catalogManager.qualifyCatalog(catalogName);
         final String qualifiedDatabaseName = catalogManager.qualifyDatabase(databaseName);
         try {
-            if (getPreposition() == null) {
+            if (preposition == null) {
                 // it's to show current_catalog.current_database
                 return catalogManager
                         .getCatalogOrError(qualifiedCatalogName)
@@ -81,10 +81,6 @@ public class ShowProceduresOperation extends AbstractShowOperation {
                             qualifiedDatabaseName, qualifiedCatalogName),
                     e);
         }
-    }
-
-    public String getDatabaseName() {
-        return databaseName;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowProceduresOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowProceduresOperation.java
@@ -41,11 +41,11 @@ import java.util.Collection;
 @Internal
 public class ShowProceduresOperation extends AbstractShowOperation {
 
-    private final String databaseName;
+    private final @Nullable String databaseName;
 
     public ShowProceduresOperation(
-            String catalogName,
-            String databaseName,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             @Nullable String preposition,
             @Nullable ShowLikeOperator likeOp) {
         super(catalogName, preposition, likeOp);
@@ -53,27 +53,38 @@ public class ShowProceduresOperation extends AbstractShowOperation {
     }
 
     public ShowProceduresOperation(
-            String catalogName, String databaseName, @Nullable ShowLikeOperator likeOp) {
+            @Nullable String catalogName,
+            @Nullable String databaseName,
+            @Nullable ShowLikeOperator likeOp) {
         this(catalogName, databaseName, null, likeOp);
     }
 
     @Override
     protected Collection<String> retrieveDataForTableResult(Context ctx) {
         final CatalogManager catalogManager = ctx.getCatalogManager();
+        final String qualifiedCatalogName = catalogManager.qualifyCatalog(getCatalogName());
+        final String qualifiedDatabaseName = catalogManager.qualifyDatabase(databaseName);
         try {
-            if (preposition == null) {
+            if (getPreposition() == null) {
                 // it's to show current_catalog.current_database
-                return catalogManager.getCatalogOrError(catalogName).listProcedures(databaseName);
+                return catalogManager
+                        .getCatalogOrError(qualifiedCatalogName)
+                        .listProcedures(qualifiedDatabaseName);
             } else {
-                Catalog catalog = catalogManager.getCatalogOrThrowException(catalogName);
-                return catalog.listProcedures(databaseName);
+                Catalog catalog = catalogManager.getCatalogOrThrowException(qualifiedCatalogName);
+                return catalog.listProcedures(qualifiedDatabaseName);
             }
         } catch (DatabaseNotExistException e) {
             throw new TableException(
                     String.format(
                             "Fail to show procedures because the Database `%s` to show from/in does not exist in Catalog `%s`.",
-                            databaseName, catalogName));
+                            qualifiedDatabaseName, qualifiedCatalogName),
+                    e);
         }
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
@@ -64,9 +64,9 @@ public class ShowTablesOperation extends AbstractShowOperation {
     @Override
     protected Set<String> retrieveDataForTableResult(Context ctx) {
         final CatalogManager catalogManager = ctx.getCatalogManager();
-        final String qualifiedCatalogName = catalogManager.qualifyCatalog(getCatalogName());
+        final String qualifiedCatalogName = catalogManager.qualifyCatalog(catalogName);
         final String qualifiedDatabaseName = catalogManager.qualifyDatabase(databaseName);
-        if (getPreposition() == null) {
+        if (preposition == null) {
             return catalogManager.listTables();
         } else {
             Catalog catalog = catalogManager.getCatalogOrThrowException(qualifiedCatalogName);
@@ -79,10 +79,6 @@ public class ShowTablesOperation extends AbstractShowOperation {
                                 qualifiedCatalogName, qualifiedDatabaseName));
             }
         }
-    }
-
-    public String getDatabaseName() {
-        return databaseName;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowTablesOperation.java
@@ -39,11 +39,11 @@ import java.util.Set;
 @Internal
 public class ShowTablesOperation extends AbstractShowOperation {
 
-    private final String databaseName;
+    private final @Nullable String databaseName;
 
     public ShowTablesOperation(
-            String catalogName,
-            String databaseName,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             @Nullable String preposition,
             @Nullable ShowLikeOperator likeOp) {
         super(catalogName, preposition, likeOp);
@@ -51,29 +51,38 @@ public class ShowTablesOperation extends AbstractShowOperation {
     }
 
     public ShowTablesOperation(
-            String catalogName, String databaseName, @Nullable ShowLikeOperator likeOp) {
+            @Nullable String catalogName,
+            @Nullable String databaseName,
+            @Nullable ShowLikeOperator likeOp) {
         this(catalogName, databaseName, null, likeOp);
     }
 
-    public ShowTablesOperation(String catalogName, String databaseName) {
+    public ShowTablesOperation(@Nullable String catalogName, @Nullable String databaseName) {
         this(catalogName, databaseName, null);
     }
 
     @Override
     protected Set<String> retrieveDataForTableResult(Context ctx) {
         final CatalogManager catalogManager = ctx.getCatalogManager();
-        if (preposition == null) {
+        final String qualifiedCatalogName = catalogManager.qualifyCatalog(getCatalogName());
+        final String qualifiedDatabaseName = catalogManager.qualifyDatabase(databaseName);
+        if (getPreposition() == null) {
             return catalogManager.listTables();
         } else {
-            Catalog catalog = catalogManager.getCatalogOrThrowException(catalogName);
-            if (catalog.databaseExists(databaseName)) {
-                return catalogManager.listTables(catalogName, databaseName);
+            Catalog catalog = catalogManager.getCatalogOrThrowException(qualifiedCatalogName);
+            if (catalog.databaseExists(qualifiedDatabaseName)) {
+                return catalogManager.listTables(qualifiedCatalogName, qualifiedDatabaseName);
             } else {
                 throw new ValidationException(
                         String.format(
-                                "Database '%s'.'%s' doesn't exist.", catalogName, databaseName));
+                                "Database '%s'.'%s' doesn't exist.",
+                                qualifiedCatalogName, qualifiedDatabaseName));
             }
         }
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowViewsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowViewsOperation.java
@@ -39,11 +39,11 @@ import java.util.Set;
 @Internal
 public class ShowViewsOperation extends AbstractShowOperation {
 
-    private final String databaseName;
+    private final @Nullable String databaseName;
 
     public ShowViewsOperation(
-            String catalogName,
-            String databaseName,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             @Nullable String preposition,
             @Nullable ShowLikeOperator likeOp) {
         super(catalogName, preposition, likeOp);
@@ -51,11 +51,13 @@ public class ShowViewsOperation extends AbstractShowOperation {
     }
 
     public ShowViewsOperation(
-            String catalogName, String databaseName, @Nullable ShowLikeOperator likeOp) {
+            @Nullable String catalogName,
+            @Nullable String databaseName,
+            @Nullable ShowLikeOperator likeOp) {
         this(catalogName, databaseName, null, likeOp);
     }
 
-    public ShowViewsOperation(String catalogName, String databaseName) {
+    public ShowViewsOperation(@Nullable String catalogName, @Nullable String databaseName) {
         this(catalogName, databaseName, null);
     }
 
@@ -66,18 +68,25 @@ public class ShowViewsOperation extends AbstractShowOperation {
 
     protected Set<String> retrieveDataForTableResult(Context ctx) {
         final CatalogManager catalogManager = ctx.getCatalogManager();
-        if (preposition == null) {
+        final String qualifiedCatalogName = catalogManager.qualifyCatalog(getCatalogName());
+        final String qualifiedDatabaseName = catalogManager.qualifyDatabase(databaseName);
+        if (getPreposition() == null) {
             return catalogManager.listViews();
         } else {
-            Catalog catalog = catalogManager.getCatalogOrThrowException(catalogName);
-            if (catalog.databaseExists(databaseName)) {
-                return catalogManager.listViews(catalogName, databaseName);
+            Catalog catalog = catalogManager.getCatalogOrThrowException(qualifiedCatalogName);
+            if (catalog.databaseExists(qualifiedDatabaseName)) {
+                return catalogManager.listViews(qualifiedCatalogName, qualifiedDatabaseName);
             } else {
                 throw new ValidationException(
                         String.format(
-                                "Database '%s'.'%s' doesn't exist.", catalogName, databaseName));
+                                "Database '%s'.'%s' doesn't exist.",
+                                qualifiedCatalogName, qualifiedDatabaseName));
             }
         }
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowViewsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowViewsOperation.java
@@ -68,9 +68,9 @@ public class ShowViewsOperation extends AbstractShowOperation {
 
     protected Set<String> retrieveDataForTableResult(Context ctx) {
         final CatalogManager catalogManager = ctx.getCatalogManager();
-        final String qualifiedCatalogName = catalogManager.qualifyCatalog(getCatalogName());
+        final String qualifiedCatalogName = catalogManager.qualifyCatalog(catalogName);
         final String qualifiedDatabaseName = catalogManager.qualifyDatabase(databaseName);
-        if (getPreposition() == null) {
+        if (preposition == null) {
             return catalogManager.listViews();
         } else {
             Catalog catalog = catalogManager.getCatalogOrThrowException(qualifiedCatalogName);
@@ -83,10 +83,6 @@ public class ShowViewsOperation extends AbstractShowOperation {
                                 qualifiedCatalogName, qualifiedDatabaseName));
             }
         }
-    }
-
-    public String getDatabaseName() {
-        return databaseName;
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/AbstractSqlShowConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/AbstractSqlShowConverter.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 
+/** An abstract class for SHOW converters. */
 public abstract class AbstractSqlShowConverter<T extends SqlShowCall>
         implements SqlNodeConverter<T> {
 
@@ -38,13 +39,8 @@ public abstract class AbstractSqlShowConverter<T extends SqlShowCall>
             final CatalogManager catalogManager = context.getCatalogManager();
             final String currentCatalogName = catalogManager.getCurrentCatalog();
             final String currentDatabaseName = catalogManager.getCurrentDatabase();
-            if (skipQualifyingDefaultCatalogAndDatabase()) {
-                return getOperationWithoutPrep(
-                        currentCatalogName, currentDatabaseName, sqlShowCall, likeOp);
-            }
-            final String catalogName = catalogManager.qualifyCatalog(currentCatalogName);
-            final String databaseName = catalogManager.qualifyDatabase(currentDatabaseName);
-            return getOperationWithoutPrep(catalogName, databaseName, sqlShowCall, likeOp);
+            return getOperationWithoutPrep(
+                    sqlShowCall, currentCatalogName, currentDatabaseName, likeOp);
         }
         final List<String> sqlIdentifierNameList = sqlShowCall.getSqlIdentifierNameList();
         if (sqlIdentifierNameList.size() > 2) {
@@ -64,14 +60,8 @@ public abstract class AbstractSqlShowConverter<T extends SqlShowCall>
                 sqlIdentifierNameList.size() == 1
                         ? sqlIdentifierNameList.get(0)
                         : sqlIdentifierNameList.get(1);
-        final String qualifiedCatalogName = catalogManager.qualifyCatalog(catalogName);
-        final String qualifiedDatabaseName = catalogManager.qualifyDatabase(databaseName);
         return getOperation(
-                sqlShowCall,
-                qualifiedCatalogName,
-                qualifiedDatabaseName,
-                sqlShowCall.getPreposition(),
-                likeOp);
+                sqlShowCall, catalogName, databaseName, sqlShowCall.getPreposition(), likeOp);
     }
 
     public ShowLikeOperator getLikeOp(SqlShowCall sqlShowCall) {
@@ -81,22 +71,18 @@ public abstract class AbstractSqlShowConverter<T extends SqlShowCall>
     }
 
     public abstract Operation getOperationWithoutPrep(
-            String catalogName,
-            String databaseName,
             T sqlShowCall,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             @Nullable ShowLikeOperator likeOp);
 
     public abstract Operation getOperation(
             T sqlShowCall,
-            String catalogName,
-            String databaseName,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             @Nullable String prep,
             @Nullable ShowLikeOperator likeOp);
 
     @Override
     public abstract Operation convertSqlNode(T node, ConvertContext context);
-
-    protected boolean skipQualifyingDefaultCatalogAndDatabase() {
-        return false;
-    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowDatabasesConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowDatabasesConverter.java
@@ -37,8 +37,7 @@ public class SqlShowDatabasesConverter implements SqlNodeConverter<SqlShowDataba
         if (sqlShowDatabases.getPreposition() == null) {
             final CatalogManager catalogManager = context.getCatalogManager();
             final String currentCatalogName = catalogManager.getCurrentCatalog();
-            final String qualifiedCatalogName = catalogManager.qualifyCatalog(currentCatalogName);
-            return new ShowDatabasesOperation(qualifiedCatalogName, likeOp);
+            return new ShowDatabasesOperation(currentCatalogName, likeOp);
         } else {
             return new ShowDatabasesOperation(
                     sqlShowDatabases.getCatalogName(), sqlShowDatabases.getPreposition(), likeOp);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowFunctionsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowFunctionsConverter.java
@@ -24,15 +24,17 @@ import org.apache.flink.table.operations.ShowFunctionsOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation.FunctionScope;
 import org.apache.flink.table.operations.utils.ShowLikeOperator;
 
+import javax.annotation.Nullable;
+
 /** A converter for {@link SqlShowFunctions}. */
 public class SqlShowFunctionsConverter extends AbstractSqlShowConverter<SqlShowFunctions> {
 
     @Override
     public Operation getOperationWithoutPrep(
-            String catalogName,
-            String databaseName,
             SqlShowFunctions sqlShowFunctions,
-            ShowLikeOperator likeOp) {
+            @Nullable String catalogName,
+            @Nullable String databaseName,
+            @Nullable ShowLikeOperator likeOp) {
         final FunctionScope functionScope = getFunctionScope(sqlShowFunctions);
         return new ShowFunctionsOperation(functionScope, catalogName, databaseName, likeOp);
     }
@@ -40,10 +42,10 @@ public class SqlShowFunctionsConverter extends AbstractSqlShowConverter<SqlShowF
     @Override
     public Operation getOperation(
             SqlShowFunctions sqlShowFunctions,
-            String catalogName,
-            String databaseName,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             String prep,
-            ShowLikeOperator likeOp) {
+            @Nullable ShowLikeOperator likeOp) {
         final FunctionScope functionScope = getFunctionScope(sqlShowFunctions);
         return new ShowFunctionsOperation(functionScope, prep, catalogName, databaseName, likeOp);
     }
@@ -55,12 +57,5 @@ public class SqlShowFunctionsConverter extends AbstractSqlShowConverter<SqlShowF
 
     private static FunctionScope getFunctionScope(SqlShowFunctions sqlShowFunctions) {
         return sqlShowFunctions.requireUser() ? FunctionScope.USER : FunctionScope.ALL;
-    }
-
-    @Override
-    protected boolean skipQualifyingDefaultCatalogAndDatabase() {
-        // It should be supported to list functions with unset catalog
-        // for more info FLINK-33093
-        return true;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowProcedureConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowProcedureConverter.java
@@ -23,25 +23,27 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ShowProceduresOperation;
 import org.apache.flink.table.operations.utils.ShowLikeOperator;
 
+import javax.annotation.Nullable;
+
 /** A converter for {@link SqlShowProcedures}. */
 public class SqlShowProcedureConverter extends AbstractSqlShowConverter<SqlShowProcedures> {
 
     @Override
     public Operation getOperationWithoutPrep(
-            String catalogName,
-            String databaseName,
             SqlShowProcedures sqlShowCall,
-            ShowLikeOperator likeOp) {
+            @Nullable String catalogName,
+            @Nullable String databaseName,
+            @Nullable ShowLikeOperator likeOp) {
         return new ShowProceduresOperation(catalogName, databaseName, likeOp);
     }
 
     @Override
     public Operation getOperation(
             SqlShowProcedures sqlShowCall,
-            String catalogName,
-            String databaseName,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             String prep,
-            ShowLikeOperator likeOp) {
+            @Nullable ShowLikeOperator likeOp) {
         return new ShowProceduresOperation(catalogName, databaseName, prep, likeOp);
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowTablesConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowTablesConverter.java
@@ -23,23 +23,25 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ShowTablesOperation;
 import org.apache.flink.table.operations.utils.ShowLikeOperator;
 
+import javax.annotation.Nullable;
+
 public class SqlShowTablesConverter extends AbstractSqlShowConverter<SqlShowTables> {
     @Override
     public Operation getOperationWithoutPrep(
-            String catalogName,
-            String databaseName,
             SqlShowTables sqlShowCall,
-            ShowLikeOperator likeOp) {
+            @Nullable String catalogName,
+            @Nullable String databaseName,
+            @Nullable ShowLikeOperator likeOp) {
         return new ShowTablesOperation(catalogName, databaseName, likeOp);
     }
 
     @Override
     public Operation getOperation(
             SqlShowTables sqlShowCall,
-            String catalogName,
-            String databaseName,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             String prep,
-            ShowLikeOperator likeOp) {
+            @Nullable ShowLikeOperator likeOp) {
         return new ShowTablesOperation(catalogName, databaseName, prep, likeOp);
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowViewsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlShowViewsConverter.java
@@ -23,23 +23,25 @@ import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.ShowViewsOperation;
 import org.apache.flink.table.operations.utils.ShowLikeOperator;
 
+import javax.annotation.Nullable;
+
 public class SqlShowViewsConverter extends AbstractSqlShowConverter<SqlShowViews> {
     @Override
     public Operation getOperationWithoutPrep(
-            String catalogName,
-            String databaseName,
             SqlShowViews sqlShowCall,
-            ShowLikeOperator likeOp) {
+            @Nullable String catalogName,
+            @Nullable String databaseName,
+            @Nullable ShowLikeOperator likeOp) {
         return new ShowViewsOperation(catalogName, databaseName, likeOp);
     }
 
     @Override
     public Operation getOperation(
             SqlShowViews sqlShowCall,
-            String catalogName,
-            String databaseName,
+            @Nullable String catalogName,
+            @Nullable String databaseName,
             String prep,
-            ShowLikeOperator likeOp) {
+            @Nullable ShowLikeOperator likeOp) {
         return new ShowViewsOperation(catalogName, databaseName, prep, likeOp);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlShowToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlShowToOperationConverterTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlShowToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlShowToOperationConverterTest.java
@@ -1,0 +1,43 @@
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class SqlShowToOperationConverterTest extends SqlNodeToOperationConversionTestBase {
+
+    @BeforeEach
+    public void before() throws TableAlreadyExistException, DatabaseNotExistException {
+        // Do nothing
+        // No need to create schema, tables and etc. since the test executes for unset catalog and
+        // database
+    }
+
+    @AfterEach
+    public void after() throws TableNotExistException {
+        // Do nothing
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"SHOW TABLES", "SHOW VIEWS", "SHOW FUNCTIONS", "SHOW PROCEDURES"})
+    void testParseShowFunctionForUnsetCatalog(String sql) {
+        catalogManager.setCurrentCatalog(null);
+        // No exception should be thrown during parsing.
+        // Validation exception should be thrown while execution.
+        parse(sql);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"SHOW TABLES", "SHOW VIEWS", "SHOW FUNCTIONS", "SHOW PROCEDURES"})
+    void testParseShowFunctionForUnsetDatabase(String sql) {
+        catalogManager.setCurrentDatabase(null);
+        // No exception should be thrown during parsing.
+        // Validation exception should be thrown while execution.
+        parse(sql);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The behavior was changed in FLINK-36085 while refactoring
this PR makes the behavior as before and adds some tests for it

Also adds some missing javadocs and getters

## Verifying this change

SqlShowToOperationConverterTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
