### PR TITLE
[FLINK-36117] Add an adaptor to convert KeyedStateBackend into AsyncKeyedStateBackend.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptorUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptorUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+/**
+ * Utilities for transforming {@link StateDescriptor} to {@link
+ * org.apache.flink.api.common.state.StateDescriptor}.
+ */
+public class StateDescriptorUtils {
+    private StateDescriptorUtils() {}
+
+    public static org.apache.flink.api.common.state.StateDescriptor transformFromV2ToV1(
+            StateDescriptor stateDescriptor) {
+        switch (stateDescriptor.getType()) {
+            case VALUE:
+                ValueStateDescriptor valueStateDesc = (ValueStateDescriptor) stateDescriptor;
+                return new org.apache.flink.api.common.state.ValueStateDescriptor(
+                        valueStateDesc.getStateId(), valueStateDesc.getSerializer());
+
+            case MAP:
+                MapStateDescriptor mapStateDesc = (MapStateDescriptor) stateDescriptor;
+                return new org.apache.flink.api.common.state.MapStateDescriptor<>(
+                        mapStateDesc.getStateId(),
+                        mapStateDesc.getUserKeySerializer(),
+                        mapStateDesc.getSerializer());
+
+            case LIST:
+                ListStateDescriptor listStateDesc = (ListStateDescriptor) stateDescriptor;
+                return new org.apache.flink.api.common.state.ListStateDescriptor<>(
+                        listStateDesc.getStateId(), listStateDesc.getSerializer());
+
+            case REDUCING:
+                ReducingStateDescriptor reducingStateDesc =
+                        (ReducingStateDescriptor) stateDescriptor;
+                return new org.apache.flink.api.common.state.ReducingStateDescriptor(
+                        reducingStateDesc.getStateId(),
+                        reducingStateDesc.getReduceFunction(),
+                        reducingStateDesc.getSerializer());
+
+            case AGGREGATING:
+                AggregatingStateDescriptor aggregatingStateDesc =
+                        (AggregatingStateDescriptor) stateDescriptor;
+                return new org.apache.flink.api.common.state.AggregatingStateDescriptor(
+                        aggregatingStateDesc.getStateId(),
+                        aggregatingStateDesc.getAggregateFunction(),
+                        aggregatingStateDesc.getSerializer());
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported state type: " + stateDescriptor.getType());
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2.adaptor;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.v2.State;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.asyncprocessing.StateExecutor;
+import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.v2.StateDescriptor;
+import org.apache.flink.runtime.state.v2.StateDescriptorUtils;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+
+/**
+ * A adaptor that transforms {@link KeyedStateBackend} into {@link AsyncKeyedStateBackend}.
+ *
+ * @param <K> The key by which state is keyed.
+ */
+public class AsyncKeyedStateBackendAdaptor<K> implements AsyncKeyedStateBackend {
+    private final KeyedStateBackend<K> keyedStateBackend;
+
+    public AsyncKeyedStateBackendAdaptor(KeyedStateBackend<K> keyedStateBackend) {
+        this.keyedStateBackend = keyedStateBackend;
+    }
+
+    @Override
+    public void setup(@Nonnull StateRequestHandler stateRequestHandler) {}
+
+    @Nonnull
+    @Override
+    public <N, S extends State, SV> S createState(
+            @Nonnull N defaultNamespace,
+            @Nonnull TypeSerializer<N> namespaceSerializer,
+            @Nonnull StateDescriptor<SV> stateDesc)
+            throws Exception {
+        org.apache.flink.api.common.state.StateDescriptor rawStateDesc =
+                StateDescriptorUtils.transformFromV2ToV1(stateDesc);
+        org.apache.flink.api.common.state.State rawState =
+                keyedStateBackend.getOrCreateKeyedState(namespaceSerializer, rawStateDesc);
+        switch (rawStateDesc.getType()) {
+            case VALUE:
+                return (S) new ValueStateWrapper((ValueState) rawState);
+            default:
+                throw new UnsupportedOperationException(
+                        String.format("Unsupported state type: %s", rawStateDesc.getType()));
+        }
+    }
+
+    @Nonnull
+    @Override
+    public StateExecutor createStateExecutor() {
+        return null;
+    }
+
+    @Override
+    public void dispose() {}
+
+    @Override
+    public void close() throws IOException {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/ValueStateWrapper.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/ValueStateWrapper.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2.adaptor;
+
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.state.v2.ValueState;
+import org.apache.flink.core.state.StateFutureUtils;
+
+import java.io.IOException;
+
+/**
+ * A wrapper that transforms {@link org.apache.flink.api.common.state.ValueState} into {@link
+ * ValueState}.
+ *
+ * @param <V> Type of the value in the state.
+ */
+public class ValueStateWrapper<V> implements ValueState<V> {
+    private final org.apache.flink.api.common.state.ValueState<V> valueState;
+
+    public ValueStateWrapper(org.apache.flink.api.common.state.ValueState<V> valueState) {
+        this.valueState = valueState;
+    }
+
+    public StateFuture<V> asyncValue() {
+        try {
+            return StateFutureUtils.completedFuture(valueState.value());
+        } catch (Exception e) {
+            throw new RuntimeException("Error while getting value from raw ValueState", e);
+        }
+    }
+
+    public StateFuture<Void> asyncUpdate(V value) {
+        try {
+            valueState.update(value);
+        } catch (IOException e) {
+            throw new RuntimeException("Error while updating value from raw ValueState", e);
+        }
+        return StateFutureUtils.completedVoidFuture();
+    }
+
+    public V value() {
+        try {
+            return valueState.value();
+        } catch (Exception e) {
+            throw new RuntimeException("Error while getting value from raw ValueState", e);
+        }
+    }
+
+    public void update(V value) {
+        try {
+            valueState.update(value);
+        } catch (IOException e) {
+            throw new RuntimeException("Error while updating value from raw ValueState", e);
+        }
+    }
+
+    public StateFuture<Void> asyncClear() {
+        valueState.clear();
+        return StateFutureUtils.completedVoidFuture();
+    }
+
+    public void clear() {
+        valueState.clear();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.runtime.state.v2.adaptor.AsyncKeyedStateBackendAdaptor;
 import org.apache.flink.runtime.util.OperatorSubtaskDescriptionText;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
@@ -209,6 +210,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
                                 managedMemoryFraction,
                                 statsCollector,
                                 StateBackend::createKeyedStateBackend);
+                asyncKeyedStateBackend = new AsyncKeyedStateBackendAdaptor<>(keyedStatedBackend);
             }
 
             // -------------- Operator State Backend --------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AsyncKeyedStateBackendAdaptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AsyncKeyedStateBackendAdaptorTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.state.State;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.KeyedStateFunction;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.v2.adaptor.AsyncKeyedStateBackendAdaptor;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link AsyncKeyedStateBackendAdaptor}. */
+public class AsyncKeyedStateBackendAdaptorTest {
+
+    @Test
+    public void testAdapt() throws Exception {
+        KeyedStateBackend<Integer> keyedStateBackend = new TestKeyedStateBackend();
+        AsyncKeyedStateBackendAdaptor<Integer> adaptor =
+                new AsyncKeyedStateBackendAdaptor<>(keyedStateBackend);
+        StateDescriptor<Integer> descriptor =
+                new ValueStateDescriptor<>("testState", BasicTypeInfo.INT_TYPE_INFO);
+
+        org.apache.flink.api.common.state.v2.ValueState<Integer> valueState =
+                adaptor.createState(
+                        VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
+
+        // test synchronous interfaces.
+        valueState.clear();
+        assertThat(valueState.value()).isNull();
+        valueState.update(10);
+        assertThat(valueState.value()).isEqualTo(10);
+
+        // test asynchronous interfaces.
+        valueState
+                .asyncClear()
+                .thenAccept(
+                        clear -> {
+                            assertThat(valueState.value()).isNull();
+                            valueState
+                                    .asyncUpdate(20)
+                                    .thenCompose(
+                                            empty -> {
+                                                assertThat(valueState.value()).isEqualTo(20);
+                                                return valueState.asyncValue();
+                                            })
+                                    .thenAccept(
+                                            value -> {
+                                                assertThat(value).isEqualTo(20);
+                                            });
+                        });
+    }
+
+    static class TestValueState implements ValueState<Integer> {
+        private Integer value;
+
+        TestValueState() {
+            this.value = null;
+        }
+
+        @Override
+        public Integer value() throws IOException {
+            return value;
+        }
+
+        @Override
+        public void update(Integer value) throws IOException {
+            this.value = value;
+        }
+
+        @Override
+        public void clear() {
+            this.value = null;
+        }
+    }
+
+    static class TestKeyedStateBackend implements KeyedStateBackend<Integer> {
+
+        @Override
+        public void setCurrentKey(Integer newKey) {}
+
+        @Override
+        public Integer getCurrentKey() {
+            return 0;
+        }
+
+        @Override
+        public TypeSerializer<Integer> getKeySerializer() {
+            return null;
+        }
+
+        @Override
+        public <N, S extends State, T> void applyToAllKeys(
+                N namespace,
+                TypeSerializer<N> namespaceSerializer,
+                org.apache.flink.api.common.state.StateDescriptor<S, T> stateDescriptor,
+                KeyedStateFunction<Integer, S> function)
+                throws Exception {}
+
+        @Override
+        public <N> Stream<Integer> getKeys(String state, N namespace) {
+            return Stream.empty();
+        }
+
+        @Override
+        public <N> Stream<Tuple2<Integer, N>> getKeysAndNamespaces(String state) {
+            return Stream.empty();
+        }
+
+        @Override
+        public <N, S extends State, T> S getOrCreateKeyedState(
+                TypeSerializer<N> namespaceSerializer,
+                org.apache.flink.api.common.state.StateDescriptor<S, T> stateDescriptor)
+                throws Exception {
+            switch (stateDescriptor.getType()) {
+                case VALUE:
+                    return (S) new TestValueState();
+                default:
+                    throw new IllegalArgumentException(
+                            "Unsupported state type: " + stateDescriptor.getType());
+            }
+        }
+
+        @Override
+        public <N, S extends State> S getPartitionedState(
+                N namespace,
+                TypeSerializer<N> namespaceSerializer,
+                org.apache.flink.api.common.state.StateDescriptor<S, ?> stateDescriptor)
+                throws Exception {
+            return null;
+        }
+
+        @Override
+        public void dispose() {}
+
+        @Override
+        public void registerKeySelectionListener(KeySelectionListener<Integer> listener) {}
+
+        @Override
+        public boolean deregisterKeySelectionListener(KeySelectionListener<Integer> listener) {
+            return false;
+        }
+
+        @Nonnull
+        @Override
+        public <N, SV, SEV, S extends State, IS extends S> IS createOrUpdateInternalState(
+                @Nonnull TypeSerializer<N> namespaceSerializer,
+                @Nonnull org.apache.flink.api.common.state.StateDescriptor<S, SV> stateDesc,
+                @Nonnull
+                        StateSnapshotTransformer.StateSnapshotTransformFactory<SEV>
+                                snapshotTransformFactory)
+                throws Exception {
+            return null;
+        }
+
+        @Nonnull
+        @Override
+        public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+                KeyGroupedInternalPriorityQueue<T> create(
+                        @Nonnull String stateName,
+                        @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pull request implements the AsyncKeyedStateBackend interface for RocksDBKeyedStateBackend and HeapKeyedStateBackend, enabling both RocksDBStateBackend and HeapStateBackend to create V2 states.

## Brief change log
1.Introduce the new `ValueStateWrapper` class, which implements the `v2.ValueState` interface and can be constructed from a `ValueState`.
2.Introduce the new `StateDescriptorTransformer` class, which can convert a `v2.StateDescriptor` to a `StateDescriptor`.
3.Implement `AsyncKeyedStateBackend` interface for `RocksDBKeyedStateBackend`.
4.Implement `AsyncKeyedStateBackend` interface for `HeapKeyedStateBackend`.


## Verifying this change

This change is a simple interface implementation without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
