### PR TITLE
[BP-1.20][FLINK-35482] ParquetInt64TimestampReaderTest unit tests fail due to system timezone

### DIFF
--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetInt64TimestampReaderTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetInt64TimestampReaderTest.java
@@ -22,48 +22,45 @@ import org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader;
 import org.apache.flink.table.data.TimestampData;
 
 import org.apache.parquet.schema.LogicalTypeAnnotation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link TimestampColumnReader}. */
 public class ParquetInt64TimestampReaderTest {
     @Test
     public void testReadInt64TimestampMicros() {
-        LocalDateTime localDateTime = LocalDateTime.of(2021, 11, 22, 17, 50, 20, 112233);
-        long time =
-                localDateTime.toEpochSecond(OffsetDateTime.now().getOffset()) * 1_000_000
-                        + localDateTime.getNano() / 1_000;
+        ZonedDateTime zonedDateTime =
+                ZonedDateTime.of(2021, 11, 22, 17, 50, 20, 112233, ZoneOffset.systemDefault());
+        long time = zonedDateTime.toEpochSecond() * 1_000_000 + zonedDateTime.getNano() / 1_000;
         TimestampData timestampData =
                 TimestampColumnReader.int64ToTimestamp(
                         false, time, LogicalTypeAnnotation.TimeUnit.MICROS);
-        assertEquals("2021-11-22T17:50:20.000112", timestampData.toString());
+        assertThat(timestampData.toString()).isEqualTo("2021-11-22T17:50:20.000112");
     }
 
     @Test
     public void testReadInt64TimestampMillis() {
-        LocalDateTime localDateTime = LocalDateTime.of(2021, 11, 22, 17, 50, 20, 112233);
-        long time =
-                localDateTime.toEpochSecond(OffsetDateTime.now().getOffset()) * 1_000
-                        + localDateTime.getNano() / 1_000_000;
+        ZonedDateTime zonedDateTime =
+                ZonedDateTime.of(2021, 11, 22, 17, 50, 20, 112233, ZoneOffset.systemDefault());
+        long time = zonedDateTime.toEpochSecond() * 1000 + zonedDateTime.getNano() / 1_000_000;
         TimestampData timestampData =
                 TimestampColumnReader.int64ToTimestamp(
                         false, time, LogicalTypeAnnotation.TimeUnit.MILLIS);
-        assertEquals("2021-11-22T17:50:20", timestampData.toString());
+        assertThat(timestampData.toString()).isEqualTo("2021-11-22T17:50:20");
     }
 
     @Test
     public void testReadInt64TimestampNanos() {
-        LocalDateTime localDateTime = LocalDateTime.of(2021, 11, 22, 17, 50, 20, 112233);
-        long time =
-                localDateTime.toEpochSecond(OffsetDateTime.now().getOffset()) * 1_000_000_000
-                        + localDateTime.getNano();
+        ZonedDateTime zonedDateTime =
+                ZonedDateTime.of(2021, 11, 22, 17, 50, 20, 112233, ZoneOffset.systemDefault());
+        long time = zonedDateTime.toEpochSecond() * 1_000_000_000 + zonedDateTime.getNano();
         TimestampData timestampData =
                 TimestampColumnReader.int64ToTimestamp(
                         false, time, LogicalTypeAnnotation.TimeUnit.NANOS);
-        assertEquals("2021-11-22T17:50:20.000112233", timestampData.toString());
+        assertThat(timestampData.toString()).isEqualTo("2021-11-22T17:50:20.000112233");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the `ParquetInt64TimestampReaderTest` unit tests.


## Brief change log

- By using `ZonedDateTime` with `ZoneOffset.systemDefault()`, the correct offset is used when converting to epoch.


## Verifying this change

This change is already covered by existing tests, `ParquetInt64TimestampReaderTest`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
