### PR TITLE
[FLINK-36140] Log a warning when pods are terminated by kubernetes

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/SignalHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/SignalHandler.java
@@ -49,7 +49,7 @@ public class SignalHandler {
          */
         @Override
         public void handle(Signal signal) {
-            LOG.info(
+            LOG.warn(
                     "RECEIVED SIGNAL {}: SIG{}. Shutting down as requested.",
                     signal.getNumber(),
                     signal.getName());


### PR DESCRIPTION
## What is the purpose of the change

Scheduled maintenance or buggy nodes on Kubernetes can result random pod termination and eventually a series of job restarts due to rolling restart of the Kubernetes cluster nodes. The larger the job is the higher the chance it is affected. The jobs should be able to auto-recover from these issues, but can cause unwanted turbulence in large scale pipeline.
In this case, it is very difficult to identify what is causing the restarts without knowing the issue at Kubernetes layer and the keyword to search with because it is logged at INFO level.
We need to log this at higher level. If changing it from INFO to ERROR breaks monitoring we should at least log as warning. 

## Brief change log

  - Change the log level from INFO to WARN


## Verifying this change


This change added tests and can be verified as follows:

  - Manually verified the change at local 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? not applicable
