### PR TITLE
[FLINK-36119][state] Conditional interfaces for StateFuture

### DIFF
--- a/flink-core-api/src/main/java/org/apache/flink/api/common/state/v2/StateFuture.java
+++ b/flink-core-api/src/main/java/org/apache/flink/api/common/state/v2/StateFuture.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.state.v2;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.function.BiFunctionWithException;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -74,4 +75,100 @@ public interface StateFuture<T> {
     <U, V> StateFuture<V> thenCombine(
             StateFuture<? extends U> other,
             BiFunctionWithException<? super T, ? super U, ? extends V, ? extends Exception> fn);
+
+    /**
+     * Apply a condition test on the result of this StateFuture, and try to perform one action out
+     * of two based on the result. Gather the results of the condition test and the selected action
+     * into a StateFuture of tuple. The relationship between the action result and the returned new
+     * StateFuture are just like the {@link #thenApply(FunctionWithException)}.
+     *
+     * @param condition the condition test.
+     * @param actionIfTrue the function to apply if the condition returns true.
+     * @param actionIfFalse the function to apply if the condition returns false.
+     * @param <U> the type of the output from actionIfTrue.
+     * @param <V> the type of the output from actionIfFalse.
+     * @return the new StateFuture with the result of condition test, and result of action.
+     */
+    <U, V> StateFuture<Tuple2<Boolean, Object>> thenConditionallyApply(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            FunctionWithException<? super T, ? extends U, ? extends Exception> actionIfTrue,
+            FunctionWithException<? super T, ? extends V, ? extends Exception> actionIfFalse);
+
+    /**
+     * Apply a condition test on the result of this StateFuture, and try to perform the action if
+     * test result is true. Gather the results of the condition test and the action (if applied)
+     * into a StateFuture of tuple. The relationship between the action result and the returned new
+     * StateFuture are just like the {@link #thenApply(FunctionWithException)}.
+     *
+     * @param condition the condition test.
+     * @param actionIfTrue the function to apply if the condition returns true.
+     * @param <U> the type of the output from actionIfTrue.
+     * @return the new StateFuture with the result of condition test, and result of action.
+     */
+    <U> StateFuture<Tuple2<Boolean, U>> thenConditionallyApply(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            FunctionWithException<? super T, ? extends U, ? extends Exception> actionIfTrue);
+
+    /**
+     * Apply a condition test on the result of this StateFuture, and try to perform one action out
+     * of two based on the result. Gather the results of the condition test StateFuture.
+     *
+     * @param condition the condition test.
+     * @param actionIfTrue the function to apply if the condition returns true.
+     * @param actionIfFalse the function to apply if the condition returns false.
+     * @return the new StateFuture.
+     */
+    StateFuture<Boolean> thenConditionallyAccept(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            ThrowingConsumer<? super T, ? extends Exception> actionIfTrue,
+            ThrowingConsumer<? super T, ? extends Exception> actionIfFalse);
+
+    /**
+     * Apply a condition test on the result of this StateFuture, and try to perform the action if
+     * test result is true. Gather the results of the condition test StateFuture.
+     *
+     * @param condition the condition test.
+     * @param actionIfTrue the function to apply if the condition returns true.
+     * @return the new StateFuture.
+     */
+    StateFuture<Boolean> thenConditionallyAccept(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            ThrowingConsumer<? super T, ? extends Exception> actionIfTrue);
+
+    /**
+     * Apply a condition test on the result of this StateFuture, and try to perform one action out
+     * of two based on the result. Gather the results of the condition test and the selected action
+     * into a StateFuture of tuple. The relationship between the action result and the returned new
+     * StateFuture are just like the {@link #thenCompose(FunctionWithException)}.
+     *
+     * @param condition the condition test.
+     * @param actionIfTrue the function to apply if the condition returns true.
+     * @param actionIfFalse the function to apply if the condition returns false.
+     * @param <U> the type of the output from actionIfTrue.
+     * @param <V> the type of the output from actionIfFalse.
+     * @return the new StateFuture with the result of condition test, and result of action.
+     */
+    <U, V> StateFuture<Tuple2<Boolean, Object>> thenConditionallyCompose(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            FunctionWithException<? super T, ? extends StateFuture<U>, ? extends Exception>
+                    actionIfTrue,
+            FunctionWithException<? super T, ? extends StateFuture<V>, ? extends Exception>
+                    actionIfFalse);
+
+    /**
+     * Apply a condition test on the result of this StateFuture, and try to perform the action if
+     * test result is true. Gather the results of the condition test and the action (if applied)
+     * into a StateFuture of tuple. The relationship between the action result and the returned new
+     * StateFuture are just like the {@link #thenCompose(FunctionWithException)}
+     * (FunctionWithException)}.
+     *
+     * @param condition the condition test.
+     * @param actionIfTrue the function to apply if the condition returns true.
+     * @param <U> the type of the output from actionIfTrue.
+     * @return the new StateFuture with the result of condition test, and result of action.
+     */
+    <U> StateFuture<Tuple2<Boolean, U>> thenConditionallyCompose(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            FunctionWithException<? super T, ? extends StateFuture<U>, ? extends Exception>
+                    actionIfTrue);
 }

--- a/flink-core/src/main/java/org/apache/flink/core/state/StateFutureImpl.java
+++ b/flink-core/src/main/java/org/apache/flink/core/state/StateFutureImpl.java
@@ -20,6 +20,7 @@ package org.apache.flink.core.state;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.function.BiFunctionWithException;
 import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -218,6 +219,290 @@ public class StateFutureImpl<T> implements InternalStateFuture<T> {
                                                             e);
                                                     return null;
                                                 });
+                            });
+            return ret;
+        }
+    }
+
+    @Override
+    public <U, V> StateFuture<Tuple2<Boolean, Object>> thenConditionallyApply(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            FunctionWithException<? super T, ? extends U, ? extends Exception> actionIfTrue,
+            FunctionWithException<? super T, ? extends V, ? extends Exception> actionIfFalse) {
+        callbackRegistered();
+        if (completableFuture.isDone()) {
+            // this branch must be invoked in task thread when expected
+            T t;
+            try {
+                t = completableFuture.get();
+            } catch (Exception e) {
+                exceptionHandler.handleException(
+                        "Caught exception when processing completed StateFuture's callback.", e);
+                return null;
+            }
+            boolean test = FunctionWithException.unchecked(condition).apply(t);
+            Object r =
+                    test
+                            ? FunctionWithException.unchecked(actionIfTrue).apply(t)
+                            : FunctionWithException.unchecked(actionIfFalse).apply(t);
+
+            callbackFinished();
+            return StateFutureUtils.completedFuture(Tuple2.of(test, r));
+        } else {
+            StateFutureImpl<Tuple2<Boolean, Object>> ret = makeNewStateFuture();
+            completableFuture
+                    .thenAccept(
+                            (t) -> {
+                                callbackRunner.submit(
+                                        () -> {
+                                            boolean test = condition.apply(t);
+                                            Object r =
+                                                    test
+                                                            ? actionIfTrue.apply(t)
+                                                            : actionIfFalse.apply(t);
+                                            ret.completeInCallbackRunner(Tuple2.of(test, r));
+                                            callbackFinished();
+                                        });
+                            })
+                    .exceptionally(
+                            (e) -> {
+                                exceptionHandler.handleException(
+                                        "Caught exception when submitting StateFuture's callback.",
+                                        e);
+                                return null;
+                            });
+            return ret;
+        }
+    }
+
+    @Override
+    public <U> StateFuture<Tuple2<Boolean, U>> thenConditionallyApply(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            FunctionWithException<? super T, ? extends U, ? extends Exception> actionIfTrue) {
+        callbackRegistered();
+        if (completableFuture.isDone()) {
+            // this branch must be invoked in task thread when expected
+            T t;
+            try {
+                t = completableFuture.get();
+            } catch (Exception e) {
+                exceptionHandler.handleException(
+                        "Caught exception when processing completed StateFuture's callback.", e);
+                return null;
+            }
+            boolean test = FunctionWithException.unchecked(condition).apply(t);
+            U r = test ? FunctionWithException.unchecked(actionIfTrue).apply(t) : null;
+
+            callbackFinished();
+            return StateFutureUtils.completedFuture(Tuple2.of(test, r));
+        } else {
+            StateFutureImpl<Tuple2<Boolean, U>> ret = makeNewStateFuture();
+            completableFuture
+                    .thenAccept(
+                            (t) -> {
+                                callbackRunner.submit(
+                                        () -> {
+                                            boolean test = condition.apply(t);
+                                            U r = test ? actionIfTrue.apply(t) : null;
+                                            ret.completeInCallbackRunner(Tuple2.of(test, r));
+                                            callbackFinished();
+                                        });
+                            })
+                    .exceptionally(
+                            (e) -> {
+                                exceptionHandler.handleException(
+                                        "Caught exception when submitting StateFuture's callback.",
+                                        e);
+                                return null;
+                            });
+            return ret;
+        }
+    }
+
+    @Override
+    public StateFuture<Boolean> thenConditionallyAccept(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            ThrowingConsumer<? super T, ? extends Exception> actionIfTrue,
+            ThrowingConsumer<? super T, ? extends Exception> actionIfFalse) {
+        callbackRegistered();
+        if (completableFuture.isDone()) {
+            // this branch must be invoked in task thread when expected
+            T t;
+            try {
+                t = completableFuture.get();
+            } catch (Exception e) {
+                exceptionHandler.handleException(
+                        "Caught exception when processing completed StateFuture's callback.", e);
+                return null;
+            }
+            boolean test = FunctionWithException.unchecked(condition).apply(t);
+            if (test) {
+                ThrowingConsumer.unchecked(actionIfTrue).accept(t);
+            } else {
+                ThrowingConsumer.unchecked(actionIfFalse).accept(t);
+            }
+            callbackFinished();
+            return StateFutureUtils.completedFuture(test);
+        } else {
+            StateFutureImpl<Boolean> ret = makeNewStateFuture();
+            completableFuture
+                    .thenAccept(
+                            (t) -> {
+                                callbackRunner.submit(
+                                        () -> {
+                                            boolean test = condition.apply(t);
+                                            if (test) {
+                                                actionIfTrue.accept(t);
+                                            } else {
+                                                actionIfFalse.accept(t);
+                                            }
+                                            ret.completeInCallbackRunner(test);
+                                            callbackFinished();
+                                        });
+                            })
+                    .exceptionally(
+                            (e) -> {
+                                exceptionHandler.handleException(
+                                        "Caught exception when submitting StateFuture's callback.",
+                                        e);
+                                return null;
+                            });
+            return ret;
+        }
+    }
+
+    @Override
+    public StateFuture<Boolean> thenConditionallyAccept(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            ThrowingConsumer<? super T, ? extends Exception> actionIfTrue) {
+        return thenConditionallyAccept(condition, actionIfTrue, (b) -> {});
+    }
+
+    @Override
+    public <U, V> StateFuture<Tuple2<Boolean, Object>> thenConditionallyCompose(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            FunctionWithException<? super T, ? extends StateFuture<U>, ? extends Exception>
+                    actionIfTrue,
+            FunctionWithException<? super T, ? extends StateFuture<V>, ? extends Exception>
+                    actionIfFalse) {
+        callbackRegistered();
+        if (completableFuture.isDone()) {
+            // this branch must be invoked in task thread when expected
+            T t;
+            try {
+                t = completableFuture.get();
+            } catch (Throwable e) {
+                exceptionHandler.handleException(
+                        "Caught exception when processing completed StateFuture's callback.", e);
+                return null;
+            }
+            boolean test = FunctionWithException.unchecked(condition).apply(t);
+            StateFuture<?> actionResult;
+            if (test) {
+                actionResult = FunctionWithException.unchecked(actionIfTrue).apply(t);
+            } else {
+                actionResult = FunctionWithException.unchecked(actionIfFalse).apply(t);
+            }
+            StateFutureImpl<Tuple2<Boolean, Object>> ret = makeNewStateFuture();
+            actionResult.thenAccept(
+                    (e) -> {
+                        ret.completeInCallbackRunner(Tuple2.of(test, e));
+                    });
+            callbackFinished();
+            return ret;
+        } else {
+            StateFutureImpl<Tuple2<Boolean, Object>> ret = makeNewStateFuture();
+            completableFuture
+                    .thenAccept(
+                            (t) -> {
+                                callbackRunner.submit(
+                                        () -> {
+                                            boolean test = condition.apply(t);
+                                            StateFuture<?> actionResult;
+                                            if (test) {
+                                                actionResult = actionIfTrue.apply(t);
+                                            } else {
+                                                actionResult = actionIfFalse.apply(t);
+                                            }
+                                            actionResult.thenAccept(
+                                                    (e) -> {
+                                                        ret.completeInCallbackRunner(
+                                                                Tuple2.of(test, e));
+                                                    });
+                                            callbackFinished();
+                                        });
+                            })
+                    .exceptionally(
+                            (e) -> {
+                                exceptionHandler.handleException(
+                                        "Caught exception when submitting StateFuture's callback.",
+                                        e);
+                                return null;
+                            });
+            return ret;
+        }
+    }
+
+    @Override
+    public <U> StateFuture<Tuple2<Boolean, U>> thenConditionallyCompose(
+            FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+            FunctionWithException<? super T, ? extends StateFuture<U>, ? extends Exception>
+                    actionIfTrue) {
+        callbackRegistered();
+        if (completableFuture.isDone()) {
+            // this branch must be invoked in task thread when expected
+            T t;
+            try {
+                t = completableFuture.get();
+            } catch (Throwable e) {
+                exceptionHandler.handleException(
+                        "Caught exception when processing completed StateFuture's callback.", e);
+                return null;
+            }
+            boolean test = FunctionWithException.unchecked(condition).apply(t);
+
+            if (test) {
+                StateFuture<U> actionResult =
+                        FunctionWithException.unchecked(actionIfTrue).apply(t);
+                StateFutureImpl<Tuple2<Boolean, U>> ret = makeNewStateFuture();
+                actionResult.thenAccept(
+                        (e) -> {
+                            ret.completeInCallbackRunner(Tuple2.of(true, e));
+                        });
+                callbackFinished();
+                return ret;
+            } else {
+                callbackFinished();
+                return StateFutureUtils.completedFuture(Tuple2.of(false, null));
+            }
+        } else {
+            StateFutureImpl<Tuple2<Boolean, U>> ret = makeNewStateFuture();
+            completableFuture
+                    .thenAccept(
+                            (t) -> {
+                                callbackRunner.submit(
+                                        () -> {
+                                            boolean test = condition.apply(t);
+                                            if (test) {
+                                                StateFuture<U> actionResult = actionIfTrue.apply(t);
+                                                actionResult.thenAccept(
+                                                        (e) -> {
+                                                            ret.completeInCallbackRunner(
+                                                                    Tuple2.of(true, e));
+                                                        });
+                                            } else {
+                                                ret.completeInCallbackRunner(
+                                                        Tuple2.of(false, null));
+                                            }
+                                            callbackFinished();
+                                        });
+                            })
+                    .exceptionally(
+                            (e) -> {
+                                exceptionHandler.handleException(
+                                        "Caught exception when submitting StateFuture's callback.",
+                                        e);
+                                return null;
                             });
             return ret;
         }

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
@@ -196,6 +197,54 @@ public class ForStDBOperationTestBase {
                 StateFuture<? extends U> other,
                 BiFunctionWithException<? super T, ? super U, ? extends V, ? extends Exception>
                         fn) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U, V> StateFuture<Tuple2<Boolean, Object>> thenConditionallyApply(
+                FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+                FunctionWithException<? super T, ? extends U, ? extends Exception> actionIfTrue,
+                FunctionWithException<? super T, ? extends V, ? extends Exception> actionIfFalse) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U> StateFuture<Tuple2<Boolean, U>> thenConditionallyApply(
+                FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+                FunctionWithException<? super T, ? extends U, ? extends Exception> actionIfTrue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public StateFuture<Boolean> thenConditionallyAccept(
+                FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+                ThrowingConsumer<? super T, ? extends Exception> actionIfTrue,
+                ThrowingConsumer<? super T, ? extends Exception> actionIfFalse) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public StateFuture<Boolean> thenConditionallyAccept(
+                FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+                ThrowingConsumer<? super T, ? extends Exception> actionIfTrue) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U, V> StateFuture<Tuple2<Boolean, Object>> thenConditionallyCompose(
+                FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+                FunctionWithException<? super T, ? extends StateFuture<U>, ? extends Exception>
+                        actionIfTrue,
+                FunctionWithException<? super T, ? extends StateFuture<V>, ? extends Exception>
+                        actionIfFalse) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <U> StateFuture<Tuple2<Boolean, U>> thenConditionallyCompose(
+                FunctionWithException<? super T, Boolean, ? extends Exception> condition,
+                FunctionWithException<? super T, ? extends StateFuture<U>, ? extends Exception>
+                        actionIfTrue) {
             throw new UnsupportedOperationException();
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

As described in FLIP-455, this PR provides some interface for conditional branchings under `StateFuture`

## Brief change log

 - Add interface in `StateFuture`

## Verifying this change

  - Added UT under `StateFutureTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
