### PR TITLE
fixup! (1.19 backport) [FLINK-35886][task] Fix watermark idleness timeout accounting when subtask is backpressured/blocked

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkGeneratorSupplier.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkGeneratorSupplier.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.common.eventtime;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.util.clock.RelativeClock;
+import org.apache.flink.util.clock.SystemClock;
 
 import java.io.Serializable;
 
@@ -61,8 +62,13 @@ public interface WatermarkGeneratorSupplier<T> extends Serializable {
          * WatermarkGenerator} could not have been executed due to execution being blocked by the
          * runtime. For example a backpressure or watermark alignment blocking the progress.
          *
+         * <p>The default implementation that returns {@link SystemClock} is only for 1.19 and 1.20
+         * release to keep binary compatibility of the user's code.
+         *
          * @see RelativeClock
          */
-        RelativeClock getInputActivityClock();
+        default RelativeClock getInputActivityClock() {
+            return SystemClock.getInstance();
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2355,7 +2355,7 @@ under the License.
 								<exclude>@org.apache.flink.annotation.Experimental</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
 								<!-- MARKER: start exclusions; these will be wiped by tools/releasing/update_japicmp_configuration.sh -->
-								<!-- New method has been added to the interface, but this interface shouldn't be implemented by users, only used/called, so this doesn't break API compatibility. -->
+								<!-- New method has been added to the interface, with a default implementation. This shouldn't break binary compatibility. -->
 								<exclude>org.apache.flink.api.common.eventtime.WatermarkGeneratorSupplier$Context</exclude>
 								<!-- Base interface has been extracted from the existing Clock class. This interface shouldn't affect user code. -->
 								<exclude>org.apache.flink.util.clock.Clock</exclude>


### PR DESCRIPTION
this fixes https://github.com/apache/flink/pull/25223 due to https://github.com/apache/flink/pull/25223#discussion_r1728928197