### PR TITLE
[FLINK-35709][Table SQL / API] Allow defining a schema in REPLACE TABLE AS (RTAS)

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReplaceTableAs.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlReplaceTableAs.java
@@ -175,33 +175,6 @@ public class SqlReplaceTableAs extends SqlCreate implements ExtendedSqlNode {
                     getParserPosition(),
                     errorMsg + " syntax does not support temporary table yet.");
         }
-
-        if (getColumnList().size() > 0) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    errorMsg + " syntax does not support to specify explicit columns yet.");
-        }
-
-        if (getWatermark().isPresent()) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    errorMsg + " syntax does not support to specify explicit watermark yet.");
-        }
-        if (getDistribution() != null) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    errorMsg + " syntax does not support creating distributed tables yet.");
-        }
-        if (getPartitionKeyList().size() > 0) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    errorMsg + " syntax does not support to create partitioned table yet.");
-        }
-        if (getFullConstraints().stream().anyMatch(SqlTableConstraint::isPrimaryKey)) {
-            throw new SqlValidateException(
-                    getParserPosition(),
-                    errorMsg + " syntax does not support primary key constraints yet.");
-        }
     }
 
     public SqlNode getAsQuery() {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -2944,17 +2944,11 @@ class FlinkSqlParserImplTest extends SqlParserTest {
 
         // test replace table as select with explicit columns
         sql("REPLACE TABLE t (col1 string) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "REPLACE TABLE AS SELECT syntax does not support to specify explicit columns yet."));
+                .node(new ValidationMatcher().ok());
 
         // test replace table as select with watermark
         sql("REPLACE TABLE t (watermark FOR ts AS ts - interval '3' second) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "REPLACE TABLE AS SELECT syntax does not support to specify explicit watermark yet."));
+                .node(new ValidationMatcher().ok());
 
         // test replace table as select with constraints
         sql("REPLACE TABLE t (PRIMARY KEY (col1)) WITH ('test' = 'zm') AS SELECT col1 FROM b")
@@ -2973,17 +2967,11 @@ class FlinkSqlParserImplTest extends SqlParserTest {
 
         // test replace table as select with partition key
         sql("REPLACE TABLE t PARTITIONED BY(col1) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "REPLACE TABLE AS SELECT syntax does not support to create partitioned table yet."));
+                .node(new ValidationMatcher().ok());
 
         // test replace table as select with distribution
         sql("REPLACE TABLE t DISTRIBUTED BY(col1) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "REPLACE TABLE AS SELECT syntax does not support creating distributed tables yet."));
+                .node(new ValidationMatcher().ok());
     }
 
     @Test
@@ -3010,17 +2998,12 @@ class FlinkSqlParserImplTest extends SqlParserTest {
 
         // test create or replace table as select with explicit columns
         sql("CREATE OR REPLACE TABLE t (col1 string) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "CREATE OR REPLACE TABLE AS SELECT syntax does not support to specify explicit columns yet."));
+                .node(new ValidationMatcher().ok());
 
         // test create or replace table as select with watermark
         sql("CREATE OR REPLACE TABLE t (watermark FOR ts AS ts - interval '3' second) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "CREATE OR REPLACE TABLE AS SELECT syntax does not support to specify explicit watermark yet."));
+                .node(new ValidationMatcher().ok());
+
         // test create or replace table as select with constraints
         sql("CREATE OR REPLACE TABLE t (PRIMARY KEY (col1)) WITH ('test' = 'zm') AS SELECT col1 FROM b")
                 .node(
@@ -3038,16 +3021,10 @@ class FlinkSqlParserImplTest extends SqlParserTest {
 
         // test create or replace table as select with partition key
         sql("CREATE OR REPLACE TABLE t PARTITIONED BY(col1) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "CREATE OR REPLACE TABLE AS SELECT syntax does not support to create partitioned table yet."));
+                .node(new ValidationMatcher().ok());
 
         sql("CREATE OR REPLACE TABLE t DISTRIBUTED BY(col1) WITH ('test' = 'zm') AS SELECT col1 FROM b")
-                .node(
-                        new ValidationMatcher()
-                                .fails(
-                                        "CREATE OR REPLACE TABLE AS SELECT syntax does not support creating distributed tables yet."));
+                .node(new ValidationMatcher().ok());
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -43,21 +43,13 @@ import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.SqlRewriterUtils;
 import org.apache.flink.table.planner.utils.OperationConverterUtils;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.RowType.RowField;
 
-import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
-import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.SqlSelect;
-import org.apache.calcite.sql.parser.SqlParserPos;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +57,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /** Helper class for converting {@link SqlCreateTable} to {@link CreateTableOperation}. */
 class SqlCreateTableConverter {
@@ -130,8 +121,12 @@ class SqlCreateTableConverter {
 
         // If needed, rewrite the query to include the new sink fields in the select list
         query =
-                maybeRewriteCreateTableAsQuery(
-                        flinkPlanner, sqlCreateTableAs, tableWithResolvedSchema, query);
+                mergeTableAsUtil.maybeRewriteQuery(
+                        catalogManager,
+                        flinkPlanner,
+                        query,
+                        sqlCreateTableAs.getAsQuery(),
+                        tableWithResolvedSchema);
 
         CreateTableOperation createTableOperation =
                 new CreateTableOperation(
@@ -142,83 +137,6 @@ class SqlCreateTableConverter {
 
         return new CreateTableASOperation(
                 createTableOperation, Collections.emptyMap(), query, false);
-    }
-
-    /**
-     * Builds and returns a new Query operation with new sink fields declared in the {@code
-     * sinkTable}.
-     */
-    private PlannerQueryOperation maybeRewriteCreateTableAsQuery(
-            FlinkPlannerImpl flinkPlanner,
-            SqlCreateTableAs sqlCreateTableAs,
-            ResolvedCatalogTable sinkTable,
-            PlannerQueryOperation query) {
-
-        // Only fields that may be persisted will be included in the select query
-        RowType sinkRowType =
-                ((RowType) sinkTable.getResolvedSchema().toSinkRowDataType().getLogicalType());
-
-        Map<String, Integer> sourceFields =
-                IntStream.range(0, query.getResolvedSchema().getColumnNames().size())
-                        .boxed()
-                        .collect(
-                                Collectors.toMap(
-                                        query.getResolvedSchema().getColumnNames()::get,
-                                        Function.identity()));
-
-        // assignedFields contains the new sink fields that are not present in the source
-        // and that will be included in the select query
-        LinkedHashMap<Integer, SqlNode> assignedFields = new LinkedHashMap<>();
-
-        // targetPositions contains the positions of the source fields that will be
-        // included in the select query
-        List<Object> targetPositions = new ArrayList<>();
-
-        int pos = -1;
-        for (RowField targetField : sinkRowType.getFields()) {
-            pos++;
-
-            if (!sourceFields.containsKey(targetField.getName())) {
-                if (!targetField.getType().isNullable()) {
-                    throw new ValidationException(
-                            "Column '"
-                                    + targetField.getName()
-                                    + "' has "
-                                    + "no default value and does not allow NULLs.");
-                }
-
-                assignedFields.put(
-                        pos,
-                        rewriterUtils.maybeCast(
-                                SqlLiteral.createNull(SqlParserPos.ZERO),
-                                typeFactory.createUnknownType(),
-                                typeFactory.createFieldTypeFromLogicalType(targetField.getType()),
-                                typeFactory));
-            } else {
-                targetPositions.add(sourceFields.get(targetField.getName()));
-            }
-        }
-
-        // if there are no new sink fields to include, then return the original query
-        if (assignedFields.isEmpty()) {
-            return query;
-        }
-
-        // rewrite query
-        SqlCall newSelect =
-                rewriterUtils.rewriteSelect(
-                        (SqlSelect) sqlCreateTableAs.getAsQuery(),
-                        typeFactory.buildRelNodeRowType(sinkRowType),
-                        assignedFields,
-                        targetPositions);
-
-        return (PlannerQueryOperation)
-                SqlNodeToOperationConversion.convert(flinkPlanner, catalogManager, newSelect)
-                        .orElseThrow(
-                                () ->
-                                        new TableException(
-                                                "CTAS unsupported node type "
-                                                        + newSelect.getClass().getSimpleName()));
     }
 
     private ResolvedCatalogTable createCatalogTable(
@@ -233,7 +151,12 @@ class SqlCreateTableConverter {
         String tableComment =
                 OperationConverterUtils.getTableComment(sqlCreateTableAs.getComment());
 
-        Schema mergedSchema = mergeTableAsUtil.mergeSchemas(sqlCreateTableAs, mergeSchema);
+        Schema mergedSchema =
+                mergeTableAsUtil.mergeSchemas(
+                        sqlCreateTableAs.getColumnList(),
+                        sqlCreateTableAs.getWatermark().orElse(null),
+                        sqlCreateTableAs.getFullConstraints(),
+                        mergeSchema);
 
         Optional<TableDistribution> tableDistribution =
                 Optional.ofNullable(sqlCreateTableAs.getDistribution())

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeConvertContext.java
@@ -73,6 +73,11 @@ public class SqlNodeConvertContext implements SqlNodeConverter.ConvertContext {
     }
 
     @Override
+    public FlinkPlannerImpl getFlinkPlanner() {
+        return flinkPlanner;
+    }
+
+    @Override
     public RelRoot toRelRoot(SqlNode sqlNode) {
         return flinkPlanner.rel(sqlNode);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverter.java
@@ -22,6 +22,7 @@ import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.utils.Expander;
 import org.apache.flink.table.types.DataType;
 
@@ -82,6 +83,9 @@ public interface SqlNodeConverter<S extends SqlNode> {
 
         /** Returns the {@link CatalogManager} in the convert context. */
         CatalogManager getCatalogManager();
+
+        /** Returns the {@link FlinkPlannerImpl} in the convert context. */
+        FlinkPlannerImpl getFlinkPlanner();
 
         /** Converts the given validated {@link SqlNode} into a {@link RelRoot}. */
         RelRoot toRelRoot(SqlNode sqlNode);


### PR DESCRIPTION
## What is the purpose of the change

Allow defining new columns and/or overriding source column types in the CREATE clause on RTAS statements.
Syntax supported:

```
CREATE OR REPLACE TABLE  table_name 
  [( <column_definition>[, ...n], [<watermark_definition>], [<table_constraint>])]
[DISTRIBUTED BY [HASH|RANGE|RANDOM](cols) [INTO n BUCKETS]]
AS SELECT query_expression;
```

Column definition supports adding new columns and/or defining columns already existing in the SELECT clause. Also, allows to pass PRIMARY KEY and WATERMARK columns.


## Brief change log

  - Added support for column definition, watermarks, primary keys and distribution in the RTAS statement


## Verifying this change

This change added tests and can be verified as follows:

- Added unit tests to validation and converter classes
- Added IT tests that verify data is written and read correctly

## Does this pull request potentially affect one of the following parts:

 - Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs (will follow-up with another PR to update docs)
