### PR TITLE
[FLINK-36147][runtime] Removes deprecated location field

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2025,9 +2025,6 @@
                   "taskName" : {
                     "type" : "string"
                   },
-                  "location" : {
-                    "type" : "string"
-                  },
                   "endpoint" : {
                     "type" : "string"
                   },
@@ -2056,9 +2053,6 @@
                           }
                         },
                         "taskName" : {
-                          "type" : "string"
-                        },
-                        "location" : {
                           "type" : "string"
                         },
                         "endpoint" : {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -242,7 +242,6 @@ public class JobExceptionsHandler
                 historyEntry.getFailureLabels(),
                 historyEntry.getFailingTaskName(),
                 toString(historyEntry.getTaskManagerLocation()),
-                toString(historyEntry.getTaskManagerLocation()),
                 toTaskManagerId(historyEntry.getTaskManagerLocation()),
                 concurrentExceptions);
     }
@@ -258,7 +257,6 @@ public class JobExceptionsHandler
                     exceptionHistoryEntry.getFailureLabels(),
                     null,
                     null,
-                    null,
                     null);
         }
 
@@ -270,7 +268,6 @@ public class JobExceptionsHandler
                 exceptionHistoryEntry.getTimestamp(),
                 exceptionHistoryEntry.getFailureLabels(),
                 exceptionHistoryEntry.getFailingTaskName(),
-                toString(exceptionHistoryEntry.getTaskManagerLocation()),
                 toString(exceptionHistoryEntry.getTaskManagerLocation()),
                 toTaskManagerId(exceptionHistoryEntry.getTaskManagerLocation()));
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
@@ -176,7 +176,6 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         public static final String FIELD_NAME_EXCEPTION_STACKTRACE = "stacktrace";
         public static final String FIELD_NAME_EXCEPTION_TIMESTAMP = "timestamp";
         public static final String FIELD_NAME_TASK_NAME = "taskName";
-        @Deprecated public static final String FIELD_NAME_LOCATION = "location";
         public static final String FIELD_NAME_ENDPOINT = "endpoint";
         public static final String FIELD_NAME_TASK_MANAGER_ID = "taskManagerId";
         public static final String FIELD_NAME_FAILURE_LABELS = "failureLabels";
@@ -195,13 +194,6 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         @Nullable
         private final String taskName;
 
-        /** @deprecated Use {@link ExceptionInfo#endpoint} instead. */
-        @Deprecated
-        @JsonInclude(NON_NULL)
-        @JsonProperty(FIELD_NAME_LOCATION)
-        @Nullable
-        private final String location;
-
         @JsonInclude(NON_NULL)
         @JsonProperty(FIELD_NAME_ENDPOINT)
         @Nullable
@@ -216,15 +208,7 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         private final Map<String, String> failureLabels;
 
         public ExceptionInfo(String exceptionName, String stacktrace, long timestamp) {
-            this(
-                    exceptionName,
-                    stacktrace,
-                    timestamp,
-                    Collections.emptyMap(),
-                    null,
-                    null,
-                    null,
-                    null);
+            this(exceptionName, stacktrace, timestamp, Collections.emptyMap(), null, null, null);
         }
 
         @JsonCreator
@@ -234,7 +218,6 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                 @JsonProperty(FIELD_NAME_EXCEPTION_TIMESTAMP) long timestamp,
                 @JsonProperty(FIELD_NAME_FAILURE_LABELS) Map<String, String> failureLabels,
                 @JsonProperty(FIELD_NAME_TASK_NAME) @Nullable String taskName,
-                @JsonProperty(FIELD_NAME_LOCATION) @Nullable String location,
                 @JsonProperty(FIELD_NAME_ENDPOINT) @Nullable String endpoint,
                 @JsonProperty(FIELD_NAME_TASK_MANAGER_ID) @Nullable String taskManagerId) {
             this.exceptionName = checkNotNull(exceptionName);
@@ -242,7 +225,6 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
             this.timestamp = timestamp;
             this.failureLabels = checkNotNull(failureLabels);
             this.taskName = taskName;
-            this.location = location;
             this.endpoint = endpoint;
             this.taskManagerId = taskManagerId;
         }
@@ -266,13 +248,6 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         @Nullable
         public String getTaskName() {
             return taskName;
-        }
-
-        @Deprecated
-        @JsonIgnore
-        @Nullable
-        public String getLocation() {
-            return location;
         }
 
         @JsonIgnore
@@ -308,20 +283,13 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                     && Objects.equals(timestamp, that.timestamp)
                     && Objects.equals(failureLabels, that.failureLabels)
                     && Objects.equals(taskName, that.taskName)
-                    && Objects.equals(location, that.location)
                     && Objects.equals(endpoint, that.endpoint);
         }
 
         @Override
         public int hashCode() {
             return Objects.hash(
-                    exceptionName,
-                    stacktrace,
-                    timestamp,
-                    failureLabels,
-                    taskName,
-                    location,
-                    endpoint);
+                    exceptionName, stacktrace, timestamp, failureLabels, taskName, endpoint);
         }
 
         @Override
@@ -362,7 +330,6 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                     null,
                     null,
                     null,
-                    null,
                     concurrentExceptions);
         }
 
@@ -373,7 +340,6 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                 @JsonProperty(FIELD_NAME_EXCEPTION_TIMESTAMP) long timestamp,
                 @JsonProperty(FIELD_NAME_FAILURE_LABELS) Map<String, String> failureLabels,
                 @JsonProperty(FIELD_NAME_TASK_NAME) @Nullable String taskName,
-                @JsonProperty(FIELD_NAME_LOCATION) @Nullable String location,
                 @JsonProperty(FIELD_NAME_ENDPOINT) @Nullable String endpoint,
                 @JsonProperty(FIELD_NAME_TASK_MANAGER_ID) @Nullable String taskManagerId,
                 @JsonProperty(FIELD_NAME_CONCURRENT_EXCEPTIONS)
@@ -384,7 +350,6 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                     timestamp,
                     failureLabels,
                     taskName,
-                    location,
                     endpoint,
                     taskManagerId);
             this.concurrentExceptions = concurrentExceptions;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
@@ -309,7 +309,7 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                     && Objects.equals(failureLabels, that.failureLabels)
                     && Objects.equals(taskName, that.taskName)
                     && Objects.equals(location, that.location)
-                    && Objects.equals(location, that.endpoint);
+                    && Objects.equals(endpoint, that.endpoint);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -710,7 +710,7 @@ class JobExceptionsHandlerTest {
         private final long expectedTimestamp;
         private final Map<String, String> expectedFailureLabels;
         private final String expectedTaskName;
-        private final String expectedLocation;
+        private final String expectedEndpoint;
         private final String expectedTaskManagerId;
 
         private ExceptionInfoMatcher(
@@ -718,14 +718,14 @@ class JobExceptionsHandlerTest {
                 long expectedTimestamp,
                 CompletableFuture<Map<String, String>> expectedFailureLabels,
                 String expectedTaskName,
-                String expectedLocation,
+                String expectedEndpoint,
                 String expectedTaskManagerId)
                 throws ExecutionException, InterruptedException {
             this.expectedException = deserializeSerializedThrowable(expectedException);
             this.expectedTimestamp = expectedTimestamp;
             this.expectedFailureLabels = expectedFailureLabels.get();
             this.expectedTaskName = expectedTaskName;
-            this.expectedLocation = expectedLocation;
+            this.expectedEndpoint = expectedEndpoint;
             this.expectedTaskManagerId = expectedTaskManagerId;
         }
 
@@ -742,8 +742,8 @@ class JobExceptionsHandlerTest {
                     .appendText(String.valueOf(expectedFailureLabels))
                     .appendText(", taskName=")
                     .appendText(expectedTaskName)
-                    .appendText(", location=")
-                    .appendText(expectedLocation)
+                    .appendText(", endpoint=")
+                    .appendText(expectedEndpoint)
                     .appendText(", taskManagerId=")
                     .appendText(expectedTaskManagerId);
         }
@@ -785,8 +785,8 @@ class JobExceptionsHandlerTest {
                     && matches(
                             info,
                             description,
-                            ExceptionInfo::getLocation,
-                            expectedLocation,
+                            ExceptionInfo::getEndpoint,
+                            expectedEndpoint,
                             "location")
                     && matches(
                             info,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistoryNoRootTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistoryNoRootTest.java
@@ -77,7 +77,6 @@ class JobExceptionsInfoWithHistoryNoRootTest
                                                         Collections.emptyMap(),
                                                         "task name #2",
                                                         "location #2",
-                                                        "location #2",
                                                         "taskManagerId #2"))),
                                 new JobExceptionsInfoWithHistory.RootExceptionInfo(
                                         "local task failure #1",
@@ -85,7 +84,6 @@ class JobExceptionsInfoWithHistoryNoRootTest
                                         1L,
                                         Collections.emptyMap(),
                                         "task name",
-                                        "location",
                                         "location",
                                         "taskManagerId",
                                         Collections.emptyList())),


### PR DESCRIPTION
## What is the purpose of the change

Removes deprecated field "location". It was replaced by the "endpoint" field in 1.19.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable