### PR TITLE
[FLINK-36152] Fix incorrect type extraction in case of cascaded inheritance when DataTypeHint is not configured

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
@@ -343,10 +343,17 @@ public final class ExtractionUtils {
             if (!baseClass.isAssignableFrom(clazz)) {
                 return Optional.empty();
             }
-            final Type t =
-                    ((ParameterizedType) clazz.getGenericSuperclass())
-                            .getActualTypeArguments()[pos];
-            return Optional.ofNullable(toClass(t));
+            for (Class<?> c = clazz; c != null && c != baseClass; c = c.getSuperclass()) {
+                Type genericSuperClass = c.getGenericSuperclass();
+                if (genericSuperClass instanceof ParameterizedType) {
+                    final Type[] typeArguments =
+                            ((ParameterizedType) genericSuperClass).getActualTypeArguments();
+                    if (typeArguments.length > pos) {
+                        return Optional.ofNullable(toClass(typeArguments[pos]));
+                    }
+                }
+            }
+            return Optional.empty();
         } catch (Exception unused) {
             return Optional.empty();
         }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -1346,6 +1346,12 @@ public class FunctionITCase extends StreamingTestBase {
         testLookupTableFunctionBase(LookupTableWithoutHintLevel1Function.class.getName());
     }
 
+    @Test
+    void testLookupTableFunctionWithoutHintLevel2()
+            throws ExecutionException, InterruptedException {
+        testLookupTableFunctionBase(LookupTableWithoutHintLevel2Function.class.getName());
+    }
+
     private void testLookupTableFunctionBase(String lookupTableFunctionClassName)
             throws ExecutionException, InterruptedException {
         final List<Row> sourceData = Arrays.asList(Row.of("Bob"), Row.of("Alice"));
@@ -2040,6 +2046,9 @@ public class FunctionITCase extends StreamingTestBase {
             collect(GenericRowData.of(StringData.fromString(s.toString()), s.toBytes()));
         }
     }
+
+    public static class LookupTableWithoutHintLevel2Function
+            extends LookupTableWithoutHintLevel1Function {}
 
     /**
      * Synchronous table function that uses {@link RowData} type for {@link LookupTableSource} and


### PR DESCRIPTION
 <!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix incorrect type extraction in case of cascaded inheritance when DataTypeHint is not configured.

In our case, there's a `ConcreteLookupFunction extends AbstractLookupFunction`, and `AbstractLookupFunction extends TableFunction<RowData>`. 

However `Class#getGenericSuperclass` only return the direct superclass, so it cannot extract the correct generic type `RowData`.

I can reproduce the exception below:
```java
// flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java

@Test
void testLookupTableFunctionWithoutHintLevel2()
        throws ExecutionException, InterruptedException {
    testLookupTableFunctionBase(LookupTableWithoutHintLevel2Function.class.getName());
}

// ... ...

public static class LookupTableWithoutHintLevel2Function
        extends LookupTableWithoutHintLevel1Function {}
```
```
org.apache.flink.table.api.ValidationException: Cannot extract a data type from an internal 'org.apache.flink.table.data.RowData' class without further information. Please use annotations to define the full logical type.
    at org.apache.flink.table.types.extraction.ExtractionUtils.extractionError(ExtractionUtils.java:424)
    at org.apache.flink.table.types.extraction.ExtractionUtils.extractionError(ExtractionUtils.java:419)
    at org.apache.flink.table.types.extraction.DataTypeExtractor.checkForCommonErrors(DataTypeExtractor.java:425)
    at org.apache.flink.table.types.extraction.DataTypeExtractor.extractDataTypeOrError(DataTypeExtractor.java:330)
    at org.apache.flink.table.types.extraction.DataTypeExtractor.extractDataTypeOrRawWithTemplate(DataTypeExtractor.java:290)
    ... 53 more
 ```


## Brief change log

- Iterate through the superclass hierarchy of a given class to extract generic type.


## Verifying this change

This change added tests and can be verified as follows:

- Added test that validates that multi-levels inheritance in FunctionITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
