### PR TITLE
[FLINK-26944][table] Add the built-in function ADD_MONTHS

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -653,6 +653,16 @@ temporal:
         CURRENT_WATERMARK(ts) IS NULL
         OR ts > CURRENT_WATERMARK(ts)
       ```
+  - sql: ADD_MONTHS(startDate, numMonths)
+    table: startDate.addMonths(numMonths)
+    description: |
+      Returns the date numMonths after startDate.
+      If numMonths is negative, -numMonths are subtracted from startDate.
+      If the resulting month has fewer days than the day component of startDate, then the result is the last day of the resulting month.
+      
+      `startDate <DATE | TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE | CHAR | VARCHAR>, numMonths <TINYINT | SMALLINT | INTEGER | BIGINT>`
+      
+      Returns a `DATE`, `NULL` if any of the arguments are `NULL` or result overflows or date string invalid.
 
 conditional:
   - sql: |

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -781,6 +781,16 @@ temporal:
         CURRENT_WATERMARK(ts) IS NULL
         OR ts > CURRENT_WATERMARK(ts)
       ```
+  - sql: ADD_MONTHS(startDate, numMonths)
+    table: startDate.addMonths(numMonths)
+    description: |
+      返回起始日期 startDate 之后 numMonths 个月的日期。
+      如果 numMonths 为负数，则从 startDate 中减去 -numMonths 个月。
+      如果结果月份的天数少于 startDate 的日期部分，则结果日期为月份的最后一天。
+      
+      `startDate <DATE | TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE | CHAR | VARCHAR>, numMonths <TINYINT | SMALLINT | INTEGER | BIGINT>`
+      
+      返回一个 `DATE`，如果任何参数为 'NULL' 或结果溢出或日期字符串非法，则返回 'NULL'。
 
 conditional:
   - sql: |

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -220,6 +220,7 @@ temporal functions
     Expression.to_time
     Expression.to_timestamp
     Expression.extract
+    Expression.add_months
     Expression.floor
     Expression.ceil
 

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1530,6 +1530,20 @@ class Expression(Generic[T]):
         return _binary_op("extract")(
             self, time_interval_unit._to_j_time_interval_unit())
 
+    def add_months(self, num_months) -> 'Expression':
+        """
+        Returns the date numMonths after startDate.
+        If numMonths is negative, -numMonths are subtracted from startDate.
+        If the resulting month has fewer days than the day component of startDate, then the result
+        is the last day of the resulting month.
+
+        null if any of the arguments are null or result overflows or date string invalid.
+
+        :param num_months: An INTEGER expression.
+        :return: A DATE.
+        """
+        return _binary_op("addMonths")(self, num_months)
+
     def floor(self, time_interval_unit: TimeIntervalUnit = None) -> 'Expression':
         """
         If time_interval_unit is specified, it rounds down a time point to the given

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1532,9 +1532,9 @@ class Expression(Generic[T]):
 
     def add_months(self, num_months) -> 'Expression':
         """
-        Returns the date numMonths after startDate.
-        If numMonths is negative, -numMonths are subtracted from startDate.
-        If the resulting month has fewer days than the day component of startDate, then the result
+        Returns the date num_months after start_date.
+        If num_months is negative, -num_months are subtracted from start_date.
+        If the resulting month has fewer days than the day component of start_date, then the result
         is the last day of the resulting month.
 
         null if any of the arguments are null or result overflows or date string invalid.

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -190,6 +190,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('extract(YEAR, a)', str(expr1.extract(TimeIntervalUnit.YEAR)))
         self.assertEqual('floor(a, YEAR)', str(expr1.floor(TimeIntervalUnit.YEAR)))
         self.assertEqual('ceil(a)', str(expr1.ceil()))
+        self.assertEqual('ADD_MONTHS(a, 3)', str(expr1.add_months(3)))
 
         # advanced type helper functions
         self.assertEqual("get(a, 'col')", str(expr1.get('col')))

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -52,6 +52,7 @@ import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCa
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ABS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ACOS;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ADD_MONTHS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AND;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_AGG;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ARRAY_APPEND;
@@ -1530,6 +1531,22 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType ceil(TimeIntervalUnit timeIntervalUnit) {
         return toApiSpecificExpression(
                 unresolvedCall(CEIL, toExpr(), valueLiteral(timeIntervalUnit)));
+    }
+
+    /**
+     * Returns the date {@code numMonths} after {@code startDate}. <br>
+     * If {@code numMonths} is negative, {@code -numMonths} are subtracted from {@code startDate}.
+     * <br>
+     * If the resulting month has fewer days than the day component of {@code startDate}, then the
+     * result is the last day of the resulting month.<br>
+     * null if any of the arguments are null or result overflows or date string invalid.
+     *
+     * @param numMonths An INTEGER expression.
+     * @return A DATE.
+     */
+    public OutType addMonths(InType numMonths) {
+        return toApiSpecificExpression(
+                unresolvedCall(ADD_MONTHS, toExpr(), objectToExpression(numMonths)));
     }
 
     // Advanced type helper functions

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -2130,6 +2130,29 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition ADD_MONTHS =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("ADD_MONTHS")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Arrays.asList("startDate", "numMonths"),
+                                    Arrays.asList(
+                                            or(
+                                                    logical(LogicalTypeRoot.DATE),
+                                                    logical(
+                                                            LogicalTypeRoot
+                                                                    .TIMESTAMP_WITHOUT_TIME_ZONE),
+                                                    logical(
+                                                            LogicalTypeRoot
+                                                                    .TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING)),
+                                            logical(LogicalTypeFamily.INTEGER_NUMERIC))))
+                    .outputTypeStrategy(explicit(DATE()))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.AddMonthsFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition TIMESTAMP_DIFF =
             BuiltInFunctionDefinition.newBuilder()
                     .name("timestampDiff")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java
@@ -127,11 +127,17 @@ public class DateTimeUtils {
     /** The valid minimum epoch seconds ('0000-01-01 00:00:00 UTC+0'). */
     private static final long MIN_EPOCH_SECONDS = -62167219200L;
 
+    /** The valid minimum epoch days ('0000-01-01 UTC+0'). */
+    private static final long MIN_EPOCH_DAYS = -719528L;
+
     /** The valid maximum epoch milliseconds ('9999-12-31 23:59:59.999 UTC+0'). */
     private static final long MAX_EPOCH_MILLS = 253402300799999L;
 
     /** The valid maximum epoch seconds ('9999-12-31 23:59:59 UTC+0'). */
     private static final long MAX_EPOCH_SECONDS = 253402300799L;
+
+    /** The valid maximum epoch days ('9999-12-31 UTC+0'). */
+    private static final long MAX_EPOCH_DAYS = 2932896L;
 
     private static final DateTimeFormatter DEFAULT_TIMESTAMP_FORMATTER =
             new DateTimeFormatterBuilder()
@@ -1533,6 +1539,10 @@ public class DateTimeUtils {
             return false;
         }
         return true;
+    }
+
+    public static boolean isIllegalDate(int numDaysFromEpoch) {
+        return numDaysFromEpoch < MIN_EPOCH_DAYS || numDaysFromEpoch > MAX_EPOCH_DAYS;
     }
 
     private static String pad(int length, long v) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/TimeFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/TimeFunctionsITCase.java
@@ -821,9 +821,14 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
                                 LocalDate.of(2023, 2, 28),
                                 DATE())
                         .testResult(
-                                $("f1").addMonths(7),
-                                "ADD_MONTHS(f1, 7)",
-                                LocalDate.of(2025, 2, 28),
+                                $("f1").addMonths(-293),
+                                "ADD_MONTHS(f1, -293)",
+                                LocalDate.of(2000, 2, 29),
+                                DATE())
+                        .testResult(
+                                $("f1").addMonths(907),
+                                "ADD_MONTHS(f1, 907)",
+                                LocalDate.of(2100, 2, 28),
                                 DATE())
                         .testResult(
                                 $("f1").addMonths(-720),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/TimeFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/TimeFunctionsITCase.java
@@ -54,10 +54,10 @@ class TimeFunctionsITCase extends BuiltInFunctionTestBase {
     @Override
     Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
-                        //                        extractTestCases(),
-                        //                        temporalOverlapsTestCases(),
-                        //                        ceilTestCases(),
-                        //                        floorTestCases(),
+                        extractTestCases(),
+                        temporalOverlapsTestCases(),
+                        ceilTestCases(),
+                        floorTestCases(),
                         addMonthsTestCases())
                 .flatMap(s -> s);
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/AddMonthsFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/AddMonthsFunction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.utils.DateTimeUtils;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#ADD_MONTHS}. */
+public class AddMonthsFunction extends BuiltInScalarFunction {
+
+    private final SpecializedFunction.ExpressionEvaluator castEvaluator;
+    private transient MethodHandle castHandle;
+
+    public AddMonthsFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.ADD_MONTHS, context);
+        final DataType startDateDataType = context.getCallContext().getArgumentDataTypes().get(0);
+        castEvaluator =
+                context.createEvaluator(
+                        $("startDate").cast(DataTypes.DATE().toInternal()),
+                        DataTypes.DATE().toInternal(),
+                        DataTypes.FIELD("startDate", startDateDataType.toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        castHandle = castEvaluator.open(context);
+    }
+
+    public @Nullable Integer eval(@Nullable Object startDate, @Nullable Number numMonths) {
+        if (startDate == null
+                || numMonths == null
+                || numMonths.longValue() > Integer.MAX_VALUE
+                || numMonths.longValue() < Integer.MIN_VALUE) {
+            return null;
+        }
+
+        try {
+            int resultDate =
+                    DateTimeUtils.addMonths(
+                            (int) castHandle.invoke(startDate), numMonths.intValue());
+            return DateTimeUtils.isIllegalDate(resultDate) ? null : resultDate;
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        castEvaluator.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the built-in function ADD_MONTHS.
Examples:

```SQL
> SELECT ADD_MONTHS('2016-08-31', 1);
 2016-09-30
> SELECT ADD_MONTHS('2016-08-31', -6);
 2016-02-29 
```

## Brief change log

[FLINK-26944](https://issues.apache.org/jira/browse/FLINK-26944)


## Verifying this change

`TimeFunctionsITCase#addMonthsTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
