### PR TITLE
[FLINK-35850][table] Add the built-in function DATEDIFF

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -599,6 +599,15 @@ temporal:
   - sql: DATE_FORMAT(timestamp, string)
     table: dateFormat(TIMESTAMP, STRING)
     description: Converts timestamp to a value of string in the format specified by the date format string. The format string is compatible with Java's SimpleDateFormat.
+  - sql: DATEDIFF(endDate, startDate)
+    table: endDate.dateDiff(startDate)
+    description: |
+      Returns the number of days from startDate to endDate.
+      If endDate is before startDate, the result is negative.
+      
+      `endDate <DATE | TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE | CHAR | VARCHAR>, startDate <DATE | TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE | CHAR | VARCHAR>`
+
+      Returns an `INTEGER`, `NULL` if any of the arguments are `NULL` or date string invalid.
   - sql: TIMESTAMPADD(timeintervalunit, interval, timepoint)
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -715,6 +715,15 @@ temporal:
     table: dateFormat(TIMESTAMP, STRING)
     description: |
       将时间戳 timestamp 转换为日期格式字符串 string 指定格式的字符串值。格式字符串与 Java 的 SimpleDateFormat 兼容。
+  - sql: DATEDIFF(endDate, startDate)
+    table: endDate.dateDiff(startDate)
+    description: |
+      返回从 startDate 到 endDate 的天数。
+      如果 endDate 早于 startDate，结果为负数。
+      
+      `endDate <DATE | TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE | CHAR | VARCHAR>, startDate <DATE | TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE | CHAR | VARCHAR>`
+
+      返回一个 `INTEGER`。如果任意参数为 `NULL` 或日期字符串非法，则返回 `NULL`。
   - sql: TIMESTAMPADD(timeintervalunit, interval, timepoint)
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -220,6 +220,7 @@ temporal functions
     Expression.to_time
     Expression.to_timestamp
     Expression.extract
+    Expression.datediff
     Expression.floor
     Expression.ceil
 

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1530,6 +1530,18 @@ class Expression(Generic[T]):
         return _binary_op("extract")(
             self, time_interval_unit._to_j_time_interval_unit())
 
+    def datediff(self, start_date) -> 'Expression':
+        """
+        Returns the number of days from start_date to end_date.
+        If end_date is before start_date, the result is negative.
+
+        null if any of the arguments are null or date string invalid.
+
+        :param start_date: A DATE expression.
+        :return: An INTEGER.
+        """
+        return _binary_op("datediff")(self, start_date)
+
     def floor(self, time_interval_unit: TimeIntervalUnit = None) -> 'Expression':
         """
         If time_interval_unit is specified, it rounds down a time point to the given

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -190,6 +190,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('extract(YEAR, a)', str(expr1.extract(TimeIntervalUnit.YEAR)))
         self.assertEqual('floor(a, YEAR)', str(expr1.floor(TimeIntervalUnit.YEAR)))
         self.assertEqual('ceil(a)', str(expr1.ceil()))
+        self.assertEqual('DATEDIFF(a, b)', str(expr1.datediff(expr2)))
 
         # advanced type helper functions
         self.assertEqual("get(a, 'col')", str(expr1.get('col')))

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -87,6 +87,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COSH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COUNT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DATEDIFF;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DECODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DEGREES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DISTINCT;
@@ -1510,6 +1511,19 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType extract(TimeIntervalUnit timeIntervalUnit) {
         return toApiSpecificExpression(
                 unresolvedCall(EXTRACT, valueLiteral(timeIntervalUnit), toExpr()));
+    }
+
+    /**
+     * Returns the number of days from {@code startDate} to {@code endDate}. <br>
+     * If {@code endDate} is before {@code startDate}, the result is negative.<br>
+     * null if any of the arguments are null or date string invalid.
+     *
+     * @param startDate A DATE expression.
+     * @return An INTEGER.
+     */
+    public OutType datediff(InType startDate) {
+        return toApiSpecificExpression(
+                unresolvedCall(DATEDIFF, toExpr(), objectToExpression(startDate)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -2130,6 +2130,37 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition DATEDIFF =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("DATEDIFF")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    Arrays.asList("endDate", "startDate"),
+                                    Arrays.asList(
+                                            or(
+                                                    logical(LogicalTypeRoot.DATE),
+                                                    logical(
+                                                            LogicalTypeRoot
+                                                                    .TIMESTAMP_WITHOUT_TIME_ZONE),
+                                                    logical(
+                                                            LogicalTypeRoot
+                                                                    .TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING)),
+                                            or(
+                                                    logical(LogicalTypeRoot.DATE),
+                                                    logical(
+                                                            LogicalTypeRoot
+                                                                    .TIMESTAMP_WITHOUT_TIME_ZONE),
+                                                    logical(
+                                                            LogicalTypeRoot
+                                                                    .TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+                                                    logical(LogicalTypeFamily.CHARACTER_STRING)))))
+                    .outputTypeStrategy(explicit(DataTypes.INT()))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.DatediffFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition TIMESTAMP_DIFF =
             BuiltInFunctionDefinition.newBuilder()
                     .name("timestampDiff")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DatediffFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DatediffFunction.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.types.DataType;
+
+import javax.annotation.Nullable;
+
+import java.lang.invoke.MethodHandle;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#DATEDIFF}. */
+public class DatediffFunction extends BuiltInScalarFunction {
+
+    private final SpecializedFunction.ExpressionEvaluator endCastEvaluator;
+    private final SpecializedFunction.ExpressionEvaluator startCastEvaluator;
+
+    private transient MethodHandle endCastHandle;
+    private transient MethodHandle startCastHandle;
+
+    public DatediffFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.DATEDIFF, context);
+        final DataType endDateDataType = context.getCallContext().getArgumentDataTypes().get(0);
+        endCastEvaluator =
+                context.createEvaluator(
+                        $("endDate").cast(DataTypes.DATE().toInternal()),
+                        DataTypes.DATE().toInternal(),
+                        DataTypes.FIELD("endDate", endDateDataType.toInternal()));
+        final DataType startDateDataType = context.getCallContext().getArgumentDataTypes().get(1);
+        startCastEvaluator =
+                context.createEvaluator(
+                        $("startDate").cast(DataTypes.DATE().toInternal()),
+                        DataTypes.DATE().toInternal(),
+                        DataTypes.FIELD("startDate", startDateDataType.toInternal()));
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        endCastHandle = endCastEvaluator.open(context);
+        startCastHandle = startCastEvaluator.open(context);
+    }
+
+    public @Nullable Integer eval(@Nullable Object endDate, @Nullable Object startDate) {
+        if (endDate == null || startDate == null) {
+            return null;
+        }
+
+        try {
+            return (int) endCastHandle.invoke(endDate) - (int) startCastHandle.invoke(startDate);
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        endCastEvaluator.close();
+        startCastEvaluator.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the built-in function DATEDIFF.
Examples:

```SQL
> SELECT DATEDIFF('2009-07-31', '2009-07-30');
 1
> SELECT DATEDIFF('2009-07-30', '2009-07-31');
 -1
```

## Brief change log

[FLINK-35850](https://issues.apache.org/jira/browse/FLINK-35850)


## Verifying this change

`TimeFunctionsITCase#datediffTestCases`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
