### PR TITLE
[FLINK-36160] Support hive advanced configuration

### DIFF
--- a/docs/content/docs/connectors/table/hive/overview.md
+++ b/docs/content/docs/connectors/table/hive/overview.md
@@ -313,6 +313,20 @@ Below are the options supported when creating a `HiveCatalog` instance with YAML
       <td>String</td>
       <td>Path to Hadoop conf dir. Only local file system paths are supported. The recommended way to set Hadoop conf is via the <b>HADOOP_CONF_DIR</b> environment variable. Use the option only if environment variable doesn't work for you, e.g. if you want to configure each HiveCatalog separately.</td>
     </tr>
+    <tr>
+      <td><h5>flink.hive.&lt;key&gt;</h5></td>
+      <td>No</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>A general option to probe hive configuration through prefix 'flink.hive.'. Flink will remove the prefix to get &lt;key&gt; (from hive-site.xml) then set the &lt;key&gt; and value to hive configuration. For example, flink.hive.hive.metastore.client.socket.timeout=5 in Flink configuration and convert to hive.metastore.client.socket.timeout=5 in hive configuration.</td>
+    </tr>
+    <tr>
+      <td><h5>flink.hive.hadoop.&lt;key&gt;</h5></td>
+      <td>No</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>A general option to probe hadoop configuration for hive through prefix 'flink.hive.hadoop.'. Flink will remove the prefix to get &lt;key&gt; (from hdfs-site.xml and core-site.xml) then set the &lt;key&gt; and value to hadoop configuration for hive. For example, flink.hive.hadoop.dfs.client.socket-timeout=5000 in Flink configuration and convert to dfs.client.socket-timeout=5000 in hadoop configuration for hive.</td>
+    </tr>
     </tbody>
 </table>
 

--- a/docs/content/docs/connectors/table/hive/overview.md
+++ b/docs/content/docs/connectors/table/hive/overview.md
@@ -313,23 +313,12 @@ Below are the options supported when creating a `HiveCatalog` instance with YAML
       <td>String</td>
       <td>Path to Hadoop conf dir. Only local file system paths are supported. The recommended way to set Hadoop conf is via the <b>HADOOP_CONF_DIR</b> environment variable. Use the option only if environment variable doesn't work for you, e.g. if you want to configure each HiveCatalog separately.</td>
     </tr>
-    <tr>
-      <td><h5>flink.hive.&lt;key&gt;</h5></td>
-      <td>No</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>String</td>
-      <td>A general option to probe hive configuration through prefix 'flink.hive.'. Flink will remove the prefix to get &lt;key&gt; (from hive-site.xml) then set the &lt;key&gt; and value to hive configuration. For example, flink.hive.hive.metastore.client.socket.timeout=5 in Flink configuration and convert to hive.metastore.client.socket.timeout=5 in hive configuration.</td>
-    </tr>
-    <tr>
-      <td><h5>flink.hive.hadoop.&lt;key&gt;</h5></td>
-      <td>No</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>String</td>
-      <td>A general option to probe hadoop configuration for hive through prefix 'flink.hive.hadoop.'. Flink will remove the prefix to get &lt;key&gt; (from hdfs-site.xml and core-site.xml) then set the &lt;key&gt; and value to hadoop configuration for hive. For example, flink.hive.hadoop.dfs.client.socket-timeout=5000 in Flink configuration and convert to dfs.client.socket-timeout=5000 in hadoop configuration for hive.</td>
-    </tr>
     </tbody>
 </table>
 
+**NOTE**: The options used to configure HiveCatalog are derived from the configuration files from `hive-conf-dir` and `hadoop-conf-dir`, if you want to configure HiveCatalog by overwriting some options in these configuration files, you can add the options with prefix `flink.hive.` or `flink.hive.hadoop.` in your Flink table configuration. 
+For example, `flink.hive.hive.metastore.client.socket.timeout: 5` and `flink.hive.hadoop.dfs.client.socket-timeout: 5000` in Flink table configuration, it will be
+converted to options `hive.metastore.client.socket.timeout: 5` and `hadoop.dfs.client.socket-timeout: 5000`, then passing them to configure HiveCatalog.
 
 ## DDL
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -244,34 +244,31 @@ public class HiveCatalog extends AbstractCatalog {
             @Nullable String hiveConfDir,
             @Nullable String hadoopConfDir,
             @Nullable ReadableConfig flinkConfiguration) {
-        HiveConf hiveconf = initHiveConf(hiveConfDir, hadoopConfDir);
+        HiveConf hiveconf = createHiveConf(hiveConfDir, hadoopConfDir);
         // add all configuration key with prefix 'flink.hive.hadoop.' and 'flink.hive.' in flink
         // conf to hive conf
         String hivePrefix = FLINK_HIVE_CONFIG_PREFIXES;
         String hadoopPrefix = "hadoop.";
         if (flinkConfiguration != null) {
-            for (String key : flinkConfiguration.toMap().keySet()) {
-                if (key.startsWith(hivePrefix)) {
-                    String newKey = key.substring(hivePrefix.length());
+            for (Map.Entry<String, String> conf : flinkConfiguration.toMap().entrySet()) {
+                if (conf.getKey().startsWith(hivePrefix)) {
+                    String newKey = conf.getKey().substring(hivePrefix.length());
                     if (newKey.startsWith(hadoopPrefix)) {
                         newKey = newKey.substring(hadoopPrefix.length());
                     }
-                    String value =
-                            flinkConfiguration.get(
-                                    ConfigOptions.key(key).stringType().noDefaultValue());
-                    hiveconf.set(newKey, value);
+                    hiveconf.set(newKey, conf.getValue());
                     LOG.debug(
                             "Adding Flink config entry for {} as {}={} to Hive config",
-                            key,
+                            conf.getKey(),
                             newKey,
-                            value);
+                            conf.getValue());
                 }
             }
         }
         return hiveconf;
     }
 
-    public static HiveConf initHiveConf(
+    public static HiveConf createHiveConf(
             @Nullable String hiveConfDir, @Nullable String hadoopConfDir) {
         // create HiveConf from hadoop configuration with hadoop conf directory configured.
         Configuration hadoopConf = null;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveConfOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveConfOptions.java
@@ -44,4 +44,7 @@ public class HiveConfOptions {
                     .durationType()
                     .defaultValue(Duration.ofMinutes(8))
                     .withDescription("The maximum time to wait for acquiring the lock.");
+
+    /** The prefixes that Flink adds to the Hive config. */
+    public static final String FLINK_HIVE_CONFIG_PREFIXES = "flink.hive.";
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveCatalogFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveCatalogFactory.java
@@ -73,6 +73,7 @@ public class HiveCatalogFactory implements CatalogFactory {
                 helper.getOptions().get(DEFAULT_DATABASE),
                 helper.getOptions().get(HIVE_CONF_DIR),
                 helper.getOptions().get(HADOOP_CONF_DIR),
-                helper.getOptions().get(HIVE_VERSION));
+                helper.getOptions().get(HIVE_VERSION),
+                context.getConfiguration());
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointFactory.java
@@ -68,7 +68,7 @@ public class HiveServer2EndpointFactory implements SqlGatewayEndpointFactory {
                 configuration.get(THRIFT_WORKER_THREADS_MAX),
                 configuration.get(THRIFT_WORKER_KEEPALIVE_TIME),
                 configuration.get(CATALOG_NAME),
-                HiveCatalog.createHiveConf(configuration.get(CATALOG_HIVE_CONF_DIR), null),
+                HiveCatalog.createHiveConf(configuration.get(CATALOG_HIVE_CONF_DIR), null, null),
                 configuration.get(CATALOG_DEFAULT_DATABASE),
                 configuration.get(MODULE_NAME));
     }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogTest.java
@@ -19,8 +19,6 @@
 package org.apache.flink.table.catalog.hive;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.datagen.table.DataGenTableSourceFactory;
-
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.CatalogBaseTable;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Supports modifying hive configuration and hive hadoop configuration through flink advanced parameters.


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
