### PR TITLE
[FLINK-36168] [runtime] AdaptiveSchedulerTest doesn't follow the production lifecycle

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutorServiceAdapter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/ComponentMainThreadExecutorServiceAdapter.java
@@ -78,6 +78,7 @@ public class ComponentMainThreadExecutorServiceAdapter implements ComponentMainT
             @Nonnull ScheduledExecutorService singleThreadExecutor) {
         final Thread thread =
                 CompletableFuture.supplyAsync(Thread::currentThread, singleThreadExecutor).join();
+        thread.setName(String.format("ComponentMainThread-%s", thread.getName()));
         return new ComponentMainThreadExecutorServiceAdapter(singleThreadExecutor, thread);
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change


This ensures that the `AdaptiveSchedulerTest` follows the correct production lifecycle. Specifically, the change aims to address the issue where the executor representing the main thread is shutting down before the `AdaptiveScheduler` is appropriately closed. This can lead to problems with scheduled tasks when the executor is shut down prematurely. By fixing the test, the change ensures that the `AdaptiveScheduler` is closed correctly in all tests, preventing potential issues during shutdown and improving the reliability and accuracy of the test.


## Brief change log

  - `AdaptiveScheduler` is closed properly after every test execution. 
  - The `AdaptiveScheduler` instance is started in the `singleThreadMainThread`


## Verifying this change

- This change affects only testing classes. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
