### PR TITLE
[FLINK-36173][docs] Fix invalid link in checkpoint documentation

### DIFF
--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>execution.checkpointing.checkpoints-after-tasks-finish</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Feature toggle for enabling checkpointing even if some of tasks have finished. Before you enable it, please take a look at <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/datastream/fault-tolerance/checkpointing/#checkpointing-with-parts-of-the-graph-finished-beta">the important considerations</a> </td>
+            <td>Feature toggle for enabling checkpointing even if some of tasks have finished. Before you enable it, please take a look at <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/datastream/fault-tolerance/checkpointing/#checkpointing-with-parts-of-the-graph-finished">the important considerations</a> </td>
         </tr>
         <tr>
             <td><h5>execution.checkpointing.cleaner.parallel-mode</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -665,7 +665,7 @@ public class CheckpointingOptions {
                                             "Feature toggle for enabling checkpointing even if some of tasks"
                                                     + " have finished. Before you enable it, please take a look at %s ",
                                             link(
-                                                    "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/datastream/fault-tolerance/checkpointing/#checkpointing-with-parts-of-the-graph-finished-beta",
+                                                    "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/datastream/fault-tolerance/checkpointing/#checkpointing-with-parts-of-the-graph-finished",
                                                     "the important considerations"))
                                     .build());
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -334,7 +334,7 @@ public class ExecutionCheckpointingOptions {
                                             "Feature toggle for enabling checkpointing even if some of tasks"
                                                     + " have finished. Before you enable it, please take a look at %s ",
                                             link(
-                                                    "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/datastream/fault-tolerance/checkpointing/#checkpointing-with-parts-of-the-graph-finished-beta",
+                                                    "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/datastream/fault-tolerance/checkpointing/#checkpointing-with-parts-of-the-graph-finished",
                                                     "the important considerations"))
                                     .build());
 


### PR DESCRIPTION
## What is the purpose of the change

Some of the places we still have `checkpointing-with-parts-of-the-graph-finished-beta` link instead of `checkpointing-with-parts-of-the-graph-finished` which doesn't lead anywhere. In this PR I've fixed it.

## Brief change log

Fixed `checkpointing-with-parts-of-the-graph-finished` link in checkpoint documentation.

## Verifying this change

* `docker run -v $(pwd):/src -p 1313:1313 jakejarvis/hugo-extended:latest server --buildDrafts --buildFuture --bind 0.0.0.0`
* Manually visited locally generated page

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
