### PR TITLE
[FLINK-35581] Remove comments from the code related to ingestDB

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
@@ -20,12 +20,17 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
+import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.RunnableWithException;
 
 import org.apache.flink.shaded.guava32.com.google.common.primitives.UnsignedBytes;
 
+import org.rocksdb.Checkpoint;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.CompactRangeOptions;
+import org.rocksdb.ExportImportFilesMetaData;
 import org.rocksdb.LiveFileMetaData;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
@@ -36,13 +41,17 @@ import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /** Utils for RocksDB Incremental Checkpoint. */
@@ -254,7 +263,6 @@ public class RocksDBIncrementalCheckpointUtils {
 
         return Optional.of(
                 () -> {
-                    /*
                     try (CompactRangeOptions compactionOptions =
                             new CompactRangeOptions()
                                     .setExclusiveManualCompaction(true)
@@ -288,7 +296,6 @@ public class RocksDBIncrementalCheckpointUtils {
                             }
                         }
                     }
-                     */
                 });
     }
 
@@ -359,7 +366,6 @@ public class RocksDBIncrementalCheckpointUtils {
      * @param resultOutput output parameter for the metadata of the export.
      * @throws RocksDBException on problems inside RocksDB.
      */
-    /*
     public static void exportColumnFamilies(
             RocksDB db,
             List<ColumnFamilyHandle> columnFamilyHandles,
@@ -396,7 +402,6 @@ public class RocksDBIncrementalCheckpointUtils {
             }
         }
     }
-    */
 
     /** check whether the bytes is before prefixBytes in the character order. */
     public static boolean beforeThePrefixBytes(@Nonnull byte[] bytes, @Nonnull byte[] prefixBytes) {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
@@ -132,8 +132,8 @@ public class RocksDBOperationUtils {
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             @Nullable RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
             @Nullable Long writeBufferManagerCapacity,
-            ICloseableRegistry cancelStreamRegistryForRestore,
-            List<ExportImportFilesMetaData> importFilesMetaData) {
+            List<ExportImportFilesMetaData> importFilesMetaData,
+            ICloseableRegistry cancelStreamRegistryForRestore) {
 
         ColumnFamilyDescriptor columnFamilyDescriptor =
                 createColumnFamilyDescriptor(
@@ -171,8 +171,8 @@ public class RocksDBOperationUtils {
                 columnFamilyOptionsFactory,
                 ttlCompactFiltersManager,
                 writeBufferManagerCapacity,
-                cancelStreamRegistryForRestore,
-                Collections.emptyList());
+                Collections.emptyList(),
+                cancelStreamRegistryForRestore);
     }
 
     /**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOperationUtils.java
@@ -33,6 +33,8 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.ExportImportFilesMetaData;
+import org.rocksdb.ImportColumnFamilyOptions;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
@@ -44,6 +46,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -119,6 +122,9 @@ public class RocksDBOperationUtils {
      *
      * <p>Creates the column family for the state. Sets TTL compaction filter if {@code
      * ttlCompactFiltersManager} is not {@code null}.
+     *
+     * @param importFilesMetaData if not empty, we import the files specified in the metadata to the
+     *     column family.
      */
     public static RocksDBKeyedStateBackend.RocksDbKvStateInfo createStateInfo(
             RegisteredStateMetaInfoBase metaInfoBase,
@@ -126,7 +132,8 @@ public class RocksDBOperationUtils {
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             @Nullable RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
             @Nullable Long writeBufferManagerCapacity,
-            ICloseableRegistry cancelStreamRegistryForRestore) {
+            ICloseableRegistry cancelStreamRegistryForRestore,
+            List<ExportImportFilesMetaData> importFilesMetaData) {
 
         ColumnFamilyDescriptor columnFamilyDescriptor =
                 createColumnFamilyDescriptor(
@@ -138,13 +145,34 @@ public class RocksDBOperationUtils {
         final ColumnFamilyHandle columnFamilyHandle;
         try {
             columnFamilyHandle =
-                    createColumnFamily(columnFamilyDescriptor, db, cancelStreamRegistryForRestore);
+                    createColumnFamily(
+                            columnFamilyDescriptor,
+                            db,
+                            importFilesMetaData,
+                            cancelStreamRegistryForRestore);
         } catch (Exception ex) {
             IOUtils.closeQuietly(columnFamilyDescriptor.getOptions());
             throw new FlinkRuntimeException("Error creating ColumnFamilyHandle.", ex);
         }
 
         return new RocksDBKeyedStateBackend.RocksDbKvStateInfo(columnFamilyHandle, metaInfoBase);
+    }
+
+    public static RocksDBKeyedStateBackend.RocksDbKvStateInfo createStateInfo(
+            RegisteredStateMetaInfoBase metaInfoBase,
+            RocksDB db,
+            Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
+            @Nullable RocksDbTtlCompactFiltersManager ttlCompactFiltersManager,
+            @Nullable Long writeBufferManagerCapacity,
+            ICloseableRegistry cancelStreamRegistryForRestore) {
+        return createStateInfo(
+                metaInfoBase,
+                db,
+                columnFamilyOptionsFactory,
+                ttlCompactFiltersManager,
+                writeBufferManagerCapacity,
+                cancelStreamRegistryForRestore,
+                Collections.emptyList());
     }
 
     /**
@@ -236,6 +264,7 @@ public class RocksDBOperationUtils {
     private static ColumnFamilyHandle createColumnFamily(
             ColumnFamilyDescriptor columnDescriptor,
             RocksDB db,
+            List<ExportImportFilesMetaData> importFilesMetaData,
             ICloseableRegistry cancelStreamRegistryForRestore)
             throws RocksDBException, InterruptedException {
         if (Thread.currentThread().isInterrupted()) {
@@ -246,7 +275,15 @@ public class RocksDBOperationUtils {
             throw new CancelTaskException("The stream was closed, aborting recovery");
         }
 
-        return db.createColumnFamily(columnDescriptor);
+        if (importFilesMetaData.isEmpty()) {
+            return db.createColumnFamily(columnDescriptor);
+        } else {
+            try (ImportColumnFamilyOptions importColumnFamilyOptions =
+                    new ImportColumnFamilyOptions().setMoveFiles(true)) {
+                return db.createColumnFamilyWithImport(
+                        columnDescriptor, importColumnFamilyOptions, importFilesMetaData);
+            }
+        }
     }
 
     public static void addColumnFamilyOptionsToCloseLater(

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
@@ -214,8 +214,8 @@ class RocksDBHandle implements AutoCloseable {
                         columnFamilyOptionsFactory,
                         ttlCompactFiltersManager,
                         writeBufferManagerCapacity,
-                        cancelStreamRegistryForRestore,
-                        cfMetaDataList);
+                        cfMetaDataList,
+                        cancelStreamRegistryForRestore);
 
         RocksDBOperationUtils.registerKvStateInformation(
                 kvStateInformation, nativeMetricMonitor, stateMetaInfo.getName(), stateInfo);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
@@ -29,11 +29,13 @@ import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.Preconditions;
 
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.ExportImportFilesMetaData;
 import org.rocksdb.RocksDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -198,7 +200,6 @@ class RocksDBHandle implements AutoCloseable {
      * @param stateMetaInfo info about the state to create.
      * @param cfMetaDataList the data to import.
      */
-    /*
     void registerStateColumnFamilyHandleWithImport(
             RegisteredStateMetaInfoBase stateMetaInfo,
             List<ExportImportFilesMetaData> cfMetaDataList,
@@ -213,15 +214,14 @@ class RocksDBHandle implements AutoCloseable {
                         columnFamilyOptionsFactory,
                         ttlCompactFiltersManager,
                         writeBufferManagerCapacity,
-                        cfMetaDataList,
-                        cancelStreamRegistryForRestore);
+                        cancelStreamRegistryForRestore,
+                        cfMetaDataList);
 
         RocksDBOperationUtils.registerKvStateInformation(
                 kvStateInformation, nativeMetricMonitor, stateMetaInfo.getName(), stateInfo);
 
         columnFamilyHandles.add(stateInfo.columnFamilyHandle);
     }
-    */
 
     /**
      * This recreates the new working directory of the recovered RocksDB instance and links/copies

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
@@ -58,7 +58,8 @@ import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUti
 
 /**
  * Utility for creating a RocksDB instance either from scratch or from restored local state. This
- * will also register {@link RocksDbKvStateInfo} when using {@link #openDB(List, List, Path, ICloseableRegistry)}.
+ * will also register {@link RocksDbKvStateInfo} when using {@link #openDB(List, List, Path,
+ * ICloseableRegistry)}.
  */
 class RocksDBHandle implements AutoCloseable {
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBHandle.java
@@ -58,7 +58,7 @@ import static org.apache.flink.contrib.streaming.state.snapshot.RocksSnapshotUti
 
 /**
  * Utility for creating a RocksDB instance either from scratch or from restored local state. This
- * will also register {@link RocksDbKvStateInfo} when using {@link #openDB(List, List, Path)}.
+ * will also register {@link RocksDbKvStateInfo} when using {@link #openDB(List, List, Path, ICloseableRegistry)}.
  */
 class RocksDBHandle implements AutoCloseable {
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -59,6 +59,7 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.ExportImportFilesMetaData;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
@@ -72,9 +73,11 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -85,6 +88,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.core.fs.ICloseableRegistry.asCloseable;
 import static org.apache.flink.runtime.metrics.MetricNames.DOWNLOAD_STATE_DURATION;
@@ -183,10 +187,8 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
         this.keyGroupPrefixBytes = keyGroupPrefixBytes;
         this.keySerializerProvider = keySerializerProvider;
         this.userCodeClassLoader = userCodeClassLoader;
-        //        this.useIngestDbRestoreMode = useIngestDbRestoreMode;
-        //        this.asyncCompactAfterRescale = asyncCompactAfterRescale;
-        this.useIngestDbRestoreMode = false;
-        this.asyncCompactAfterRescale = false;
+        this.useIngestDbRestoreMode = useIngestDbRestoreMode;
+        this.asyncCompactAfterRescale = asyncCompactAfterRescale;
         this.useDeleteFilesInRange = useDeleteFilesInRange;
         this.ioExecutor = ioExecutor;
     }
@@ -453,7 +455,6 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
             byte[] stopKeyGroupPrefixBytes)
             throws Exception {
 
-        /*
         final Path absolutInstanceBasePath = instanceBasePath.getAbsoluteFile().toPath();
         final Path exportCfBasePath = absolutInstanceBasePath.resolve("export-cfs");
         Files.createDirectories(exportCfBasePath);
@@ -493,7 +494,6 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
             // Cleanup export base directory
             cleanUpPathQuietly(exportCfBasePath);
         }
-        */
     }
 
     /**
@@ -509,7 +509,6 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
      * @return the total key-groups range of the exported data.
      * @throws Exception on any export error.
      */
-    /*
     private KeyGroupRange exportColumnFamiliesWithSstDataInKeyGroupsRange(
             Path exportCfBasePath,
             List<IncrementalLocalKeyedStateHandle> localKeyedStateHandles,
@@ -590,7 +589,6 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                 ? new KeyGroupRange(minExportKeyGroup, maxExportKeyGroup)
                 : KeyGroupRange.EMPTY_KEY_GROUP_RANGE;
     }
-     */
 
     /**
      * Helper method that merges the data from multiple state handles into the restoring base DB by
@@ -640,7 +638,6 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
      * @param exportKeyGroupRange the total key-groups range of the exported data.
      * @throws Exception on import error.
      */
-    /*
     private void initBaseDBFromColumnFamilyImports(
             Map<RegisteredStateMetaInfoBase, List<ExportImportFilesMetaData>>
                     exportedColumnFamilyMetaData,
@@ -653,10 +650,10 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                 keyGroupRange,
                 operatorIdentifier);
         rocksHandle.openDB();
-        for (Map.Entry<RegisteredStateMetaInfoBase.Key, List<ExportImportFilesMetaData>> entry :
+        for (Map.Entry<RegisteredStateMetaInfoBase, List<ExportImportFilesMetaData>> entry :
                 exportedColumnFamilyMetaData.entrySet()) {
             rocksHandle.registerStateColumnFamilyHandleWithImport(
-                    entry.getKey(), entry.getValue(), cancelStreamRegistryForRestore);
+                    entry.getKey(), entry.getValue(), cancelStreamRegistry);
         }
 
         // Use Range delete to clip the temp db to the target range of the backend
@@ -665,14 +662,14 @@ public class RocksDBIncrementalRestoreOperation<K> implements RocksDBRestoreOper
                 rocksHandle.getColumnFamilyHandles(),
                 keyGroupRange,
                 exportKeyGroupRange,
-                keyGroupPrefixBytes);
+                keyGroupPrefixBytes,
+                useDeleteFilesInRange);
 
         logger.info(
                 "Completed importing exported state handles for backend with range {} in operator {} using Clip/Ingest DB.",
                 keyGroupRange,
                 operatorIdentifier);
     }
-    */
 
     /**
      * Restores the checkpointing status and state for this backend. This can only be done if the


### PR DESCRIPTION
Revert commit 268a3080 "[FLINK-31238] Deactivate parts of the code until new FRocksDB release is available."

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
