### PR TITLE
[FLINK-36116] Update Javadoc plugin

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -52,7 +52,6 @@ mvn clean install -B -DskipTests -Dfast -Dskip.npm -Pskip-webui-build
 # build java/scala docs
 mkdir -p docs/target/api
 mvn javadoc:aggregate -B \
-    -DadditionalJOption="-Xdoclint:none --allow-script-in-comments" \
     -Dmaven.javadoc.failOnError=false \
     -Dcheckstyle.skip=true \
     -Dspotless.check.skip=true \

--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -52,7 +52,7 @@ mvn clean install -B -DskipTests -Dfast -Dskip.npm -Pskip-webui-build
 # build java/scala docs
 mkdir -p docs/target/api
 mvn javadoc:aggregate -B \
-    -Dmaven.javadoc.failOnError=false \
+    -Dmaven.javadoc.failOnError=true \
     -Dcheckstyle.skip=true \
     -Dspotless.check.skip=true \
     -Denforcer.skip=true \

--- a/pom.xml
+++ b/pom.xml
@@ -2238,12 +2238,13 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9.1</version><!--$NO-MVN-MAN-VER$-->
+					<version>3.8.0</version>
 					<configuration>
 						<quiet>true</quiet>
 						<detectOfflineLinks>false</detectOfflineLinks>
-						<additionalJOptions combine.children="append">
+						<additionalJOptions>
 							<additionalJOption>-Xdoclint:none</additionalJOption>
+							<additionalJOption>--allow-script-in-comments</additionalJOption>
 						</additionalJOptions>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
## What is the purpose of the change

The Javadoc needs to be updated since Javadoc generation fails with a failed cast (com.sun.tools.javadoc.ClassDocImpl cannot be cast to com.sun.javadoc.AnnotationTypeDoc)

## Brief change log

* Update Maven Javadoc plugin

## Verifying this change

This change added tests and can be verified as follows:

Running ```docker run --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink && ./.github/workflows/docs.sh"```  locally now correctly generates Javadocs
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
