### PR TITLE
[FLINK-36189] Skip NPM build during Javadocs generation

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -52,6 +52,7 @@ mvn clean install -B -DskipTests -Dfast -Dskip.npm -Pskip-webui-build
 # build java/scala docs
 mkdir -p docs/target/api
 mvn javadoc:aggregate -B \
+    -Pskip-webui-build
     -Dmaven.javadoc.failOnError=true \
     -Dcheckstyle.skip=true \
     -Dspotless.check.skip=true \


### PR DESCRIPTION
## What is the purpose of the change

* Prevent NPM build during Javadocs generation

## Brief change log

* Active profile to skip web-build during Javadocs run

## Verifying this change

This change has been tested locally by running `docker run --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink && ./.github/workflows/docs.sh"`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
