### PR TITLE
[FLINK-36191][tests] FsMergingCheckpointStorageLocationTest generates test data not in tmp folder

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/FsMergingCheckpointStorageLocationTest.java
@@ -32,13 +32,13 @@ import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.filemerging.SegmentFileStateHandle;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nonnull;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -53,8 +53,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Tests for {@link FsMergingCheckpointStorageLocation}. */
-public class FsMergingCheckpointStorageLocationTest {
-    @Rule public final TemporaryFolder tmpFolder = new TemporaryFolder();
+class FsMergingCheckpointStorageLocationTest {
+    @TempDir File tmpFolder;
 
     public static Path checkpointBaseDir;
 
@@ -74,9 +74,9 @@ public class FsMergingCheckpointStorageLocationTest {
             new FileMergingSnapshotManager.SubtaskKey(
                     jobId.toHexString(), opId.toHexString(), 1, 1);
 
-    @Before
-    public void prepareDirectories() {
-        checkpointBaseDir = new Path(tmpFolder.toString());
+    @BeforeEach
+    void prepareDirectories() {
+        checkpointBaseDir = new Path(tmpFolder.getAbsolutePath());
         sharedStateDir =
                 new Path(
                         checkpointBaseDir,
@@ -88,7 +88,7 @@ public class FsMergingCheckpointStorageLocationTest {
     }
 
     @Test
-    public void testWriteMultipleStateFilesWithinCheckpoint() throws Exception {
+    void testWriteMultipleStateFilesWithinCheckpoint() throws Exception {
         testWriteMultipleStateFiles();
     }
 
@@ -118,7 +118,7 @@ public class FsMergingCheckpointStorageLocationTest {
     }
 
     @Test
-    public void testCheckpointStreamClosedExceptionally() throws Exception {
+    void testCheckpointStreamClosedExceptionally() throws Exception {
         try (FileMergingSnapshotManager snapshotManager = createFileMergingSnapshotManager()) {
             Path filePath1 = null;
             try (FileMergingCheckpointStateOutputStream stream1 =
@@ -139,7 +139,7 @@ public class FsMergingCheckpointStorageLocationTest {
     }
 
     @Test
-    public void testWritingToClosedStream() {
+    void testWritingToClosedStream() {
         FileMergingSnapshotManager snapshotManager = createFileMergingSnapshotManager();
         FsMergingCheckpointStorageLocation storageLocation =
                 createFsMergingCheckpointStorageLocation(1, snapshotManager);
@@ -155,7 +155,7 @@ public class FsMergingCheckpointStorageLocationTest {
     }
 
     @Test
-    public void testWriteAndReadPositionInformation() throws Exception {
+    void testWriteAndReadPositionInformation() throws Exception {
         long maxFileSize = 128;
         FileMergingSnapshotManager snapshotManager = createFileMergingSnapshotManager(maxFileSize);
         FsMergingCheckpointStorageLocation storageLocation1 =


### PR DESCRIPTION
## What is the purpose of the change
The issue is that execution of `FsMergingCheckpointStorageLocationTest` generates files and folders outside of tmp folders which appear in git change
easy way to reproduce
```bash
cd flink-runtime && ./../mvnw -Dtest=FsMergingCheckpointStorageLocationTest test && git status
```

The change makes generated files/folder appearing into tmp

also, since this test is touched it is migrated to junit5

## Verifying this change

```bash
cd flink-runtime && ./../mvnw -Dtest=FsMergingCheckpointStorageLocationTest test && git status
```
this shouldn't returned any changed file

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
