### PR TITLE
[BP-1.20][FLINK-36125][checkpoint] Fix concurrent duplicated discard of logical file in cp file-merging

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/filemerging/FileMergingSnapshotManagerTestBase.java
@@ -180,6 +180,10 @@ public abstract class FileMergingSnapshotManagerTestBase {
             assertThat(physicalFile1.isDeleted()).isFalse();
             assertThat(physicalFile1.getRefCount()).isZero();
 
+            // duplicated discard takes no effect
+            logicalFile1.discardWithCheckpointId(2);
+            assertThat(physicalFile1.getRefCount()).isZero();
+
             physicalFile1.close();
             assertThat(physicalFile1.isOpen()).isFalse();
             assertThat(physicalFile1.isDeleted()).isTrue();


### PR DESCRIPTION
## What is the purpose of the change

There might be a duplicate discard of logical file in cp file-merging when cp abortion + io exception + two threads happen to release the file at the same time.

## Brief change log

 - Make the `LogicalFile` can only be discarded once.

## Verifying this change

It is not easy to verify this, since it is a rare concurrent issue.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
