### PR TITLE
[FLINK-36207][build] Disables deprecated API from japicmp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2332,6 +2332,8 @@ under the License.
 								<!--<include>@org.apache.flink.annotation.PublicEvolving</include>-->
 							</includes>
 							<excludes>
+								<exclude>@java.lang.Deprecated</exclude>
+								<exclude>*.scala</exclude>
 								<exclude>@org.apache.flink.annotation.Experimental</exclude>
 								<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
@@ -2341,6 +2343,8 @@ under the License.
 								<exclude>org.apache.flink.configuration.Configuration#setBytes(java.lang.String,byte[])</exclude>
 								<!-- FLINK-34085 Deprecated string config should be removed in 2.0 -->
 								<exclude>org.apache.flink.configuration.ConfigConstants</exclude>
+								<!-- FLINK-35886: WatermarksWithIdleness constructor was marked as deprecated -->
+								<exclude>org.apache.flink.api.common.eventtime.WatermarksWithIdleness</exclude>
 								<!-- FLINK-35812 move tuple interfaces into flink-core-api, should be removed in 2.0 -->
 								<exclude>org.apache.flink.api.java.tuple.*</exclude>
 								<exclude>org.apache.flink.types.NullFieldException</exclude>


### PR DESCRIPTION
## What is the purpose of the change

The japicmp plugin doesn't seem to work well with Scala annotations (more specifically @scala.deprecated). But we're planning to remove the Scala code as part of the 2.0 release, anyway. Hence, excluding all *scala files should be good enough.

## Brief change log

* Adds @java.lang.Deprecated and *scala to the exclusion list

## Verifying this change

* [Test run](https://github.com/XComp/flink/actions/runs/10690860484/job/29636625406) with no API changes but the new exclusions
* [Test run](https://github.com/XComp/flink/actions/runs/10690878791/job/29636748572#step:7:737) containing @Public API changes that are identified
* [Test run](https://github.com/XComp/flink/actions/runs/10690871294/job/29636697081) containing deprecated @Public API changes that should be ignored

Check the corresponding branches the workflows ran on to see the changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable