### PR TITLE
[FLINK-35972][state/runtime] Async process a runnable with a key provided

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessingOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessingOperator.java
@@ -53,4 +53,13 @@ public interface AsyncStateProcessingOperator extends AsyncStateProcessing {
      * @param processing the record processing logic.
      */
     void preserveRecordOrderAndProcess(ThrowingRunnable<Exception> processing);
+
+    /**
+     * Asynchronously process a code with a key provided.
+     *
+     * @param key the specified key.
+     * @param processing the process logic.
+     * @param <K> the type of key.
+     */
+    <K> void asyncProcessWithKey(K key, ThrowingRunnable<Exception> processing);
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AbstractAsyncStateStreamOperatorV2.java
@@ -147,6 +147,25 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
     }
 
     @Override
+    @SuppressWarnings("unchecked")
+    public <K> void asyncProcessWithKey(K key, ThrowingRunnable<Exception> processing) {
+        RecordContext<K> previousContext = currentProcessingContext;
+
+        // build a context and switch to the new context
+        currentProcessingContext = asyncExecutionController.buildContext(null, key);
+        currentProcessingContext.retain();
+        asyncExecutionController.setCurrentContext(currentProcessingContext);
+        // Same logic as RECORD_ORDER, since FIRST_STATE_ORDER is problematic when the call's key
+        // pass the same key in.
+        preserveRecordOrderAndProcess(processing);
+        postProcessElement();
+
+        // switch to original context
+        asyncExecutionController.setCurrentContext(previousContext);
+        currentProcessingContext = previousContext;
+    }
+
+    @Override
     public final <T> ThrowingConsumer<StreamRecord<T>, Exception> getRecordProcessor(int inputId) {
         // The real logic should be in First/SecondInputOfTwoInput#getRecordProcessor.
         throw new UnsupportedOperationException(


### PR DESCRIPTION
## What is the purpose of the change

An internal interface for executing a runnable with a specific key. This PR enables the async keyed processing operators, where the key is managed by the framework, the equivalent capabilities of following code:
```
setCurrentKey(anotherKey);
valueState.update(newValue);
setCurrentKey(back);
```
This is mainly for the ease of sql implementation.


## Brief change log

 - A new interface `asyncProcessWithKey` in `AsyncStateProcessingOperator` and two implementation.

## Verifying this change

 - Corresponding tests in `AbstractAsyncStateStreamOperatorTest` and `AbstractAsyncStateStreamOperatorV2Test`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
