### PR TITLE
[FLINK-36123][table] Add the built-in function PERCENTILE

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -251,6 +251,26 @@ arithmetic:
   - sql: TRUNCATE(numeric1, integer2)
     table: NUMERIC1.truncate(INTEGER2)
     description: Returns a numeric of truncated to integer2 decimal places. Returns NULL if numeric1 or integer2 is NULL. If integer2 is 0, the result has no decimal point or fractional part. integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero. This function can also pass in only one numeric1 parameter and not set integer2 to use. If integer2 is not set, the function truncates as if integer2 were 0. E.g. 42.324.truncate(2) to 42.32. and 42.324.truncate() to 42.0.
+  - sql: PERCENTILE(expr, percentage[, frequency])
+    table: expr.percentile(percentage[, frequency])
+    description: |
+      Returns the exact percentile value of expr at the specified percentage in a group.
+      
+      percentage must be a literal numeric value between `[0.0, 1.0]` or an array of such values. 
+      If a variable expression is passed to this function, the result will be calculated using any one of them.
+      frequency describes how many times expr should be counted, the default value is 1.
+      
+      If no expr lies exactly at the desired percentile, the result is calculated using linear interpolation of the two nearest exprs. 
+      If expr or frequency is `NULL`, or frequency is not positive, the input row will be ignored.
+      
+      NOTE: It is recommended to use this function in a window scenario, as it typically offers better performance. 
+      In a regular group aggregation scenario, users should be aware of the performance overhead caused by a full sort triggered by each record.
+      
+      `value <NUMERIC>, percentage [<NUMERIC NOT NULL> | <ARRAY<NUMERIC NOT NULL> NOT NULL>], frequency <INTEGER_NUMERIC>`
+      `(INTEGER_NUMERIC: TINYINT, SMALLINT, INTEGER, BIGINT)`
+      `(NUMERIC: INTEGER_NUMERIC, FLOAT, DOUBLE, DECIMAL)`
+      
+      Returns a `DOUBLE` if percentage is numeric, or an `ARRAY<DOUBLE>` if percentage is an array. `NULL` if percentage is an empty array.
 
 string:
   - sql: string1 || string2

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -313,6 +313,26 @@ arithmetic:
       如果 integer2 为 0，则结果没有小数点或小数部分。integer2 可以为负数，使值的小数点左边的 integer2 位变为零。
       此函数也可以只传入一个参数 numeric1 且不设置参数 integer2 来使用。如果未设置 integer2 则 integer2 默认为 0。
       例如 42.324.truncate(2) 为 42.32，42.324.truncate() 为 42.0。
+  - sql: PERCENTILE(expr, percentage[, frequency])
+    table: expr.percentile(percentage[, frequency])
+    description: |
+      返回 expr 的 percentage 百分位值。
+
+      percentage 必须是一个在 `[0.0, 1.0]` 之间的字面数值，或者是一个该范围的数组。
+      如果传递了一个可变表达式给这个函数，结果将根据其中的任意一个值进行计算。
+      frequency 描述了 expr 的统计次数，默认值为 1。
+
+      如果没有 expr 恰好位于指定的百分位上，则结果通过对两个最接近的 expr 进行线性插值来计算。
+      如果 expr 或 frequency 为 `NULL`，或者 frequency 不是正数，则将忽略该输入行。
+
+      注意: 建议在窗口场景中使用此函数，因为它通常能提供更好的性能。
+      在常规的分组聚合场景中，用户应注意每条记录引发的全面排序带来的性能开销。
+
+      `value <NUMERIC>, percentage [<NUMERIC NOT NULL> | <ARRAY<NUMERIC NOT NULL> NOT NULL>], frequency <INTEGER_NUMERIC>`
+      `(INTEGER_NUMERIC: TINYINT, SMALLINT, INTEGER, BIGINT)`
+      `(NUMERIC: INTEGER_NUMERIC, FLOAT, DOUBLE, DECIMAL)`
+
+      如果 percentage 是数字，返回类型为 `DOUBLE`；如果 percentage 是数组，返回类型为 `ARRAY<DOUBLE>`。 如果 percentage 是空数组，则返回 `NULL`。
 
 string:
   - sql: string1 || string2

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -151,6 +151,7 @@ arithmetic functions
     Expression.hex
     Expression.unhex
     Expression.truncate
+    Expression.percentile
 
 string functions
 ----------------

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1026,6 +1026,33 @@ class Expression(Generic[T]):
         """
         return _binary_op("truncate")(self, n)
 
+    def percentile(self, percentage, frequency=None) -> 'Expression':
+        """
+        Returns the exact percentile value of expr at the specified percentage in a group.
+
+        percentage must be a literal numeric value between [0.0, 1.0] or an array of such values.
+        If a variable expression is passed to this function, the result will be calculated using
+        any one of them. frequency describes how many times expr should be counted, the default
+        value is 1.
+
+        If no expr lies exactly at the desired percentile, the result is calculated using linear
+        interpolation of the two nearest exprs. If expr or frequency is null, or frequency is not
+        positive, the input row will be ignored.
+
+        NOTE: It is recommended to use this function in a window scenario, as it typically offers
+        better performance. In a regular group aggregation scenario, users should be aware of the
+        performance overhead caused by a full sort triggered by each record.
+
+        :param percentage: A NUMERIC NOT NULL or ARRAY<NUMERIC NOT NULL> NOT NULL expression.
+        :param frequency: An optional INTEGER_NUMERIC expression.
+        :return: A DOUBLE if percentage is numeric, or an ARRAY<DOUBLE> if percentage is an
+                 array. null if percentage is an empty array.
+        """
+        if frequency is None:
+            return _binary_op("percentile")(self, percentage)
+        else:
+            return _ternary_op("percentile")(self, percentage, frequency)
+
     # ---------------------------- string functions ----------------------------------
 
     def starts_with(self, start_expr) -> 'Expression':

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -126,6 +126,12 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('hex(a)', str(expr1.hex))
         self.assertEqual("UNHEX(a)", str(expr1.unhex))
         self.assertEqual('truncate(a, 3)', str(expr1.truncate(3)))
+        self.assertEqual('PERCENTILE(a, 0.5)', str(expr1.percentile(0.5)))
+        self.assertEqual('PERCENTILE(a, 0.5, b)',
+                         str(expr1.percentile(0.5, expr2)))
+        self.assertEqual('PERCENTILE(a, array(0.1, 0.5))', str(expr1.percentile(array(0.1, 0.5))))
+        self.assertEqual('PERCENTILE(a, array(0.1, 0.5), b)',
+                         str(expr1.percentile(array(0.1, 0.5), expr2)))
 
         # string functions
         self.assertEqual('substring(a, b)', str(expr1.substring(expr2)))

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -154,6 +154,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ORDER_
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.OVER;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.OVERLAY;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PARSE_URL;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PERCENTILE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.PLUS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.POSITION;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.POWER;
@@ -2425,5 +2426,44 @@ public abstract class BaseExpressions<InType, OutType> {
      */
     public OutType jsonQuery(String path, DataType returnType) {
         return jsonQuery(path, returnType, JsonQueryWrapper.WITHOUT_ARRAY);
+    }
+
+    /** See {@link BaseExpressions#percentile(Object, Object)}. */
+    public OutType percentile(InType percentage) {
+        return toApiSpecificExpression(
+                unresolvedCall(PERCENTILE, toExpr(), objectToExpression(percentage)));
+    }
+
+    /**
+     * Returns the exact percentile value of {@code expr} at the specified {@code percentage} in a
+     * group.
+     *
+     * <p>{@code percentage} must be a literal numeric value between [0.0, 1.0] or an array of such
+     * values. If a variable expression is passed to this function, the result will be calculated
+     * using any one of them.
+     *
+     * <p>{@code frequency} describes how many times {@code expr} should be counted, the default
+     * value is 1.
+     *
+     * <p>If no {@code expr} lies exactly at the desired percentile, the result is calculated using
+     * linear interpolation of the two nearest exprs. If {@code expr} or {@code frequency} is null,
+     * or {@code frequency} is not positive, the input row will be ignored.
+     *
+     * <p>NOTE: It is recommended to use this function in a window scenario, as it typically offers
+     * better performance. In a regular group aggregation scenario, users should be aware of the
+     * performance overhead caused by a full sort triggered by each record.
+     *
+     * @param percentage A NUMERIC NOT NULL or ARRAY&lt;NUMERIC NOT NULL&gt; NOT NULL expression.
+     * @param frequency An optional INTEGER_NUMERIC expression.
+     * @return A DOUBLE if percentage is numeric, or an ARRAY&lt;DOUBLE&gt; if percentage is an
+     *     array. null if percentage is an empty array.
+     */
+    public OutType percentile(InType percentage, InType frequency) {
+        return toApiSpecificExpression(
+                unresolvedCall(
+                        PERCENTILE,
+                        toExpr(),
+                        objectToExpression(percentage),
+                        objectToExpression(frequency)));
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -104,6 +104,8 @@ import static org.apache.flink.table.types.inference.strategies.SpecificInputTyp
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.JSON_ARGUMENT;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.TWO_EQUALS_COMPARABLE;
 import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.TWO_FULLY_COMPARABLE;
+import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.percentage;
+import static org.apache.flink.table.types.inference.strategies.SpecificInputTypeStrategies.percentageArray;
 import static org.apache.flink.table.types.inference.strategies.SpecificTypeStrategies.ARRAY_APPEND_PREPEND;
 
 /** Dictionary of function definitions for all built-in functions. */
@@ -862,6 +864,27 @@ public final class BuiltInFunctionDefinitions {
                     .name("ARRAY_AGG")
                     .kind(AGGREGATE)
                     .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.ARRAY))
+                    .build();
+
+    public static final BuiltInFunctionDefinition PERCENTILE =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("PERCENTILE")
+                    .kind(AGGREGATE)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            Arrays.asList("expr", "percentage"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.NUMERIC),
+                                                    or(percentage(false), percentageArray(false)))),
+                                    sequence(
+                                            Arrays.asList("expr", "percentage", "frequency"),
+                                            Arrays.asList(
+                                                    logical(LogicalTypeFamily.NUMERIC),
+                                                    or(percentage(false), percentageArray(false)),
+                                                    logical(LogicalTypeFamily.INTEGER_NUMERIC)))))
+                    .outputTypeStrategy(SpecificTypeStrategies.PERCENTILE)
+                    .runtimeProvided()
                     .build();
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/PercentageArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/PercentageArgumentTypeStrategy.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+
+import java.util.Optional;
+
+/** An {@link ArgumentTypeStrategy} that expects a percentage value between [0.0, 1.0]. */
+@Internal
+public final class PercentageArgumentTypeStrategy implements ArgumentTypeStrategy {
+
+    private final boolean expectedNullability;
+
+    public PercentageArgumentTypeStrategy(boolean nullable) {
+        this.expectedNullability = nullable;
+    }
+
+    @Override
+    public Optional<DataType> inferArgumentType(
+            CallContext callContext, int argumentPos, boolean throwOnFailure) {
+        final LogicalType actualType =
+                callContext.getArgumentDataTypes().get(argumentPos).getLogicalType();
+
+        if (!actualType.is(LogicalTypeFamily.NUMERIC)) {
+            return callContext.fail(throwOnFailure, "Percentage must be of NUMERIC type.");
+        }
+        if (!expectedNullability && actualType.isNullable()) {
+            return callContext.fail(throwOnFailure, "Percentage must be of NOT NULL type.");
+        }
+
+        if (callContext.isArgumentLiteral(argumentPos)) {
+            Optional<Number> literalVal = callContext.getArgumentValue(argumentPos, Number.class);
+
+            Double val = null;
+            if (literalVal.isPresent()) {
+                val = literalVal.get().doubleValue();
+            }
+
+            if (val == null || val < 0.0 || val > 1.0) {
+                return callContext.fail(
+                        throwOnFailure,
+                        "Percentage must be between [0.0, 1.0], but was '%s'.",
+                        val);
+            }
+        }
+
+        return Optional.of(expectedNullability ? DataTypes.DOUBLE() : DataTypes.DOUBLE().notNull());
+    }
+
+    @Override
+    public Signature.Argument getExpectedArgument(
+            FunctionDefinition functionDefinition, int argumentPos) {
+        return Signature.Argument.of(expectedNullability ? "<NUMERIC>" : "<NUMERIC NOT NULL>");
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/PercentageArrayArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/PercentageArrayArgumentTypeStrategy.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import java.util.Optional;
+
+/**
+ * An {@link ArgumentTypeStrategy} that expects an array of percentages with each element between
+ * [0.0, 1.0].
+ */
+@Internal
+public final class PercentageArrayArgumentTypeStrategy implements ArgumentTypeStrategy {
+
+    private final boolean expectedNullability;
+
+    public PercentageArrayArgumentTypeStrategy(boolean nullable) {
+        this.expectedNullability = nullable;
+    }
+
+    @Override
+    public Optional<DataType> inferArgumentType(
+            CallContext callContext, int argumentPos, boolean throwOnFailure) {
+        final LogicalType actualType =
+                callContext.getArgumentDataTypes().get(argumentPos).getLogicalType();
+
+        if (!actualType.is(LogicalTypeRoot.ARRAY)) {
+            return callContext.fail(throwOnFailure, "Percentage must be an array.");
+        }
+        if (!expectedNullability && actualType.isNullable()) {
+            return callContext.fail(throwOnFailure, "Percentage must be a non-null array.");
+        }
+
+        LogicalType elementType = ((ArrayType) actualType).getElementType();
+        if (!elementType.is(LogicalTypeFamily.NUMERIC)) {
+            return callContext.fail(
+                    throwOnFailure, "Value in the percentage array must be of NUMERIC type.");
+        }
+        if (!expectedNullability && elementType.isNullable()) {
+            return callContext.fail(
+                    throwOnFailure, "Value in the percentage array must be of NOT NULL type.");
+        }
+
+        if (callContext.isArgumentLiteral(argumentPos)) {
+            Optional<Number[]> literalVal =
+                    callContext.getArgumentValue(argumentPos, Number[].class);
+
+            if (!literalVal.isPresent()) {
+                return callContext.fail(
+                        throwOnFailure,
+                        "Percentage must be an array of NUMERIC values between [0.0, 1.0].");
+            }
+
+            for (Number value : literalVal.get()) {
+                if (value.doubleValue() < 0.0 || value.doubleValue() > 1.0) {
+                    return callContext.fail(
+                            throwOnFailure,
+                            "Value in the percentage array must be between [0.0, 1.0], but was '%s'.",
+                            value.doubleValue());
+                }
+            }
+        }
+
+        return Optional.of(
+                expectedNullability
+                        ? DataTypes.ARRAY(DataTypes.DOUBLE())
+                        : DataTypes.ARRAY(DataTypes.DOUBLE().notNull()).notNull());
+    }
+
+    @Override
+    public Signature.Argument getExpectedArgument(
+            FunctionDefinition functionDefinition, int argumentPos) {
+        return Signature.Argument.of(
+                expectedNullability ? "ARRAY<NUMERIC>" : "ARRAY<NUMERIC NOT NULL> NOT NULL");
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -125,6 +125,19 @@ public final class SpecificInputTypeStrategies {
      */
     public static final ArgumentTypeStrategy INDEX = new IndexArgumentTypeStrategy();
 
+    /** An {@link ArgumentTypeStrategy} that expects a percentage value between [0.0, 1.0]. */
+    public static ArgumentTypeStrategy percentage(boolean expectedNullability) {
+        return new PercentageArgumentTypeStrategy(expectedNullability);
+    }
+
+    /**
+     * An {@link ArgumentTypeStrategy} that expects an array of percentages with each element
+     * between [0.0, 1.0].
+     */
+    public static ArgumentTypeStrategy percentageArray(boolean expectedNullability) {
+        return new PercentageArrayArgumentTypeStrategy(expectedNullability);
+    }
+
     // --------------------------------------------------------------------------------------------
     // Strategies composed of other strategies
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
 import java.util.Optional;
 
@@ -92,6 +93,18 @@ public final class SpecificTypeStrategies {
 
     /** See {@link DecimalTimesTypeStrategy}. */
     public static final TypeStrategy DECIMAL_TIMES = new DecimalTimesTypeStrategy();
+
+    /** Type strategy specific for {@link BuiltInFunctionDefinitions#PERCENTILE}. */
+    public static final TypeStrategy PERCENTILE =
+            callContext ->
+                    Optional.of(
+                            callContext
+                                            .getArgumentDataTypes()
+                                            .get(1)
+                                            .getLogicalType()
+                                            .is(LogicalTypeRoot.ARRAY)
+                                    ? DataTypes.ARRAY(DataTypes.DOUBLE())
+                                    : DataTypes.DOUBLE());
 
     /** See {@link SourceWatermarkTypeStrategy}. */
     public static final TypeStrategy SOURCE_WATERMARK = new SourceWatermarkTypeStrategy();

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
@@ -31,6 +31,7 @@ import static org.apache.flink.table.types.inference.TypeStrategies.explicit;
 import static org.apache.flink.table.types.inference.TypeStrategies.nullableIfAllArgs;
 import static org.apache.flink.table.types.inference.TypeStrategies.nullableIfArgs;
 import static org.apache.flink.table.types.inference.TypeStrategies.varyingString;
+import static org.apache.flink.table.types.inference.strategies.SpecificTypeStrategies.PERCENTILE;
 
 /** Tests for built-in {@link TypeStrategies}. */
 class TypeStrategiesTest extends TypeStrategiesTestBase {
@@ -169,6 +170,14 @@ class TypeStrategiesTest extends TypeStrategiesTestBase {
                                 "Average without grouped aggregation",
                                 TypeStrategies.aggArg0(LogicalTypeMerging::findAvgAggType, true))
                         .inputTypes(DataTypes.INT().notNull())
-                        .expectDataType(DataTypes.INT()));
+                        .expectDataType(DataTypes.INT()),
+
+                // PercentileTypeStrategy
+                TypeStrategiesTestBase.TestSpec.forStrategy(PERCENTILE)
+                        .inputTypes(DataTypes.INT(), DataTypes.DOUBLE())
+                        .expectDataType(DataTypes.DOUBLE()),
+                TypeStrategiesTestBase.TestSpec.forStrategy(PERCENTILE)
+                        .inputTypes(DataTypes.INT(), DataTypes.ARRAY(DataTypes.DECIMAL(5, 2)))
+                        .expectDataType(DataTypes.ARRAY(DataTypes.DOUBLE())));
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInAggregateFunctionTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/BuiltInAggregateFunctionTestBase.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableDescriptor;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.SourceFunctionProvider;
@@ -42,7 +43,7 @@ import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
-import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.Preconditions;
 
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -59,17 +60,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.runtime.state.StateBackendLoader.HASHMAP_STATE_BACKEND_NAME;
 import static org.apache.flink.runtime.state.StateBackendLoader.ROCKSDB_STATE_BACKEND_NAME;
 import static org.apache.flink.table.test.TableAssertions.assertThat;
 import static org.apache.flink.table.types.DataType.getFieldDataTypes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /** Test base for testing aggregate {@link BuiltInFunctionDefinition built-in functions}. */
 @Execution(ExecutionMode.CONCURRENT)
@@ -214,17 +219,6 @@ abstract class BuiltInAggregateFunctionTestBase {
             return this;
         }
 
-        TestSpec testSqlRuntimeError(
-                Function<Table, String> sqlSpec,
-                DataType expectedRowType,
-                Class<? extends Throwable> exceptionClass,
-                String exceptionMessage) {
-            this.testItems.add(
-                    new SqlRuntimeErrorItem(
-                            sqlSpec, expectedRowType, exceptionClass, exceptionMessage));
-            return this;
-        }
-
         TestSpec testApiResult(
                 List<Expression> selectExpr,
                 List<Expression> groupByExpr,
@@ -272,6 +266,45 @@ abstract class BuiltInAggregateFunctionTestBase {
                     tableApiSpec.groupByExpr,
                     expectedSqlRowType,
                     expectedRows);
+            return this;
+        }
+
+        TestSpec testSqlValidationError(Function<Table, String> sqlSpec, String errorMessage) {
+            this.testItems.add(
+                    new SqlErrorTestItem(
+                            sqlSpec, null, ValidationException.class, errorMessage, true));
+            return this;
+        }
+
+        TestSpec testTableApiValidationError(TableApiAggSpec tableApiSpec, String errorMessage) {
+            this.testItems.add(
+                    new TableApiErrorTestItem(
+                            tableApiSpec.selectExpr,
+                            tableApiSpec.groupByExpr,
+                            null,
+                            ValidationException.class,
+                            errorMessage,
+                            true));
+            return this;
+        }
+
+        TestSpec testValidationError(
+                Function<Table, String> sqlSpec,
+                TableApiAggSpec tableApiSpec,
+                String errorMessage) {
+            testSqlValidationError(sqlSpec, errorMessage);
+            testTableApiValidationError(tableApiSpec, errorMessage);
+            return this;
+        }
+
+        TestSpec testSqlRuntimeError(
+                Function<Table, String> sqlSpec,
+                DataType expectedRowType,
+                Class<? extends Throwable> errorClass,
+                String errorMessage) {
+            this.testItems.add(
+                    new SqlErrorTestItem(
+                            sqlSpec, expectedRowType, errorClass, errorMessage, false));
             return this;
         }
 
@@ -326,9 +359,13 @@ abstract class BuiltInAggregateFunctionTestBase {
         }
     }
 
+    // ---------------------------------------------------------------------------------------------
+
     private interface TestItem {
         void execute(TableEnvironment tEnv, Table sourceTable);
     }
+
+    // ---------------------------------------------------------------------------------------------
 
     private abstract static class SuccessItem implements TestItem {
         private final @Nullable DataType expectedRowType;
@@ -362,41 +399,6 @@ abstract class BuiltInAggregateFunctionTestBase {
         protected abstract TableResult getResult(TableEnvironment tEnv, Table sourceTable);
     }
 
-    private abstract static class RuntimeErrorItem implements TestItem {
-        private final @Nullable DataType expectedRowType;
-        private final Class<? extends Throwable> exceptionClass;
-        private final String exceptionMessage;
-
-        public RuntimeErrorItem(
-                @Nullable DataType expectedRowType,
-                Class<? extends Throwable> exceptionClass,
-                String exceptionMessage) {
-            this.expectedRowType = expectedRowType;
-            this.exceptionClass = exceptionClass;
-            this.exceptionMessage = exceptionMessage;
-        }
-
-        @Override
-        public void execute(TableEnvironment tEnv, Table sourceTable) {
-            final TableResult tableResult = getResult(tEnv, sourceTable);
-
-            if (expectedRowType != null) {
-                final DataType actualRowType =
-                        tableResult.getResolvedSchema().toSourceRowDataType();
-
-                assertThat(actualRowType)
-                        .getChildren()
-                        .containsExactlyElementsOf(getFieldDataTypes(expectedRowType));
-            }
-
-            assertThatThrownBy(() -> CollectionUtil.iteratorToList(tableResult.collect()))
-                    .hasRootCauseInstanceOf(exceptionClass)
-                    .hasRootCauseMessage(exceptionMessage);
-        }
-
-        protected abstract TableResult getResult(TableEnvironment tEnv, Table sourceTable);
-    }
-
     private static class SqlTestItem extends SuccessItem {
         private final Function<Table, String> spec;
 
@@ -405,24 +407,6 @@ abstract class BuiltInAggregateFunctionTestBase {
                 @Nullable DataType expectedRowType,
                 @Nullable List<Row> expectedRows) {
             super(expectedRowType, expectedRows);
-            this.spec = spec;
-        }
-
-        @Override
-        protected TableResult getResult(TableEnvironment tEnv, Table sourceTable) {
-            return tEnv.sqlQuery(spec.apply(sourceTable)).execute();
-        }
-    }
-
-    private static class SqlRuntimeErrorItem extends RuntimeErrorItem {
-        private final Function<Table, String> spec;
-
-        public SqlRuntimeErrorItem(
-                Function<Table, String> spec,
-                @Nullable DataType expectedRowType,
-                Class<? extends Throwable> exceptionClass,
-                String exceptionMessage) {
-            super(expectedRowType, exceptionClass, exceptionMessage);
             this.spec = spec;
         }
 
@@ -561,6 +545,117 @@ abstract class BuiltInAggregateFunctionTestBase {
                                     .map(Expression::asSummaryString)
                                     .collect(Collectors.joining(", "))
                             : "");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+
+    private abstract static class ErrorTestItem implements TestItem {
+        private final DataType expectedRowType;
+        private final Class<? extends Throwable> errorClass;
+        private final String errorMessage;
+        private final boolean expectedDuringValidation;
+
+        public ErrorTestItem(
+                @Nullable DataType expectedRowType,
+                @Nullable Class<? extends Throwable> errorClass,
+                @Nullable String errorMessage,
+                boolean expectedDuringValidation) {
+            Preconditions.checkState(errorClass != null || errorMessage != null);
+            this.expectedRowType = expectedRowType;
+            this.errorClass = errorClass;
+            this.errorMessage = errorMessage;
+            this.expectedDuringValidation = expectedDuringValidation;
+        }
+
+        Consumer<? super Throwable> errorMatcher() {
+            if (errorClass != null && errorMessage != null) {
+                return anyCauseMatches(errorClass, errorMessage);
+            }
+            if (errorMessage != null) {
+                return anyCauseMatches(errorMessage);
+            }
+            return anyCauseMatches(errorClass);
+        }
+
+        @Override
+        public void execute(TableEnvironment tEnv, Table sourceTable) {
+            AtomicReference<TableResult> tableResult = new AtomicReference<>();
+
+            Throwable t =
+                    catchThrowable(() -> tableResult.set(this.query(tEnv, sourceTable).execute()));
+
+            if (this.expectedDuringValidation) {
+                assertThat(t)
+                        .as("Expected a validation exception")
+                        .isNotNull()
+                        .satisfies(this.errorMatcher());
+                return;
+            } else {
+                assertThat(t).as("Error while validating the query").isNull();
+            }
+
+            if (expectedRowType != null) {
+                final DataType actualRowType =
+                        tableResult.get().getResolvedSchema().toSourceRowDataType();
+
+                assertThat(actualRowType)
+                        .getChildren()
+                        .containsExactlyElementsOf(getFieldDataTypes(expectedRowType));
+            }
+
+            assertThatThrownBy(() -> tableResult.get().await())
+                    .isNotNull()
+                    .satisfies(this.errorMatcher());
+        }
+
+        protected abstract Table query(TableEnvironment tEnv, @Nullable Table inputTable);
+    }
+
+    private static final class SqlErrorTestItem extends ErrorTestItem {
+        private final Function<Table, String> spec;
+
+        public SqlErrorTestItem(
+                Function<Table, String> spec,
+                @Nullable DataType expectedRowType,
+                Class<? extends Throwable> errorClass,
+                String errorMessage,
+                boolean expectedDuringValidation) {
+            super(expectedRowType, errorClass, errorMessage, expectedDuringValidation);
+            this.spec = spec;
+        }
+
+        @Override
+        protected Table query(TableEnvironment tEnv, Table sourceTable) {
+            return tEnv.sqlQuery(spec.apply(sourceTable));
+        }
+    }
+
+    private static final class TableApiErrorTestItem extends ErrorTestItem {
+        private final List<Expression> selectExpr;
+        private final List<Expression> groupByExpr;
+
+        public TableApiErrorTestItem(
+                List<Expression> selectExpr,
+                List<Expression> groupByExpr,
+                DataType expectedRowType,
+                Class<? extends Throwable> errorClass,
+                String errorMessage,
+                boolean expectedDuringValidation) {
+            super(expectedRowType, errorClass, errorMessage, expectedDuringValidation);
+            this.selectExpr = selectExpr;
+            this.groupByExpr = groupByExpr;
+        }
+
+        @Override
+        protected Table query(TableEnvironment tEnv, Table sourceTable) {
+            if (groupByExpr != null) {
+                return sourceTable
+                        .groupBy(groupByExpr.toArray(new Expression[0]))
+                        .select(selectExpr.toArray(new Expression[0]));
+            } else {
+                return sourceTable.select(selectExpr.toArray(new Expression[0]));
+            }
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/PercentileAggFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/PercentileAggFunctionITCase.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.types.Row;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.DataTypes.ARRAY;
+import static org.apache.flink.table.api.DataTypes.DECIMAL;
+import static org.apache.flink.table.api.DataTypes.DOUBLE;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.array;
+import static org.apache.flink.types.RowKind.DELETE;
+import static org.apache.flink.types.RowKind.INSERT;
+import static org.apache.flink.types.RowKind.UPDATE_AFTER;
+import static org.apache.flink.types.RowKind.UPDATE_BEFORE;
+
+/** Tests for built-in ARRAY_AGG aggregation functions. */
+class PercentileAggFunctionITCase extends BuiltInAggregateFunctionTestBase {
+
+    @Override
+    Stream<TestSpec> getTestCaseSpecs() {
+        return Stream.of(percentileTestCases()).flatMap(s -> s);
+    }
+
+    private Stream<TestSpec> percentileTestCases() {
+        return Stream.of(
+                TestSpec.forFunction(BuiltInFunctionDefinitions.PERCENTILE)
+                        .withDescription("Double value")
+                        .withSource(
+                                ROW(DOUBLE(), INT(), STRING()),
+                                Arrays.asList(
+                                        // normal
+                                        Row.ofKind(INSERT, 1.0, 1, "A"),
+                                        Row.ofKind(INSERT, 5.0, 2, "A"),
+                                        Row.ofKind(INSERT, 4.0, 1, "A"),
+                                        Row.ofKind(INSERT, 2.0, 4, "A"),
+                                        Row.ofKind(INSERT, 9.0, 3, "A"),
+                                        Row.ofKind(INSERT, 1.0, 2, "A"),
+                                        Row.ofKind(INSERT, 4.0, 1, "A"),
+                                        // retract
+                                        Row.ofKind(INSERT, null, 1, "B"),
+                                        Row.ofKind(DELETE, null, 1, "B"),
+                                        Row.ofKind(INSERT, 3.0, null, "B"),
+                                        Row.ofKind(INSERT, 2.0, 3, "B"),
+                                        Row.ofKind(INSERT, 2.0, -1, "B"),
+                                        Row.ofKind(INSERT, 6.0, 2, "B"),
+                                        Row.ofKind(INSERT, 9.0, 1, "B"),
+                                        Row.ofKind(DELETE, 9.0, 1, "B"),
+                                        Row.ofKind(UPDATE_BEFORE, 2.0, 3, "B"),
+                                        Row.ofKind(UPDATE_AFTER, 4.0, 1, "B"),
+                                        // retract value with special frequency
+                                        Row.ofKind(INSERT, 1.0, 2, "C"),
+                                        Row.ofKind(INSERT, 2.0, 1, "C"),
+                                        Row.ofKind(INSERT, 2.0, -1, "C"),
+                                        Row.ofKind(INSERT, 2.0, null, "C"),
+                                        Row.ofKind(DELETE, 2.0, 1, "C"),
+                                        Row.ofKind(DELETE, 2.0, -1, "C"),
+                                        Row.ofKind(DELETE, 2.0, null, "C"),
+                                        Row.ofKind(UPDATE_BEFORE, 1.0, 2, "C"),
+                                        Row.ofKind(UPDATE_AFTER, 2.0, 1, "C")))
+                        // SinglePercentile without frequency
+                        .testResult(
+                                source ->
+                                        "SELECT PERCENTILE(f0, 0.5), f2 FROM "
+                                                + source
+                                                + " GROUP BY f2",
+                                TableApiAggSpec.groupBySelect(
+                                        Collections.singletonList($("f2")),
+                                        $("f0").percentile(0.5),
+                                        $("f2")),
+                                ROW(DOUBLE(), STRING()),
+                                ROW(DOUBLE(), STRING()),
+                                Arrays.asList(Row.of(4.0, "A"), Row.of(3.5, "B"), Row.of(2.0, "C")))
+                        .testResult(
+                                source ->
+                                        "SELECT PERCENTILE(f0, 0.5), PERCENTILE(f0, 0.3), f2 FROM "
+                                                + source
+                                                + " GROUP BY f2",
+                                TableApiAggSpec.groupBySelect(
+                                        Collections.singletonList($("f2")),
+                                        $("f0").percentile(0.5),
+                                        $("f0").percentile(0.3),
+                                        $("f2")),
+                                ROW(DOUBLE(), DOUBLE(), STRING()),
+                                ROW(DOUBLE(), DOUBLE(), STRING()),
+                                Arrays.asList(
+                                        Row.of(4.0, 1.7999999999999998, "A"),
+                                        Row.of(3.5, 2.9, "B"),
+                                        Row.of(2.0, 2.0, "C")))
+                        // SinglePercentile with frequency
+                        .testResult(
+                                source ->
+                                        "SELECT PERCENTILE(f0, 0.5, f1), f2 FROM "
+                                                + source
+                                                + " GROUP BY f2",
+                                TableApiAggSpec.groupBySelect(
+                                        Collections.singletonList($("f2")),
+                                        $("f0").percentile(0.5, $("f1")),
+                                        $("f2")),
+                                ROW(DOUBLE(), STRING()),
+                                ROW(DOUBLE(), STRING()),
+                                Arrays.asList(Row.of(3.0, "A"), Row.of(6.0, "B"), Row.of(2.0, "C")))
+                        // MultiPercentile without frequency
+                        .testResult(
+                                source ->
+                                        "SELECT PERCENTILE(f0, ARRAY[0.9, 0.7, 0.3, 1.0]), f2 FROM "
+                                                + source
+                                                + " GROUP BY f2",
+                                TableApiAggSpec.groupBySelect(
+                                        Collections.singletonList($("f2")),
+                                        $("f0").percentile(new double[] {0.9, 0.7, 0.3, 1.0}),
+                                        $("f2")),
+                                ROW(ARRAY(DOUBLE()), STRING()),
+                                ROW(ARRAY(DOUBLE()), STRING()),
+                                Arrays.asList(
+                                        Row.of(
+                                                new Double[] {
+                                                    6.600000000000001,
+                                                    4.199999999999999,
+                                                    1.7999999999999998,
+                                                    9.0
+                                                },
+                                                "A"),
+                                        Row.of(
+                                                new Double[] {5.4, 4.199999999999999, 2.9, 6.0},
+                                                "B"),
+                                        Row.of(new Double[] {2.0, 2.0, 2.0, 2.0}, "C")))
+                        .testResult(
+                                source ->
+                                        "SELECT PERCENTILE(f0, ARRAY_REMOVE(ARRAY[0.0], 0.0)), f2 FROM "
+                                                + source
+                                                + " GROUP BY f2",
+                                TableApiAggSpec.groupBySelect(
+                                        Collections.singletonList($("f2")),
+                                        $("f0").percentile(array(0.0).arrayRemove(0.0)),
+                                        $("f2")),
+                                ROW(ARRAY(DOUBLE()), STRING()),
+                                ROW(ARRAY(DOUBLE()), STRING()),
+                                Arrays.asList(
+                                        Row.of(null, "A"), Row.of(null, "B"), Row.of(null, "C")))
+                        // MultiPercentile with frequency
+                        .testResult(
+                                source ->
+                                        "SELECT PERCENTILE(f0, ARRAY[0.9, 0.7, 0.3, 1.0], f1), f2 FROM "
+                                                + source
+                                                + " GROUP BY f2",
+                                TableApiAggSpec.groupBySelect(
+                                        Collections.singletonList($("f2")),
+                                        $("f0").percentile(
+                                                        new double[] {0.9, 0.7, 0.3, 1.0}, $("f1")),
+                                        $("f2")),
+                                ROW(ARRAY(DOUBLE()), STRING()),
+                                ROW(ARRAY(DOUBLE()), STRING()),
+                                Arrays.asList(
+                                        Row.of(new Double[] {9.0, 5.0, 2.0, 9.0}, "A"),
+                                        Row.of(new Double[] {6.0, 6.0, 5.2, 6.0}, "B"),
+                                        Row.of(new Double[] {2.0, 2.0, 2.0, 2.0}, "C"))),
+                TestSpec.forFunction(BuiltInFunctionDefinitions.PERCENTILE)
+                        .withDescription("DecimalData value")
+                        .withSource(
+                                ROW(DECIMAL(2, 1), STRING()),
+                                Arrays.asList(
+                                        Row.ofKind(INSERT, null, "B"),
+                                        Row.ofKind(DELETE, null, "B"),
+                                        Row.ofKind(INSERT, BigDecimal.valueOf(3.0), "B"),
+                                        Row.ofKind(INSERT, BigDecimal.valueOf(2.0), "B"),
+                                        Row.ofKind(INSERT, BigDecimal.valueOf(2.0), "B"),
+                                        Row.ofKind(INSERT, BigDecimal.valueOf(9.0), "B"),
+                                        Row.ofKind(DELETE, BigDecimal.valueOf(2.0), "B"),
+                                        Row.ofKind(UPDATE_BEFORE, BigDecimal.valueOf(2.0), "B"),
+                                        Row.ofKind(UPDATE_AFTER, BigDecimal.valueOf(5.0), "B")))
+                        .testResult(
+                                source ->
+                                        "SELECT PERCENTILE(f0, 0.1), f1 FROM "
+                                                + source
+                                                + " GROUP BY f1",
+                                TableApiAggSpec.groupBySelect(
+                                        Collections.singletonList($("f1")),
+                                        $("f0").percentile(0.1),
+                                        $("f1")),
+                                ROW(DOUBLE(), STRING()),
+                                ROW(DOUBLE(), STRING()),
+                                Arrays.asList(Row.of(3.4000000000000004, "B"))),
+                TestSpec.forFunction(BuiltInFunctionDefinitions.PERCENTILE)
+                        .withDescription("Validation Error")
+                        .withSource(
+                                ROW(DOUBLE(), STRING()),
+                                Arrays.asList(
+                                        Row.ofKind(INSERT, 1.0, "A"),
+                                        Row.ofKind(INSERT, 2.0, "A"),
+                                        Row.ofKind(INSERT, 3.0, "A")))
+                        .testValidationError(
+                                source ->
+                                        "SELECT PERCENTILE(f0, 1.5), f1 FROM "
+                                                + source
+                                                + " GROUP BY f1",
+                                TableApiAggSpec.groupBySelect(
+                                        Collections.singletonList($("f1")),
+                                        $("f0").percentile(1.5),
+                                        $("f1")),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "PERCENTILE(expr <NUMERIC>, percentage [<NUMERIC NOT NULL> | ARRAY<NUMERIC NOT NULL> NOT NULL])\n"
+                                        + "PERCENTILE(expr <NUMERIC>, percentage [<NUMERIC NOT NULL> | ARRAY<NUMERIC NOT NULL> NOT NULL], frequency <INTEGER_NUMERIC>)")
+                        .testValidationError(
+                                source ->
+                                        "SELECT PERCENTILE(f0, -1), f1 FROM "
+                                                + source
+                                                + " GROUP BY f1",
+                                TableApiAggSpec.groupBySelect(
+                                        Collections.singletonList($("f1")),
+                                        $("f0").percentile(-1),
+                                        $("f1")),
+                                "Invalid input arguments. Expected signatures are:\n"
+                                        + "PERCENTILE(expr <NUMERIC>, percentage [<NUMERIC NOT NULL> | ARRAY<NUMERIC NOT NULL> NOT NULL])\n"
+                                        + "PERCENTILE(expr <NUMERIC>, percentage [<NUMERIC NOT NULL> | ARRAY<NUMERIC NOT NULL> NOT NULL], frequency <INTEGER_NUMERIC>)"),
+                TestSpec.forFunction(BuiltInFunctionDefinitions.PERCENTILE)
+                        .withDescription("Runtime Error")
+                        .withSource(
+                                ROW(DOUBLE(), STRING()),
+                                Arrays.asList(Row.ofKind(INSERT, 1.0, "A")))
+                        .testSqlRuntimeError(
+                                source ->
+                                        "SELECT PERCENTILE(f0, 1.0 + 2.0), f1 FROM "
+                                                + source
+                                                + " GROUP BY f1",
+                                null,
+                                IllegalArgumentException.class,
+                                "Percentage of PERCENTILE should be between [0.0, 1.0], but was '3.0'.")
+                        .testSqlRuntimeError(
+                                source ->
+                                        "SELECT PERCENTILE(f0, 1.0 - 2.0, 2), f1 FROM "
+                                                + source
+                                                + " GROUP BY f1",
+                                null,
+                                IllegalArgumentException.class,
+                                "Percentage of PERCENTILE should be between [0.0, 1.0], but was '-1.0'.")
+                        .testSqlRuntimeError(
+                                source ->
+                                        "SELECT PERCENTILE(f0, ARRAY[0.0, 1.5]), f1 FROM "
+                                                + source
+                                                + " GROUP BY f1",
+                                null,
+                                IllegalArgumentException.class,
+                                "Percentage of PERCENTILE should be between [0.0, 1.0], but was '1.5'.")
+                        .testSqlRuntimeError(
+                                source ->
+                                        "SELECT PERCENTILE(f0, ARRAY[0.5, -2.0], 2), f1 FROM "
+                                                + source
+                                                + " GROUP BY f1",
+                                null,
+                                IllegalArgumentException.class,
+                                "Percentage of PERCENTILE should be between [0.0, 1.0], but was '-2.0'."));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverAggregateITCase.scala
@@ -2902,6 +2902,36 @@ class OverAggregateITCase extends BatchTestBase {
       )
     )
   }
+
+  @Test
+  def testPercentile(): Unit = {
+    checkResult(
+      "SELECT " +
+        "e, " +
+        "PERCENTILE(e, 0.5) over (order by e), " +
+        "PERCENTILE(e, 0.5, d) over (order by e), " +
+        "PERCENTILE(e, ARRAY[0.25, 0.75]) over (order by e), " +
+        "PERCENTILE(e, ARRAY[0.25, 0.75], d) over (order by e) " +
+        "FROM Table5",
+      Seq(
+        row(1, 1.0, 1.0, Array(1.0, 1.0), Array(1.0, 1.0)),
+        row(2, 1.5, 2.0, Array(1.25, 1.75), Array(1.5, 2.0)),
+        row(3, 2.0, 2.0, Array(1.5, 2.5), Array(2.0, 3.0)),
+        row(4, 2.5, 3.0, Array(1.75, 3.25), Array(2.0, 4.0)),
+        row(5, 3.0, 4.0, Array(2.0, 4.0), Array(2.5, 4.5)),
+        row(6, 3.5, 4.0, Array(2.25, 4.75), Array(3.0, 5.0)),
+        row(7, 4.0, 5.0, Array(2.5, 5.5), Array(3.25, 6.0)),
+        row(8, 4.5, 5.5, Array(2.75, 6.25), Array(4.0, 7.0)),
+        row(9, 5.0, 6.0, Array(3.0, 7.0), Array(4.0, 8.0)),
+        row(10, 5.5, 7.0, Array(3.25, 7.75), Array(4.25, 8.75)),
+        row(11, 6.0, 7.0, Array(3.5, 8.5), Array(5.0, 9.5)),
+        row(12, 6.5, 8.0, Array(3.75, 9.25), Array(5.0, 10.25)),
+        row(13, 7.0, 9.0, Array(4.0, 10.0), Array(6.0, 11.0)),
+        row(14, 7.5, 9.0, Array(4.25, 10.75), Array(6.0, 12.0)),
+        row(15, 8.0, 10.0, Array(4.5, 11.5), Array(6.5, 13.0))
+      )
+    )
+  }
 }
 
 /** The initial accumulator for count aggregate function */

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/OverAggregateITCase.scala
@@ -32,6 +32,7 @@ import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTe
 import org.apache.flink.types.Row
 
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
+import org.assertj.core.data.Percentage
 import org.junit.jupiter.api.{BeforeEach, TestTemplate}
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -1397,5 +1398,66 @@ class OverAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTest
       "6.660000000000000000",
       "11.100000000000000000")
     assertThat(sink.getAppendResults).isEqualTo(expected)
+  }
+
+  @TestTemplate
+  def testPercentile(): Unit = {
+    val sql =
+      """
+        |SELECT
+        |  PERCENTILE(b, 0.5)
+        |  OVER (ORDER BY proctime ROWS BETWEEN 3 PRECEDING AND CURRENT ROW) AS `swo`,
+        |  PERCENTILE(b, 0.5, a) 
+        |  OVER (ORDER BY proctime ROWS BETWEEN 3 PRECEDING AND CURRENT ROW) AS `sw`,
+        |  PERCENTILE(b, ARRAY[0.5, 0.9, 0.3])
+        |  OVER (ORDER BY proctime ROWS BETWEEN 3 PRECEDING AND CURRENT ROW) AS `mwo`,
+        |  PERCENTILE(b, ARRAY[0.5, 0.9, 0.3], a)
+        |  OVER (ORDER BY proctime ROWS BETWEEN 3 PRECEDING AND CURRENT ROW) AS `mw`
+        |FROM MyTable
+      """.stripMargin
+    val outer =
+      s"""
+         |SELECT
+         | `swo`,
+         | `sw`,
+         | `mwo`[1], `mwo`[2], `mwo`[3],
+         | `mw`[1], `mw`[2], `mw`[3]
+         |FROM ($sql)
+    """.stripMargin
+
+    val t =
+      failingDataSource(TestData.tupleData5).toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
+    tEnv.createTemporaryView("MyTable", t)
+
+    val sink = new TestingAppendSink()
+    tEnv.sqlQuery(outer).toDataStream.addSink(sink).setParallelism(1)
+    env.execute()
+
+    val expected = List(
+      List(1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+      List(1.5, 2.0, 1.5, 1.9, 1.3, 2.0, 2.0, 1.6),
+      List(2.0, 2.0, 2.0, 2.8, 1.6, 2.0, 3.0, 2.0),
+      List(2.5, 3.0, 2.5, 3.7, 1.9, 3.0, 4.0, 2.1),
+      List(3.5, 4.0, 3.5, 4.7, 2.9, 4.0, 5.0, 3.0),
+      List(4.5, 5.0, 4.5, 5.7, 3.9, 5.0, 6.0, 4.0),
+      List(5.5, 6.0, 5.5, 6.7, 4.9, 6.0, 7.0, 5.0),
+      List(6.5, 7.0, 6.5, 7.7, 5.9, 7.0, 8.0, 6.0),
+      List(7.5, 8.0, 7.5, 8.7, 6.9, 8.0, 9.0, 7.0),
+      List(8.5, 8.5, 8.5, 9.7, 7.9, 8.5, 10.0, 8.0),
+      List(9.5, 10.0, 9.5, 10.7, 8.9, 10.0, 11.0, 9.0),
+      List(10.5, 11.0, 10.5, 11.7, 9.9, 11.0, 12.0, 10.0),
+      List(11.5, 12.0, 11.5, 12.7, 10.9, 12.0, 13.0, 11.0),
+      List(12.5, 12.5, 12.5, 13.7, 11.9, 12.5, 14.0, 12.0),
+      List(13.5, 13.5, 13.5, 14.7, 12.9, 13.5, 15.0, 13.0)
+    )
+    val ERROR_RATE = Percentage.withPercentage(1e-6)
+
+    val result = sink.getAppendResults
+    for (i <- result.indices) {
+      val actual = result(i).split(",")
+      for (j <- expected(i).indices) {
+        assertThat(actual(j).toDouble).isCloseTo(expected(i)(j), ERROR_RATE)
+      }
+    }
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/WindowAggregateITCase.scala
@@ -23,6 +23,7 @@ import org.apache.flink.core.execution.CheckpointingMode
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.config.{AggregatePhaseStrategy, OptimizerConfigOptions}
+import org.apache.flink.table.api.config.AggregatePhaseStrategy._
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow
 import org.apache.flink.table.planner.plan.utils.JavaUserDefinedAggFunctions.ConcatDistinctAggFunction
@@ -32,8 +33,8 @@ import org.apache.flink.table.planner.runtime.utils.TimeTestUtil.TimestampAndWat
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
 import org.apache.flink.types.Row
 
-import AggregatePhaseStrategy._
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Percentage
 import org.junit.jupiter.api.{BeforeEach, TestTemplate}
 import org.junit.jupiter.api.extension.ExtendWith
 
@@ -1323,6 +1324,71 @@ class WindowAggregateITCase(
     )
     assertThat(sink.getAppendResults.sorted.mkString("\n"))
       .isEqualTo(expected.sorted.mkString("\n"))
+  }
+
+  @TestTemplate
+  def testPercentileOnEventTimeTumbleWindow(): Unit = {
+    val sql =
+      """
+        |SELECT
+        |  `name`,
+        |  window_start,
+        |  window_end,
+        |  PERCENTILE(`double`, 0.5) as `swo`,
+        |  PERCENTILE(`double`, 0.5, `int`) as `sw`,
+        |  PERCENTILE(`double`, ARRAY[0.5, 0.2, 0.6]) as `mwo`,
+        |  PERCENTILE(`double`, ARRAY[0.5, 0.2, 0.6], `int`) as `mw`
+        |FROM TABLE(
+        |   TUMBLE(TABLE T1_CDC, DESCRIPTOR(rowtime), INTERVAL '5' SECOND))
+        |GROUP BY `name`, window_start, window_end
+      """.stripMargin
+    val outer =
+      s"""
+         |select
+         | `name`,
+         | window_start,
+         | window_end,
+         | `swo`,
+         | `sw`,
+         | `mwo`[1], `mwo`[2], `mwo`[3],
+         | `mw`[1], `mw`[2], `mw`[3]
+         |FROM ($sql)
+    """.stripMargin
+
+    val sink = new TestingAppendSink
+    tEnv.sqlQuery(outer).toDataStream.addSink(sink)
+    env.execute()
+
+    val expected_key = List(
+      List("a", "2020-10-10T00:00", "2020-10-10T00:00:05"),
+      List("a", "2020-10-10T00:00:05", "2020-10-10T00:00:10"),
+      List("b", "2020-10-10T00:00:05", "2020-10-10T00:00:10"),
+      List("b", "2020-10-10T00:00:15", "2020-10-10T00:00:20")
+    )
+    // Double.NaN indicates null value
+    val expected_value = List(
+      List(5.0, 22.0, 5.0, 3.2, 8.4, 22.0, 5.0, 22.0),
+      List.fill(8)(Double.NaN),
+      List(4.5, 6.0, 4.5, 3.6, 4.8, 6.0, 3.0, 6.0),
+      List.fill(8)(4.0)
+    )
+    val key_length = expected_key.head.length
+    val ERROR_RATE = Percentage.withPercentage(1e-6)
+
+    val result = sink.getAppendResults.sorted
+    for (i <- result.indices) {
+      val actual = result(i).split(",")
+      for (j <- expected_key(i).indices) {
+        assertThat(actual(j)).isEqualTo(expected_key(i)(j))
+      }
+      for (j <- expected_value(i).indices) {
+        if (!expected_value(i)(j).isNaN) {
+          assertThat(actual(j + key_length).toDouble).isCloseTo(expected_value(i)(j), ERROR_RATE)
+        } else {
+          assertThat(actual(j + key_length)).isEqualTo("null")
+        }
+      }
+    }
   }
 }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/PercentileAggFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/aggregate/PercentileAggFunction.java
@@ -1,0 +1,389 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.aggregate;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.dataview.MapView;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.DecimalDataUtils;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.commons.math3.util.Pair;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.table.types.utils.DataTypeUtils.toInternalDataType;
+
+/** Built-in PERCENTILE aggregate function. */
+@Internal
+public abstract class PercentileAggFunction<T>
+        extends BuiltInAggregateFunction<T, PercentileAggFunction.PercentileAccumulator> {
+
+    protected final transient DataType valueType;
+    protected final transient DataType frequencyType;
+
+    public PercentileAggFunction(LogicalType inputType, LogicalType frequencyType) {
+        this.valueType = toInternalDataType(inputType);
+        this.frequencyType = frequencyType == null ? null : toInternalDataType(frequencyType);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Accumulator
+    // --------------------------------------------------------------------------------------------
+
+    /** Accumulator for PERCENTILE. */
+    public static class PercentileAccumulator {
+
+        public double[] percentages;
+        public MapView<Double, Long> valueCount;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PercentileAccumulator that = (PercentileAccumulator) o;
+            return Arrays.equals(percentages, that.percentages)
+                    && Objects.equals(valueCount, that.valueCount);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(Arrays.hashCode(percentages), valueCount.hashCode());
+        }
+
+        public Double[] getValue() {
+            // calculate totalCount here to avoid the inconsistent expiration of the two different
+            // states (ValueState acc.totalCount vs MapState acc.valueCount) when operating them
+            // serially
+            long totalCount = 0L;
+
+            // get a sorted list from hashmap for single traversal
+            List<Map.Entry<Double, Long>> sortedList = new ArrayList<>();
+            try {
+                for (Map.Entry<Double, Long> entry : valueCount.entries()) {
+                    sortedList.add(entry);
+                    totalCount += entry.getValue();
+                }
+            } catch (Exception e) {
+                throw new FlinkRuntimeException(e);
+            }
+
+            if (totalCount <= 0) {
+                return null;
+            }
+
+            sortedList.sort(Map.Entry.comparingByKey());
+
+            // calculate the position for each percentage and sort it, so that all percentiles can
+            // be obtained with a single traversal
+            List<Pair<Double, Integer>> sortedPercentages = new ArrayList<>();
+            for (int index = 0; index < percentages.length; index++) {
+                sortedPercentages.add(new Pair<>(percentages[index] * (totalCount - 1) + 1, index));
+            }
+            sortedPercentages.sort(Comparator.comparing(Pair::getKey));
+
+            Double[] percentiles = new Double[percentages.length];
+
+            long preCnt = sortedList.get(0).getValue();
+            for (int i = 0, j = 0; i < sortedPercentages.size(); i++) {
+                Pair<Double, Integer> entry = sortedPercentages.get(i);
+                double position = entry.getKey();
+                long lower = (long) Math.floor(position);
+                long higher = (long) Math.ceil(position);
+
+                // lower <= (totalCount - 1) * percentage + 1 <= totalCount
+                // hence, j will never overflow
+                while (preCnt < lower) {
+                    j++;
+                    preCnt += sortedList.get(j).getValue();
+                }
+
+                percentiles[entry.getValue()] =
+                        preCnt >= higher
+                                // 1. position is between two same values
+                                // 2. position corresponds to an exact index in the list
+                                ? sortedList.get(j).getKey()
+                                // linear interpolation to get the exact percentile
+                                : (higher - position) * sortedList.get(j).getKey()
+                                        + (position - lower) * sortedList.get(j + 1).getKey();
+            }
+
+            return percentiles;
+        }
+
+        public void setPercentages(Double percentage) {
+            // save and verify percentage values only the first time to avoid redundant assignments
+            // and verifications
+            if (percentage < 0.0 || percentage > 1.0) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Percentage of PERCENTILE should be between [0.0, 1.0], but was '%s'.",
+                                percentage));
+            }
+            percentages = new double[] {percentage};
+        }
+
+        public void setPercentages(Double[] percentage) {
+            // save and verify percentage values only the first time to avoid redundant assignments
+            // and verifications
+            percentages = new double[percentage.length];
+            for (int i = 0; i < percentages.length; i++) {
+                if (percentage[i] < 0.0 || percentage[i] > 1.0) {
+                    throw new IllegalArgumentException(
+                            String.format(
+                                    "Percentage of PERCENTILE should be between [0.0, 1.0], but was '%s'.",
+                                    percentage[i]));
+                }
+                percentages[i] = percentage[i];
+            }
+        }
+    }
+
+    @Override
+    public DataType getAccumulatorDataType() {
+        return DataTypes.STRUCTURED(
+                PercentileAccumulator.class,
+                DataTypes.FIELD(
+                        "percentages",
+                        DataTypes.ARRAY(DataTypes.DOUBLE()).bridgedTo(double[].class)),
+                DataTypes.FIELD(
+                        "valueCount",
+                        MapView.newMapViewDataType(DataTypes.DOUBLE(), DataTypes.BIGINT())));
+    }
+
+    @Override
+    public PercentileAccumulator createAccumulator() {
+        final PercentileAccumulator acc = new PercentileAccumulator();
+        acc.percentages = null;
+        acc.valueCount = new MapView<>();
+        return acc;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // accumulate methods
+    // --------------------------------------------------------------------------------------------
+
+    public void accumulate(PercentileAccumulator acc, @Nullable Object value, Double percentage)
+            throws Exception {
+        if (acc.percentages == null) {
+            acc.setPercentages(percentage);
+        }
+        update(acc, value, 1L);
+    }
+
+    public void accumulate(
+            PercentileAccumulator acc,
+            @Nullable Object value,
+            Double percentage,
+            @Nullable Number frequency)
+            throws Exception {
+        if (acc.percentages == null) {
+            acc.setPercentages(percentage);
+        }
+        if (frequency == null || frequency.longValue() <= 0) {
+            return;
+        }
+        update(acc, value, frequency.longValue());
+    }
+
+    public void accumulate(PercentileAccumulator acc, @Nullable Object value, Double[] percentage)
+            throws Exception {
+        if (acc.percentages == null) {
+            acc.setPercentages(percentage);
+        }
+        update(acc, value, 1L);
+    }
+
+    public void accumulate(
+            PercentileAccumulator acc,
+            @Nullable Object value,
+            Double[] percentage,
+            @Nullable Number frequency)
+            throws Exception {
+        if (acc.percentages == null) {
+            acc.setPercentages(percentage);
+        }
+        if (frequency == null || frequency.longValue() <= 0) {
+            return;
+        }
+        update(acc, value, frequency.longValue());
+    }
+
+    private void update(PercentileAccumulator acc, @Nullable Object value, long frequency)
+            throws Exception {
+        // skip input if value is null
+        if (value == null) {
+            return;
+        }
+
+        double val =
+                (value instanceof Number)
+                        ? ((Number) value).doubleValue()
+                        : DecimalDataUtils.doubleValue((DecimalData) value);
+
+        long cnt = Optional.ofNullable(acc.valueCount.get(val)).orElse(0L) + frequency;
+        if (cnt != 0) {
+            acc.valueCount.put(val, cnt);
+        } else {
+            acc.valueCount.remove(val);
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // retract methods
+    // --------------------------------------------------------------------------------------------
+
+    public void retract(PercentileAccumulator acc, @Nullable Object value, Double percentage)
+            throws Exception {
+        update(acc, value, -1L);
+    }
+
+    public void retract(
+            PercentileAccumulator acc,
+            @Nullable Object value,
+            Double percentage,
+            @Nullable Number frequency)
+            throws Exception {
+        if (frequency == null || frequency.longValue() <= 0) {
+            return;
+        }
+        update(acc, value, -frequency.longValue());
+    }
+
+    public void retract(PercentileAccumulator acc, @Nullable Object value, Double[] percentage)
+            throws Exception {
+        update(acc, value, -1L);
+    }
+
+    public void retract(
+            PercentileAccumulator acc,
+            @Nullable Object value,
+            Double[] percentage,
+            @Nullable Number frequency)
+            throws Exception {
+        if (frequency == null || frequency.longValue() <= 0) {
+            return;
+        }
+        update(acc, value, -frequency.longValue());
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // merge methods
+    // --------------------------------------------------------------------------------------------
+
+    public void merge(PercentileAccumulator acc, Iterable<PercentileAccumulator> its)
+            throws Exception {
+        for (PercentileAccumulator mergedAcc : its) {
+            if (acc.percentages == null && mergedAcc.percentages != null) {
+                acc.percentages = mergedAcc.percentages.clone();
+            }
+
+            for (Map.Entry<Double, Long> entry : mergedAcc.valueCount.entries()) {
+                long cnt =
+                        Optional.ofNullable(acc.valueCount.get(entry.getKey())).orElse(0L)
+                                + entry.getValue();
+                if (cnt != 0) {
+                    acc.valueCount.put(entry.getKey(), cnt);
+                } else {
+                    acc.valueCount.remove(entry.getKey());
+                }
+            }
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // implementation classes
+    // --------------------------------------------------------------------------------------------
+
+    /** Percentile agg function with only one percentage parameter. */
+    public static class SinglePercentileAggFunction extends PercentileAggFunction<Double> {
+
+        public SinglePercentileAggFunction(LogicalType valueType, LogicalType frequencyType) {
+            super(valueType, frequencyType);
+        }
+
+        @Override
+        public List<DataType> getArgumentDataTypes() {
+            return frequencyType == null
+                    ? Arrays.asList(valueType, DataTypes.DOUBLE().notNull())
+                    : Arrays.asList(valueType, DataTypes.DOUBLE().notNull(), frequencyType);
+        }
+
+        @Override
+        public DataType getOutputDataType() {
+            return DataTypes.DOUBLE();
+        }
+
+        @Override
+        public Double getValue(PercentileAccumulator acc) {
+            if (acc.percentages == null) {
+                return null;
+            }
+            Double[] result = acc.getValue();
+            return result == null ? null : result[0];
+        }
+    }
+
+    /** Percentile agg function with multiple percentage parameters. */
+    public static class MultiPercentileAggFunction extends PercentileAggFunction<Double[]> {
+
+        public MultiPercentileAggFunction(LogicalType valueType, LogicalType frequencyType) {
+            super(valueType, frequencyType);
+        }
+
+        @Override
+        public List<DataType> getArgumentDataTypes() {
+            return frequencyType == null
+                    ? Arrays.asList(
+                            valueType, DataTypes.ARRAY(DataTypes.DOUBLE().notNull()).notNull())
+                    : Arrays.asList(
+                            valueType,
+                            DataTypes.ARRAY(DataTypes.DOUBLE().notNull()).notNull(),
+                            frequencyType);
+        }
+
+        @Override
+        public DataType getOutputDataType() {
+            return DataTypes.ARRAY(DataTypes.DOUBLE());
+        }
+
+        @Override
+        public Double[] getValue(PercentileAccumulator acc) {
+            if (acc.percentages == null || acc.percentages.length == 0) {
+                return null;
+            }
+            return acc.getValue();
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add the built-in function PERCENTILE.
Examples:
```SQL
> SELECT PERCENTILE(col, 0.3) FROM VALUES (0), (10), (10) AS tab(col);
 6.0

> SELECT PERCENTILE(col, 0.3, freq) FROM VALUES (0, 1), (10, 2) AS tab(col, freq);
 6.0

> SELECT PERCENTILE(col, array(0.25, 0.75)) FROM VALUES (0), (10) AS tab(col);
 [2.5,7.5]
```

## Brief change log

- Add `ArgumentTypeStrategy` for percentage (array) value with literal value checking
- Refactor error test for built-in agg functions
- Support creating `AggregateInfo` through `BuiltInFunctionDefinition` directly to avoid an extra `SqlAggFunction` conversion
- [FLINK-36123](https://issues.apache.org/jira/browse/FLINK-36123)

## Verifying this change

For the two `ArgumentTypestrategy`: `InputTypeStrategiesTest`

For the `PercentileTypestrategy`: `TypeStrategiesTest`

For the function PERCENTILE:
- `PercentileAggFunctionITCase`,
- `WindowAggregateITCase#testPercentileOnEventTimeTumbleWindow()`
- `stream/OverAggregateITCase#testPercentile()`, `batch/OverAggregateITCase#testPercentile()`
- `sql/AggregateITCase#testSinglePercentile()`, `sql/AggregateITCase#testMultiPercentile()`
- `table/AggregateITCase#testSinglePercentile()`, `table/AggregateITCase#testMultiPercentile()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
