### PR TITLE
[FLINK-36241] Table API .plus should support string concatenation

### DIFF
--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -631,6 +631,12 @@ class Expression(Generic[T]):
         """
         return _binary_op("round")(self, places)
 
+    def concat(self, other: Union[str, 'Expression[str]']) -> 'Expression[str]':
+        """
+        Concatenates two strings.
+        """
+        return _binary_op("concat")(self, other)
+
     def between(self, lower_bound, upper_bound) -> 'Expression[bool]':
         """
         Returns true if the given expression is between lower_bound and upper_bound

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -83,6 +83,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CEIL;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CHAR_LENGTH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CHR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COLLECT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CONCAT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COSH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COT;
@@ -369,6 +370,11 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Returns left multiplied by right. */
     public OutType times(InType other) {
         return toApiSpecificExpression(unresolvedCall(TIMES, toExpr(), objectToExpression(other)));
+    }
+
+    /** Concatenates two strings. */
+    public OutType concat(InType other) {
+        return toApiSpecificExpression(unresolvedCall(CONCAT, toExpr(), objectToExpression(other)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1582,7 +1582,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition PLUS =
             BuiltInFunctionDefinition.newBuilder()
                     .name("plus")
-                    .callSyntax("+", SqlCallSyntax.BINARY_OP)
+                    .callSyntax("+", SqlCallSyntax.PLUS_OP)
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             or(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.TimeIntervalUnit;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.utils.EncodingUtils;
 
 import java.util.List;
@@ -100,7 +101,7 @@ public interface SqlCallSyntax {
                                     .map(ResolvedExpression::asSerializableString)
                                     .collect(Collectors.joining(", ")));
 
-    /** Binary operator syntax, as in "x + y". */
+    /** Binary operator syntax, as in "x - y". */
     SqlCallSyntax BINARY_OP =
             (sqlName, operands) ->
                     String.format(
@@ -108,6 +109,24 @@ public interface SqlCallSyntax {
                             CallSyntaxUtils.asSerializableOperand(operands.get(0)),
                             sqlName,
                             CallSyntaxUtils.asSerializableOperand(operands.get(1)));
+
+    /** Syntax for unparsing '+', Special handling for a plus on string arguments. */
+    SqlCallSyntax PLUS_OP =
+            (sqlName, operands) -> {
+                boolean isString =
+                        operands.stream()
+                                .anyMatch(
+                                        op ->
+                                                op.getOutputDataType()
+                                                        .getLogicalType()
+                                                        .is(LogicalTypeFamily.CHARACTER_STRING));
+                if (isString) {
+                    return FUNCTION.unparse(
+                            BuiltInFunctionDefinitions.CONCAT.getSqlName(), operands);
+                } else {
+                    return BINARY_OP.unparse(sqlName, operands);
+                }
+            };
 
     /**
      * Binary operator syntax that in Table API can accept multiple operands, as in "x AND y AND t

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/StringFunctionsITCase.java
@@ -31,6 +31,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.concat;
 import static org.apache.flink.table.api.Expressions.lit;
 
 /** Test String functions correct behaviour. */
@@ -44,8 +45,31 @@ class StringFunctionsITCase extends BuiltInFunctionTestBase {
                         endsWithTestCases(),
                         printfTestCases(),
                         startsWithTestCases(),
-                        translateTestCases())
+                        translateTestCases(),
+                        concatenateTestCases())
                 .flatMap(s -> s);
+    }
+
+    private Stream<TestSetSpec> concatenateTestCases() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.PLUS)
+                        .onFieldsWithData("Beginning", " Middle ", "Ending")
+                        .andDataTypes(DataTypes.STRING(), DataTypes.STRING(), DataTypes.STRING())
+                        .testResult(
+                                $("f0").concat($("f1")).concat($("f2")),
+                                "concat(concat(f0, f1), f2)",
+                                "Beginning Middle Ending",
+                                DataTypes.STRING())
+                        .testResult(
+                                concat($("f0"), $("f1"), $("f2")),
+                                "concat(f0, f1, f2)",
+                                "Beginning Middle Ending",
+                                DataTypes.STRING())
+                        .testResult(
+                                $("f0").plus($("f1")).plus($("f2")),
+                                "concat(concat(f0, f1), f2)",
+                                "Beginning Middle Ending",
+                                DataTypes.STRING()));
     }
 
     private Stream<TestSetSpec> bTrimTestCases() {


### PR DESCRIPTION


## What is the purpose of the change

This PR improves handling of `+` operator in more cases.


## Verifying this change

Added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
