### PR TITLE
[FLINK-36242][table] Fix unstable test in MaterializedTableITCase

### DIFF
--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointMaterializedTableITCase.java
@@ -140,6 +140,11 @@ public class SqlGatewayRestEndpointMaterializedTableITCase
         GenericMapData clusterInfo = ((GenericMapData) results.get(0).getMap(1));
         assertThat(clusterInfo.get(StringData.fromString(TARGET.key())))
                 .isEqualTo(StringData.fromString("remote"));
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(
+                        fileSystemCatalogName, TEST_DEFAULT_DATABASE, "my_materialized_table"));
     }
 
     @Test
@@ -214,6 +219,11 @@ public class SqlGatewayRestEndpointMaterializedTableITCase
         GenericMapData clusterInfo = ((GenericMapData) results.get(0).getMap(1));
         assertThat(clusterInfo.get(StringData.fromString(TARGET.key())))
                 .isEqualTo(StringData.fromString("remote"));
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(
+                        fileSystemCatalogName, TEST_DEFAULT_DATABASE, "my_materialized_table"));
     }
 
     FetchResultsResponseBody fetchResults(

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/MaterializedTableStatementITCase.java
@@ -169,6 +169,10 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
         long checkpointInterval =
                 getCheckpointIntervalConfig(restClusterClient, activeRefreshHandler.getJobId());
         assertThat(checkpointInterval).isEqualTo(30 * 1000);
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(fileSystemCatalogName, TEST_DEFAULT_DATABASE, "users_shops"));
     }
 
     @Test
@@ -230,6 +234,10 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
         long actualCheckpointInterval =
                 getCheckpointIntervalConfig(restClusterClient, activeRefreshHandler.getJobId());
         assertThat(actualCheckpointInterval).isEqualTo(checkpointInterval);
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(fileSystemCatalogName, TEST_DEFAULT_DATABASE, "users_shops"));
     }
 
     @Test
@@ -330,10 +338,14 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                 .containsKey("table.catalog-store.file.path")
                 .doesNotContainKey(WORKFLOW_SCHEDULER_TYPE.key())
                 .doesNotContainKey(RESOURCES_DOWNLOAD_DIR.key());
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(fileSystemCatalogName, TEST_DEFAULT_DATABASE, "users_shops"));
     }
 
     @Test
-    void testCreateMaterializedTableFailedInInContinuousMode() {
+    void testCreateMaterializedTableFailedInInContinuousMode() throws Exception {
         // create a materialized table with invalid SQL
         String materializedTableDDL =
                 "CREATE MATERIALIZED TABLE users_shops"
@@ -429,6 +441,11 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                                         "SELECT * FROM my_materialized_table where ds = '2024-01-02'")
                                 .size())
                 .isEqualTo(1);
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(
+                        fileSystemCatalogName, TEST_DEFAULT_DATABASE, "my_materialized_table"));
     }
 
     @Test
@@ -509,6 +526,10 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                         "Currently, refreshing materialized table only supports referring to char, varchar and string type partition keys. All specified partition keys in partition specs with unsupported types are:\n"
                                 + "\n"
                                 + "ds2");
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(fileSystemCatalogName, TEST_DEFAULT_DATABASE, "users_shops"));
     }
 
     @Test
@@ -654,6 +675,10 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                 getJobRestoreSavepointPath(restClusterClient, resumeJobId);
         assertThat(actualRestorePath).isNotEmpty();
         assertThat(actualRestorePath.get()).isEqualTo(actualSavepointPath);
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(fileSystemCatalogName, TEST_DEFAULT_DATABASE, "users_shops"));
     }
 
     @Test
@@ -714,6 +739,10 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining(
                         "Savepoint directory is not configured, can't stop job with savepoint.");
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(fileSystemCatalogName, TEST_DEFAULT_DATABASE, "users_shops"));
     }
 
     @Test
@@ -921,6 +950,10 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                 fromJson((String) jobDetail.getJobDataMap().get(WORKFLOW_INFO), WorkflowInfo.class);
         assertThat(workflowInfo.getDynamicOptions())
                 .containsEntry("debezium-json.ignore-parse-errors", "true");
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(fileSystemCatalogName, TEST_DEFAULT_DATABASE, "users_shops"));
     }
 
     @Test
@@ -1324,6 +1357,11 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                                         "SELECT * FROM my_materialized_table where ds = '2024-01-01'")
                                 .size())
                 .isNotEqualTo(getPartitionSize(data, "2024-01-01"));
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(
+                        fileSystemCatalogName, TEST_DEFAULT_DATABASE, "my_materialized_table"));
     }
 
     @Test
@@ -1387,6 +1425,13 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                                         "SELECT * FROM my_materialized_table_without_partition_options where ds = '2024-01-02'")
                                 .size())
                 .isEqualTo(getPartitionSize(data, "2024-01-02"));
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(
+                        fileSystemCatalogName,
+                        TEST_DEFAULT_DATABASE,
+                        "my_materialized_table_without_partition_options"));
     }
 
     @Test
@@ -1448,6 +1493,11 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                                         "SELECT * FROM my_materialized_table where ds = '2024-01-01'")
                                 .size())
                 .isNotEqualTo(getPartitionSize(data, "2024-01-01"));
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(
+                        fileSystemCatalogName, TEST_DEFAULT_DATABASE, "my_materialized_table"));
     }
 
     @Test
@@ -1517,6 +1567,11 @@ public class MaterializedTableStatementITCase extends AbstractMaterializedTableS
                                                 TEST_DEFAULT_DATABASE,
                                                 "my_materialized_table")
                                         .asSerializableString()));
+
+        // drop the materialized table
+        dropMaterializedTable(
+                ObjectIdentifier.of(
+                        fileSystemCatalogName, TEST_DEFAULT_DATABASE, "my_materialized_table"));
     }
 
     private int getPartitionSize(List<Row> data, String partition) {

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/main/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalog.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/main/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalog.java
@@ -241,6 +241,7 @@ public class TestFileSystemCatalog extends AbstractCatalog {
             return Arrays.stream(fs.listStatus(dbPath))
                     .filter(FileStatus::isDir)
                     .map(fileStatus -> fileStatus.getPath().getName())
+                    .filter(name -> tableExists(new ObjectPath(databaseName, name)))
                     .collect(Collectors.toList());
         } catch (IOException e) {
             throw new CatalogException(
@@ -355,10 +356,12 @@ public class TestFileSystemCatalog extends AbstractCatalog {
         try {
             if (!fs.exists(path)) {
                 fs.mkdirs(path);
+            }
+            if (!fs.exists(tableSchemaPath)) {
                 fs.mkdirs(tableSchemaPath);
-                if (isFileSystemTable(catalogTable.getOptions())) {
-                    fs.mkdirs(tableDataPath);
-                }
+            }
+            if (isFileSystemTable(catalogTable.getOptions()) && !fs.exists(tableDataPath)) {
+                fs.mkdirs(tableDataPath);
             }
 
             // write table schema

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogTest.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogTest.java
@@ -42,6 +42,8 @@ import org.apache.flink.table.refresh.RefreshHandler;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -305,12 +307,21 @@ public class TestFileSystemCatalogTest extends TestFileSystemCatalogTestBase {
 
         // test list table
         List<String> tables = catalog.listTables(TEST_DEFAULT_DATABASE);
-        assertThat(tables.contains(tablePath1.getObjectName())).isTrue();
-        assertThat(tables.contains(tablePath2.getObjectName())).isTrue();
+        assertThat(tables).contains(tablePath1.getObjectName());
+        assertThat(tables).contains(tablePath2.getObjectName());
 
         // test list non-exist database table
         assertThrows(
                 DatabaseNotExistException.class, () -> catalog.listTables(NONE_EXIST_DATABASE));
+
+        // test list table ignore the empty path
+        String nonExistTablePath =
+                String.format(
+                        "%s/%s/%s",
+                        tempFile.getAbsolutePath(), TEST_DEFAULT_DATABASE, NONE_EXIST_TABLE);
+        Files.createDirectories(Paths.get(nonExistTablePath));
+        tables = catalog.listTables(TEST_DEFAULT_DATABASE);
+        assertThat(tables).doesNotContain(NONE_EXIST_TABLE);
     }
 
     @Test

--- a/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogTestBase.java
+++ b/flink-test-utils-parent/flink-table-filesystem-test-utils/src/test/java/org/apache/flink/table/file/testutils/catalog/TestFileSystemCatalogTestBase.java
@@ -32,6 +32,7 @@ public abstract class TestFileSystemCatalogTestBase extends AbstractTestBase {
     protected static final String TEST_CATALOG = "test_catalog";
     protected static final String TEST_DEFAULT_DATABASE = "test_db";
     protected static final String NONE_EXIST_DATABASE = "none_exist_database";
+    protected static final String NONE_EXIST_TABLE = "none_exist_table";
 
     protected TestFileSystemCatalog catalog;
 


### PR DESCRIPTION
## Fix unstable test in MaterializedTableITCase

Problem:

As shown in the error message above, in the test method afterEach, we will list all materialized tables and then drop them to prevent any remaining refresh tasks.
However, since the Drop Materialized Table has already been deleted, it causes the error mentioned above.

* Why does listing tables show they exist when dropping tables results in an error stating they do not exist?
1. In the test dropMaterializedTableWithDeletedRefreshWorkflowInFullMode, we manually dropped the Materialized Table.
2. Despite manual deletion, background refresh tasks are still being submitted. This leads to data continuing to be written into the corresponding table data directory.
3. TestFileSystemCatalog lists all directories for existing tables during listTable. If a directory exists, it returns true. However, during dropTable it checks if both table and schema files exist simultaneously. This inconsistency caused the mentioned issue.
Solution:

1. Fix TestFileSystemCatalog logic for listTable by checking not only directories but also schema file existence.
2. To further avoid this problem, change all tables in MaterializedTableITCase to be manually dropped instead.


## Brief change log

  - *Fix inconsistent logic between listTable and getTable in TestFileSystemCatalog*
  - *Drop all materialized tables manually instead of automatically dropping them in the after method*


## Verifying this change

1. The existing UT of MaterializedTableITCase can cover these modifications.
2. Modify some logic in TestFileSystemCatalogTest to cover the new changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
