### PR TITLE
[FLINK-36262][table] Avoid unnecessary String concatenations in the RexFieldAccess constructor: port fix for CALCITE-5965

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
@@ -49,6 +49,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *     AND gender = 'F')</pre>
  *
  * </blockquote>
+ *
+ * <p>FLINK modifications are at lines
+ *
+ * <ol>
+ *   <li>Should be removed after fixing CALCITE-6342 (Calcite 1.36.0): Lines 84-89
+ * </ol>
  */
 public class RexFieldAccess extends RexNode {
     // ~ Instance fields --------------------------------------------------------
@@ -74,7 +80,11 @@ public class RexFieldAccess extends RexNode {
                 fieldIdx >= 0
                         && fieldIdx < exprType.getFieldList().size()
                         && exprType.getFieldList().get(fieldIdx).equals(field),
-                "Field " + field + " does not exist for expression " + expr);
+                // FLINK MODIFICATION BEGIN
+                "Field %s does not exist for expression %s",
+                field,
+                expr);
+        // FLINK MODIFICATION END
     }
 
     public RelDataTypeField getField() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/calcite/rex/RexFieldAccess.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rex;
+
+import com.google.common.base.Preconditions;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlKind;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Access to a field of a row-expression.
+ *
+ * <p>You might expect to use a <code>RexFieldAccess</code> to access columns of relational tables,
+ * for example, the expression <code>emp.empno</code> in the query
+ *
+ * <blockquote>
+ *
+ * <pre>SELECT emp.empno FROM emp</pre>
+ *
+ * </blockquote>
+ *
+ * <p>but there is a specialized expression {@link RexInputRef} for this purpose. So in practice,
+ * <code>RexFieldAccess</code> is usually used to access fields of correlating variables, for
+ * example the expression <code>emp.deptno</code> in
+ *
+ * <blockquote>
+ *
+ * <pre>SELECT ename
+ * FROM dept
+ * WHERE EXISTS (
+ *     SELECT NULL
+ *     FROM emp
+ *     WHERE emp.deptno = dept.deptno
+ *     AND gender = 'F')</pre>
+ *
+ * </blockquote>
+ */
+public class RexFieldAccess extends RexNode {
+    // ~ Instance fields --------------------------------------------------------
+
+    private final RexNode expr;
+    private final RelDataTypeField field;
+
+    // ~ Constructors -----------------------------------------------------------
+
+    RexFieldAccess(RexNode expr, RelDataTypeField field) {
+        checkValid(expr, field);
+        this.expr = expr;
+        this.field = field;
+        this.digest = expr + "." + field.getName();
+    }
+
+    // ~ Methods ----------------------------------------------------------------
+
+    private static void checkValid(RexNode expr, RelDataTypeField field) {
+        RelDataType exprType = expr.getType();
+        int fieldIdx = field.getIndex();
+        Preconditions.checkArgument(
+                fieldIdx >= 0
+                        && fieldIdx < exprType.getFieldList().size()
+                        && exprType.getFieldList().get(fieldIdx).equals(field),
+                "Field " + field + " does not exist for expression " + expr);
+    }
+
+    public RelDataTypeField getField() {
+        return field;
+    }
+
+    @Override
+    public RelDataType getType() {
+        return field.getType();
+    }
+
+    @Override
+    public SqlKind getKind() {
+        return SqlKind.FIELD_ACCESS;
+    }
+
+    @Override
+    public <R> R accept(RexVisitor<R> visitor) {
+        return visitor.visitFieldAccess(this);
+    }
+
+    @Override
+    public <R, P> R accept(RexBiVisitor<R, P> visitor, P arg) {
+        return visitor.visitFieldAccess(this, arg);
+    }
+
+    /** Returns the expression whose field is being accessed. */
+    public RexNode getReferenceExpr() {
+        return expr;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RexFieldAccess that = (RexFieldAccess) o;
+
+        return field.equals(that.field) && expr.equals(that.expr);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = expr.hashCode();
+        result = 31 * result + field.hashCode();
+        return result;
+    }
+}


### PR DESCRIPTION


## What is the purpose of the change
In case of tables with deeply nested structures this issue with unnecessary String concatenations in the RexFieldAccess constructor started to play significant role

and we faced it already.

Since the fix ([CALCITE-5965](https://issues.apache.org/jira/browse/CALCITE-5965)) is only in Calcite 1.36.0 it can take a long time before it comes with Calcite upgrade (currently there are 1.33 and 1.34 in ready for review only)


## Brief change log

There are 2 commits:
1. Copy paste of `RexFieldAccess` from (1.32.0)
2. Port fix from CALCITE-5965

## Verifying this change

to test it need to create a table with deeply nested columns and execute select.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
