### PR TITLE
[FLINK-36013] [runtime] Introduce the transition from Restarting to CreatingExecutionGraph state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1229,6 +1229,7 @@ public class AdaptiveScheduler
             ExecutionGraphHandler executionGraphHandler,
             OperatorCoordinatorHandler operatorCoordinatorHandler,
             Duration backoffTime,
+            boolean forcedRestart,
             List<ExceptionHistoryEntry> failureCollection) {
 
         for (ExecutionVertex executionVertex : executionGraph.getAllExecutionVertices()) {
@@ -1249,6 +1250,7 @@ public class AdaptiveScheduler
                         operatorCoordinatorHandler,
                         LOG,
                         backoffTime,
+                        forcedRestart,
                         userCodeClassLoader,
                         failureCollection));
         numRestarts++;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -156,6 +156,7 @@ class Executing extends StateWithExecutionGraph
                 getExecutionGraphHandler(),
                 getOperatorCoordinatorHandler(),
                 Duration.ofMillis(0L),
+                true,
                 getFailures());
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/FailureResultUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/FailureResultUtil.java
@@ -30,6 +30,7 @@ public class FailureResultUtil {
                     sweg.getExecutionGraphHandler(),
                     sweg.getOperatorCoordinatorHandler(),
                     failureResult.getBackoffTime(),
+                    false,
                     sweg.getFailures());
         } else {
             sweg.getLogger().info("Failing job.", failureResult.getFailureCause());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitions.java
@@ -128,6 +128,9 @@ public interface StateTransitions {
          *     Restarting} state
          * @param backoffTime backoffTime to wait before transitioning to the {@link Restarting}
          *     state
+         * @param forcedRestart if the {@link WaitingForResources} state should be omitted and the
+         *     {@link CreatingExecutionGraph} state should be entered directly from the {@link
+         *     Restarting} state
          * @param failureCollection collection of failures that are propagated
          */
         void goToRestarting(
@@ -135,6 +138,7 @@ public interface StateTransitions {
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
                 Duration backoffTime,
+                boolean forcedRestart,
                 List<ExceptionHistoryEntry> failureCollection);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
@@ -191,7 +191,7 @@ class RestartingTest {
         private final StateValidator<ExecutingTest.CancellingArguments> cancellingStateValidator =
                 new StateValidator<>("Cancelling");
 
-        private final StateValidator<Void> waitingForResourcesStateValidator =
+        private final StateValidator<ExecutionGraph> waitingForResourcesStateValidator =
                 new StateValidator<>("WaitingForResources");
 
         private final StateValidator<ExecutionGraph> creatingExecutionGraphStateValidator =
@@ -202,7 +202,7 @@ class RestartingTest {
         }
 
         public void setExpectWaitingForResources() {
-            waitingForResourcesStateValidator.expectInput((none) -> {});
+            waitingForResourcesStateValidator.expectInput(assertNonNull());
         }
 
         public void setExpectCreatingExecutionGraph() {
@@ -225,8 +225,8 @@ class RestartingTest {
         public void archiveFailure(RootExceptionHistoryEntry failure) {}
 
         @Override
-        public void goToWaitingForResources(ExecutionGraph previousExecutionGraph) {
-            waitingForResourcesStateValidator.validateInput(null);
+        public void goToWaitingForResources(@Nullable ExecutionGraph previousExecutionGraph) {
+            waitingForResourcesStateValidator.validateInput(previousExecutionGraph);
             hadStateTransition = true;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/RestartingTest.java
@@ -20,8 +20,6 @@ package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.core.testutils.CompletedScheduledFuture;
-import org.apache.flink.runtime.JobException;
-import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.failure.FailureEnricherUtils;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
@@ -30,8 +28,12 @@ import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry
 import org.apache.flink.runtime.scheduler.exceptionhistory.RootExceptionHistoryEntry;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -57,11 +59,17 @@ class RestartingTest {
         }
     }
 
-    @Test
-    void testTransitionToWaitingForResourcesWhenCancellationComplete() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testTransitionToSubsequentStateWhenCancellationComplete(boolean forcedRestart)
+            throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
-            Restarting restarting = createRestartingState(ctx);
-            ctx.setExpectWaitingForResources();
+            Restarting restarting = createRestartingState(ctx, forcedRestart);
+            if (forcedRestart) {
+                ctx.setExpectCreatingExecutionGraph();
+            } else {
+                ctx.setExpectWaitingForResources();
+            }
             restarting.onGloballyTerminalState(JobStatus.CANCELED);
         }
     }
@@ -114,15 +122,22 @@ class RestartingTest {
         }
     }
 
-    @Test
-    void testStateDoesNotExposeGloballyTerminalExecutionGraph() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testStateDoesNotExposeGloballyTerminalExecutionGraph(boolean forcedRestart)
+            throws Exception {
         try (MockRestartingContext ctx = new MockRestartingContext()) {
             StateTrackingMockExecutionGraph mockExecutionGraph =
                     new StateTrackingMockExecutionGraph();
-            Restarting restarting = createRestartingState(ctx, mockExecutionGraph);
+            Restarting restarting = createRestartingState(ctx, mockExecutionGraph, forcedRestart);
 
             // ideally we'd just delay the state transitions, but the context does not support that
-            ctx.setExpectWaitingForResources();
+            if (forcedRestart) {
+                ctx.setExpectCreatingExecutionGraph();
+            } else {
+                ctx.setExpectWaitingForResources();
+            }
+
             mockExecutionGraph.completeTerminationFuture(JobStatus.CANCELED);
 
             // this is just a sanity check for the test
@@ -134,8 +149,17 @@ class RestartingTest {
         }
     }
 
+    public Restarting createRestartingState(MockRestartingContext ctx, boolean forcedRestart) {
+        return createRestartingState(ctx, new StateTrackingMockExecutionGraph(), forcedRestart);
+    }
+
     public Restarting createRestartingState(
             MockRestartingContext ctx, ExecutionGraph executionGraph) {
+        return createRestartingState(ctx, executionGraph, false);
+    }
+
+    public Restarting createRestartingState(
+            MockRestartingContext ctx, ExecutionGraph executionGraph, boolean forcedRestart) {
         final ExecutionGraphHandler executionGraphHandler =
                 new ExecutionGraphHandler(
                         executionGraph,
@@ -152,12 +176,12 @@ class RestartingTest {
                 operatorCoordinatorHandler,
                 log,
                 Duration.ZERO,
+                forcedRestart,
                 ClassLoader.getSystemClassLoader(),
                 new ArrayList<>());
     }
 
-    public Restarting createRestartingState(MockRestartingContext ctx)
-            throws JobException, JobExecutionException {
+    public Restarting createRestartingState(MockRestartingContext ctx) {
         return createRestartingState(ctx, new StateTrackingMockExecutionGraph());
     }
 
@@ -170,12 +194,19 @@ class RestartingTest {
         private final StateValidator<Void> waitingForResourcesStateValidator =
                 new StateValidator<>("WaitingForResources");
 
+        private final StateValidator<ExecutionGraph> creatingExecutionGraphStateValidator =
+                new StateValidator<>("CreatingExecutionGraph");
+
         public void setExpectCancelling(Consumer<ExecutingTest.CancellingArguments> asserter) {
             cancellingStateValidator.expectInput(asserter);
         }
 
         public void setExpectWaitingForResources() {
             waitingForResourcesStateValidator.expectInput((none) -> {});
+        }
+
+        public void setExpectCreatingExecutionGraph() {
+            creatingExecutionGraphStateValidator.expectInput(assertNonNull());
         }
 
         @Override
@@ -200,6 +231,12 @@ class RestartingTest {
         }
 
         @Override
+        public void goToCreatingExecutionGraph(@Nullable ExecutionGraph previousExecutionGraph) {
+            creatingExecutionGraphStateValidator.validateInput(previousExecutionGraph);
+            hadStateTransition = true;
+        }
+
+        @Override
         public ScheduledFuture<?> runIfState(State expectedState, Runnable action, Duration delay) {
             if (!hadStateTransition) {
                 action.run();
@@ -212,6 +249,7 @@ class RestartingTest {
             super.close();
             cancellingStateValidator.close();
             waitingForResourcesStateValidator.close();
+            creatingExecutionGraphStateValidator.close();
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StopWithSavepointTest.java
@@ -264,7 +264,11 @@ class StopWithSavepointTest {
             ctx.setStopWithSavepoint(sws);
             ctx.setHowToHandleFailure(failure -> FailureResult.canRestart(failure, Duration.ZERO));
 
-            ctx.setExpectRestarting(assertNonNull());
+            ctx.setExpectRestarting(
+                    (restartingArguments) -> {
+                        assertThat(restartingArguments).isNotNull();
+                        assertThat(restartingArguments.isForcedRestart()).isFalse();
+                    });
 
             Exception exception = new RuntimeException();
             TestingAccessExecution execution =
@@ -576,6 +580,7 @@ class StopWithSavepointTest {
                 ExecutionGraphHandler executionGraphHandler,
                 OperatorCoordinatorHandler operatorCoordinatorHandler,
                 Duration backoffTime,
+                boolean forcedRestart,
                 List<ExceptionHistoryEntry> failureCollection) {
             if (hadStateTransition) {
                 throw new IllegalStateException("Only one state transition is allowed.");
@@ -586,7 +591,8 @@ class StopWithSavepointTest {
                             executionGraph,
                             executionGraphHandler,
                             operatorCoordinatorHandler,
-                            backoffTime));
+                            backoffTime,
+                            forcedRestart));
             hadStateTransition = true;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

The `AdaptiveScheduler` omits the `WaitingForResources` state when rescaling to avoid an additional waiting in that state. 

## Brief change log

- Pass the `forcedRestart` flag into the `Restarting` state 
- Directs the state transition to the `CreatingExecutingGraph` instead of `WaitingForResources` if flag `forcedRestart` is set


## Verifying this change

This change added tests and can be verified as follows:

  - Added test to verify final state transition if the flag is set or not

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

