### PR TITLE
[FLINK-5336][core] Remove IOReadableWritable from Path

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/Path.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
  * {@code serializeToDataOutputView} and {@code deserializeFromDataInputView} instead.
  */
 @Public
-public class Path implements IOReadableWritable, Serializable {
+public class Path implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -447,49 +447,6 @@ public class Path implements IOReadableWritable, Serializable {
         }
 
         return new Path(scheme + ":" + "//" + authority + pathUri.getPath());
-    }
-
-    // ------------------------------------------------------------------------
-    //  Legacy Serialization
-    // ------------------------------------------------------------------------
-
-    /**
-     * Read uri from {@link DataInputView}.
-     *
-     * @param in the input view to read the uri.
-     * @throws IOException if an error happened.
-     * @deprecated the method is deprecated since Flink 1.19 because Path will no longer implement
-     *     {@link IOReadableWritable} in future versions. Please use {@code
-     *     deserializeFromDataInputView} instead.
-     * @see <a
-     *     href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-347%3A+Remove+IOReadableWritable
-     *     +serialization+in+Path"> FLIP-347: Remove IOReadableWritable serialization in Path </a>
-     */
-    @Deprecated
-    @Override
-    public void read(DataInputView in) throws IOException {
-        Path path = deserializeFromDataInputView(in);
-        if (path != null) {
-            uri = path.toUri();
-        }
-    }
-
-    /**
-     * Write uri to {@link DataOutputView}.
-     *
-     * @param out the output view to be written the uri.
-     * @throws IOException if an error happened.
-     * @deprecated the method is deprecated since Flink 1.19 because Path will no longer implement
-     *     {@link IOReadableWritable} in future versions. Please use {@code
-     *     serializeToDataOutputView} instead.
-     * @see <a
-     *     href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-347%3A+Remove+IOReadableWritable
-     *     +serialization+in+Path"> FLIP-347: Remove IOReadableWritable serialization in Path </a>
-     */
-    @Deprecated
-    @Override
-    public void write(DataOutputView out) throws IOException {
-        serializeToDataOutputView(this, out);
     }
 
     // ------------------------------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -2380,6 +2380,8 @@ under the License.
 								<exclude>
 									org.apache.flink.api.common.functions.RuntimeContext#getExecutionConfig()
 								</exclude>
+								<!-- FLINK-5336 Remove IOReadableWritable from Path in flink-2.0. -->
+								<exclude>org.apache.flink.core.fs.Path</exclude>
 								<!-- MARKER: end exclusions -->
 							</excludes>
 							<accessModifier>public</accessModifier>


### PR DESCRIPTION
## What is the purpose of the change

*We have already deprecated related read and write method in 1.19, and should be remove it in 2.0-preview.*


## Brief change log

  - *Remove IOReadableWritable from Path*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
