### PR TITLE
[FLINK-36016] [runtime] Synchronize initialization time and clock usage in DefaultStateTransitionManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -151,6 +151,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.apache.flink.configuration.JobManagerOptions.MAXIMUM_DELAY_FOR_SCALE_TRIGGER;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphUtils.isAnyOutputBlocking;
@@ -192,16 +193,16 @@ public class AdaptiveScheduler
      *
      * @see
      *     DefaultStateTransitionManager#DefaultStateTransitionManager(StateTransitionManager.Context,
-     *     Duration, Duration, Duration, Temporal)
+     *     Supplier, Duration, Duration, Duration)
      */
     @FunctionalInterface
     interface StateTransitionManagerFactory {
         StateTransitionManager create(
                 StateTransitionManager.Context context,
+                Supplier<Temporal> clock,
                 Duration cooldownTimeout,
                 Duration resourceStabilizationTimeout,
-                Duration maximumDelayForTrigger,
-                Temporal lastStateTransition);
+                Duration maximumDelayForTrigger);
     }
 
     /**
@@ -410,6 +411,8 @@ public class AdaptiveScheduler
 
     private final JobFailureMetricReporter jobFailureMetricReporter;
     private final boolean reportEventsAsSpans;
+
+    private final Supplier<Temporal> clock = Instant::now;
 
     public AdaptiveScheduler(
             Settings settings,
@@ -1157,10 +1160,10 @@ public class AdaptiveScheduler
             StateTransitionManager.Context ctx) {
         return stateTransitionManagerFactory.create(
                 ctx,
+                clock,
                 Duration.ZERO, // skip cooldown phase
                 settings.getResourceStabilizationTimeout(),
-                Duration.ZERO, // trigger immediately once the stabilization phase is over
-                Instant.now());
+                Duration.ZERO); // trigger immediately once the stabilization phase is over
     }
 
     private void declareDesiredResources() {
@@ -1196,13 +1199,13 @@ public class AdaptiveScheduler
     }
 
     private StateTransitionManager createExecutingStateTransitionManager(
-            StateTransitionManager.Context ctx, Instant lastRescaleTimestamp) {
+            StateTransitionManager.Context ctx) {
         return stateTransitionManagerFactory.create(
                 ctx,
+                clock,
                 settings.getScalingIntervalMin(),
                 settings.getScalingResourceStabilizationTimeout(),
-                settings.getMaximumDelayForTriggeringRescale(),
-                lastRescaleTimestamp);
+                settings.getMaximumDelayForTriggeringRescale());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Executing.java
@@ -43,7 +43,6 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -51,7 +50,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /** State which represents a running job with an {@link ExecutionGraph} and assigned slots. */
@@ -73,10 +72,9 @@ class Executing extends StateWithExecutionGraph
             Context context,
             ClassLoader userCodeClassLoader,
             List<ExceptionHistoryEntry> failureCollection,
-            BiFunction<StateTransitionManager.Context, Instant, StateTransitionManager>
+            Function<StateTransitionManager.Context, StateTransitionManager>
                     stateTransitionManagerFactory,
-            int rescaleOnFailedCheckpointCount,
-            Instant lastRescale) {
+            int rescaleOnFailedCheckpointCount) {
         super(
                 context,
                 executionGraph,
@@ -89,7 +87,7 @@ class Executing extends StateWithExecutionGraph
         Preconditions.checkState(
                 executionGraph.getState() == JobStatus.RUNNING, "Assuming running execution graph");
 
-        this.stateTransitionManager = stateTransitionManagerFactory.apply(this, lastRescale);
+        this.stateTransitionManager = stateTransitionManagerFactory.apply(this);
 
         Preconditions.checkArgument(
                 rescaleOnFailedCheckpointCount > 0,
@@ -341,7 +339,7 @@ class Executing extends StateWithExecutionGraph
         private final OperatorCoordinatorHandler operatorCoordinatorHandler;
         private final ClassLoader userCodeClassLoader;
         private final List<ExceptionHistoryEntry> failureCollection;
-        private final BiFunction<StateTransitionManager.Context, Instant, StateTransitionManager>
+        private final Function<StateTransitionManager.Context, StateTransitionManager>
                 stateTransitionManagerFactory;
         private final int rescaleOnFailedCheckpointCount;
 
@@ -353,7 +351,7 @@ class Executing extends StateWithExecutionGraph
                 Context context,
                 ClassLoader userCodeClassLoader,
                 List<ExceptionHistoryEntry> failureCollection,
-                BiFunction<StateTransitionManager.Context, Instant, StateTransitionManager>
+                Function<StateTransitionManager.Context, StateTransitionManager>
                         stateTransitionManagerFactory,
                 int rescaleOnFailedCheckpointCount) {
             this.context = context;
@@ -381,8 +379,7 @@ class Executing extends StateWithExecutionGraph
                     userCodeClassLoader,
                     failureCollection,
                     stateTransitionManagerFactory,
-                    rescaleOnFailedCheckpointCount,
-                    Instant.now());
+                    rescaleOnFailedCheckpointCount);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerTest.java
@@ -152,6 +152,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -2363,10 +2364,10 @@ public class AdaptiveSchedulerTest {
 
         public StateTransitionManager create(
                 StateTransitionManager.Context context,
+                Supplier<Temporal> ignoredClock,
                 Duration cooldownTimeout,
                 Duration resourceStabilizationTimeout,
-                Duration maximumDelayForTrigger,
-                Temporal ignoredTimestamp) {
+                Duration maximumDelayForTrigger) {
             this.cooldownTimeout = cooldownTimeout;
             this.resourceStabilizationTimeout = resourceStabilizationTimeout;
             this.maximumDelayForTrigger = maximumDelayForTrigger;
@@ -2409,10 +2410,10 @@ public class AdaptiveSchedulerTest {
                         .setDeclarativeSlotPool(slotPool)
                         .setStateTransitionManagerFactory(
                                 (context,
+                                        ignoredClock,
                                         ignoredCooldown,
                                         ignoredResourceStabilizationTimeout,
-                                        ignoredMaxTriggerDelay,
-                                        ignoredTimestamp) ->
+                                        ignoredMaxTriggerDelay) ->
                                         TestingStateTransitionManager.withOnTriggerEventOnly(
                                                 () -> {
                                                     singleThreadMainThreadExecutor

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManagerTest.java
@@ -591,13 +591,12 @@ class DefaultStateTransitionManagerTest {
                 Consumer<DefaultStateTransitionManager> callback) {
             final DefaultStateTransitionManager testInstance =
                     new DefaultStateTransitionManager(
+                            this,
                             // clock that returns the time based on the configured elapsedTime
                             () -> Objects.requireNonNull(initializationTime).plus(elapsedTime),
-                            this,
                             cooldownTimeout,
                             resourceStabilizationTimeout,
-                            maxTriggerDelay,
-                            initializationTime) {
+                            maxTriggerDelay) {
                         @Override
                         public void onChange() {
                             super.onChange();


### PR DESCRIPTION
## What is the purpose of the change

StateTransitionManager's initialization time is based on the same time coming from the AdaptiveScheduler

## Brief change log

 - `AdaptiveScheduler` holds a time supplier and propagates it to states,
 - `DefaultStateTransitionManager` sets the initialization time in a constructor from the provided time supplier

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializer:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
