### PR TITLE
[FLINK-36248][table] Introduce new Join Operator with Async State API

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -57,6 +57,12 @@
             <td>The async timeout for the asynchronous operation to complete.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.async-state.enabled</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Set whether to use the SQL/Table operators based on the asynchronous state api. Default value is false.</td>
+        </tr>
+        <tr>
             <td><h5>table.exec.deduplicate.insert-update-after-sensitive-enabled</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -50,9 +50,7 @@ import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.StateBackend;
-import org.apache.flink.runtime.state.StateBackendTestUtils;
 import org.apache.flink.runtime.state.TestTaskStateManager;
-import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.ttl.MockTtlTimeProvider;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
@@ -75,7 +73,6 @@ import org.apache.flink.streaming.api.operators.StreamOperatorFactoryUtil;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
 import org.apache.flink.streaming.api.watermark.Watermark;
-import org.apache.flink.streaming.runtime.operators.asyncprocessing.AsyncStateProcessing;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -305,14 +302,6 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 
         ttlTimeProvider = new MockTtlTimeProvider();
         ttlTimeProvider.setCurrentTimestamp(0);
-
-        if (operator instanceof AsyncStateProcessing
-                || (factory instanceof SimpleOperatorFactory
-                        && ((SimpleOperatorFactory<OUT>) factory).getOperator()
-                                instanceof AsyncStateProcessing)) {
-            setStateBackend(
-                    StateBackendTestUtils.buildAsyncStateBackend(new HashMapStateBackend()));
-        }
 
         this.streamTaskStateInitializer =
                 createStreamTaskStateManager(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -664,6 +664,15 @@ public class ExecutionConfigOptions {
                                     + "leading to possible discarding of these records by downstream watermark-dependent operators, such as window operators. "
                                     + "The default value is 0, which means it will clean up unmatched records immediately.");
 
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<Boolean> TABLE_EXEC_ASYNC_STATE_ENABLED =
+            key("table.exec.async-state.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Set whether to use the SQL/Table operators based on the asynchronous state api. "
+                                    + "Default value is false.");
+
     // ------------------------------------------------------------------------------------------
     // Enum option types
     // ------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -221,6 +221,13 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-statebackend-forst</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<!-- For using the filesystem connector in tests -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-files</artifactId>

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -221,13 +221,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-forst</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
 			<!-- For using the filesystem connector in tests -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-files</artifactId>

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -70,7 +70,7 @@ import org.apache.flink.table.planner.plan.utils.RankProcessStrategy;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.types.RowKind;
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.plan.utils.IntervalJoinUtil.satisfyInterva
 import org.apache.flink.table.planner.plan.utils.TemporalJoinUtil.satisfyTemporalJoin
 import org.apache.flink.table.planner.plan.utils.WindowJoinUtil.satisfyWindowJoin
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.{LogicalType, RowType}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.{MiniBatchMode, MiniBatchOff, MiniBatchOn}
-import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{FORSTDB_BACKEND, HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
 import org.apache.flink.types.Row
 
@@ -1711,8 +1711,8 @@ object JoinITCase {
       Array(MiniBatchOff, ROCKSDB_BACKEND, Boolean.box(false)),
       Array(MiniBatchOn, HEAP_BACKEND, Boolean.box(false)),
       Array(MiniBatchOn, ROCKSDB_BACKEND, Boolean.box(false)),
-      Array(MiniBatchOff, FORSTDB_BACKEND, Boolean.box(false)),
-      Array(MiniBatchOn, FORSTDB_BACKEND, Boolean.box(true))
+      Array(MiniBatchOff, HEAP_BACKEND, Boolean.box(true)),
+      Array(MiniBatchOn, HEAP_BACKEND, Boolean.box(true))
     )
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/JoinITCase.scala
@@ -107,33 +107,6 @@ class JoinITCase(miniBatch: MiniBatchMode, state: StateBackendMode, enableAsyncS
   override def after(): Unit = {}
 
   @TestTemplate
-  def test(): Unit = {
-    val tableA = failingDataSource(
-      Seq[(Int, Long, String)]((1, 1L, "Hi"), (2, 2L, "Hello"), (3, 3L, "Hello world")))
-      .toTable(tEnv, 'a1, 'a2, 'a3)
-    val tableB = failingDataSource(
-      Seq[(Int, Long, String)]((1, 1L, "Hi"), (2, 2L, "Hello"), (3, 3L, "Hello world")))
-      .toTable(tEnv, 'b1, 'b2, 'b3)
-    tEnv.createTemporaryView("C", tableA)
-    tEnv.createTemporaryView("D", tableB)
-
-    val sqlQuery = "SELECT * FROM C, D WHERE a1 = b1 and a2 = 1"
-
-    val sink = new TestingRetractSink
-    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
-    env.execute()
-
-    val expected = mutable.Seq(
-      "1,1,Hi,2,2,1,Hallo Welt,2",
-      "2,2,Hello,4,10,9,FGH,2",
-      "2,2,Hello,4,7,6,CDE,2",
-      "2,2,Hello,4,8,7,DEF,1",
-      "2,2,Hello,4,9,8,EFG,1")
-
-    assertThat(sink.getRetractResults.sorted).isEqualTo(expected.sorted)
-  }
-
-  @TestTemplate
   def testDependentConditionDerivationInnerJoin(): Unit = {
     val sqlQuery = "SELECT * FROM A, B WHERE (a2 = 1 and b2 = 2) or (a1 = 2 and b1 = 4)"
 
@@ -1711,8 +1684,7 @@ object JoinITCase {
       Array(MiniBatchOff, ROCKSDB_BACKEND, Boolean.box(false)),
       Array(MiniBatchOn, HEAP_BACKEND, Boolean.box(false)),
       Array(MiniBatchOn, ROCKSDB_BACKEND, Boolean.box(false)),
-      Array(MiniBatchOff, HEAP_BACKEND, Boolean.box(true)),
-      Array(MiniBatchOn, HEAP_BACKEND, Boolean.box(true))
+      Array(MiniBatchOff, HEAP_BACKEND, Boolean.box(true))
     )
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.planner.expressions.utils.FuncWithOpen
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedAggFunctions.{CountDistinct, WeightedAvg}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBase.{MiniBatchMode, MiniBatchOff, MiniBatchOn}
-import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{FORSTDB_BACKEND, HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.utils.CountAggFunction
 import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
@@ -1827,8 +1827,8 @@ object JoinITCase {
       Array(MiniBatchOff, ROCKSDB_BACKEND, Boolean.box(false)),
       Array(MiniBatchOn, HEAP_BACKEND, Boolean.box(false)),
       Array(MiniBatchOn, ROCKSDB_BACKEND, Boolean.box(false)),
-      Array(MiniBatchOff, FORSTDB_BACKEND, Boolean.box(false)),
-      Array(MiniBatchOn, FORSTDB_BACKEND, Boolean.box(true))
+      Array(MiniBatchOff, HEAP_BACKEND, Boolean.box(true)),
+      Array(MiniBatchOn, HEAP_BACKEND, Boolean.box(true))
     )
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/JoinITCase.scala
@@ -1827,8 +1827,7 @@ object JoinITCase {
       Array(MiniBatchOff, ROCKSDB_BACKEND, Boolean.box(false)),
       Array(MiniBatchOn, HEAP_BACKEND, Boolean.box(false)),
       Array(MiniBatchOn, ROCKSDB_BACKEND, Boolean.box(false)),
-      Array(MiniBatchOff, HEAP_BACKEND, Boolean.box(true)),
-      Array(MiniBatchOn, HEAP_BACKEND, Boolean.box(true))
+      Array(MiniBatchOff, HEAP_BACKEND, Boolean.box(true))
     )
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
 import org.apache.flink.table.data.{RowData, StringData}
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.data.writer.BinaryRowWriter
-import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{FORSTDB_BACKEND, HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.utils.TableTestUtil
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
@@ -50,7 +50,6 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
   enableObjectReuse = state match {
     case HEAP_BACKEND => false // TODO heap statebackend not support obj reuse now.
     case ROCKSDB_BACKEND => true
-    case FORSTDB_BACKEND => true
   }
 
   private val classLoader = Thread.currentThread.getContextClassLoader
@@ -240,9 +239,9 @@ object StreamingWithStateTestBase {
     override def toString: String = backend.toString
   }
 
+  // TODO test FORSTDB_BACKEND after 2.0-preview
   val HEAP_BACKEND = StateBackendMode("HEAP")
   val ROCKSDB_BACKEND = StateBackendMode("ROCKSDB")
-  val FORSTDB_BACKEND = StateBackendMode("FORSTDB")
 
   @Parameters(name = "StateBackend={0}")
   def parameters(): util.Collection[Array[java.lang.Object]] = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.api.bridge.scala.StreamTableEnvironment
 import org.apache.flink.table.data.{RowData, StringData}
 import org.apache.flink.table.data.binary.BinaryRowData
 import org.apache.flink.table.data.writer.BinaryRowWriter
-import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{FORSTDB_BACKEND, HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.planner.utils.TableTestUtil
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
@@ -50,6 +50,7 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
   enableObjectReuse = state match {
     case HEAP_BACKEND => false // TODO heap statebackend not support obj reuse now.
     case ROCKSDB_BACKEND => true
+    case FORSTDB_BACKEND => true
   }
 
   private val classLoader = Thread.currentThread.getContextClassLoader
@@ -241,6 +242,7 @@ object StreamingWithStateTestBase {
 
   val HEAP_BACKEND = StateBackendMode("HEAP")
   val ROCKSDB_BACKEND = StateBackendMode("ROCKSDB")
+  val FORSTDB_BACKEND = StateBackendMode("FORSTDB")
 
   @Parameters(name = "StateBackend={0}")
   def parameters(): util.Collection[Array[java.lang.Object]] = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -239,7 +239,7 @@ object StreamingWithStateTestBase {
     override def toString: String = backend.toString
   }
 
-  // TODO test FORSTDB_BACKEND after 2.0-preview
+  // TODO FLINK-36354: test FORSTDB_BACKEND after 2.0-preview
   val HEAP_BACKEND = StateBackendMode("HEAP")
   val ROCKSDB_BACKEND = StateBackendMode("ROCKSDB")
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/MiniBatchStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/MiniBatchStreamingJoinOperator.java
@@ -31,8 +31,8 @@ import org.apache.flink.table.runtime.operators.join.stream.bundle.BufferBundle;
 import org.apache.flink.table.runtime.operators.join.stream.bundle.InputSideHasNoUniqueKeyBundle;
 import org.apache.flink.table.runtime.operators.join.stream.bundle.InputSideHasUniqueKeyBundle;
 import org.apache.flink.table.runtime.operators.join.stream.bundle.JoinKeyContainsUniqueKeyBundle;
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
 import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateView;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.operators.metrics.SimpleGauge;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
@@ -22,11 +22,13 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.RowDataUtil;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
 import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateView;
 import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateViews;
 import org.apache.flink.table.runtime.operators.join.stream.state.OuterJoinRecordStateView;
 import org.apache.flink.table.runtime.operators.join.stream.state.OuterJoinRecordStateViews;
+import org.apache.flink.table.runtime.operators.join.stream.utils.AssociatedRecords;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.utils.OuterRecord;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.types.RowKind;
 
@@ -105,7 +107,8 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
     public void processElement1(StreamRecord<RowData> element) throws Exception {
         RowData input = element.getValue();
         AssociatedRecords associatedRecords =
-                AssociatedRecords.of(input, true, rightRecordStateView, joinCondition);
+                AssociatedRecords.fromSyncStateView(
+                        input, true, rightRecordStateView, joinCondition);
         if (associatedRecords.isEmpty()) {
             if (isAntiJoin) {
                 collector.collect(input);
@@ -169,7 +172,8 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
         input.setRowKind(RowKind.INSERT); // erase RowKind for later state updating
 
         AssociatedRecords associatedRecords =
-                AssociatedRecords.of(input, false, leftRecordStateView, joinCondition);
+                AssociatedRecords.fromSyncStateView(
+                        input, false, leftRecordStateView, joinCondition);
         if (isAccumulateMsg) { // record is accumulate
             rightRecordStateView.addRecord(input);
             if (!associatedRecords.isEmpty()) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/AbstractAsyncStateStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/AbstractAsyncStateStreamingJoinOperator.java
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.operators.join.stream;
+package org.apache.flink.table.runtime.operators.join.stream.asyncprocessing;
 
 import org.apache.flink.api.common.functions.DefaultOpenContext;
-import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.AbstractAsyncStateStreamOperator;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.generated.JoinCondition;
@@ -30,13 +30,14 @@ import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideS
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 
 /**
- * Abstract implementation for streaming unbounded Join operator which defines some member fields
- * can be shared between different implementations.
+ * Abstract implementation for streaming unbounded Join operator based on async state api, which
+ * defines some member fields can be shared between different implementations.
  */
-public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperator<RowData>
+public abstract class AbstractAsyncStateStreamingJoinOperator
+        extends AbstractAsyncStateStreamOperator<RowData>
         implements TwoInputStreamOperator<RowData, RowData, RowData> {
 
-    private static final long serialVersionUID = -376944622236540545L;
+    private static final long serialVersionUID = 1L;
 
     protected static final String LEFT_RECORDS_STATE_NAME = "left-records";
     protected static final String RIGHT_RECORDS_STATE_NAME = "right-records";
@@ -56,7 +57,7 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
     protected transient JoinConditionWithNullFilters joinCondition;
     protected transient TimestampedCollector<RowData> collector;
 
-    public AbstractStreamingJoinOperator(
+    public AbstractAsyncStateStreamingJoinOperator(
             InternalTypeInfo<RowData> leftType,
             InternalTypeInfo<RowData> rightType,
             GeneratedJoinCondition generatedJoinCondition,

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/AbstractAsyncStateStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/AbstractAsyncStateStreamingJoinOperator.java
@@ -19,9 +19,9 @@
 package org.apache.flink.table.runtime.operators.join.stream.asyncprocessing;
 
 import org.apache.flink.api.common.functions.DefaultOpenContext;
+import org.apache.flink.runtime.asyncprocessing.operators.AbstractAsyncStateStreamOperator;
 import org.apache.flink.streaming.api.operators.TimestampedCollector;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
-import org.apache.flink.streaming.runtime.operators.asyncprocessing.AbstractAsyncStateStreamOperator;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.generated.JoinCondition;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/AsyncStateStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/AsyncStateStreamingJoinOperator.java
@@ -16,45 +16,49 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.operators.join.stream;
+package org.apache.flink.table.runtime.operators.join.stream.asyncprocessing;
 
+import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.utils.JoinedRowData;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateView;
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateViews;
-import org.apache.flink.table.runtime.operators.join.stream.state.OuterJoinRecordStateView;
-import org.apache.flink.table.runtime.operators.join.stream.state.OuterJoinRecordStateViews;
+import org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state.JoinRecordAsyncStateView;
+import org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state.JoinRecordAsyncStateViews;
+import org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state.OuterJoinRecordAsyncStateView;
+import org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state.OuterJoinRecordAsyncStateViews;
 import org.apache.flink.table.runtime.operators.join.stream.utils.AssociatedRecords;
 import org.apache.flink.table.runtime.operators.join.stream.utils.JoinHelper;
 import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.types.RowKind;
 
-/** Streaming unbounded Join operator which supports INNER/LEFT/RIGHT/FULL JOIN. */
-public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
+/**
+ * Streaming unbounded Join operator based on async state api, which supports INNER/LEFT/RIGHT/FULL
+ * JOIN.
+ */
+public class AsyncStateStreamingJoinOperator extends AbstractAsyncStateStreamingJoinOperator {
 
-    private static final long serialVersionUID = -376944622236540545L;
+    private static final long serialVersionUID = 1L;
 
     // whether left side is outer side, e.g. left is outer but right is not when LEFT OUTER JOIN
-    protected final boolean leftIsOuter;
+    private final boolean leftIsOuter;
     // whether right side is outer side, e.g. right is outer but left is not when RIGHT OUTER JOIN
-    protected final boolean rightIsOuter;
+    private final boolean rightIsOuter;
 
     private transient JoinedRowData outRow;
     private transient RowData leftNullRow;
     private transient RowData rightNullRow;
 
     // left join state
-    protected transient JoinRecordStateView leftRecordStateView;
+    private transient JoinRecordAsyncStateView leftRecordAsyncStateView;
     // right join state
-    protected transient JoinRecordStateView rightRecordStateView;
+    private transient JoinRecordAsyncStateView rightRecordAsyncStateView;
 
-    private transient SyncStateJoinHelper joinHelper;
+    private transient AsyncStateJoinHelper joinHelper;
 
-    public StreamingJoinOperator(
+    public AsyncStateStreamingJoinOperator(
             InternalTypeInfo<RowData> leftType,
             InternalTypeInfo<RowData> rightType,
             GeneratedJoinCondition generatedJoinCondition,
@@ -88,106 +92,118 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
 
         // initialize states
         if (leftIsOuter) {
-            this.leftRecordStateView =
-                    OuterJoinRecordStateViews.create(
+            this.leftRecordAsyncStateView =
+                    OuterJoinRecordAsyncStateViews.create(
                             getRuntimeContext(),
-                            "left-records",
+                            LEFT_RECORDS_STATE_NAME,
                             leftInputSideSpec,
                             leftType,
                             leftStateRetentionTime);
         } else {
-            this.leftRecordStateView =
-                    JoinRecordStateViews.create(
+            this.leftRecordAsyncStateView =
+                    JoinRecordAsyncStateViews.create(
                             getRuntimeContext(),
-                            "left-records",
+                            LEFT_RECORDS_STATE_NAME,
                             leftInputSideSpec,
                             leftType,
                             leftStateRetentionTime);
         }
 
         if (rightIsOuter) {
-            this.rightRecordStateView =
-                    OuterJoinRecordStateViews.create(
+            this.rightRecordAsyncStateView =
+                    OuterJoinRecordAsyncStateViews.create(
                             getRuntimeContext(),
-                            "right-records",
+                            RIGHT_RECORDS_STATE_NAME,
                             rightInputSideSpec,
                             rightType,
                             rightStateRetentionTime);
         } else {
-            this.rightRecordStateView =
-                    JoinRecordStateViews.create(
+            this.rightRecordAsyncStateView =
+                    JoinRecordAsyncStateViews.create(
                             getRuntimeContext(),
-                            "right-records",
+                            RIGHT_RECORDS_STATE_NAME,
                             rightInputSideSpec,
                             rightType,
                             rightStateRetentionTime);
         }
-        this.joinHelper = new SyncStateJoinHelper();
+
+        this.joinHelper = new AsyncStateJoinHelper();
     }
 
     @Override
     public void processElement1(StreamRecord<RowData> element) throws Exception {
-        processElement(element.getValue(), leftRecordStateView, rightRecordStateView, true, false);
+        doProcessElement(
+                element.getValue(), leftRecordAsyncStateView, rightRecordAsyncStateView, true);
     }
 
     @Override
     public void processElement2(StreamRecord<RowData> element) throws Exception {
-        processElement(element.getValue(), rightRecordStateView, leftRecordStateView, false, false);
+        doProcessElement(
+                element.getValue(), rightRecordAsyncStateView, leftRecordAsyncStateView, false);
     }
 
-    protected void processElement(
+    private void doProcessElement(
             RowData input,
-            JoinRecordStateView inputSideStateView,
-            JoinRecordStateView otherSideStateView,
-            boolean inputIsLeft,
-            boolean isSuppress)
+            JoinRecordAsyncStateView inputSideAsyncStateView,
+            JoinRecordAsyncStateView otherSideAsyncStateView,
+            boolean inputIsLeft)
             throws Exception {
         RowKind originalRowKind = input.getRowKind();
         // erase RowKind for later state updating
         input.setRowKind(RowKind.INSERT);
 
-        AssociatedRecords associatedRecords =
-                AssociatedRecords.fromSyncStateView(
-                        input, inputIsLeft, otherSideStateView, joinCondition);
+        StateFuture<AssociatedRecords> associatedRecordsFuture =
+                AssociatedRecords.fromAsyncStateView(
+                        input, inputIsLeft, otherSideAsyncStateView, joinCondition);
         // set back RowKind
         input.setRowKind(originalRowKind);
-        joinHelper.processJoin(
-                input,
-                inputSideStateView,
-                otherSideStateView,
-                inputIsLeft,
-                associatedRecords,
-                isSuppress);
+        associatedRecordsFuture.thenAccept(
+                associatedRecords ->
+                        joinHelper.processJoin(
+                                input,
+                                inputSideAsyncStateView,
+                                otherSideAsyncStateView,
+                                inputIsLeft,
+                                associatedRecords,
+                                false));
     }
 
-    private class SyncStateJoinHelper
-            extends JoinHelper<JoinRecordStateView, OuterJoinRecordStateView> {
-        public SyncStateJoinHelper() {
+    private class AsyncStateJoinHelper
+            extends JoinHelper<JoinRecordAsyncStateView, OuterJoinRecordAsyncStateView> {
+
+        public AsyncStateJoinHelper() {
             super(leftIsOuter, rightIsOuter, outRow, leftNullRow, rightNullRow, collector);
         }
 
         @Override
-        public void addRecord(JoinRecordStateView stateView, RowData record) throws Exception {
+        public void addRecord(JoinRecordAsyncStateView stateView, RowData record) throws Exception {
+            // no need to wait for the future
             stateView.addRecord(record);
         }
 
         @Override
-        public void retractRecord(JoinRecordStateView stateView, RowData record) throws Exception {
+        public void retractRecord(JoinRecordAsyncStateView stateView, RowData record)
+                throws Exception {
+            // no need to wait for the future
             stateView.retractRecord(record);
         }
 
         @Override
         public void addRecordInOuterSide(
-                OuterJoinRecordStateView stateView, RowData record, int numOfAssociations)
+                OuterJoinRecordAsyncStateView stateView, RowData record, int numOfAssociations)
                 throws Exception {
+            // no need to wait for the future
             stateView.addRecord(record, numOfAssociations);
         }
 
         @Override
         public void updateNumOfAssociationsInOuterSide(
-                OuterJoinRecordStateView stateView, RowData record, int numOfAssociations)
+                OuterJoinRecordAsyncStateView outerJoinRecordAsyncStateView,
+                RowData record,
+                int numOfAssociations)
                 throws Exception {
-            stateView.updateNumOfAssociations(record, numOfAssociations);
+            // no need to wait for the future
+            outerJoinRecordAsyncStateView.updateNumOfAssociations(record, numOfAssociations);
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/JoinRecordAsyncStateView.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/JoinRecordAsyncStateView.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state;
+
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateView;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.utils.OuterRecord;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A {@link JoinRecordAsyncStateView} is a view to the join state. It encapsulates the join state
+ * and provides some APIs facing the input records. The join state is used to store input records.
+ * The structure of the join state is vary depending on the {@link JoinInputSideSpec}.
+ *
+ * <p>For example: when the {@link JoinInputSideSpec} is JoinKeyContainsUniqueKey, we will use
+ * {@link org.apache.flink.api.common.state.v2.ValueState} to store records which has better
+ * performance.
+ *
+ * <p>Different with {@link JoinRecordStateView}, this interface is based on async state api.
+ */
+public interface JoinRecordAsyncStateView {
+
+    /** Add a new record to the state view. */
+    StateFuture<Void> addRecord(RowData record);
+
+    /** Retract the record from the state view. */
+    StateFuture<Void> retractRecord(RowData record);
+
+    /** Find all the records matched the condition under the current context (i.e. join key). */
+    StateFuture<List<OuterRecord>> findMatchedRecords(Function<RowData, Boolean> condition);
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/JoinRecordAsyncStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/JoinRecordAsyncStateViews.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state;
+
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.v2.MapState;
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.state.v2.ValueState;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.core.state.StateFutureUtils;
+import org.apache.flink.runtime.state.v2.MapStateDescriptor;
+import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.utils.OuterRecord;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Utility to create a {@link JoinRecordAsyncStateView} depends on {@link JoinInputSideSpec}. */
+public final class JoinRecordAsyncStateViews {
+
+    /** Creates a {@link JoinRecordAsyncStateView} depends on {@link JoinInputSideSpec}. */
+    public static JoinRecordAsyncStateView create(
+            StreamingRuntimeContext ctx,
+            String stateName,
+            JoinInputSideSpec inputSideSpec,
+            InternalTypeInfo<RowData> recordType,
+            long retentionTime) {
+        StateTtlConfig ttlConfig = createTtlConfig(retentionTime);
+        if (inputSideSpec.hasUniqueKey()) {
+            if (inputSideSpec.joinKeyContainsUniqueKey()) {
+                return new JoinKeyContainsUniqueKey(ctx, stateName, recordType, ttlConfig);
+            } else {
+                return new InputSideHasUniqueKey(
+                        ctx,
+                        stateName,
+                        recordType,
+                        inputSideSpec.getUniqueKeyType(),
+                        inputSideSpec.getUniqueKeySelector(),
+                        ttlConfig);
+            }
+        } else {
+            return new InputSideHasNoUniqueKey(ctx, stateName, recordType, ttlConfig);
+        }
+    }
+
+    // ------------------------------------------------------------------------------------
+
+    private static final class JoinKeyContainsUniqueKey implements JoinRecordAsyncStateView {
+
+        private final ValueState<RowData> recordState;
+        private final List<OuterRecord> reusedList;
+
+        private JoinKeyContainsUniqueKey(
+                StreamingRuntimeContext ctx,
+                String stateName,
+                InternalTypeInfo<RowData> recordType,
+                StateTtlConfig ttlConfig) {
+            ValueStateDescriptor<RowData> recordStateDesc =
+                    new ValueStateDescriptor<>(stateName, recordType);
+            if (ttlConfig.isEnabled()) {
+                recordStateDesc.enableTimeToLive(ttlConfig);
+            }
+            this.recordState = ctx.getValueState(recordStateDesc);
+            // the result records always not more than 1
+            this.reusedList = new ArrayList<>(1);
+        }
+
+        @Override
+        public StateFuture<Void> addRecord(RowData record) {
+            return recordState.asyncUpdate(record);
+        }
+
+        @Override
+        public StateFuture<Void> retractRecord(RowData record) {
+            return recordState.asyncClear();
+        }
+
+        @Override
+        public StateFuture<List<OuterRecord>> findMatchedRecords(
+                Function<RowData, Boolean> condition) {
+            return recordState
+                    .asyncValue()
+                    .thenApply(
+                            v -> {
+                                reusedList.clear();
+                                if (v != null) {
+                                    reusedList.add(new OuterRecord(v));
+                                }
+                                return reusedList;
+                            });
+        }
+    }
+
+    private static final class InputSideHasUniqueKey implements JoinRecordAsyncStateView {
+
+        // stores record in the mapping <UK, Record>
+        private final MapState<RowData, RowData> recordState;
+        private final KeySelector<RowData, RowData> uniqueKeySelector;
+
+        private InputSideHasUniqueKey(
+                StreamingRuntimeContext ctx,
+                String stateName,
+                InternalTypeInfo<RowData> recordType,
+                InternalTypeInfo<RowData> uniqueKeyType,
+                KeySelector<RowData, RowData> uniqueKeySelector,
+                StateTtlConfig ttlConfig) {
+            checkNotNull(uniqueKeyType);
+            checkNotNull(uniqueKeySelector);
+            MapStateDescriptor<RowData, RowData> recordStateDesc =
+                    new MapStateDescriptor<>(stateName, uniqueKeyType, recordType);
+            if (ttlConfig.isEnabled()) {
+                recordStateDesc.enableTimeToLive(ttlConfig);
+            }
+            this.recordState = ctx.getMapState(recordStateDesc);
+            this.uniqueKeySelector = uniqueKeySelector;
+        }
+
+        @Override
+        public StateFuture<Void> addRecord(RowData record) {
+            return StateFutureUtils.completedVoidFuture()
+                    .thenCompose(
+                            VOID -> {
+                                RowData uniqueKey = uniqueKeySelector.getKey(record);
+                                return recordState.asyncPut(uniqueKey, record);
+                            });
+        }
+
+        @Override
+        public StateFuture<Void> retractRecord(RowData record) {
+            return StateFutureUtils.completedVoidFuture()
+                    .thenCompose(
+                            VOID -> {
+                                RowData uniqueKey = uniqueKeySelector.getKey(record);
+                                return recordState.asyncRemove(uniqueKey);
+                            });
+        }
+
+        @Override
+        public StateFuture<List<OuterRecord>> findMatchedRecords(
+                Function<RowData, Boolean> condition) {
+            List<OuterRecord> matchedRecords = new ArrayList<>();
+            return recordState
+                    .asyncValues()
+                    .thenCompose(
+                            it ->
+                                    it.onNext(
+                                            v -> {
+                                                if (condition.apply(v)) {
+                                                    matchedRecords.add(new OuterRecord(v));
+                                                }
+                                            }))
+                    .thenApply(VOID -> matchedRecords);
+        }
+    }
+
+    private static final class InputSideHasNoUniqueKey implements JoinRecordAsyncStateView {
+
+        private final MapState<RowData, Integer> recordState;
+
+        private InputSideHasNoUniqueKey(
+                StreamingRuntimeContext ctx,
+                String stateName,
+                InternalTypeInfo<RowData> recordType,
+                StateTtlConfig ttlConfig) {
+            MapStateDescriptor<RowData, Integer> recordStateDesc =
+                    new MapStateDescriptor<>(stateName, recordType, Types.INT);
+            if (ttlConfig.isEnabled()) {
+                recordStateDesc.enableTimeToLive(ttlConfig);
+            }
+            this.recordState = ctx.getMapState(recordStateDesc);
+        }
+
+        @Override
+        public StateFuture<Void> addRecord(RowData record) {
+            return recordState
+                    .asyncGet(record)
+                    .thenApply(
+                            cnt -> {
+                                if (cnt != null) {
+                                    return cnt + 1;
+                                } else {
+                                    return 1;
+                                }
+                            })
+                    .thenCompose(updateCnt -> recordState.asyncPut(record, updateCnt));
+        }
+
+        @Override
+        public StateFuture<Void> retractRecord(RowData record) {
+            return recordState
+                    .asyncGet(record)
+                    .thenCompose(
+                            cnt -> {
+                                if (cnt != null) {
+                                    if (cnt > 1) {
+                                        return recordState.asyncPut(record, cnt - 1);
+                                    } else {
+                                        return recordState.asyncRemove(record);
+                                    }
+                                }
+                                // ignore cnt == null, which means state may be expired
+                                return StateFutureUtils.completedVoidFuture();
+                            });
+        }
+
+        @Override
+        public StateFuture<List<OuterRecord>> findMatchedRecords(
+                Function<RowData, Boolean> condition) {
+            List<OuterRecord> matchedRecords = new ArrayList<>();
+            return recordState
+                    .asyncEntries()
+                    .thenCompose(
+                            it ->
+                                    it.onNext(
+                                            entry -> {
+                                                RowData record = entry.getKey();
+                                                int cnt = entry.getValue();
+                                                if (condition.apply(record)) {
+                                                    for (int i = 0; i < cnt; i++) {
+                                                        matchedRecords.add(new OuterRecord(record));
+                                                    }
+                                                }
+                                            }))
+                    .thenApply(VOID -> matchedRecords);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/JoinRecordAsyncStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/JoinRecordAsyncStateViews.java
@@ -109,7 +109,9 @@ public final class JoinRecordAsyncStateViews {
                             v -> {
                                 reusedList.clear();
                                 if (v != null) {
-                                    reusedList.add(new OuterRecord(v));
+                                    if (condition.apply(v)) {
+                                        reusedList.add(new OuterRecord(v));
+                                    }
                                 }
                                 return reusedList;
                             });

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/OuterJoinRecordAsyncStateView.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/OuterJoinRecordAsyncStateView.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state;
+
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.stream.utils.OuterRecord;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * A {@link OuterJoinRecordAsyncStateView} is an extension to {@link JoinRecordAsyncStateView}. The
+ * {@link OuterJoinRecordAsyncStateView} is used to store records for the outer input side of the
+ * Join, e.g. the left side of left join, the both side of full join.
+ *
+ * <p>The additional information we should store with the record is the number of associations which
+ * is the number of records associated this record with other side. This is an important information
+ * when to send/retract a null padding row, to avoid recompute the associated numbers every time.
+ *
+ * @see JoinRecordAsyncStateView
+ */
+public interface OuterJoinRecordAsyncStateView extends JoinRecordAsyncStateView {
+
+    /**
+     * Adds a new record with the number of associations to the state view.
+     *
+     * @param record the added record
+     * @param numOfAssociations the number of records associated with other side
+     */
+    StateFuture<Void> addRecord(RowData record, int numOfAssociations);
+
+    /**
+     * Updates the number of associations belongs to the record.
+     *
+     * @param record the record to update
+     * @param numOfAssociations the new number of records associated with other side
+     */
+    StateFuture<Void> updateNumOfAssociations(RowData record, int numOfAssociations);
+
+    /**
+     * Find all the records matched the condition and the corresponding number of associations under
+     * the current context (i.e. join key).
+     */
+    StateFuture<List<OuterRecord>> findMatchedRecordsAndNumOfAssociations(
+            Function<RowData, Boolean> condition);
+
+    // ----------------------------------------------------------------------------------------
+
+    @Override
+    default StateFuture<Void> addRecord(RowData record) {
+        return addRecord(record, -1);
+    }
+
+    @Override
+    default StateFuture<List<OuterRecord>> findMatchedRecords(
+            Function<RowData, Boolean> condition) {
+        return findMatchedRecordsAndNumOfAssociations(condition);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/OuterJoinRecordAsyncStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/OuterJoinRecordAsyncStateViews.java
@@ -122,7 +122,9 @@ public final class OuterJoinRecordAsyncStateViews {
                             tuple -> {
                                 reusedList.clear();
                                 if (tuple != null) {
-                                    reusedList.add(new OuterRecord(tuple.f0, tuple.f1));
+                                    if (condition.apply(tuple.f0)) {
+                                        reusedList.add(new OuterRecord(tuple.f0, tuple.f1));
+                                    }
                                 }
                                 return StateFutureUtils.completedFuture(reusedList);
                             });

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/OuterJoinRecordAsyncStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/asyncprocessing/state/OuterJoinRecordAsyncStateViews.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state;
+
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.v2.MapState;
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.state.v2.ValueState;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.core.state.StateFutureUtils;
+import org.apache.flink.runtime.state.v2.MapStateDescriptor;
+import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.utils.OuterRecord;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.apache.flink.table.runtime.util.StateConfigUtil.createTtlConfig;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Utility to create a {@link OuterJoinRecordAsyncStateViews} depends on {@link JoinInputSideSpec}.
+ */
+public final class OuterJoinRecordAsyncStateViews {
+
+    /** Creates a {@link OuterJoinRecordAsyncStateView} depends on {@link JoinInputSideSpec}. */
+    public static OuterJoinRecordAsyncStateView create(
+            StreamingRuntimeContext ctx,
+            String stateName,
+            JoinInputSideSpec inputSideSpec,
+            InternalTypeInfo<RowData> recordType,
+            long retentionTime) {
+        StateTtlConfig ttlConfig = createTtlConfig(retentionTime);
+        if (inputSideSpec.hasUniqueKey()) {
+            if (inputSideSpec.joinKeyContainsUniqueKey()) {
+                return new OuterJoinRecordAsyncStateViews.JoinKeyContainsUniqueKey(
+                        ctx, stateName, recordType, ttlConfig);
+            } else {
+                return new OuterJoinRecordAsyncStateViews.InputSideHasUniqueKey(
+                        ctx,
+                        stateName,
+                        recordType,
+                        inputSideSpec.getUniqueKeyType(),
+                        inputSideSpec.getUniqueKeySelector(),
+                        ttlConfig);
+            }
+        } else {
+            return new OuterJoinRecordAsyncStateViews.InputSideHasNoUniqueKey(
+                    ctx, stateName, recordType, ttlConfig);
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    private static final class JoinKeyContainsUniqueKey implements OuterJoinRecordAsyncStateView {
+
+        private final ValueState<Tuple2<RowData, Integer>> recordState;
+        private final List<OuterRecord> reusedList;
+
+        private JoinKeyContainsUniqueKey(
+                StreamingRuntimeContext ctx,
+                String stateName,
+                InternalTypeInfo<RowData> recordType,
+                StateTtlConfig ttlConfig) {
+            TupleTypeInfo<Tuple2<RowData, Integer>> valueTypeInfo =
+                    new TupleTypeInfo<>(recordType, Types.INT);
+            ValueStateDescriptor<Tuple2<RowData, Integer>> recordStateDesc =
+                    new ValueStateDescriptor<>(stateName, valueTypeInfo);
+            if (ttlConfig.isEnabled()) {
+                recordStateDesc.enableTimeToLive(ttlConfig);
+            }
+            this.recordState = ctx.getValueState(recordStateDesc);
+            // the result records always not more than 1
+            this.reusedList = new ArrayList<>(1);
+        }
+
+        @Override
+        public StateFuture<Void> addRecord(RowData record, int numOfAssociations) {
+            return recordState.asyncUpdate(Tuple2.of(record, numOfAssociations));
+        }
+
+        @Override
+        public StateFuture<Void> updateNumOfAssociations(RowData record, int numOfAssociations) {
+            return recordState.asyncUpdate(Tuple2.of(record, numOfAssociations));
+        }
+
+        @Override
+        public StateFuture<Void> retractRecord(RowData record) {
+            return recordState.asyncClear();
+        }
+
+        @Override
+        public StateFuture<List<OuterRecord>> findMatchedRecordsAndNumOfAssociations(
+                Function<RowData, Boolean> condition) {
+            return recordState
+                    .asyncValue()
+                    .thenCompose(
+                            tuple -> {
+                                reusedList.clear();
+                                if (tuple != null) {
+                                    reusedList.add(new OuterRecord(tuple.f0, tuple.f1));
+                                }
+                                return StateFutureUtils.completedFuture(reusedList);
+                            });
+        }
+    }
+
+    private static final class InputSideHasUniqueKey implements OuterJoinRecordAsyncStateView {
+
+        // stores record in the mapping <UK, <Record, associated-num>>
+        private final MapState<RowData, Tuple2<RowData, Integer>> recordState;
+        private final KeySelector<RowData, RowData> uniqueKeySelector;
+
+        private InputSideHasUniqueKey(
+                StreamingRuntimeContext ctx,
+                String stateName,
+                InternalTypeInfo<RowData> recordType,
+                InternalTypeInfo<RowData> uniqueKeyType,
+                KeySelector<RowData, RowData> uniqueKeySelector,
+                StateTtlConfig ttlConfig) {
+            checkNotNull(uniqueKeyType);
+            checkNotNull(uniqueKeySelector);
+            TupleTypeInfo<Tuple2<RowData, Integer>> valueTypeInfo =
+                    new TupleTypeInfo<>(recordType, Types.INT);
+            MapStateDescriptor<RowData, Tuple2<RowData, Integer>> recordStateDesc =
+                    new MapStateDescriptor<>(stateName, uniqueKeyType, valueTypeInfo);
+            if (ttlConfig.isEnabled()) {
+                recordStateDesc.enableTimeToLive(ttlConfig);
+            }
+            this.recordState = ctx.getMapState(recordStateDesc);
+            this.uniqueKeySelector = uniqueKeySelector;
+        }
+
+        @Override
+        public StateFuture<Void> addRecord(RowData record, int numOfAssociations) {
+            return StateFutureUtils.completedVoidFuture()
+                    .thenCompose(
+                            VOID -> {
+                                RowData uniqueKey = uniqueKeySelector.getKey(record);
+                                return recordState.asyncPut(
+                                        uniqueKey, Tuple2.of(record, numOfAssociations));
+                            });
+        }
+
+        @Override
+        public StateFuture<Void> updateNumOfAssociations(RowData record, int numOfAssociations) {
+            return StateFutureUtils.completedVoidFuture()
+                    .thenCompose(
+                            VOID -> {
+                                RowData uniqueKey = uniqueKeySelector.getKey(record);
+                                return recordState.asyncPut(
+                                        uniqueKey, Tuple2.of(record, numOfAssociations));
+                            });
+        }
+
+        @Override
+        public StateFuture<Void> retractRecord(RowData record) {
+            return StateFutureUtils.completedVoidFuture()
+                    .thenCompose(
+                            VOID -> {
+                                RowData uniqueKey = uniqueKeySelector.getKey(record);
+                                return recordState.asyncRemove(uniqueKey);
+                            });
+        }
+
+        @Override
+        public StateFuture<List<OuterRecord>> findMatchedRecordsAndNumOfAssociations(
+                Function<RowData, Boolean> condition) {
+            List<OuterRecord> matchedRecords = new ArrayList<>();
+            return recordState
+                    .asyncValues()
+                    .thenCompose(
+                            it ->
+                                    it.onNext(
+                                            v -> {
+                                                if (condition.apply(v.f0)) {
+                                                    matchedRecords.add(new OuterRecord(v.f0, v.f1));
+                                                }
+                                            }))
+                    .thenApply(VOID -> matchedRecords);
+        }
+    }
+
+    private static final class InputSideHasNoUniqueKey implements OuterJoinRecordAsyncStateView {
+
+        // stores record in the mapping <Record, <appear-times, associated-num>>
+        private final MapState<RowData, Tuple2<Integer, Integer>> recordState;
+
+        private InputSideHasNoUniqueKey(
+                StreamingRuntimeContext ctx,
+                String stateName,
+                InternalTypeInfo<RowData> recordType,
+                StateTtlConfig ttlConfig) {
+            TupleTypeInfo<Tuple2<Integer, Integer>> tupleTypeInfo =
+                    new TupleTypeInfo<>(Types.INT, Types.INT);
+            MapStateDescriptor<RowData, Tuple2<Integer, Integer>> recordStateDesc =
+                    new MapStateDescriptor<>(stateName, recordType, tupleTypeInfo);
+            if (ttlConfig.isEnabled()) {
+                recordStateDesc.enableTimeToLive(ttlConfig);
+            }
+            this.recordState = ctx.getMapState(recordStateDesc);
+        }
+
+        @Override
+        public StateFuture<Void> addRecord(RowData record, int numOfAssociations) {
+            return recordState
+                    .asyncGet(record)
+                    .thenApply(
+                            tuple -> {
+                                if (tuple != null) {
+                                    tuple.f0 = tuple.f0 + 1;
+                                    tuple.f1 = numOfAssociations;
+                                    return tuple;
+                                } else {
+                                    return Tuple2.of(1, numOfAssociations);
+                                }
+                            })
+                    .thenCompose(updatedTuple -> recordState.asyncPut(record, updatedTuple));
+        }
+
+        @Override
+        public StateFuture<Void> updateNumOfAssociations(RowData record, int numOfAssociations) {
+            return recordState
+                    .asyncGet(record)
+                    .thenApply(
+                            tuple -> {
+                                if (tuple != null) {
+                                    tuple.f1 = numOfAssociations;
+                                    return tuple;
+                                } else {
+                                    // compatible for state ttl
+                                    return Tuple2.of(1, numOfAssociations);
+                                }
+                            })
+                    .thenCompose(updatedTuple -> recordState.asyncPut(record, updatedTuple));
+        }
+
+        @Override
+        public StateFuture<Void> retractRecord(RowData record) {
+            return recordState
+                    .asyncGet(record)
+                    .thenCompose(
+                            tuple -> {
+                                if (tuple != null) {
+                                    if (tuple.f0 > 1) {
+                                        tuple.f0 = tuple.f0 - 1;
+                                        return recordState.asyncPut(record, tuple);
+                                    } else {
+                                        return recordState.asyncRemove(record);
+                                    }
+                                }
+                                return StateFutureUtils.completedVoidFuture();
+                            });
+        }
+
+        @Override
+        public StateFuture<List<OuterRecord>> findMatchedRecordsAndNumOfAssociations(
+                Function<RowData, Boolean> condition) {
+            List<OuterRecord> matchedRecords = new ArrayList<>();
+            return recordState
+                    .asyncEntries()
+                    .thenCompose(
+                            it ->
+                                    it.onNext(
+                                            entry -> {
+                                                RowData record = entry.getKey();
+                                                int appearTimes = entry.getValue().f0;
+                                                int associatedNum = entry.getValue().f1;
+
+                                                if (condition.apply(record)) {
+                                                    for (int i = 0; i < appearTimes; i++) {
+                                                        matchedRecords.add(
+                                                                new OuterRecord(
+                                                                        record, associatedNum));
+                                                    }
+                                                }
+                                            }))
+                    .thenApply(VOID -> matchedRecords);
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/bundle/BufferBundle.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/bundle/BufferBundle.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.operators.join.stream.bundle;
 
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 
 import javax.annotation.Nullable;
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateView.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateView.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.join.stream.state;
 
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 
 /**
  * A {@link JoinRecordStateView} is a view to the join state. It encapsulates the join state and

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/JoinRecordStateViews.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.util.IterableIterator;
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.util.IterableIterator;
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/utils/AssociatedRecords.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/utils/AssociatedRecords.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream.utils;
+
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.JoinCondition;
+import org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state.JoinRecordAsyncStateView;
+import org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.state.OuterJoinRecordAsyncStateView;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateView;
+import org.apache.flink.table.runtime.operators.join.stream.state.OuterJoinRecordStateView;
+import org.apache.flink.util.IterableIterator;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The {@link AssociatedRecords} is the records associated to the input row. It is a wrapper of
+ * {@code List<OuterRecord>} which provides two helpful methods {@link #getRecords()} and {@link
+ * #getOuterRecords()}. See the method Javadoc for more details.
+ */
+public class AssociatedRecords {
+    private final List<OuterRecord> records;
+
+    private AssociatedRecords(List<OuterRecord> records) {
+        checkNotNull(records);
+        this.records = records;
+    }
+
+    public boolean isEmpty() {
+        return records.isEmpty();
+    }
+
+    public int size() {
+        return records.size();
+    }
+
+    /**
+     * Gets the iterable of records. This is usually be called when the {@link AssociatedRecords} is
+     * from inner side.
+     */
+    public Iterable<RowData> getRecords() {
+        return new RecordsIterable(records);
+    }
+
+    /**
+     * Gets the iterable of {@link OuterRecord} which composites record and numOfAssociations. This
+     * is usually be called when the {@link AssociatedRecords} is from outer side.
+     */
+    public Iterable<OuterRecord> getOuterRecords() {
+        return records;
+    }
+
+    /**
+     * Creates an {@link AssociatedRecords} which represents the records associated to the input
+     * row.
+     *
+     * <p>This method is used in the sync state join operator.
+     */
+    public static AssociatedRecords fromSyncStateView(
+            RowData input,
+            boolean inputIsLeft,
+            JoinRecordStateView otherSideStateView,
+            JoinCondition condition)
+            throws Exception {
+        List<OuterRecord> associations = new ArrayList<>();
+        if (otherSideStateView instanceof OuterJoinRecordStateView) {
+            OuterJoinRecordStateView outerStateView = (OuterJoinRecordStateView) otherSideStateView;
+            Iterable<Tuple2<RowData, Integer>> records =
+                    outerStateView.getRecordsAndNumOfAssociations();
+            for (Tuple2<RowData, Integer> record : records) {
+                boolean matched =
+                        inputIsLeft
+                                ? condition.apply(input, record.f0)
+                                : condition.apply(record.f0, input);
+                if (matched) {
+                    associations.add(new OuterRecord(record.f0, record.f1));
+                }
+            }
+        } else {
+            Iterable<RowData> records = otherSideStateView.getRecords();
+            for (RowData record : records) {
+                boolean matched =
+                        inputIsLeft
+                                ? condition.apply(input, record)
+                                : condition.apply(record, input);
+                if (matched) {
+                    // use -1 as the default number of associations
+                    associations.add(new OuterRecord(record, -1));
+                }
+            }
+        }
+        return new AssociatedRecords(associations);
+    }
+
+    /**
+     * Creates an {@link AssociatedRecords} which represents the records associated to the input
+     * row.
+     *
+     * <p>This method is used in the async state join operator.
+     */
+    public static StateFuture<AssociatedRecords> fromAsyncStateView(
+            RowData input,
+            boolean inputIsLeft,
+            JoinRecordAsyncStateView otherSideAsyncStateView,
+            JoinCondition joinCondition)
+            throws Exception {
+        Function<RowData, Boolean> conditionFunction =
+                recordInState ->
+                        inputIsLeft
+                                ? joinCondition.apply(input, recordInState)
+                                : joinCondition.apply(recordInState, input);
+
+        if (otherSideAsyncStateView instanceof OuterJoinRecordAsyncStateView) {
+            OuterJoinRecordAsyncStateView outerAsyncStateView =
+                    (OuterJoinRecordAsyncStateView) otherSideAsyncStateView;
+            return outerAsyncStateView
+                    .findMatchedRecordsAndNumOfAssociations(conditionFunction)
+                    .thenApply(AssociatedRecords::new);
+
+        } else {
+            return otherSideAsyncStateView
+                    .findMatchedRecords(conditionFunction)
+                    .thenApply(AssociatedRecords::new);
+        }
+    }
+
+    /** A lazy Iterable which transform {@code List<OuterRecord>} to {@code Iterable<RowData>}. */
+    private static final class RecordsIterable implements IterableIterator<RowData> {
+        private final List<OuterRecord> records;
+        private int index = 0;
+
+        private RecordsIterable(List<OuterRecord> records) {
+            this.records = records;
+        }
+
+        @Override
+        public Iterator<RowData> iterator() {
+            index = 0;
+            return this;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return index < records.size();
+        }
+
+        @Override
+        public RowData next() {
+            RowData row = records.get(index).record;
+            index++;
+            return row;
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/utils/JoinHelper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/utils/JoinHelper.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream.utils;
+
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.RowDataUtil;
+import org.apache.flink.table.data.utils.JoinedRowData;
+import org.apache.flink.types.RowKind;
+
+/** A helper to do the logic of streaming join. */
+public abstract class JoinHelper<STATE_VIEW, OUTER_STATE_VIEW extends STATE_VIEW> {
+
+    private final boolean leftIsOuter;
+    private final boolean rightIsOuter;
+    private final JoinedRowData outRow;
+    private final RowData leftNullRow;
+    private final RowData rightNullRow;
+
+    private final TimestampedCollector<RowData> collector;
+
+    public JoinHelper(
+            boolean leftIsOuter,
+            boolean rightIsOuter,
+            JoinedRowData outRow,
+            RowData leftNullRow,
+            RowData rightNullRow,
+            TimestampedCollector<RowData> collector) {
+        this.leftIsOuter = leftIsOuter;
+        this.rightIsOuter = rightIsOuter;
+        this.outRow = outRow;
+        this.leftNullRow = leftNullRow;
+        this.rightNullRow = rightNullRow;
+        this.collector = collector;
+    }
+
+    /**
+     * Process an input element and output incremental joined records, retraction messages will be
+     * sent in some scenarios.
+     *
+     * <p>Following is the pseudo code to describe the core logic of this method. The logic of this
+     * method is too complex, so we provide the pseudo code to help understand the logic. We should
+     * keep sync the following pseudo code with the real logic of the method.
+     *
+     * <p>Note: "+I" represents "INSERT", "-D" represents "DELETE", "+U" represents "UPDATE_AFTER",
+     * "-U" represents "UPDATE_BEFORE". We forward input RowKind if it is inner join, otherwise, we
+     * always send insert and delete for simplification. We can optimize this to send -U & +U
+     * instead of D & I in the future (see FLINK-17337). They are equivalent in this join case. It
+     * may need some refactoring if we want to send -U & +U, so we still keep -D & +I for now for
+     * simplification. See {@code
+     * FlinkChangelogModeInferenceProgram.SatisfyModifyKindSetTraitVisitor}.
+     *
+     * <pre>
+     * if input record is accumulate
+     * |  if input side is outer
+     * |  |  if there is no matched rows on the other side, send +I[record+null], state.add(record, 0)
+     * |  |  if there are matched rows on the other side
+     * |  |  | if other side is outer
+     * |  |  | |  if the matched num in the matched rows == 0, send -D[null+other]
+     * |  |  | |  if the matched num in the matched rows > 0, skip
+     * |  |  | |  otherState.update(other, old + 1)
+     * |  |  | endif
+     * |  |  | send +I[record+other]s, state.add(record, other.size)
+     * |  |  endif
+     * |  endif
+     * |  if input side not outer
+     * |  |  state.add(record)
+     * |  |  if there is no matched rows on the other side, skip
+     * |  |  if there are matched rows on the other side
+     * |  |  |  if other side is outer
+     * |  |  |  |  if the matched num in the matched rows == 0, send -D[null+other]
+     * |  |  |  |  if the matched num in the matched rows > 0, skip
+     * |  |  |  |  otherState.update(other, old + 1)
+     * |  |  |  |  send +I[record+other]s
+     * |  |  |  else
+     * |  |  |  |  send +I/+U[record+other]s (using input RowKind)
+     * |  |  |  endif
+     * |  |  endif
+     * |  endif
+     * endif
+     *
+     * if input record is retract
+     * |  state.retract(record)
+     * |  if there is no matched rows on the other side
+     * |  | if input side is outer, send -D[record+null]
+     * |  endif
+     * |  if there are matched rows on the other side, send -D[record+other]s if outer, send -D/-U[record+other]s if inner.
+     * |  |  if other side is outer
+     * |  |  |  if the matched num in the matched rows == 0, this should never happen!
+     * |  |  |  if the matched num in the matched rows == 1, send +I[null+other]
+     * |  |  |  if the matched num in the matched rows > 1, skip
+     * |  |  |  otherState.update(other, old - 1)
+     * |  |  endif
+     * |  endif
+     * endif
+     * </pre>
+     *
+     * @param input the input element
+     * @param inputSideAsyncStateView state of input side
+     * @param otherSideAsyncStateView state of other side
+     * @param inputIsLeft whether input side is left side
+     * @param otherSideAssociatedRecords associated records in the state of the other side
+     */
+    public void processJoin(
+            RowData input,
+            STATE_VIEW inputSideAsyncStateView,
+            STATE_VIEW otherSideAsyncStateView,
+            boolean inputIsLeft,
+            AssociatedRecords otherSideAssociatedRecords,
+            boolean isSuppress)
+            throws Exception {
+        boolean inputIsOuter = inputIsLeft ? leftIsOuter : rightIsOuter;
+        boolean otherIsOuter = inputIsLeft ? rightIsOuter : leftIsOuter;
+        boolean isAccumulateMsg = RowDataUtil.isAccumulateMsg(input);
+        RowKind inputRowKind = input.getRowKind();
+        input.setRowKind(RowKind.INSERT); // erase RowKind for later state updating
+
+        if (isAccumulateMsg) { // record is accumulate
+            if (inputIsOuter) { // input side is outer
+                OUTER_STATE_VIEW inputSideOuterStateView =
+                        (OUTER_STATE_VIEW) inputSideAsyncStateView;
+                if (otherSideAssociatedRecords
+                        .isEmpty()) { // there is no matched rows on the other side
+                    // send +I[record+null]
+                    outRow.setRowKind(RowKind.INSERT);
+                    outputNullPadding(input, inputIsLeft);
+                    // state.add(record, 0)
+                    addRecordInOuterSide(inputSideOuterStateView, input, 0);
+                } else { // there are matched rows on the other side
+                    if (otherIsOuter) { // other side is outer
+                        OUTER_STATE_VIEW otherSideOuterStateView =
+                                (OUTER_STATE_VIEW) otherSideAsyncStateView;
+                        for (OuterRecord outerRecord :
+                                otherSideAssociatedRecords.getOuterRecords()) {
+                            RowData other = outerRecord.record;
+                            // if the matched num in the matched rows == 0
+                            if (outerRecord.numOfAssociations == 0 && !isSuppress) {
+                                // send -D[null+other]
+                                outRow.setRowKind(RowKind.DELETE);
+                                outputNullPadding(other, !inputIsLeft);
+                            } // ignore matched number > 0
+                            // otherState.update(other, old + 1)
+                            updateNumOfAssociationsInOuterSide(
+                                    otherSideOuterStateView,
+                                    other,
+                                    outerRecord.numOfAssociations + 1);
+                        }
+                    }
+                    // send +I[record+other]s
+                    outRow.setRowKind(RowKind.INSERT);
+                    for (RowData other : otherSideAssociatedRecords.getRecords()) {
+                        output(input, other, inputIsLeft);
+                    }
+                    // state.add(record, other.size)
+                    addRecordInOuterSide(
+                            inputSideOuterStateView, input, otherSideAssociatedRecords.size());
+                }
+            } else { // input side not outer
+                // state.add(record)
+                addRecord(inputSideAsyncStateView, input);
+                if (!otherSideAssociatedRecords
+                        .isEmpty()) { // if there are matched rows on the other side
+                    if (otherIsOuter) { // if other side is outer
+                        OUTER_STATE_VIEW otherSideOuterStateView =
+                                (OUTER_STATE_VIEW) otherSideAsyncStateView;
+                        for (OuterRecord outerRecord :
+                                otherSideAssociatedRecords.getOuterRecords()) {
+                            if (outerRecord.numOfAssociations == 0
+                                    && !isSuppress) { // if the matched num in the matched rows == 0
+                                // send -D[null+other]
+                                outRow.setRowKind(RowKind.DELETE);
+                                outputNullPadding(outerRecord.record, !inputIsLeft);
+                            }
+                            // otherState.update(other, old + 1)
+                            updateNumOfAssociationsInOuterSide(
+                                    otherSideOuterStateView,
+                                    outerRecord.record,
+                                    outerRecord.numOfAssociations + 1);
+                        }
+                        // send +I[record+other]s
+                        outRow.setRowKind(RowKind.INSERT);
+                    } else {
+                        // send +I/+U[record+other]s (using input RowKind)
+                        outRow.setRowKind(inputRowKind);
+                    }
+                    for (RowData other : otherSideAssociatedRecords.getRecords()) {
+                        output(input, other, inputIsLeft);
+                    }
+                }
+                // skip when there is no matched rows on the other side
+            }
+        } else { // input record is retract
+            // state.retract(record)
+            if (!isSuppress) {
+                retractRecord(inputSideAsyncStateView, input);
+            }
+            if (otherSideAssociatedRecords
+                    .isEmpty()) { // there is no matched rows on the other side
+                if (inputIsOuter) { // input side is outer
+                    // send -D[record+null]
+                    outRow.setRowKind(RowKind.DELETE);
+                    outputNullPadding(input, inputIsLeft);
+                }
+                // nothing to do when input side is not outer
+            } else { // there are matched rows on the other side
+                if (inputIsOuter) {
+                    // send -D[record+other]s
+                    outRow.setRowKind(RowKind.DELETE);
+                } else {
+                    // send -D/-U[record+other]s (using input RowKind)
+                    outRow.setRowKind(inputRowKind);
+                }
+                for (RowData other : otherSideAssociatedRecords.getRecords()) {
+                    output(input, other, inputIsLeft);
+                }
+                // if other side is outer
+                if (otherIsOuter) {
+                    OUTER_STATE_VIEW otherSideOuterStateView =
+                            (OUTER_STATE_VIEW) otherSideAsyncStateView;
+                    for (OuterRecord outerRecord : otherSideAssociatedRecords.getOuterRecords()) {
+                        if (outerRecord.numOfAssociations == 1 && !isSuppress) {
+                            // send +I[null+other]
+                            outRow.setRowKind(RowKind.INSERT);
+                            outputNullPadding(outerRecord.record, !inputIsLeft);
+                        } // nothing else to do when number of associations > 1
+                        // otherState.update(other, old - 1)
+                        updateNumOfAssociationsInOuterSide(
+                                otherSideOuterStateView,
+                                outerRecord.record,
+                                outerRecord.numOfAssociations - 1);
+                    }
+                }
+            }
+        }
+    }
+
+    // ---------- common methods for accessing the state ----------
+
+    public abstract void addRecord(STATE_VIEW stateView, RowData record) throws Exception;
+
+    public abstract void retractRecord(STATE_VIEW stateView, RowData record) throws Exception;
+
+    // ---------- unique methods for accessing the state of the outer side ----------
+    public abstract void addRecordInOuterSide(
+            OUTER_STATE_VIEW stateView, RowData record, int numOfAssociations) throws Exception;
+
+    public abstract void updateNumOfAssociationsInOuterSide(
+            OUTER_STATE_VIEW stateView, RowData record, int numOfAssociations) throws Exception;
+
+    // ----------------------------------------------------------
+
+    private void output(RowData inputRow, RowData otherRow, boolean inputIsLeft) {
+        if (inputIsLeft) {
+            outRow.replace(inputRow, otherRow);
+        } else {
+            outRow.replace(otherRow, inputRow);
+        }
+        collector.collect(outRow);
+    }
+
+    private void outputNullPadding(RowData row, boolean isLeft) {
+        if (isLeft) {
+            outRow.replace(row, rightNullRow);
+        } else {
+            outRow.replace(leftNullRow, row);
+        }
+        collector.collect(outRow);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/utils/JoinInputSideSpec.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/utils/JoinInputSideSpec.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.operators.join.stream.state;
+package org.apache.flink.table.runtime.operators.join.stream.utils;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/utils/OuterRecord.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/utils/OuterRecord.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.stream.utils;
+
+import org.apache.flink.table.data.RowData;
+
+/**
+ * An {@link OuterRecord} is a composite of record and {@code numOfAssociations}. The {@code
+ * numOfAssociations} represents the number of associated records in the other side. It is used when
+ * the record is from outer side (e.g. left side in LEFT OUTER JOIN). When the {@code
+ * numOfAssociations} is ZERO, we need to send a null padding row. This is useful to avoid recompute
+ * the associated numbers every time.
+ *
+ * <p>When the record is from inner side (e.g. right side in LEFT OUTER JOIN), the {@code
+ * numOfAssociations} will always be {@code -1}.
+ */
+public final class OuterRecord {
+    public final RowData record;
+    public final int numOfAssociations;
+
+    public OuterRecord(RowData record, int numOfAssociations) {
+        this.record = record;
+        this.numOfAssociations = numOfAssociations;
+    }
+
+    public OuterRecord(RowData record) {
+        this.record = record;
+        // use -1 as the default number of associations
+        this.numOfAssociations = -1;
+    }
+
+    public RowData getRecord() {
+        return record;
+    }
+
+    public int getNumOfAssociations() {
+        return numOfAssociations;
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/BufferBundleTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/BufferBundleTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.runtime.operators.join.stream.bundle.BufferBundle;
 import org.apache.flink.table.runtime.operators.join.stream.bundle.InputSideHasNoUniqueKeyBundle;
 import org.apache.flink.table.runtime.operators.join.stream.bundle.InputSideHasUniqueKeyBundle;
 import org.apache.flink.table.runtime.operators.join.stream.bundle.JoinKeyContainsUniqueKeyBundle;
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LogicalType;

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
@@ -18,14 +18,24 @@
 
 package org.apache.flink.table.runtime.operators.join.stream;
 
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.join.stream.asyncprocessing.AsyncStateStreamingJoinOperator;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.types.RowKind;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -35,23 +45,50 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 
 /** Harness tests for {@link StreamingJoinOperator}. */
+@ExtendWith(ParameterizedTestExtension.class)
 class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
 
+    @Parameters(name = "enableAsyncState = {0}")
+    public static List<Boolean> enableAsyncState() {
+        return Arrays.asList(false, true);
+    }
+
+    @Parameter private boolean enableAsyncState;
+
     @Override
-    protected StreamingJoinOperator createJoinOperator(TestInfo testInfo) {
-        Boolean[] joinTypeSpec = JOIN_TYPE_EXTRACTOR.apply(testInfo.getDisplayName());
+    protected TwoInputStreamOperator<RowData, RowData, RowData> createJoinOperator(
+            TestInfo testInfo) {
+        Boolean[] joinTypeSpec =
+                JOIN_TYPE_EXTRACTOR.apply(
+                        testInfo.getTestMethod()
+                                .map(Method::getName)
+                                .orElse(testInfo.getDisplayName()));
         Long[] ttl = STATE_RETENTION_TIME_EXTRACTOR.apply(testInfo.getTags());
-        return new StreamingJoinOperator(
-                leftTypeInfo,
-                rightTypeInfo,
-                joinCondition,
-                leftInputSpec,
-                rightInputSpec,
-                joinTypeSpec[0],
-                joinTypeSpec[1],
-                new boolean[] {true},
-                ttl[0],
-                ttl[1]);
+        if (!enableAsyncState) {
+            return new StreamingJoinOperator(
+                    leftTypeInfo,
+                    rightTypeInfo,
+                    joinCondition,
+                    leftInputSpec,
+                    rightInputSpec,
+                    joinTypeSpec[0],
+                    joinTypeSpec[1],
+                    new boolean[] {true},
+                    ttl[0],
+                    ttl[1]);
+        } else {
+            return new AsyncStateStreamingJoinOperator(
+                    leftTypeInfo,
+                    rightTypeInfo,
+                    joinCondition,
+                    leftInputSpec,
+                    rightInputSpec,
+                    joinTypeSpec[0],
+                    joinTypeSpec[1],
+                    new boolean[] {true},
+                    ttl[0],
+                    ttl[1]);
+        }
     }
 
     @Override
@@ -75,7 +112,7 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      */
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=1000")
-    @Test
+    @TestTemplate
     void testInnerJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
@@ -141,7 +178,7 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      * The equivalent SQL is same with {@link #testInnerJoinWithDifferentStateRetentionTime}. The
      * only difference is that the state retention is disabled.
      */
-    @Test
+    @TestTemplate
     void testInnerJoinWithStateRetentionDisabled() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
@@ -230,7 +267,7 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      */
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=4000")
-    @Test
+    @TestTemplate
     void testInnerJoinWithSameStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
@@ -299,7 +336,7 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      */
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=1000")
-    @Test
+    @TestTemplate
     void testLeftOuterJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
@@ -411,7 +448,7 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      * #testLeftOuterJoinWithDifferentStateRetentionTime()}. The only difference is that the state
      * retention is disabled.
      */
-    @Test
+    @TestTemplate
     void testLeftOuterJoinWithStateRetentionDisabled() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
@@ -522,7 +559,7 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      */
     @Tag("leftStateRetentionTime=4000")
     @Tag("rightStateRetentionTime=1000")
-    @Test
+    @TestTemplate
     void testRightOuterJoinWithDifferentStateRetentionTime() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
@@ -593,7 +630,7 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
      * #testRightOuterJoinWithDifferentStateRetentionTime()}. The only difference is that the state
      * retention is disabled.
      */
-    @Test
+    @TestTemplate
     void testRightOuterJoinWithDStateRetentionDisabled() throws Exception {
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTest.java
@@ -43,6 +43,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 /** Harness tests for {@link StreamingJoinOperator}. */
 @ExtendWith(ParameterizedTestExtension.class)
@@ -114,6 +115,9 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Tag("rightStateRetentionTime=1000")
     @TestTemplate
     void testInnerJoinWithDifferentStateRetentionTime() throws Exception {
+        // async state op is not supported to set ttl yet
+        assumeFalse(enableAsyncState);
+
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -269,6 +273,9 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Tag("rightStateRetentionTime=4000")
     @TestTemplate
     void testInnerJoinWithSameStateRetentionTime() throws Exception {
+        // async state op is not supported to set ttl yet
+        assumeFalse(enableAsyncState);
+
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -338,6 +345,9 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Tag("rightStateRetentionTime=1000")
     @TestTemplate
     void testLeftOuterJoinWithDifferentStateRetentionTime() throws Exception {
+        // async state op is not supported to set ttl yet
+        assumeFalse(enableAsyncState);
+
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));
@@ -561,6 +571,9 @@ class StreamingJoinOperatorTest extends StreamingJoinOperatorTestBase {
     @Tag("rightStateRetentionTime=1000")
     @TestTemplate
     void testRightOuterJoinWithDifferentStateRetentionTime() throws Exception {
+        // async state op is not supported to set ttl yet
+        assumeFalse(enableAsyncState);
+
         testHarness.setStateTtlProcessingTime(1);
         testHarness.processElement1(
                 insertRecord("Ord#1", "LineOrd#1", "3 Bellevue Drive, Pottstown, PA 19464"));

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperatorTestBase.java
@@ -18,11 +18,12 @@
 
 package org.apache.flink.table.runtime.operators.join.stream;
 
+import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.util.KeyedTwoInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
 import org.apache.flink.table.types.logical.CharType;
@@ -138,7 +139,8 @@ public abstract class StreamingJoinOperatorTestBase {
             };
 
     /** Create streaming join operator according to {@link TestInfo}. */
-    protected abstract AbstractStreamingJoinOperator createJoinOperator(TestInfo testInfo);
+    protected abstract TwoInputStreamOperator<RowData, RowData, RowData> createJoinOperator(
+            TestInfo testInfo);
 
     /** Get the output row type of join operator. */
     protected abstract RowType getOutputType();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingMiniBatchJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/stream/StreamingMiniBatchJoinOperatorTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.operators.bundle.trigger.CountCoBundleTrigger;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
-import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.CharType;


### PR DESCRIPTION
## What is the purpose of the change

*Introduce new join operator with async state api.*

## Brief change log

  - *Introduce new join operator with async state api*
  - *ITCases and harness tests are added to verity this pr*


## Verifying this change

ITCases and harness tests are added to verity this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? Yes
  - If yes, how is the feature documented? A independent doc pr about this feature will be added later.

