### PR TITLE
[FLINK-36269][python] Remove usage about TableEnvironmentInternal#fromTableSource in python module

### DIFF
--- a/docs/content.zh/docs/dev/python/table/table_environment.md
+++ b/docs/content.zh/docs/dev/python/table/table_environment.md
@@ -186,17 +186,6 @@ TableEnvironment API
   <tbody>
     <tr>
       <td>
-        <strong>from_table_source(table_source)</strong>
-      </td>
-      <td>
-        通过 table source 创建一张表。
-      </td>
-      <td class="text-center">
-        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_table_source" name="链接">}}
-      </td>
-    </tr>
-    <tr>
-      <td>
         <strong>scan(*table_path)</strong>
       </td>
       <td>

--- a/docs/content/docs/dev/python/table/table_environment.md
+++ b/docs/content/docs/dev/python/table/table_environment.md
@@ -186,17 +186,6 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
   <tbody>
     <tr>
       <td>
-        <strong>from_table_source(table_source)</strong>
-      </td>
-      <td>
-        Creates a table from a table source. 
-      </td>
-      <td class="text-center">
-        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.from_table_source" name="link">}}
-      </td>
-    </tr>
-    <tr>
-      <td>
         <strong>scan(*table_path)</strong>
       </td>
       <td>

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1335,10 +1335,10 @@ class TableEnvironment(object):
             data_type = data_type.bridgedTo(
                 load_java_class('org.apache.flink.table.data.RowData'))
 
-            j_arrow_table_source = \
-                jvm.org.apache.flink.table.runtime.arrow.ArrowUtils.createArrowTableSource(
+            j_arrow_table_source_descriptor = \
+                jvm.org.apache.flink.table.runtime.arrow.ArrowUtils.createArrowTableSourceDesc(
                     data_type, temp_file.name)
-            return Table(self._j_tenv.fromTableSource(j_arrow_table_source), self)
+            return Table(getattr(self._j_tenv, "from")(j_arrow_table_source_descriptor), self)
         finally:
             os.unlink(temp_file.name)
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ByteArrayUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ByteArrayUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Base64;
+
+/** A utility class for converting byte[][] to String and String to byte[][]. */
+@Internal
+public class ByteArrayUtils {
+
+    /** Convert byte[][] to String. */
+    public static String twoDimByteArrayToString(byte[][] byteArray) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos);
+        oos.writeObject(byteArray);
+        oos.flush();
+        byte[] serializedArray = bos.toByteArray();
+
+        return Base64.getEncoder().encodeToString(serializedArray);
+    }
+
+    /** Convert String to byte[][]. */
+    public static byte[][] stringToTwoDimByteArray(String str)
+            throws IOException, ClassNotFoundException {
+        byte[] bytes = Base64.getDecoder().decode(str);
+
+        ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
+        ObjectInputStream ois = new ObjectInputStream(bis);
+        return (byte[][]) ois.readObject();
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowTableSourceFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowTableSourceFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** Factory for creating configured instances of {@link ArrowTableSource}.. */
+public class ArrowTableSourceFactory implements DynamicTableSourceFactory {
+
+    public static final String IDENTIFIER = "python-arrow-source";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(ArrowTableSourceOptions.DATA);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return new HashSet<>();
+    }
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        ReadableConfig tableOptions = helper.getOptions();
+
+        String data = tableOptions.get(ArrowTableSourceOptions.DATA);
+        DataType dataType = context.getPhysicalRowDataType();
+        return new ArrowTableSource(dataType, data);
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowTableSourceOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowTableSourceOptions.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/** Table options for the {@link ArrowTableSource}. */
+public class ArrowTableSourceOptions {
+
+    public static final ConfigOption<String> DATA =
+            ConfigOptions.key("data")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "This is the data serialized by Arrow with a byte two-dimensional array. "
+                                    + "Note: The byte two-dimensional array is converted into a string using base64.");
+}

--- a/flink-python/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-python/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.table.utils.python.PythonDynamicTableFactory
+org.apache.flink.table.runtime.arrow.sources.ArrowTableSourceFactory


### PR DESCRIPTION
## What is the purpose of the change

Remove apis about `fromTableSource` in python module

## Brief change log

  - *Add a new ArrowTableSource for python*
  - *Remove `fromTableSource` in python module*
  - *Update document in python*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 