### PR TITLE
[FLINK-36283][table-planner] Fix an issue where a UDAF incorrectly accessed the implementation of a built-in function with the same name

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -62,10 +62,6 @@ class AggFunctionFactory(
   /** The entry point to create an aggregate function from the given [[AggregateCall]]. */
   def createAggFunction(call: AggregateCall, index: Int): UserDefinedFunction = {
 
-    object BuiltInAggFunctionName {
-      val PERCENTILE: String = BuiltInFunctionDefinitions.PERCENTILE.getName
-    }
-
     val argTypes: Array[LogicalType] = call.getArgList
       .map(inputRowType.getChildren.get(_))
       .toArray
@@ -170,9 +166,9 @@ class AggFunctionFactory(
         udagg.makeFunction(constants.toArray, argTypes)
 
       case bridge: BridgingSqlAggFunction =>
-        bridge.getName match {
+        bridge.getDefinition match {
           // built-in imperativeFunction
-          case BuiltInAggFunctionName.PERCENTILE =>
+          case BuiltInFunctionDefinitions.PERCENTILE =>
             createPercentileAggFunction(argTypes)
           // DeclarativeAggregateFunction & UDF
           case _ =>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
@@ -190,6 +190,23 @@ object UserDefinedFunctionTestUtils {
 
   }
 
+  class FakePercentile extends AggregateFunction[Double, Tuple1[Double]] {
+    def accumulate(acc: Tuple1[Double], value: Int, percentage: Double): Unit = acc.f0 += value
+
+    override def createAccumulator: Tuple1[Double] = Tuple1.of(0d)
+
+    override def getValue(acc: Tuple1[Double]): Double = acc.f0
+
+    override def getTypeInference(typeFactory: DataTypeFactory): TypeInference = {
+      TypeInference.newBuilder
+        .typedArguments(DataTypes.INT(), DataTypes.DOUBLE())
+        .accumulatorTypeStrategy(TypeStrategies.explicit(
+          DataTypes.STRUCTURED(classOf[Tuple1[Double]], DataTypes.FIELD("f0", DataTypes.DOUBLE()))))
+        .outputTypeStrategy(TypeStrategies.explicit(DataTypes.DOUBLE()))
+        .build
+    }
+  }
+
   // ------------------------------------------------------------------------------------
   // ScalarFunctions
   // ------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Fix an issue where a UDAF incorrectly accessed the implementation of a built-in function with the same name.

## Brief change log

[FLINK-36283](https://issues.apache.org/jira/browse/FLINK-36283)

UDAFs may have function names that are the same as built-in agg functions. Considering the resolving priority, we can't rely solely on names to match functions; instead, we should use something unique, like their definitions.

## Verifying this change

`sql/AggregateITCase#testAggFunctionPriority()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? 
