### PR TITLE
 [FLINK-36240][runtime/metrics] Fix incorrect Ports display in the PrometheusReporter constructor in case of the httpServer creation failure

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/PortRange.java
+++ b/flink-core/src/main/java/org/apache/flink/util/PortRange.java
@@ -16,10 +16,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.util;
+package org.apache.flink.util;
 
 import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.util.NetUtils;
 
 import java.util.Iterator;
 

--- a/flink-core/src/test/java/org/apache/flink/util/PortRangeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/PortRangeTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.util;
+package org.apache.flink.util;
 
 import org.apache.flink.configuration.IllegalConfigurationException;
 

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporter.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.util.PortRange;
 import org.apache.flink.util.Preconditions;
 
 import io.prometheus.client.exporter.HTTPServer;
@@ -43,9 +44,10 @@ public class PrometheusReporter extends AbstractPrometheusReporter {
         return port;
     }
 
-    PrometheusReporter(Iterator<Integer> ports) {
-        while (ports.hasNext()) {
-            port = ports.next();
+    PrometheusReporter(PortRange portRange) {
+        Iterator<Integer> portsIterator = portRange.getPortsIterator();
+        while (portsIterator.hasNext()) {
+            port = portsIterator.next();
             try {
                 httpServer = new HTTPServer(new InetSocketAddress(port), this.registry);
                 log.info("Started PrometheusReporter HTTP server on port {}.", port);
@@ -58,7 +60,7 @@ public class PrometheusReporter extends AbstractPrometheusReporter {
         if (httpServer == null) {
             throw new RuntimeException(
                     "Could not start PrometheusReporter HTTP server on any configured port. Ports: "
-                            + ports);
+                            + portRange);
         }
     }
 

--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/PrometheusReporterFactory.java
@@ -19,9 +19,8 @@ package org.apache.flink.metrics.prometheus;
 
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
-import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.PortRange;
 
-import java.util.Iterator;
 import java.util.Properties;
 
 /** {@link MetricReporterFactory} for {@link PrometheusReporter}. */
@@ -34,8 +33,8 @@ public class PrometheusReporterFactory implements MetricReporterFactory {
     public PrometheusReporter createMetricReporter(Properties properties) {
         MetricConfig metricConfig = (MetricConfig) properties;
         String portsConfig = metricConfig.getString(ARG_PORT, DEFAULT_PORT);
-        Iterator<Integer> ports = NetUtils.getPortRangeFromString(portsConfig);
+        PortRange portRange = new PortRange(portsConfig);
 
-        return new PrometheusReporter(ports);
+        return new PrometheusReporter(portRange);
     }
 }

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTaskScopeTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.metrics.util.TestHistogram;
 import org.apache.flink.metrics.util.TestMeter;
-import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.PortRange;
 
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.junit.jupiter.api.AfterEach;
@@ -59,7 +59,7 @@ class PrometheusReporterTaskScopeTest {
 
     @BeforeEach
     void setupReporter() {
-        reporter = new PrometheusReporter(NetUtils.getPortRangeFromString("9400-9500"));
+        reporter = new PrometheusReporter(new PortRange("9400-9500"));
     }
 
     @AfterEach

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.net.SSLUtils;
-import org.apache.flink.runtime.util.PortRange;
+import org.apache.flink.util.PortRange;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.io.network.partition.BoundedBlockingSubpartition
 import org.apache.flink.runtime.io.network.partition.hybrid.tiered.common.TieredStorageConfiguration;
 import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
-import org.apache.flink.runtime.util.PortRange;
+import org.apache.flink.util.PortRange;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerFromPortRangeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerFromPortRangeTest.java
@@ -19,8 +19,8 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.util.PortRange;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.PortRange;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## What is the purpose of the change
* Fixes incorrect Ports display in the PrometheusReporter constructor in case of the httpServer creation failure. Instead of printing the port numbers, the error message currently displays an Iterator object reference, which is not useful for debugging.

## Brief change log
* Moved the `PortsRange` from the runtime module to the core module
* Use `PortsRange` utility class from the core module instead of the `iterator`. This ensures that the actual ports are printed in the exception message instead of the Iterator reference.
* Update the tests to rely one on the `PortsRange` as the `PrometheusReposter` only constructor parameter instead of the Iterator

## Verifying this change
 - Extends the existing cannotStartTwoReportersOnSamePort test by checking the exception message thrown to verify that the log message contains the actual ports and not the object reference.
- Examples 
   - before: `Could not start PrometheusReporter HTTP server on any configured port. Ports: org.apache.flink.util.UnionIterator@67065fd3` 
   - after: `Could not start PrometheusReporter HTTP server on any configured port. Ports: [9000, 9001, 9002, ...]` 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

### TBD
I have also considered changing the constructor parameter from `Iterable<Integer>` to `List<Integer>`, as it would provide a more straightforward way to manage the port numbers. This change would require minor adjustments in the codebase, namely modifying the `PrometheusReporterFactory` and some test cases, which currently use `Iterable<Integer>` and would need conversion to `List<Integer>`. I’d like to discuss if this change is worthwhile, as it could improve code clarity but requires slightly more effort.

Alternatively, converting the `Iterable<Integer>` to a `List<Integer>` at the beginning of the constructor, and then attempting to create the HTTP server using this list, could also be a solution. In my opinion, this would make the code a bit cleaner and easier to read. However, it would require iterating over the ports twice: once when converting the `Iterable` to a list, and again during the actual HTTP server initialization. While this extra iteration may have a small impact on performance, I don't think it would be significant enough to cause issues.

**Questions for Discussion**:
- Is it worth refactoring the constructor to use `List<Integer>` instead of `Iterable<Integer>`, considering the minor adjustments required across the codebase?
- Would the conversion from `Iterable` to `List` in the constructor be a good trade-off for improved readability, even if it introduces a second iteration?
- Does the current implementation fit well as-is, or could these refinements be valuable improvements?