### PR TITLE
[FLINK-36146][connector] Fix SingleThreadFetcherManager race condition

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -100,6 +101,7 @@ public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
     }
 
     protected SplitFetcher<E, SplitT> getRunningFetcher() {
-        return fetchers.isEmpty() ? null : fetchers.values().iterator().next();
+        Iterator<SplitFetcher<E, SplitT>> iter = fetchers.values().iterator();
+        return iter.hasNext() ? iter.next() : null;
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.core.testutils.OneShotLatch;
 
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -43,6 +44,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.test.util.TestUtils.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -193,6 +195,53 @@ class SplitFetcherManagerTest {
         } finally {
             fetcherManager.close(30_000);
         }
+    }
+
+    @RepeatedTest(100)
+    public void testAddSplitAfterCloseFetcher() throws Exception {
+        // This testcase reproduces https://issues.apache.org/jira/browse/FLINK-36146.
+        // One thread adds splits to a fetcher manager, while another thread closes the manager
+        // after a short delay. This fails ~50% of the time before the bug fix.
+        final SingleThreadFetcherManager<Object, TestingSourceSplit> fetcherManager =
+                new SingleThreadFetcherManager<>(TestingSplitReader::new, new Configuration());
+
+        // Add splits in a tight loop, and memoize any exception
+        AtomicReference<Exception> addSplitsException = new AtomicReference<>();
+        Thread adder =
+                new Thread(
+                        () -> {
+                            while (true) {
+                                try {
+                                    fetcherManager.addSplits(
+                                            Collections.singletonList(new TestingSourceSplit("x")));
+                                } catch (Exception e) {
+                                    addSplitsException.set(e);
+                                    break;
+                                }
+                            }
+                        });
+
+        // Close the fetcher manager after a short delay
+        Thread closer =
+                new Thread(
+                        () -> {
+                            try {
+                                Thread.sleep(50);
+                                fetcherManager.close(1000);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+        // Start the threads, adder first
+        adder.start();
+        closer.start();
+
+        // Block until adder thread finalizes
+        adder.join(2000);
+
+        // On close, addSplits should always exit with IllegalStateException.
+        assertThat(addSplitsException.get()).isInstanceOf(IllegalStateException.class);
     }
 
     // the final modifier is important so that '@SafeVarargs' is accepted on Java 8


### PR DESCRIPTION
This issue triggered when running a highly parallel batch job with FileSource pointed at a large S3 bucket. The visible symptom was:

    java.util.NoSuchElementException
        at java.base/java.util.concurrent.ConcurrentHashMap$ValueIterator.next(ConcurrentHashMap.java:3471)
        at org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager.getRunningFetcher(SingleThreadFetcherManager.java:94)
        at org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager.addSplits(SingleThreadFetcherManager.java:82)
        at org.apache.flink.connector.base.source.reader.SourceReaderBase.addSplits(SourceReaderBase.java:242)
        at org.apache.flink.streaming.api.operators.SourceOperator.handleOperatorEvent(SourceOperator.java:428)
        ...

While the exact sequence of events is unclear, there's an obvious time-of-check/time-of-use bug in getRunningFetcher where fetchers may be cleared between the time it's checked for empty and the time we try to take the first element.

Use an Iterator, which provides a consistent view of the data even if the underlying collection changes.

## What is the purpose of the change

There is a tiny race condition in `SingleThreadFetcherManager` that can cause `java.util.NoSuchElementException` on reader close. This patch fixes the race condition.


## Brief change log

Use the consistent view provided by `ConcurrentHashMap`'s `ValuesView` and its iterator.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

(Caveat: it would be possible to verify this using a multithreaded stress test, but they usually require some time to run to be useful. I did run a reduced testcase for `ConcurrentHashMap` to see that the fix behaves better than the original code.)

## Does this pull request potentially affect one of the following parts:

  - The S3 file system connector: actually, yes! But not in a way that should be noticeable except for better stability.

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
