### PR TITLE
[FLINK-36279][runtime] Making desired resources being calculated based on all available slots for the job

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1078,9 +1078,7 @@ public class AdaptiveScheduler
 
     @Override
     public boolean hasDesiredResources() {
-        final Collection<? extends SlotInfo> freeSlots =
-                declarativeSlotPool.getFreeSlotTracker().getFreeSlotsInformation();
-        return hasDesiredResources(desiredResources, freeSlots);
+        return hasDesiredResources(desiredResources, declarativeSlotPool.getAllSlotsInformation());
     }
 
     @VisibleForTesting

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/RescaleOnCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/RescaleOnCheckpointITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -40,6 +41,8 @@ import org.apache.flink.util.TestLoggerExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Iterator;
@@ -50,6 +53,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(TestLoggerExtension.class)
 class RescaleOnCheckpointITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RescaleOnCheckpointITCase.class);
 
     // Scaling down is used here because scaling up is not supported by the NumberSequenceSource
     // that's used in this test.
@@ -111,34 +116,59 @@ class RescaleOnCheckpointITCase {
         assertThat(jobVertexIterator.hasNext())
                 .as("There needs to be at least one JobVertex.")
                 .isTrue();
+        final JobVertexID jobVertexId = jobVertexIterator.next().getID();
         final JobResourceRequirements jobResourceRequirements =
                 JobResourceRequirements.newBuilder()
-                        .setParallelismForJobVertex(
-                                jobVertexIterator.next().getID(), 1, AFTER_RESCALE_PARALLELISM)
+                        .setParallelismForJobVertex(jobVertexId, 1, AFTER_RESCALE_PARALLELISM)
                         .build();
         assertThat(jobVertexIterator.hasNext())
                 .as("This test expects to have only one JobVertex.")
                 .isFalse();
 
         restClusterClient.submitJob(jobGraph).join();
-        try {
-            final JobID jobId = jobGraph.getJobID();
 
+        final JobID jobId = jobGraph.getJobID();
+        try {
+
+            LOG.info(
+                    "Waiting for job {} to reach parallelism of {} for vertex {}.",
+                    jobId,
+                    BEFORE_RESCALE_PARALLELISM,
+                    jobVertexId);
             waitForRunningTasks(restClusterClient, jobId, BEFORE_RESCALE_PARALLELISM);
 
+            LOG.info(
+                    "Job {} reached parallelism of {} for vertex {}. Updating the vertex parallelism next to {}.",
+                    jobId,
+                    BEFORE_RESCALE_PARALLELISM,
+                    jobVertexId,
+                    AFTER_RESCALE_PARALLELISM);
             restClusterClient.updateJobResourceRequirements(jobId, jobResourceRequirements).join();
 
             // timeout to allow any unexpected rescaling to happen anyway
             Thread.sleep(REQUIREMENT_UPDATE_TO_CHECKPOINT_GAP.toMillis());
 
             // verify that the previous timeout didn't result in a change of parallelism
+            LOG.info(
+                    "Checking that job {} hasn't changed its parallelism even after some delay, yet.",
+                    jobId);
             waitForRunningTasks(restClusterClient, jobId, BEFORE_RESCALE_PARALLELISM);
 
             miniCluster.triggerCheckpoint(jobId);
 
+            LOG.info(
+                    "Waiting for job {} to reach parallelism of {} for vertex {}.",
+                    jobId,
+                    AFTER_RESCALE_PARALLELISM,
+                    jobVertexId);
             waitForRunningTasks(restClusterClient, jobId, AFTER_RESCALE_PARALLELISM);
 
-            waitForAvailableSlots(restClusterClient, NUMBER_OF_SLOTS - AFTER_RESCALE_PARALLELISM);
+            final int expectedFreeSlotCount = NUMBER_OF_SLOTS - AFTER_RESCALE_PARALLELISM;
+            LOG.info(
+                    "Waiting for {} slot(s) to become available due to the scale down.",
+                    expectedFreeSlotCount);
+            waitForAvailableSlots(restClusterClient, expectedFreeSlotCount);
+            LOG.info("{} free slot(s) detected. Finishing test.", expectedFreeSlotCount);
         } finally {
             restClusterClient.cancel(jobGraph.getJobID()).join();
         }

--- a/flink-tests/src/test/resources/log4j2-test.properties
+++ b/flink-tests/src/test/resources/log4j2-test.properties
@@ -28,7 +28,7 @@ appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR
 appender.testlogger.layout.type = PatternLayout
-appender.testlogger.layout.pattern = [%-32X{flink-job-id}] %c{0} [%t] %-5p %m%n
+appender.testlogger.layout.pattern =  %-4r [%-32X{flink-job-id}] %c{0} [%t] %-5p %m%n
 
 logger.migration.name = org.apache.flink.test.migration
 logger.migration.level = INFO


### PR DESCRIPTION
## What is the purpose of the change

FLINK-36014 aligned the triggering of the execution graph creation in `WaitingForResources` and rescaling in `Executing` state. Before that change, only `WaitingForResources` relied on this method. Relying on free slots was good enough because in `WaitingForResources` state, there are no slots allocated, yet.
    
Using this method for `Executing` state now as well changes this premise because there are slots allocated while checking the slot availability that would become available after the restart. Hence, considering these slots in the slot availability check is good enough. This will not break the premise for the `WaitingForResources` state.

## Brief change log

* Make the `AdaptiveScheduler#hasDesiredResources` check rely on all available slots rather than only the free slots to support this metric even in `Executing` state

## Verifying this change

* `RescaleOnCheckpointITCase` succeeds again

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable