### PR TITLE
[hotfix][doc] Fix the wrong link of materialized table

### DIFF
--- a/docs/content.zh/docs/dev/table/materialized-table/quickstart.md
+++ b/docs/content.zh/docs/dev/table/materialized-table/quickstart.md
@@ -76,7 +76,7 @@ mkdir -p {savepoints_path}
 tar -xzf flink-*.tgz
 ```
 
-[下载](https://https://repo.maven.apache.org/maven2/org/apache/flink/flink-table-filesystem-test-utils/) test-filesystem 连接器， 并将其放入 lib 目录：
+[下载](https://repo.maven.apache.org/maven2/org/apache/flink/flink-table-filesystem-test-utils/) test-filesystem 连接器， 并将其放入 lib 目录：
 
 ```
 cp flink-table-filesystem-test-utils-{VERSION}.jar flink-*/lib/

--- a/docs/content/docs/dev/table/materialized-table/quickstart.md
+++ b/docs/content/docs/dev/table/materialized-table/quickstart.md
@@ -75,7 +75,7 @@ The method here is similar to the steps recorded in [local installation]({{< ref
 tar -xzf flink-*.tgz
 ```
 
-[Download](https://https://repo.maven.apache.org/maven2/org/apache/flink/flink-table-filesystem-test-utils/) the test-filesystem connector and place it in the lib directory:
+[Download](https://repo.maven.apache.org/maven2/org/apache/flink/flink-table-filesystem-test-utils/) the test-filesystem connector and place it in the lib directory:
 
 ```
 cp flink-table-filesystem-test-utils-{VERSION}.jar flink-*/lib/


### PR DESCRIPTION
## What is the purpose of the change

The link has 2 `https://` prefixes.


## Brief change log

[hotfix][doc] Fix the wrong link of materialized table
