### PR TITLE
[FLINK-34125][serializer] Remove deprecated TypeInformation#createSerializer(ExecutionConfig) method

### DIFF
--- a/flink-connectors/flink-connector-datagen/src/main/java/org/apache/flink/connector/datagen/functions/IndexLookupGeneratorFunction.java
+++ b/flink-connectors/flink-connector-datagen/src/main/java/org/apache/flink/connector/datagen/functions/IndexLookupGeneratorFunction.java
@@ -79,7 +79,7 @@ public class IndexLookupGeneratorFunction<OUT> implements GeneratorFunction<Long
             TypeInformation<OUT> typeInfo, ExecutionConfig config, Iterable<OUT> elements) {
         // must not have null elements and mixed elements
         checkIterable(elements, typeInfo.getTypeClass());
-        this.serializer = typeInfo.createSerializer(config);
+        this.serializer = typeInfo.createSerializer(config.getSerializerConfig());
         trySerialize(elements);
     }
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestTypeInfo.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.file.sink.compactor.operator;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -80,11 +79,6 @@ public class CompactorRequestTypeInfo extends TypeInformation<CompactorRequest> 
     public TypeSerializer<CompactorRequest> createSerializer(SerializerConfig config) {
         return new SimpleVersionedSerializerTypeSerializerProxy<>(
                 () -> new CompactorRequestSerializer(createCommittableSerializer()));
-    }
-
-    @Override
-    public TypeSerializer<CompactorRequest> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/typeutils/WritableTypeInfo.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/typeutils/WritableTypeInfo.java
@@ -114,14 +114,7 @@ public class WritableTypeInfo<T extends Writable> extends TypeInformation<T>
     @Override
     @PublicEvolving
     public TypeSerializer<T> createSerializer(SerializerConfig serializerConfig) {
-        return new WritableSerializer<T>(typeClass);
-    }
-
-    @Override
-    @Deprecated
-    @PublicEvolving
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
+        return new WritableSerializer<>(typeClass);
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -146,7 +146,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
     @Internal
     public ExecutionConfig(Configuration configuration) {
         this.configuration = configuration;
-        this.serializerConfig = new SerializerConfigImpl(configuration, this);
+        this.serializerConfig = new SerializerConfigImpl(configuration);
     }
 
     /**

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfigImpl.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializerConfigImpl.java
@@ -49,13 +49,6 @@ public final class SerializerConfigImpl implements SerializerConfig {
 
     private final Configuration configuration;
 
-    /**
-     * Note: This field is used only for compatibility while {@link
-     * org.apache.flink.api.common.typeinfo.TypeInformation#createSerializer(ExecutionConfig)} is
-     * deprecated; If it is removed, this field will also be removed.
-     */
-    private final ExecutionConfig executionConfig;
-
     // ------------------------------- User code values --------------------------------------------
 
     // Serializers and types registered with Kryo and the PojoSerializer
@@ -88,13 +81,11 @@ public final class SerializerConfigImpl implements SerializerConfig {
     public SerializerConfigImpl() {
         Configuration conf = new Configuration();
         this.configuration = conf;
-        this.executionConfig = new ExecutionConfig(conf);
     }
 
     @Internal
-    public SerializerConfigImpl(Configuration configuration, ExecutionConfig executionConfig) {
+    public SerializerConfigImpl(Configuration configuration) {
         this.configuration = configuration;
-        this.executionConfig = executionConfig;
     }
 
     /**
@@ -557,15 +548,6 @@ public final class SerializerConfigImpl implements SerializerConfig {
                     "A TypeInfoFactory for type '" + t + "' is already registered.");
         }
         registeredTypeInfoFactories.put(t, factory);
-    }
-
-    /**
-     * Note: This method is used only for compatibility while {@link
-     * org.apache.flink.api.common.typeinfo.TypeInformation#createSerializer(ExecutionConfig)} is
-     * deprecated; If it is removed, this method will also be removed.
-     */
-    public ExecutionConfig getExecutionConfig() {
-        return executionConfig;
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicArrayTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicArrayTypeInfo.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.common.typeinfo;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -135,13 +134,6 @@ public final class BasicArrayTypeInfo<T, C> extends TypeInformation<T> {
                             this.componentInfo.getTypeClass(),
                             this.componentInfo.createSerializer(serializerConfig));
         }
-    }
-
-    @Override
-    @Deprecated
-    @PublicEvolving
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/BasicTypeInfo.java
@@ -242,13 +242,6 @@ public class BasicTypeInfo<T> extends TypeInformation<T> implements AtomicType<T
     }
 
     @Override
-    @Deprecated
-    @PublicEvolving
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
-    @Override
     @PublicEvolving
     public TypeComparator<T> createComparator(
             boolean sortOrderAscending, ExecutionConfig executionConfig) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/LocalTimeTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/LocalTimeTypeInfo.java
@@ -113,11 +113,6 @@ public class LocalTimeTypeInfo<T extends Temporal> extends TypeInformation<T>
     }
 
     @Override
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
-    @Override
     public TypeComparator<T> createComparator(
             boolean sortOrderAscending, ExecutionConfig executionConfig) {
         return instantiateComparator(comparatorClass, sortOrderAscending);

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NothingTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/NothingTypeInfo.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.common.typeinfo;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.types.Nothing;
@@ -71,12 +70,6 @@ public class NothingTypeInfo extends TypeInformation<Nothing> {
     @PublicEvolving
     public TypeSerializer<Nothing> createSerializer(SerializerConfig serializerConfig) {
         throw new RuntimeException("The Nothing type cannot have a serializer.");
-    }
-
-    @Override
-    @Deprecated
-    public TypeSerializer<Nothing> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/PrimitiveArrayTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/PrimitiveArrayTypeInfo.java
@@ -176,12 +176,6 @@ public class PrimitiveArrayTypeInfo<T> extends TypeInformation<T> implements Ato
         return this.serializer;
     }
 
-    @Override
-    @PublicEvolving
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
     /**
      * Gets the class that represents the component type.
      *

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/SqlTimeTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/SqlTimeTypeInfo.java
@@ -113,11 +113,6 @@ public class SqlTimeTypeInfo<T> extends TypeInformation<T> implements AtomicType
     }
 
     @Override
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
-    @Override
     public TypeComparator<T> createComparator(
             boolean sortOrderAscending, ExecutionConfig executionConfig) {
         return instantiateComparator(comparatorClass, sortOrderAscending);

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeinfo/TypeInformation.java
@@ -20,10 +20,8 @@ package org.apache.flink.api.common.typeinfo;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.serialization.SerializerConfig;
-import org.apache.flink.api.common.serialization.SerializerConfigImpl;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
@@ -176,29 +174,7 @@ public abstract class TypeInformation<T> implements Serializable {
      * @return A serializer for this type.
      */
     @PublicEvolving
-    public TypeSerializer<T> createSerializer(SerializerConfig config) {
-        if (config != null) {
-            ExecutionConfig executionConfig = ((SerializerConfigImpl) config).getExecutionConfig();
-            return createSerializer(executionConfig);
-        } else {
-            return createSerializer((ExecutionConfig) null);
-        }
-    }
-
-    /**
-     * Create {@link TypeSerializer} for this type.
-     *
-     * @param config the configuration of this job execution
-     * @deprecated This method is deprecated since Flink 1.19 and will be removed in Flink 1.20. The
-     *     users are recommended to implement {@link #createSerializer(SerializerConfig config)}. If
-     *     you implement {@link #createSerializer(SerializerConfig)}, this method will never be
-     *     invoked. If you don't implement {@link #createSerializer(SerializerConfig)}, this method
-     *     will be invoked in the default implementation of {@link
-     *     #createSerializer(SerializerConfig)}.
-     */
-    @PublicEvolving
-    @Deprecated
-    public abstract TypeSerializer<T> createSerializer(ExecutionConfig config);
+    public abstract TypeSerializer<T> createSerializer(SerializerConfig config);
 
     @Override
     public abstract String toString();

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EitherTypeInfo.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.java.typeutils;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -102,15 +101,8 @@ public class EitherTypeInfo<L, R> extends TypeInformation<Either<L, R>> {
     @Override
     @PublicEvolving
     public TypeSerializer<Either<L, R>> createSerializer(SerializerConfig config) {
-        return new EitherSerializer<L, R>(
+        return new EitherSerializer<>(
                 leftType.createSerializer(config), rightType.createSerializer(config));
-    }
-
-    @Override
-    @Deprecated
-    @PublicEvolving
-    public TypeSerializer<Either<L, R>> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EnumTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/EnumTypeInfo.java
@@ -104,13 +104,6 @@ public class EnumTypeInfo<T extends Enum<T>> extends TypeInformation<T> implemen
         return new EnumSerializer<T>(typeClass);
     }
 
-    @Override
-    @Deprecated
-    @PublicEvolving
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
     // ------------------------------------------------------------------------
     //  Standard utils
     // ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/GenericTypeInfo.java
@@ -92,13 +92,6 @@ public class GenericTypeInfo<T> extends TypeInformation<T> implements AtomicType
         return new KryoSerializer<T>(this.typeClass, config);
     }
 
-    @Override
-    @Deprecated
-    @PublicEvolving
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     @PublicEvolving

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ListTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ListTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.api.java.typeutils;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -99,11 +98,6 @@ public final class ListTypeInfo<T> extends TypeInformation<List<T>> {
     public TypeSerializer<List<T>> createSerializer(SerializerConfig config) {
         TypeSerializer<T> elementTypeSerializer = elementTypeInfo.createSerializer(config);
         return new ListSerializer<>(elementTypeSerializer);
-    }
-
-    @Override
-    public TypeSerializer<List<T>> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/MapTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/MapTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.api.java.typeutils;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -114,11 +113,6 @@ public class MapTypeInfo<K, V> extends TypeInformation<Map<K, V>> {
         TypeSerializer<V> valueTypeSerializer = valueTypeInfo.createSerializer(config);
 
         return new MapSerializer<>(keyTypeSerializer, valueTypeSerializer);
-    }
-
-    @Override
-    public TypeSerializer<Map<K, V>> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/MissingTypeInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -91,11 +90,6 @@ public class MissingTypeInfo extends TypeInformation<InvalidTypesException> {
             SerializerConfig serializerConfig) {
         throw new UnsupportedOperationException(
                 "The missing type information cannot be used as a type information.");
-    }
-
-    @Override
-    public TypeSerializer<InvalidTypesException> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ObjectArrayTypeInfo.java
@@ -20,7 +20,6 @@ package org.apache.flink.api.java.typeutils;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -96,13 +95,6 @@ public class ObjectArrayTypeInfo<T, C> extends TypeInformation<T> {
                 new GenericArraySerializer<C>(
                         componentInfo.getTypeClass(),
                         componentInfo.createSerializer(serializerConfig));
-    }
-
-    @Override
-    @Deprecated
-    @PublicEvolving
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/PojoTypeInfo.java
@@ -360,27 +360,6 @@ public class PojoTypeInfo<T> extends CompositeType<T> {
     }
 
     @Override
-    @PublicEvolving
-    @Deprecated
-    @SuppressWarnings("unchecked")
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        if (config.isForceKryoEnabled()) {
-            return new KryoSerializer<>(getTypeClass(), config.getSerializerConfig());
-        }
-
-        if (config.isForceAvroEnabled()) {
-            return AvroUtils.getAvroUtils().createAvroSerializer(getTypeClass());
-        }
-
-        return createPojoSerializer(config);
-    }
-
-    @Deprecated
-    public PojoSerializer<T> createPojoSerializer(ExecutionConfig config) {
-        return createPojoSerializer(config.getSerializerConfig());
-    }
-
-    @Override
     public boolean equals(Object obj) {
         if (obj instanceof PojoTypeInfo) {
             @SuppressWarnings("unchecked")

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/RowTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/RowTypeInfo.java
@@ -263,11 +263,6 @@ public class RowTypeInfo extends TupleTypeInfoBase<Row> {
     }
 
     @Override
-    public TypeSerializer<Row> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
-    @Override
     public boolean canEqual(Object obj) {
         return obj instanceof RowTypeInfo;
     }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TupleTypeInfo.java
@@ -112,13 +112,6 @@ public final class TupleTypeInfo<T extends Tuple> extends TupleTypeInfoBase<T> {
     }
 
     @Override
-    @Deprecated
-    @PublicEvolving
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
-    @Override
     protected TypeComparatorBuilder<T> createTypeComparatorBuilder() {
         return new TupleTypeComparatorBuilder();
     }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ValueTypeInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/ValueTypeInfo.java
@@ -192,12 +192,6 @@ public class ValueTypeInfo<T extends Value> extends TypeInformation<T> implement
         }
     }
 
-    @Override
-    @Deprecated
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     @PublicEvolving

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -177,10 +177,6 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
 
     // ------------------------------------------------------------------------
 
-    public KryoSerializer(Class<T> type, ExecutionConfig executionConfig) {
-        this(type, executionConfig.getSerializerConfig());
-    }
-
     public KryoSerializer(Class<T> type, SerializerConfig serializerConfig) {
         this.type = checkNotNull(type);
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeInformationTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeInformationTestBase.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.common.typeutils;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.util.InstantiationUtil;
@@ -151,11 +150,6 @@ public abstract class TypeInformationTestBase<T extends TypeInformation<?>> {
         @Override
         public TypeSerializer<Object> createSerializer(SerializerConfig config) {
             return null;
-        }
-
-        @Override
-        public TypeSerializer<Object> createSerializer(ExecutionConfig config) {
-            return createSerializer(config.getSerializerConfig());
         }
 
         @Override

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TupleTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TupleTypeInfoTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
@@ -53,11 +52,6 @@ class TupleTypeInfoTest extends TypeInformationTestBase<TupleTypeInfo<?>> {
                     @Override
                     public TypeSerializer<Tuple1> createSerializer(SerializerConfig config) {
                         return null;
-                    }
-
-                    @Override
-                    public TypeSerializer<Tuple1> createSerializer(ExecutionConfig config) {
-                        return createSerializer(config.getSerializerConfig());
                     }
 
                     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeExtractorTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.functions.JoinFunction;
 import org.apache.flink.api.common.functions.MapFunction;
@@ -2391,11 +2390,6 @@ public class TypeExtractorTest {
                     @Override
                     public TypeSerializer<Object> createSerializer(SerializerConfig config) {
                         return null;
-                    }
-
-                    @Override
-                    public TypeSerializer<Object> createSerializer(ExecutionConfig config) {
-                        return createSerializer(config.getSerializerConfig());
                     }
 
                     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeInfoFactoryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/TypeInfoFactoryTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.typeutils;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.serialization.SerializerConfig;
@@ -272,11 +271,6 @@ public class TypeInfoFactoryTest {
         }
 
         @Override
-        public TypeSerializer<MyFaulty> createSerializer(ExecutionConfig config) {
-            return createSerializer(config.getSerializerConfig());
-        }
-
-        @Override
         public String toString() {
             return null;
         }
@@ -376,11 +370,6 @@ public class TypeInfoFactoryTest {
         }
 
         @Override
-        public TypeSerializer<MyTuple<T0, T1>> createSerializer(ExecutionConfig config) {
-            return createSerializer(config.getSerializerConfig());
-        }
-
-        @Override
         public String toString() {
             return null;
         }
@@ -476,11 +465,6 @@ public class TypeInfoFactoryTest {
         @Override
         public TypeSerializer<MyOption<T>> createSerializer(SerializerConfig config) {
             return null;
-        }
-
-        @Override
-        public TypeSerializer<MyOption<T>> createSerializer(ExecutionConfig config) {
-            return createSerializer(config.getSerializerConfig());
         }
 
         @Override

--- a/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SingleThreadAccessCheckingTypeInfo.java
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/src/main/java/org/apache/flink/streaming/tests/SingleThreadAccessCheckingTypeInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.tests;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.SingleThreadAccessCheckingTypeSerializer;
@@ -72,11 +71,6 @@ public class SingleThreadAccessCheckingTypeInfo<T> extends TypeInformation<T> {
     public TypeSerializer<T> createSerializer(SerializerConfig config) {
         return new SingleThreadAccessCheckingTypeSerializer<>(
                 originalTypeInformation.createSerializer(config));
-    }
-
-    @Override
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroTypeInfo.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.formats.avro.typeutils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -59,11 +58,6 @@ public class AvroTypeInfo<T extends SpecificRecordBase> extends PojoTypeInfo<T> 
     @Override
     public TypeSerializer<T> createSerializer(SerializerConfig config) {
         return new AvroSerializer<>(getTypeClass());
-    }
-
-    @Override
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Internal

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/GenericRecordAvroTypeInfo.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/GenericRecordAvroTypeInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.formats.avro.typeutils;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -78,11 +77,6 @@ public class GenericRecordAvroTypeInfo extends TypeInformation<GenericRecord> {
     @Override
     public TypeSerializer<GenericRecord> createSerializer(SerializerConfig config) {
         return new AvroSerializer<>(GenericRecord.class, schema);
-    }
-
-    @Override
-    public TypeSerializer<GenericRecord> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroKryoSerializerRegistrationsTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroKryoSerializerRegistrationsTest.java
@@ -91,7 +91,9 @@ class AvroKryoSerializerRegistrationsTest {
     void testEnableForceKryoAvroRegister() {
         ExecutionConfig executionConfig = new ExecutionConfig();
         executionConfig.getSerializerConfig().setForceKryoAvro(true);
-        final Kryo kryo = new KryoSerializer<>(Integer.class, executionConfig).getKryo();
+        final Kryo kryo =
+                new KryoSerializer<>(Integer.class, executionConfig.getSerializerConfig())
+                        .getKryo();
         kryo.setRegistrationRequired(true);
         assertThatCode(() -> kryo.getRegistration(GenericData.Array.class))
                 .doesNotThrowAnyException();
@@ -100,7 +102,9 @@ class AvroKryoSerializerRegistrationsTest {
     @Test
     void testDefaultForceKryoAvroRegister() {
         ExecutionConfig executionConfig = new ExecutionConfig();
-        final Kryo kryo = new KryoSerializer<>(Integer.class, executionConfig).getKryo();
+        final Kryo kryo =
+                new KryoSerializer<>(Integer.class, executionConfig.getSerializerConfig())
+                        .getKryo();
         kryo.setRegistrationRequired(true);
         assertThatCode(() -> kryo.getRegistration(GenericData.Array.class))
                 .doesNotThrowAnyException();
@@ -111,7 +115,9 @@ class AvroKryoSerializerRegistrationsTest {
         Configuration configuration = new Configuration();
         configuration.set(PipelineOptions.FORCE_KRYO_AVRO, false);
         ExecutionConfig executionConfig = new ExecutionConfig(configuration);
-        final Kryo kryo = new KryoSerializer<>(Integer.class, executionConfig).getKryo();
+        final Kryo kryo =
+                new KryoSerializer<>(Integer.class, executionConfig.getSerializerConfig())
+                        .getKryo();
         kryo.setRegistrationRequired(true);
         assertThatThrownBy(() -> kryo.getRegistration(GenericData.Array.class))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/flink-python/pyflink/datastream/connectors/tests/test_cassandra.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_cassandra.py
@@ -22,6 +22,7 @@ from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase
 
 class CassandraSinkTest(PyFlinkStreamingTestCase):
 
+    @unittest.skip("Disable due to cassandra connectors is not support 2.0 for new.")
     def test_cassandra_sink(self):
         type_info = Types.ROW([Types.STRING(), Types.INT()])
         ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)],

--- a/flink-python/pyflink/datastream/connectors/tests/test_cassandra.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_cassandra.py
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import unittest
+
 from pyflink.common import Types
 from pyflink.datastream.connectors.cassandra import CassandraSink, MapperOptions, ConsistencyLevel
 from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/typeinfo/python/PickledByteArrayTypeInfo.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/typeinfo/python/PickledByteArrayTypeInfo.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.api.typeinfo.python;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -71,11 +70,6 @@ public class PickledByteArrayTypeInfo extends TypeInformation<byte[]> {
     @Override
     public TypeSerializer<byte[]> createSerializer(SerializerConfig config) {
         return BytePrimitiveArraySerializer.INSTANCE;
-    }
-
-    @Override
-    public TypeSerializer<byte[]> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/VoidNamespaceTypeInfo.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/client/VoidNamespaceTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.queryablestate.client;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -69,11 +68,6 @@ public class VoidNamespaceTypeInfo extends TypeInformation<VoidNamespace> {
     @Override
     public TypeSerializer<VoidNamespace> createSerializer(SerializerConfig config) {
         return VoidNamespaceSerializer.INSTANCE;
-    }
-
-    @Override
-    public TypeSerializer<VoidNamespace> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespaceTypeInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/VoidNamespaceTypeInfo.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.state;
 
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -73,13 +72,6 @@ public class VoidNamespaceTypeInfo extends TypeInformation<VoidNamespace> {
     @PublicEvolving
     public TypeSerializer<VoidNamespace> createSerializer(SerializerConfig config) {
         return VoidNamespaceSerializer.INSTANCE;
-    }
-
-    @Override
-    @Deprecated
-    @PublicEvolving
-    public TypeSerializer<VoidNamespace> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableMessageTypeInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableMessageTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.api.connector.sink2;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -112,11 +111,6 @@ public class CommittableMessageTypeInfo<CommT> extends TypeInformation<Committab
                 return from;
             }
         };
-    }
-
-    @Override
-    public TypeSerializer<CommittableMessage<CommT>> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -21,7 +21,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.serialization.SerializerConfig;
@@ -584,11 +583,6 @@ public class CoGroupedStreams<T1, T2> {
         public TypeSerializer<TaggedUnion<T1, T2>> createSerializer(SerializerConfig config) {
             return new UnionSerializer<>(
                     oneType.createSerializer(config), twoType.createSerializer(config));
-        }
-
-        @Override
-        public TypeSerializer<TaggedUnion<T1, T2>> createSerializer(ExecutionConfig config) {
-            return createSerializer(config.getSerializerConfig());
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/KeyedSortPartitionOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/KeyedSortPartitionOperator.java
@@ -152,7 +152,8 @@ public class KeyedSortPartitionOperator<INPUT, KEY> extends AbstractStreamOperat
                             inputType);
             KeyAndValueSerializer<Tuple2<?, INPUT>> valueSerializer =
                     new KeyAndValueSerializer<>(
-                            valueType.createSerializer(getExecutionConfig()), keyLength);
+                            valueType.createSerializer(getExecutionConfig().getSerializerConfig()),
+                            keyLength);
             TypeComparator<Tuple2<byte[], Tuple2<?, INPUT>>> sortTypeComparator;
             if (keyLength > 0) {
                 sortTypeComparator =
@@ -179,7 +180,8 @@ public class KeyedSortPartitionOperator<INPUT, KEY> extends AbstractStreamOperat
         } else {
             KeyAndValueSerializer<INPUT> valueSerializer =
                     new KeyAndValueSerializer<>(
-                            inputType.createSerializer(getExecutionConfig()), keyLength);
+                            inputType.createSerializer(getExecutionConfig().getSerializerConfig()),
+                            keyLength);
             TypeComparator<Tuple2<byte[], INPUT>> sortTypeComparator;
             if (keyLength > 0) {
                 sortTypeComparator =

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sortpartition/SortPartitionOperator.java
@@ -137,7 +137,7 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
                             inputType);
             recordSorterForKeySelector =
                     getSorter(
-                            sortTypeInfo.createSerializer(executionConfig),
+                            sortTypeInfo.createSerializer(executionConfig.getSerializerConfig()),
                             ((CompositeType<Tuple2<?, INPUT>>) sortTypeInfo)
                                     .createComparator(
                                             getSortFieldIndex(),
@@ -148,7 +148,7 @@ public class SortPartitionOperator<INPUT> extends AbstractStreamOperator<INPUT>
         } else {
             recordSorter =
                     getSorter(
-                            inputType.createSerializer(executionConfig),
+                            inputType.createSerializer(executionConfig.getSerializerConfig()),
                             ((CompositeType<INPUT>) inputType)
                                     .createComparator(
                                             getSortFieldIndex(),

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/codegen/TypeInformationGen.scala
@@ -158,9 +158,6 @@ private[flink] trait TypeInformationGen[C <: Context] {
 
           new ScalaCaseClassSerializer[T](getTypeClass, fieldSerializers)
         }
-
-        override def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[T] =
-          createSerializer(executionConfig.getSerializerConfig)
       }
     }
   }
@@ -272,11 +269,7 @@ private[flink] trait TypeInformationGen[C <: Context] {
 
       val elementTpe = $elementTypeInfo
       new TraversableTypeInfo($collectionClass, elementTpe) {
-        def createSerializer(executionConfig: ExecutionConfig) = {
-          createSerializer(executionConfig.getSerializerConfig)
-        }
-
-        override def createSerializer(serializerConfig: SerializerConfig) = {
+        def createSerializer(serializerConfig: SerializerConfig) = {
 
           // -------------------------------------------------------------------------------------
           // NOTE:

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/package.scala
@@ -147,10 +147,6 @@ package object scala {
 
         new Tuple2CaseClassSerializer[T1, T2](classOf[(T1, T2)], fieldSerializers)
       }
-
-      override def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[(T1, T2)] =
-        createSerializer(executionConfig.getSerializerConfig)
-
     }
 
   class Tuple2CaseClassSerializer[T1, T2](

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EitherTypeInfo.scala
@@ -75,11 +75,6 @@ class EitherTypeInfo[A, B, T <: Either[A, B]](
     new EitherSerializer[A, B](leftSerializer, rightSerializer).asInstanceOf[TypeSerializer[T]]
   }
 
-  @PublicEvolving
-  @Deprecated
-  def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[T] = createSerializer(
-    executionConfig.getSerializerConfig)
-
   override def equals(obj: Any): Boolean = {
     obj match {
       case eitherTypeInfo: EitherTypeInfo[_, _, _] =>

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/EnumValueTypeInfo.scala
@@ -64,11 +64,6 @@ class EnumValueTypeInfo[E <: Enumeration](val enum: E, val clazz: Class[E#Value]
   }
 
   @PublicEvolving
-  def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[T] = {
-    createSerializer(executionConfig.getSerializerConfig)
-  }
-
-  @PublicEvolving
   override def createComparator(ascOrder: Boolean, config: ExecutionConfig): TypeComparator[T] = {
     new EnumValueComparator[E](ascOrder)
   }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/OptionTypeInfo.scala
@@ -81,12 +81,6 @@ class OptionTypeInfo[A, T <: Option[A]](private val elemTypeInfo: TypeInformatio
     }
   }
 
-  @PublicEvolving
-  @Deprecated
-  def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[T] = {
-    createSerializer(executionConfig.getSerializerConfig)
-  }
-
   override def toString = s"Option[$elemTypeInfo]"
 
   override def equals(obj: Any): Boolean = {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/ScalaNothingTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/ScalaNothingTypeInfo.scala
@@ -52,10 +52,6 @@ class ScalaNothingTypeInfo extends TypeInformation[Nothing] {
   override def createSerializer(config: SerializerConfig): TypeSerializer[Nothing] =
     (new NothingSerializer).asInstanceOf[TypeSerializer[Nothing]]
 
-  @PublicEvolving
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[Nothing] =
-    createSerializer(config.getSerializerConfig)
-
   override def hashCode(): Int = classOf[ScalaNothingTypeInfo].hashCode
 
   override def toString: String = "ScalaNothingTypeInfo"

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TryTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/TryTypeInfo.scala
@@ -66,11 +66,6 @@ class TryTypeInfo[A, T <: Try[A]](val elemTypeInfo: TypeInformation[A]) extends 
     }
   }
 
-  @PublicEvolving
-  def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[T] = {
-    createSerializer(executionConfig.getSerializerConfig)
-  }
-
   override def equals(obj: Any): Boolean = {
     obj match {
       case tryTypeInfo: TryTypeInfo[_, _] =>

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/typeutils/UnitTypeInfo.scala
@@ -51,10 +51,6 @@ class UnitTypeInfo extends TypeInformation[Unit] {
   override def createSerializer(config: SerializerConfig): TypeSerializer[Unit] =
     (new UnitSerializer).asInstanceOf[TypeSerializer[Unit]]
 
-  @PublicEvolving
-  override def createSerializer(config: ExecutionConfig): TypeSerializer[Unit] =
-    createSerializer(config.getSerializerConfig)
-
   override def canEqual(obj: scala.Any): Boolean = {
     obj.isInstanceOf[UnitTypeInfo]
   }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TraversableSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/runtime/TraversableSerializerTest.scala
@@ -17,7 +17,6 @@
  */
 package org.apache.flink.api.scala.runtime
 
-import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.serialization.SerializerConfigImpl
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfoTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/CaseClassTypeInfoTest.scala
@@ -32,8 +32,6 @@ class CaseClassTypeInfoTest extends TypeInformationTestBase[CaseClassTypeInfo[_]
       Array(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO),
       Array("_1", "_2")) {
       override def createSerializer(config: SerializerConfig): TypeSerializer[(Int, String)] = ???
-
-      override def createSerializer(config: ExecutionConfig): TypeSerializer[(Int, String)] = ???
     },
     new CaseClassTypeInfo[(Int, Boolean)](
       classOf[(Int, Boolean)],
@@ -41,8 +39,6 @@ class CaseClassTypeInfoTest extends TypeInformationTestBase[CaseClassTypeInfo[_]
       Array(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.BOOLEAN_TYPE_INFO),
       Array("_1", "_2")) {
       override def createSerializer(config: SerializerConfig): TypeSerializer[(Int, Boolean)] = ???
-
-      override def createSerializer(config: ExecutionConfig): TypeSerializer[(Int, Boolean)] = ???
     }
   )
 }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableTypeInfoTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TraversableTypeInfoTest.scala
@@ -17,8 +17,7 @@
  */
 package org.apache.flink.api.scala.typeutils
 
-import org.apache.flink.api.common.ExecutionConfig
-import org.apache.flink.api.common.serialization.{SerializerConfig, SerializerConfigImpl}
+import org.apache.flink.api.common.serialization.SerializerConfig
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.{TypeInformationTestBase, TypeSerializer}
 
@@ -31,17 +30,11 @@ class TraversableTypeInfoTest extends TypeInformationTestBase[TraversableTypeInf
       BasicTypeInfo.INT_TYPE_INFO.asInstanceOf[TypeInformation[Int]]) {
       override def createSerializer(serializerConfig: SerializerConfig): TypeSerializer[Seq[Int]] =
         ???
-
-      override def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[Seq[Int]] =
-        ???
     },
     new TraversableTypeInfo[List[Int], Int](
       classOf[List[Int]],
       BasicTypeInfo.INT_TYPE_INFO.asInstanceOf[TypeInformation[Int]]) {
       override def createSerializer(serializerConfig: SerializerConfig): TypeSerializer[List[Int]] =
-        ???
-
-      override def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[List[Int]] =
         ???
     }
   )

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TypeInfoFactoryTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/TypeInfoFactoryTest.scala
@@ -144,8 +144,6 @@ object TypeInfoFactoryTest {
 
     override def createSerializer(config: SerializerConfig): TypeSerializer[MyOption[_]] = ???
 
-    override def createSerializer(config: ExecutionConfig): TypeSerializer[MyOption[_]] = ???
-
     override def canEqual(obj: scala.Any): Boolean = ???
 
     override def hashCode(): Int = ???

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorTest.java
@@ -1337,7 +1337,8 @@ class WindowOperatorTest {
                 new ReducingStateDescriptor<>(
                         "window-contents",
                         new SumReducer(),
-                        STRING_INT_TUPLE.createSerializer(new ExecutionConfig()));
+                        STRING_INT_TUPLE.createSerializer(
+                                new ExecutionConfig().getSerializerConfig()));
 
         WindowOperator<
                         String,
@@ -1351,7 +1352,7 @@ class WindowOperatorTest {
                                 new GlobalWindow.Serializer(),
                                 new TupleKeySelector(),
                                 BasicTypeInfo.STRING_TYPE_INFO.createSerializer(
-                                        new ExecutionConfig()),
+                                        new ExecutionConfig().getSerializerConfig()),
                                 stateDesc,
                                 new InternalSingleValueWindowFunction<>(
                                         new PassThroughWindowFunction<

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/ListViewTypeInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/ListViewTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.dataview;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -101,11 +100,6 @@ public class ListViewTypeInfo<T> extends TypeInformation<ListView<T>> {
             TypeSerializer<T> elementSerializer = elementType.createSerializer(config);
             return new ListViewSerializer<>(new ListSerializer<>(elementSerializer));
         }
-    }
-
-    @Override
-    public TypeSerializer<ListView<T>> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/MapViewTypeInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/MapViewTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.dataview;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -126,11 +125,6 @@ public class MapViewTypeInfo<K, V> extends TypeInformation<MapView<K, V>> {
                 return new MapViewSerializer<>(new MapSerializer<>(keySer, valueSer));
             }
         }
-    }
-
-    @Override
-    public TypeSerializer<MapView<K, V>> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/typeutils/TimeIndicatorTypeInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/typeutils/TimeIndicatorTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.typeutils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -70,11 +69,6 @@ public class TimeIndicatorTypeInfo extends SqlTimeTypeInfo<Timestamp> {
     @SuppressWarnings("unchecked")
     public TypeSerializer<Timestamp> createSerializer(SerializerConfig serializerConfig) {
         return (TypeSerializer) LongSerializer.INSTANCE;
-    }
-
-    @Override
-    public TypeSerializer<Timestamp> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     public boolean isEventTime() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/typeutils/TimeIntervalTypeInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/typeutils/TimeIntervalTypeInfo.java
@@ -118,11 +118,6 @@ public final class TimeIntervalTypeInfo<T> extends TypeInformation<T>
     }
 
     @Override
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
-    }
-
-    @Override
     public TypeComparator<T> createComparator(
             boolean sortOrderAscending, ExecutionConfig executionConfig) {
         try {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/TypeInfoDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/TypeInfoDataTypeConverterTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.types;
 
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
@@ -234,11 +233,6 @@ class TypeInfoDataTypeConverterTest {
         @Override
         public TypeSerializer<Object> createSerializer(SerializerConfig config) {
             return null;
-        }
-
-        @Override
-        public TypeSerializer<Object> createSerializer(ExecutionConfig config) {
-            return createSerializer(config.getSerializerConfig());
         }
 
         @Override

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TemporalTableFunctionJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TemporalTableFunctionJoinTest.xml
@@ -25,7 +25,7 @@ LogicalJoin(condition=[=($3, $1)], joinType=[inner])
 :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
 :        :- LogicalProject(o_rowtime=[AS($0, _UTF-16LE'o_rowtime')], o_comment=[AS($1, _UTF-16LE'o_comment')], o_amount=[AS($2, _UTF-16LE'o_amount')], o_currency=[AS($3, _UTF-16LE'o_currency')], o_secondary_key=[AS($4, _UTF-16LE'o_secondary_key')])
 :        :  +- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-:        +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$ae03d78aca8b4919271ccb64f0664e6f*($0)], rowType=[RecordType(TIMESTAMP(3) *ROWTIME* rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)])
+:        +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$4db4fe8818b9ec1c238f98fdebb360ab*($0)], rowType=[RecordType(TIMESTAMP(3) *ROWTIME* rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)])
 +- LogicalTableScan(table=[[default_catalog, default_database, ThirdTable]])
 ]]>
     </Resource>
@@ -53,7 +53,7 @@ LogicalProject(rate=[AS(*($0, $4), _UTF-16LE'rate')])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
       :- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$97b122b4de2e954f0786da94005051ef*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
+      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$f8f4a219153953804523629ff013365c*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -95,7 +95,7 @@ LogicalProject(rate=[AS(*($0, $4), _UTF-16LE'rate')])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
       :- LogicalTableScan(table=[[default_catalog, default_database, ProctimeOrders]])
-      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$c029f3cbf9d82adfbc18bcda5c7d44ae*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP_LTZ(3) *PROCTIME* proctime)])
+      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$14e96611bbf1dcf2a3979f9531ae2006*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP_LTZ(3) *PROCTIME* proctime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -117,7 +117,7 @@ LogicalProject(rate=[AS(*($0, $4), _UTF-16LE'rate')])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
       :- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$97b122b4de2e954f0786da94005051ef*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
+      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$f8f4a219153953804523629ff013365c*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/MiniBatchStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/stream/MiniBatchStreamingJoinOperator.java
@@ -83,8 +83,9 @@ public abstract class MiniBatchStreamingJoinOperator extends StreamingJoinOperat
         coBundleTrigger.reset();
         LOG.info("Initialize MiniBatchStreamingJoinOperator successfully.");
 
-        this.leftSerializer = leftType.createSerializer(getExecutionConfig());
-        this.rightSerializer = rightType.createSerializer(getExecutionConfig());
+        this.leftSerializer = leftType.createSerializer(getExecutionConfig().getSerializerConfig());
+        this.rightSerializer =
+                rightType.createSerializer(getExecutionConfig().getSerializerConfig());
 
         // register metrics
         leftBundleReducedSizeGauge = new SimpleGauge<>(0);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/DecimalDataTypeInfo.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/DecimalDataTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.typeutils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -87,11 +86,6 @@ public class DecimalDataTypeInfo extends TypeInformation<DecimalData> implements
     @Override
     public TypeSerializer<DecimalData> createSerializer(SerializerConfig config) {
         return new DecimalDataSerializer(precision, scale);
-    }
-
-    @Override
-    public TypeSerializer<DecimalData> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ExternalTypeInfo.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ExternalTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.typeutils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -141,11 +140,6 @@ public final class ExternalTypeInfo<T> extends TypeInformation<T> implements Dat
     @Override
     public TypeSerializer<T> createSerializer(SerializerConfig config) {
         return typeSerializer;
-    }
-
-    @Override
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/InternalTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.typeutils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -197,11 +196,6 @@ public final class InternalTypeInfo<T> extends TypeInformation<T> implements Dat
     @Override
     public TypeSerializer<T> createSerializer(SerializerConfig config) {
         return typeSerializer;
-    }
-
-    @Override
-    public TypeSerializer<T> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/SortedMapTypeInfo.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/SortedMapTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.typeutils;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -83,11 +82,6 @@ public class SortedMapTypeInfo<K, V> extends AbstractMapTypeInfo<K, V, SortedMap
         TypeSerializer<V> valueTypeSerializer = valueTypeInfo.createSerializer(config);
 
         return new SortedMapSerializer<>(comparator, keyTypeSerializer, valueTypeSerializer);
-    }
-
-    @Override
-    public TypeSerializer<SortedMap<K, V>> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/StringDataTypeInfo.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/StringDataTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.typeutils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -67,11 +66,6 @@ public class StringDataTypeInfo extends TypeInformation<StringData> {
     @Override
     public TypeSerializer<StringData> createSerializer(SerializerConfig config) {
         return StringDataSerializer.INSTANCE;
-    }
-
-    @Override
-    public TypeSerializer<StringData> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TimestampDataTypeInfo.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TimestampDataTypeInfo.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.runtime.typeutils;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -72,11 +71,6 @@ public class TimestampDataTypeInfo extends TypeInformation<TimestampData> {
     @Override
     public TypeSerializer<TimestampData> createSerializer(SerializerConfig config) {
         return new TimestampDataSerializer(precision);
-    }
-
-    @Override
-    public TypeSerializer<TimestampData> createSerializer(ExecutionConfig config) {
-        return createSerializer(config.getSerializerConfig());
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

*Remove deprecated TypeInformation#createSerializer(ExecutionConfig) method*


## Brief change log

- *Remove deprecated TypeInformation#createSerializer(ExecutionConfig) method* 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
