### PR TITLE
  [FLINK-35764][runtime/metrics] Fix TimerGauge producing incorrect results when updating during a measurement

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/TimerGauge.java
@@ -116,9 +116,11 @@ public class TimerGauge implements Gauge<Long>, View {
         if (currentMeasurementStartTS == 0) {
             return;
         }
-        long currentMeasurement = clock.absoluteTimeMillis() - currentMeasurementStartTS;
-        currentCount += currentMeasurement;
-        accumulatedCount += currentMeasurement;
+        long now = clock.absoluteTimeMillis();
+        long currentMeasurement = now - currentMeasurementStartTS;
+        long currentIncrement = now - currentUpdateTS;
+        currentCount += currentIncrement;
+        accumulatedCount += currentIncrement;
         currentMaxSingleMeasurement = Math.max(currentMaxSingleMeasurement, currentMeasurement);
         currentUpdateTS = 0;
         currentMeasurementStartTS = 0;


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a problem where the `TimerGauge` produces incorrect results when updated during a measurement. For details, see [FLINK-35764](https://issues.apache.org/jira/browse/FLINK-35764).

## Brief change log

- In `TimerGauge`, only add the time since `currentUpdateTS` to `currentCount` in `markEnd()`.
- Add the test case above to `TimerGaugeTest`, and adjust other test cases.

## Verifying this change

This change added tests and can be verified as follows:

- Added unit test case where `TimerGauge` is updated during a measurement

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**