### PR TITLE
[FLINK-36287] Disallow UC for inner sink channels 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -68,7 +68,6 @@ import org.apache.flink.streaming.api.transformations.TimestampsAndWatermarksTra
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.streaming.api.transformations.WithBoundedness;
-import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.translators.BroadcastStateTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.CacheTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.KeyedBroadcastStateTransformationTranslator;
@@ -277,7 +276,8 @@ public class StreamGraphGenerator {
         streamGraph.setLineageGraph(lineageGraph);
 
         for (StreamNode node : streamGraph.getStreamNodes()) {
-            if (node.getInEdges().stream().anyMatch(this::shouldDisableUnalignedCheckpointing)) {
+            if (node.getInEdges().stream()
+                    .anyMatch(e -> !e.getPartitioner().isSupportsUnalignedCheckpoint())) {
                 for (StreamEdge edge : node.getInEdges()) {
                     edge.setSupportsUnalignedCheckpoints(false);
                 }
@@ -291,11 +291,6 @@ public class StreamGraphGenerator {
         streamGraph = null;
 
         return builtStreamGraph;
-    }
-
-    private boolean shouldDisableUnalignedCheckpointing(StreamEdge edge) {
-        StreamPartitioner<?> partitioner = edge.getPartitioner();
-        return partitioner.isPointwise() || partitioner.isBroadcast();
     }
 
     private void setDynamic(final StreamGraph graph) {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardForConsecutiveHashPartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/partitioner/ForwardForConsecutiveHashPartitioner.java
@@ -102,6 +102,11 @@ public class ForwardForConsecutiveHashPartitioner<T> extends ForwardPartitioner<
     }
 
     @Override
+    public void disableUnalignedCheckpoints() {
+        hashPartitioner.disableUnalignedCheckpoints();
+    }
+
+    @Override
     public int selectChannel(SerializationDelegate<StreamRecord<T>> record) {
         throw new RuntimeException(
                 "ForwardForConsecutiveHashPartitioner is a intermediate partitioner in optimization phase, "

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/partitioner/StreamPartitioner.java
@@ -34,6 +34,13 @@ public abstract class StreamPartitioner<T>
 
     protected int numberOfChannels;
 
+    /**
+     * By default, all partitioner except {@link #isBroadcast()} or {@link #isPointwise()} support
+     * unaligned checkpoints. However, transformations may disable unaligned checkpoints for
+     * specific cases.
+     */
+    private boolean supportsUnalignedCheckpoint = true;
+
     @Override
     public void setup(int numberOfChannels) {
         this.numberOfChannels = numberOfChannels;
@@ -78,4 +85,12 @@ public abstract class StreamPartitioner<T>
     public abstract SubtaskStateMapper getDownstreamSubtaskStateMapper();
 
     public abstract boolean isPointwise();
+
+    public boolean isSupportsUnalignedCheckpoint() {
+        return supportsUnalignedCheckpoint && !isPointwise() && !isBroadcast();
+    }
+
+    public void disableUnalignedCheckpoints() {
+        this.supportsUnalignedCheckpoint = false;
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorITCaseBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/graph/SinkTransformationTranslatorITCaseBase.java
@@ -109,6 +109,7 @@ abstract class SinkTransformationTranslatorITCaseBase<SinkT> {
                 findNodeName(streamGraph, name -> name.contains("Committer"));
 
         assertThat(streamGraph.getStreamNodes()).hasSize(3);
+        assertNoUnalignedOutput(writerNode);
 
         validateTopology(
                 writerNode,
@@ -211,6 +212,10 @@ abstract class SinkTransformationTranslatorITCaseBase<SinkT> {
         assertThat(dest.getOperatorFactory().getChainingStrategy())
                 .isEqualTo(ChainingStrategy.ALWAYS);
         assertThat(dest.getSlotSharingGroup()).isEqualTo(SLOT_SHARE_GROUP);
+    }
+
+    protected static void assertNoUnalignedOutput(StreamNode src) {
+        assertThat(src.getOutEdges()).allMatch(e -> !e.supportsUnalignedCheckpoints());
     }
 
     StreamGraph buildGraph(SinkT sink, RuntimeExecutionMode runtimeExecutionMode) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV1TransformationTranslatorITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/SinkV1TransformationTranslatorITCase.java
@@ -84,8 +84,8 @@ class SinkV1TransformationTranslatorITCase
                 SinkWriterOperatorFactory.class,
                 PARALLELISM,
                 -1);
+        assertNoUnalignedOutput(writerNode);
 
-        StreamNode lastNode;
         if (runtimeExecutionMode == RuntimeExecutionMode.STREAMING) {
             // in streaming writer and committer are merged into one operator
 
@@ -99,12 +99,12 @@ class SinkV1TransformationTranslatorITCase
                     CommitterOperatorFactory.class,
                     PARALLELISM,
                     -1);
+            assertNoUnalignedOutput(committerNode);
         }
-        lastNode = committerNode;
 
         final StreamNode globalCommitterNode = findGlobalCommitter(streamGraph);
         validateTopology(
-                lastNode,
+                committerNode,
                 SimpleVersionedSerializerTypeSerializerProxy.class,
                 globalCommitterNode,
                 SimpleOperatorFactory.class,
@@ -138,6 +138,7 @@ class SinkV1TransformationTranslatorITCase
         final StreamNode committerNode = findCommitter(streamGraph);
         final StreamNode globalCommitterNode = findGlobalCommitter(streamGraph);
 
+        assertNoUnalignedOutput(writerNode);
         validateTopology(
                 writerNode,
                 SimpleVersionedSerializerTypeSerializerProxy.class,
@@ -146,6 +147,7 @@ class SinkV1TransformationTranslatorITCase
                 PARALLELISM,
                 -1);
 
+        assertNoUnalignedOutput(committerNode);
         validateTopology(
                 committerNode,
                 SimpleVersionedSerializerTypeSerializerProxy.class,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperatorTestBase.java
@@ -40,6 +40,7 @@ import static org.apache.flink.streaming.runtime.operators.sink.SinkTestUtil.fro
 import static org.apache.flink.streaming.runtime.operators.sink.SinkTestUtil.toCommittableSummary;
 import static org.apache.flink.streaming.runtime.operators.sink.SinkTestUtil.toCommittableWithLinage;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 abstract class CommitterOperatorTestBase {
 
@@ -86,7 +87,7 @@ abstract class CommitterOperatorTestBase {
     }
 
     @Test
-    void testWaitForCommittablesOfLatestCheckpointBeforeCommitting() throws Exception {
+    void ensureAllCommittablesArrivedBeforeCommitting() throws Exception {
         SinkAndCounters sinkAndCounters = sinkWithPostCommit();
         final OneInputStreamOperatorTestHarness<
                         CommittableMessage<String>, CommittableMessage<String>>
@@ -109,8 +110,7 @@ abstract class CommitterOperatorTestBase {
         final CommittableWithLineage<String> second = new CommittableWithLineage<>("2", 1L, 1);
         testHarness.processElement(new StreamRecord<>(second));
 
-        // Trigger commit Retry
-        testHarness.getProcessingTimeService().setCurrentTime(2000);
+        assertThatCode(() -> testHarness.notifyOfCompletedCheckpoint(1)).doesNotThrowAnyException();
 
         final List<StreamElement> output = fromOutput(testHarness.getOutput());
         assertThat(output).hasSize(3);
@@ -123,42 +123,6 @@ abstract class CommitterOperatorTestBase {
                 .isEqualTo(copyCommittableWithDifferentOrigin(first, 0));
         SinkV2Assertions.assertThat(toCommittableWithLinage(output.get(2)))
                 .isEqualTo(copyCommittableWithDifferentOrigin(second, 0));
-        testHarness.close();
-    }
-
-    @Test
-    void testImmediatelyCommitLateCommittables() throws Exception {
-        SinkAndCounters sinkAndCounters = sinkWithPostCommit();
-
-        final OneInputStreamOperatorTestHarness<
-                        CommittableMessage<String>, CommittableMessage<String>>
-                testHarness = createTestHarness(sinkAndCounters.sink, false, true);
-        testHarness.open();
-
-        final CommittableSummary<String> committableSummary =
-                new CommittableSummary<>(1, 1, 1L, 1, 1, 0);
-        testHarness.processElement(new StreamRecord<>(committableSummary));
-
-        // Receive notify checkpoint completed before the last data. This might happen for unaligned
-        // checkpoints.
-        testHarness.notifyOfCompletedCheckpoint(1);
-
-        assertThat(testHarness.getOutput()).isEmpty();
-
-        final CommittableWithLineage<String> first = new CommittableWithLineage<>("1", 1L, 1);
-
-        // Commit elements with lower or equal the latest checkpoint id immediately
-        testHarness.processElement(new StreamRecord<>(first));
-
-        final List<StreamElement> output = fromOutput(testHarness.getOutput());
-        assertThat(output).hasSize(2);
-        assertThat(sinkAndCounters.commitCounter.getAsInt()).isEqualTo(1);
-        SinkV2Assertions.assertThat(toCommittableSummary(output.get(0)))
-                .hasFailedCommittables(committableSummary.getNumberOfFailedCommittables())
-                .hasOverallCommittables(committableSummary.getNumberOfCommittables())
-                .hasPendingCommittables(0);
-        SinkV2Assertions.assertThat(toCommittableWithLinage(output.get(1)))
-                .isEqualTo(copyCommittableWithDifferentOrigin(first, 0));
         testHarness.close();
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkITCase.java
@@ -29,6 +29,8 @@ import org.apache.flink.connector.datagen.source.TestDataGenerators;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.runtime.operators.sink.TestSink;
 import org.apache.flink.streaming.runtime.operators.sink.TestSinkV2;
 import org.apache.flink.test.util.AbstractTestBase;
@@ -148,7 +150,7 @@ class SinkITCase extends AbstractTestBase {
                                 (Supplier<Queue<String>> & Serializable) () -> GLOBAL_COMMIT_QUEUE)
                         .build());
 
-        env.execute();
+        executeAndVerifyStreamGraph(env);
 
         // TODO: At present, for a bounded scenario, the occurrence of final checkpoint is not a
         // deterministic event, so
@@ -178,7 +180,7 @@ class SinkITCase extends AbstractTestBase {
                                                 () -> GLOBAL_COMMIT_QUEUE)
                                 .build());
 
-        env.execute();
+        executeAndVerifyStreamGraph(env);
 
         assertThat(COMMIT_QUEUE).containsExactlyInAnyOrder(EXPECTED_COMMITTED_DATA_IN_BATCH_MODE);
 
@@ -202,7 +204,9 @@ class SinkITCase extends AbstractTestBase {
                         .setDefaultCommitter(
                                 (Supplier<Queue<String>> & Serializable) () -> COMMIT_QUEUE)
                         .build());
-        env.execute();
+
+        executeAndVerifyStreamGraph(env);
+
         assertThat(COMMIT_QUEUE)
                 .containsExactlyInAnyOrder(EXPECTED_COMMITTED_DATA_IN_STREAMING_MODE);
     }
@@ -254,7 +258,9 @@ class SinkITCase extends AbstractTestBase {
                                 .setDefaultCommitter(
                                         (Supplier<Queue<String>> & Serializable) () -> COMMIT_QUEUE)
                                 .build());
-        env.execute();
+
+        executeAndVerifyStreamGraph(env);
+
         assertThat(COMMIT_QUEUE).containsExactlyInAnyOrder(EXPECTED_COMMITTED_DATA_IN_BATCH_MODE);
     }
 
@@ -275,7 +281,7 @@ class SinkITCase extends AbstractTestBase {
                                 (Supplier<Queue<String>> & Serializable) () -> GLOBAL_COMMIT_QUEUE)
                         .build());
 
-        env.execute();
+        executeAndVerifyStreamGraph(env);
 
         // TODO: At present, for a bounded scenario, the occurrence of final checkpoint is not a
         // deterministic event, so
@@ -299,10 +305,27 @@ class SinkITCase extends AbstractTestBase {
                                         (Supplier<Queue<String>> & Serializable)
                                                 () -> GLOBAL_COMMIT_QUEUE)
                                 .build());
-        env.execute();
+
+        executeAndVerifyStreamGraph(env);
 
         assertThat(GLOBAL_COMMIT_QUEUE)
                 .containsExactlyInAnyOrder(EXPECTED_GLOBAL_COMMITTED_DATA_IN_BATCH_MODE);
+    }
+
+    private void executeAndVerifyStreamGraph(StreamExecutionEnvironment env) throws Exception {
+        StreamGraph streamGraph = env.getStreamGraph();
+        assertNoUnalignedCheckpointInSink(streamGraph);
+        env.execute(streamGraph);
+    }
+
+    private void assertNoUnalignedCheckpointInSink(StreamGraph streamGraph) {
+        // all the edges out of the sink nodes should not support unaligned checkpoints
+        // we rely on other tests that this property is correctly used.
+        assertThat(streamGraph.getStreamNodes())
+                .filteredOn(t -> t.getOperatorName().contains("Sink"))
+                .flatMap(StreamNode::getOutEdges)
+                .allMatch(e -> !e.supportsUnalignedCheckpoints())
+                .isNotEmpty();
     }
 
     private static List<String> getSplitGlobalCommittedData() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Between sink writer, the committer, and any pre/post commit topology (including global committer), we don't send actual payload but just committables. These committables must be committed on notifyCheckpointCompleted. However, if a barrier overtakes these committables, they may only be read after the RPC call has been made leading to violations. In particular, we could even have these issues during a final checkpoint.

This commit generalizes the way, we disable UC for broadcast and pointwise connections, such that the SinkTransformationTranslator can also disable it for other distribution pattern.


## Brief change log

* Migrate SinkITCase to AssertJ
* Disallow UC for inner sink channels <- main commit

## Verifying this change

Added assertion on existing SinkITCase, which looks at different topologies already.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / **don't know**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
