### PR TITLE
[hotfix][docs] Fix typo in Hive connector overview Python example

### DIFF
--- a/docs/content/docs/connectors/table/hive/overview.md
+++ b/docs/content/docs/connectors/table/hive/overview.md
@@ -227,7 +227,7 @@ hive_catalog = HiveCatalog(catalog_name, default_database, hive_conf_dir)
 t_env.register_catalog("myhive", hive_catalog)
 
 # set the HiveCatalog as the current catalog of the session
-tableEnv.use_catalog("myhive")
+t_env.use_catalog("myhive")
 ```
 {{< /tab >}}
 {{< tab "YAML" >}}


### PR DESCRIPTION
Fix python example variable `t_env` being mistakenly referenced as `tableEnv`.