### PR TITLE
[FLINK-36015] [runtime] Align rescale parameters

### DIFF
--- a/docs/layouts/shortcodes/generated/all_jobmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_jobmanager_section.html
@@ -9,40 +9,40 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.executing.cooldown-after-rescaling</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Determines the minimum time between scaling operations.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.executing.resource-stabilization-timeout</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
             <td>Defines the duration the JobManager delays the scaling operation after a resource change if only sufficient resources are available. The scaling operation is performed immediately if the resources have changed and the desired resources are available. The timeout begins as soon as either the available resources or the job's resource requirements are changed.<br />The resource requirements of a running job can be changed using the <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/ops/rest_api/#jobs-jobid-resource-requirements-1">REST API endpoint</a>.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.adaptive-scheduler.max-delay-for-scale-trigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Duration</td>
-            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count if checkpointing is enabled).</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.adaptive-scheduler.resource-stabilization-timeout</h5></td>
-            <td style="word-wrap: break-word;">10 s</td>
-            <td>Duration</td>
-            <td>The resource stabilization timeout defines the time the JobManager will wait if fewer than the desired but sufficient resources are available. The timeout starts once sufficient resources for running the job are available. Once this timeout has passed, the job will start executing with the available resources.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to 0, so that jobs are starting immediately with the available resources.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.adaptive-scheduler.resource-wait-timeout</h5></td>
-            <td style="word-wrap: break-word;">5 min</td>
-            <td>Duration</td>
-            <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count</h5></td>
+            <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>
             <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.adaptive-scheduler.scaling-interval.min</h5></td>
-            <td style="word-wrap: break-word;">30 s</td>
+            <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-delay</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>Determines the minimum time between scaling operations.</td>
+            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures if checkpointing is enabled).</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.submission.resource-stabilization-timeout</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>The resource stabilization timeout defines the time the JobManager will wait if fewer than the desired but sufficient resources are available during job submission. The timeout starts once sufficient resources for running the job are available. Once this timeout has passed, the job will start executing with the available resources.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to 0, so that jobs are starting immediately with the available resources.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.submission.resource-wait-timeout</h5></td>
+            <td style="word-wrap: break-word;">5 min</td>
+            <td>Duration</td>
+            <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.archive.fs.dir</h5></td>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -87,40 +87,40 @@
             <td>The size of the write buffer of JobEventStore. The content will be flushed to external file system once the buffer is full</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.executing.cooldown-after-rescaling</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Determines the minimum time between scaling operations.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.executing.resource-stabilization-timeout</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
             <td>Defines the duration the JobManager delays the scaling operation after a resource change if only sufficient resources are available. The scaling operation is performed immediately if the resources have changed and the desired resources are available. The timeout begins as soon as either the available resources or the job's resource requirements are changed.<br />The resource requirements of a running job can be changed using the <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/ops/rest_api/#jobs-jobid-resource-requirements-1">REST API endpoint</a>.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.adaptive-scheduler.max-delay-for-scale-trigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Duration</td>
-            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count if checkpointing is enabled).</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.adaptive-scheduler.resource-stabilization-timeout</h5></td>
-            <td style="word-wrap: break-word;">10 s</td>
-            <td>Duration</td>
-            <td>The resource stabilization timeout defines the time the JobManager will wait if fewer than the desired but sufficient resources are available. The timeout starts once sufficient resources for running the job are available. Once this timeout has passed, the job will start executing with the available resources.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to 0, so that jobs are starting immediately with the available resources.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.adaptive-scheduler.resource-wait-timeout</h5></td>
-            <td style="word-wrap: break-word;">5 min</td>
-            <td>Duration</td>
-            <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count</h5></td>
+            <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>
             <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.adaptive-scheduler.scaling-interval.min</h5></td>
-            <td style="word-wrap: break-word;">30 s</td>
+            <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-delay</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>Determines the minimum time between scaling operations.</td>
+            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures if checkpointing is enabled).</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.submission.resource-stabilization-timeout</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>The resource stabilization timeout defines the time the JobManager will wait if fewer than the desired but sufficient resources are available during job submission. The timeout starts once sufficient resources for running the job are available. Once this timeout has passed, the job will start executing with the available resources.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to 0, so that jobs are starting immediately with the available resources.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.submission.resource-wait-timeout</h5></td>
+            <td style="word-wrap: break-word;">5 min</td>
+            <td>Duration</td>
+            <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.partition.hybrid.partition-data-consume-constraint</h5></td>

--- a/docs/layouts/shortcodes/generated/job_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/job_manager_configuration.html
@@ -9,40 +9,40 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>jobmanager.adaptive-scheduler.executing.cooldown-after-rescaling</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Determines the minimum time between scaling operations.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.adaptive-scheduler.executing.resource-stabilization-timeout</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
             <td>Defines the duration the JobManager delays the scaling operation after a resource change if only sufficient resources are available. The scaling operation is performed immediately if the resources have changed and the desired resources are available. The timeout begins as soon as either the available resources or the job's resource requirements are changed.<br />The resource requirements of a running job can be changed using the <a href="{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/ops/rest_api/#jobs-jobid-resource-requirements-1">REST API endpoint</a>.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.adaptive-scheduler.max-delay-for-scale-trigger</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Duration</td>
-            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count if checkpointing is enabled).</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.adaptive-scheduler.resource-stabilization-timeout</h5></td>
-            <td style="word-wrap: break-word;">10 s</td>
-            <td>Duration</td>
-            <td>The resource stabilization timeout defines the time the JobManager will wait if fewer than the desired but sufficient resources are available. The timeout starts once sufficient resources for running the job are available. Once this timeout has passed, the job will start executing with the available resources.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to 0, so that jobs are starting immediately with the available resources.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.adaptive-scheduler.resource-wait-timeout</h5></td>
-            <td style="word-wrap: break-word;">5 min</td>
-            <td>Duration</td>
-            <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
-        </tr>
-        <tr>
-            <td><h5>jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count</h5></td>
+            <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>
             <td>The number of consecutive failed checkpoints that will trigger rescaling even in the absence of a completed checkpoint.</td>
         </tr>
         <tr>
-            <td><h5>jobmanager.adaptive-scheduler.scaling-interval.min</h5></td>
-            <td style="word-wrap: break-word;">30 s</td>
+            <td><h5>jobmanager.adaptive-scheduler.rescale-trigger.max-delay</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>Determines the minimum time between scaling operations.</td>
+            <td>The maximum time the JobManager will wait with evaluating previously observed events for rescaling (default: 0ms if checkpointing is disabled and the checkpointing interval multiplied by the by-1-incremented parameter value of jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures if checkpointing is enabled).</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.submission.resource-stabilization-timeout</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>The resource stabilization timeout defines the time the JobManager will wait if fewer than the desired but sufficient resources are available during job submission. The timeout starts once sufficient resources for running the job are available. Once this timeout has passed, the job will start executing with the available resources.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to 0, so that jobs are starting immediately with the available resources.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.adaptive-scheduler.submission.resource-wait-timeout</h5></td>
+            <td style="word-wrap: break-word;">5 min</td>
+            <td>Duration</td>
+            <td>The maximum time the JobManager will wait to acquire all required resources after a job submission or restart. Once elapsed it will try to run the job with a lower parallelism, or fail if the minimum amount of resources could not be acquired.<br />Increasing this value will make the cluster more resilient against temporary resources shortages (e.g., there is more time for a failed TaskManager to be restarted).<br />Setting a negative duration will disable the resource timeout: The JobManager will wait indefinitely for resources to appear.<br />If <code class="highlighter-rouge">scheduler-mode</code> is configured to <code class="highlighter-rouge">REACTIVE</code>, this configuration value will default to a negative value to disable the resource timeout.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.archive.fs.dir</h5></td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -153,7 +153,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static org.apache.flink.configuration.JobManagerOptions.MAXIMUM_DELAY_FOR_SCALE_TRIGGER;
+import static org.apache.flink.configuration.JobManagerOptions.SCHEDULER_RESCALE_TRIGGER_MAX_DELAY;
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphUtils.isAnyOutputBlocking;
 
 /**
@@ -221,26 +221,28 @@ public class AdaptiveScheduler
                 throws ConfigurationException {
             final SchedulerExecutionMode executionMode =
                     configuration.get(JobManagerOptions.SCHEDULER_MODE);
-            Duration allocationTimeoutDefault =
-                    JobManagerOptions.RESOURCE_WAIT_TIMEOUT.defaultValue();
-            Duration stabilizationTimeoutDefault =
-                    JobManagerOptions.RESOURCE_STABILIZATION_TIMEOUT.defaultValue();
+            Duration submissionResourceWaitTimeoutDefault =
+                    JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_WAIT_TIMEOUT.defaultValue();
+            Duration submissionStabilizationTimeoutDefault =
+                    JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_STABILIZATION_TIMEOUT
+                            .defaultValue();
             if (executionMode == SchedulerExecutionMode.REACTIVE) {
-                allocationTimeoutDefault = Duration.ofMillis(-1);
-                stabilizationTimeoutDefault = Duration.ZERO;
+                submissionResourceWaitTimeoutDefault = Duration.ofMillis(-1);
+                submissionStabilizationTimeoutDefault = Duration.ZERO;
             }
 
-            final Duration scalingIntervalMin =
-                    configuration.get(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN);
+            final Duration executingCooldownTimeout =
+                    configuration.get(
+                            JobManagerOptions.SCHEDULER_EXECUTING_COOLDOWN_AFTER_RESCALING);
 
             final int rescaleOnFailedCheckpointsCount =
                     configuration.get(
-                            JobManagerOptions.SCHEDULER_SCALE_ON_FAILED_CHECKPOINTS_COUNT);
+                            JobManagerOptions.SCHEDULER_RESCALE_TRIGGER_MAX_CHECKPOINT_FAILURES);
             if (rescaleOnFailedCheckpointsCount < 1) {
                 throw new ConfigurationException(
                         String.format(
                                 "%s should have a value of 1 or higher.",
-                                JobManagerOptions.SCHEDULER_SCALE_ON_FAILED_CHECKPOINTS_COUNT
+                                JobManagerOptions.SCHEDULER_RESCALE_TRIGGER_MAX_CHECKPOINT_FAILURES
                                         .key()));
             }
 
@@ -252,13 +254,13 @@ public class AdaptiveScheduler
                                             .isCheckpointingEnabled()
                             // incrementing the rescaleOnFailedCheckpointsCount by 1 is done to
                             // avoid introducing a race-condition between the two parameters
-                            // (SCHEDULER_SCALE_ON_FAILED_CHECKPOINTS_COUNT and
-                            // MAXIMUM_DELAY_FOR_SCALE_TRIGGER). Without the increment, we would
+                            // (SCHEDULER_RESCALE_TRIGGER_MAX_CHECKPOINT_FAILURES and
+                            // SCHEDULER_RESCALE_TRIGGER_MAX_DELAY). Without the increment, we would
                             // have two configuration parameters that result in roughly the same
-                            // timeout (with the MAXIMUM_DELAY_FOR_SCALE_TRIGGER being probably a
-                            // bit faster). The user might experience unexpected behavior if the
-                            // SCHEDULER_SCALE_ON_FAILED_CHECKPOINTS_COUNT is configured and
-                            // MAXIMUM_DELAY_FOR_SCALE_TRIGGER is kept untouched in that case.
+                            // timeout (with the SCHEDULER_RESCALE_TRIGGER_MAX_DELAY being probably
+                            // a bit faster). The user might experience unexpected behavior if the
+                            // SCHEDULER_RESCALE_TRIGGER_MAX_CHECKPOINT_FAILURES is configured and
+                            // SCHEDULER_RESCALE_TRIGGER_MAX_DELAY is kept untouched in that case.
                             // Incrementing the default value should help avoiding causing this kind
                             // of confusing race condition.
                             ? Duration.ofMillis(
@@ -271,53 +273,58 @@ public class AdaptiveScheduler
             if (configuration.getOptional(JobManagerOptions.MIN_PARALLELISM_INCREASE).isPresent()) {
                 LOG.warn(
                         "The configuration option {} is deprecated and will be removed in future versions. It's not used anymore. "
-                                + "Please use the configuration option {} and {} to control the sensitivity of a scaling operation.",
+                                + "Please use the configuration option {} and {} to control the sensitivity of a scaling operation. "
+                                + "Or you can change resource requirements of a running job can using the REST API.",
                         JobManagerOptions.MIN_PARALLELISM_INCREASE.key(),
-                        JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN.key(),
-                        JobManagerOptions.SCHEDULER_SCALING_RESOURCE_STABILIZATION_TIMEOUT.key());
+                        JobManagerOptions.SCHEDULER_EXECUTING_COOLDOWN_AFTER_RESCALING.key(),
+                        JobManagerOptions.SCHEDULER_EXECUTING_RESOURCE_STABILIZATION_TIMEOUT.key());
             }
 
             return new Settings(
                     executionMode,
                     configuration
-                            .getOptional(JobManagerOptions.RESOURCE_WAIT_TIMEOUT)
-                            .orElse(allocationTimeoutDefault),
+                            .getOptional(
+                                    JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_WAIT_TIMEOUT)
+                            .orElse(submissionResourceWaitTimeoutDefault),
                     configuration
-                            .getOptional(JobManagerOptions.RESOURCE_STABILIZATION_TIMEOUT)
-                            .orElse(stabilizationTimeoutDefault),
+                            .getOptional(
+                                    JobManagerOptions
+                                            .SCHEDULER_SUBMISSION_RESOURCE_STABILIZATION_TIMEOUT)
+                            .orElse(submissionStabilizationTimeoutDefault),
                     configuration.get(JobManagerOptions.SLOT_IDLE_TIMEOUT),
-                    scalingIntervalMin,
+                    executingCooldownTimeout,
                     configuration.get(
-                            JobManagerOptions.SCHEDULER_SCALING_RESOURCE_STABILIZATION_TIMEOUT),
+                            JobManagerOptions.SCHEDULER_EXECUTING_RESOURCE_STABILIZATION_TIMEOUT),
                     configuration.get(
-                            MAXIMUM_DELAY_FOR_SCALE_TRIGGER, maximumDelayForRescaleTriggerDefault),
+                            SCHEDULER_RESCALE_TRIGGER_MAX_DELAY,
+                            maximumDelayForRescaleTriggerDefault),
                     rescaleOnFailedCheckpointsCount);
         }
 
         private final SchedulerExecutionMode executionMode;
-        private final Duration initialResourceAllocationTimeout;
-        private final Duration resourceStabilizationTimeout;
+        private final Duration submissionResourceWaitTimeout;
+        private final Duration submissionResourceStabilizationTimeout;
         private final Duration slotIdleTimeout;
-        private final Duration scalingIntervalMin;
-        private final Duration scalingResourceStabilizationTimeout;
+        private final Duration executingCooldownTimeout;
+        private final Duration executingResourceStabilizationTimeout;
         private final Duration maximumDelayForTriggeringRescale;
         private final int rescaleOnFailedCheckpointCount;
 
         private Settings(
                 SchedulerExecutionMode executionMode,
-                Duration initialResourceAllocationTimeout,
-                Duration resourceStabilizationTimeout,
+                Duration submissionResourceWaitTimeout,
+                Duration submissionResourceStabilizationTimeout,
                 Duration slotIdleTimeout,
-                Duration scalingIntervalMin,
-                Duration scalingResourceStabilizationTimeout,
+                Duration executingCooldownTimeout,
+                Duration executingResourceStabilizationTimeout,
                 Duration maximumDelayForTriggeringRescale,
                 int rescaleOnFailedCheckpointCount) {
             this.executionMode = executionMode;
-            this.initialResourceAllocationTimeout = initialResourceAllocationTimeout;
-            this.resourceStabilizationTimeout = resourceStabilizationTimeout;
+            this.submissionResourceWaitTimeout = submissionResourceWaitTimeout;
+            this.submissionResourceStabilizationTimeout = submissionResourceStabilizationTimeout;
             this.slotIdleTimeout = slotIdleTimeout;
-            this.scalingIntervalMin = scalingIntervalMin;
-            this.scalingResourceStabilizationTimeout = scalingResourceStabilizationTimeout;
+            this.executingCooldownTimeout = executingCooldownTimeout;
+            this.executingResourceStabilizationTimeout = executingResourceStabilizationTimeout;
             this.maximumDelayForTriggeringRescale = maximumDelayForTriggeringRescale;
             this.rescaleOnFailedCheckpointCount = rescaleOnFailedCheckpointCount;
         }
@@ -326,24 +333,24 @@ public class AdaptiveScheduler
             return executionMode;
         }
 
-        public Duration getInitialResourceAllocationTimeout() {
-            return initialResourceAllocationTimeout;
+        public Duration getSubmissionResourceWaitTimeout() {
+            return submissionResourceWaitTimeout;
         }
 
-        public Duration getResourceStabilizationTimeout() {
-            return resourceStabilizationTimeout;
+        public Duration getSubmissionResourceStabilizationTimeout() {
+            return submissionResourceStabilizationTimeout;
         }
 
         public Duration getSlotIdleTimeout() {
             return slotIdleTimeout;
         }
 
-        public Duration getScalingIntervalMin() {
-            return scalingIntervalMin;
+        public Duration getExecutingCooldownTimeout() {
+            return executingCooldownTimeout;
         }
 
-        public Duration getScalingResourceStabilizationTimeout() {
-            return scalingResourceStabilizationTimeout;
+        public Duration getExecutingResourceStabilizationTimeout() {
+            return executingResourceStabilizationTimeout;
         }
 
         public Duration getMaximumDelayForTriggeringRescale() {
@@ -1149,7 +1156,7 @@ public class AdaptiveScheduler
                 new WaitingForResources.Factory(
                         this,
                         LOG,
-                        settings.getInitialResourceAllocationTimeout(),
+                        settings.getSubmissionResourceWaitTimeout(),
                         this::createWaitingForResourceStateTransitionManager,
                         previousExecutionGraph));
     }
@@ -1160,7 +1167,7 @@ public class AdaptiveScheduler
                 ctx,
                 clock,
                 Duration.ZERO, // skip cooldown phase
-                settings.getResourceStabilizationTimeout(),
+                settings.getSubmissionResourceStabilizationTimeout(),
                 Duration.ZERO); // trigger immediately once the stabilization phase is over
     }
 
@@ -1201,8 +1208,8 @@ public class AdaptiveScheduler
         return stateTransitionManagerFactory.create(
                 ctx,
                 clock,
-                settings.getScalingIntervalMin(),
-                settings.getScalingResourceStabilizationTimeout(),
+                settings.getExecutingCooldownTimeout(),
+                settings.getExecutingResourceStabilizationTimeout(),
                 settings.getMaximumDelayForTriggeringRescale());
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/WaitingForResources.java
@@ -49,29 +49,28 @@ class WaitingForResources extends StateWithoutExecutionGraph
     WaitingForResources(
             Context context,
             Logger log,
-            Duration initialResourceAllocationTimeout,
+            Duration submissionResourceWaitTimeout,
             Function<StateTransitionManager.Context, StateTransitionManager>
                     stateTransitionManagerFactory) {
-        this(context, log, initialResourceAllocationTimeout, null, stateTransitionManagerFactory);
+        this(context, log, submissionResourceWaitTimeout, null, stateTransitionManagerFactory);
     }
 
     WaitingForResources(
             Context context,
             Logger log,
-            Duration initialResourceAllocationTimeout,
+            Duration submissionResourceWaitTimeout,
             @Nullable ExecutionGraph previousExecutionGraph,
             Function<StateTransitionManager.Context, StateTransitionManager>
                     stateTransitionManagerFactory) {
         super(context, log);
         this.context = Preconditions.checkNotNull(context);
-        Preconditions.checkNotNull(initialResourceAllocationTimeout);
+        Preconditions.checkNotNull(submissionResourceWaitTimeout);
         this.stateTransitionManager = stateTransitionManagerFactory.apply(this);
 
         // since state transitions are not allowed in state constructors, schedule calls for later.
-        if (!initialResourceAllocationTimeout.isNegative()) {
+        if (!submissionResourceWaitTimeout.isNegative()) {
             resourceTimeoutFuture =
-                    context.runIfState(
-                            this, this::resourceTimeout, initialResourceAllocationTimeout);
+                    context.runIfState(this, this::resourceTimeout, submissionResourceWaitTimeout);
         }
         this.previousExecutionGraph = previousExecutionGraph;
         context.runIfState(this, this::checkPotentialStateTransition, Duration.ZERO);
@@ -167,7 +166,7 @@ class WaitingForResources extends StateWithoutExecutionGraph
 
         private final Context context;
         private final Logger log;
-        private final Duration initialResourceAllocationTimeout;
+        private final Duration submissionResourceWaitTimeout;
         @Nullable private final ExecutionGraph previousExecutionGraph;
         private final Function<StateTransitionManager.Context, StateTransitionManager>
                 stateTransitionManagerFactory;
@@ -175,13 +174,13 @@ class WaitingForResources extends StateWithoutExecutionGraph
         public Factory(
                 Context context,
                 Logger log,
-                Duration initialResourceAllocationTimeout,
+                Duration submissionResourceWaitTimeout,
                 Function<StateTransitionManager.Context, StateTransitionManager>
                         stateTransitionManagerFactory,
                 @Nullable ExecutionGraph previousExecutionGraph) {
             this.context = context;
             this.log = log;
-            this.initialResourceAllocationTimeout = initialResourceAllocationTimeout;
+            this.submissionResourceWaitTimeout = submissionResourceWaitTimeout;
             this.previousExecutionGraph = previousExecutionGraph;
             this.stateTransitionManagerFactory = stateTransitionManagerFactory;
         }
@@ -194,7 +193,7 @@ class WaitingForResources extends StateWithoutExecutionGraph
             return new WaitingForResources(
                     context,
                     log,
-                    initialResourceAllocationTimeout,
+                    submissionResourceWaitTimeout,
                     previousExecutionGraph,
                     stateTransitionManagerFactory);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -110,7 +110,8 @@ class MiniClusterITCase {
         // this triggers the failure for the default scheduler
         config.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, slotRequestTimeout);
         // this triggers the failure for the adaptive scheduler
-        config.set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, slotRequestTimeout);
+        config.set(
+                JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_WAIT_TIMEOUT, slotRequestTimeout);
 
         // we have to disable sending the slot-unavailable request to allow for the timeout to kick
         // in
@@ -133,7 +134,8 @@ class MiniClusterITCase {
         // this triggers the failure for the default scheduler
         config.set(JobManagerOptions.SLOT_REQUEST_TIMEOUT, slotRequestTimeout);
         // this triggers the failure for the adaptive scheduler
-        config.set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, slotRequestTimeout);
+        config.set(
+                JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_WAIT_TIMEOUT, slotRequestTimeout);
 
         // overwrite the default check delay to speed up the test execution
         config.set(ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY, Duration.ofMillis(20));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
@@ -92,10 +92,14 @@ public class AdaptiveSchedulerClusterITCase {
         final Configuration configuration = new Configuration();
 
         configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);
-        configuration.set(JobManagerOptions.RESOURCE_STABILIZATION_TIMEOUT, Duration.ofMillis(1L));
-        configuration.set(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN, Duration.ofMillis(1L));
         configuration.set(
-                JobManagerOptions.SCHEDULER_SCALING_RESOURCE_STABILIZATION_TIMEOUT,
+                JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_STABILIZATION_TIMEOUT,
+                Duration.ofMillis(1L));
+        configuration.set(
+                JobManagerOptions.SCHEDULER_EXECUTING_COOLDOWN_AFTER_RESCALING,
+                Duration.ofMillis(1L));
+        configuration.set(
+                JobManagerOptions.SCHEDULER_EXECUTING_RESOURCE_STABILIZATION_TIMEOUT,
                 Duration.ofMillis(1L));
         // required for #testCheckpointStatsPersistedAcrossRescale
         configuration.set(WebOptions.CHECKPOINTS_HISTORY_SIZE, Integer.MAX_VALUE);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerSimpleITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerSimpleITCase.java
@@ -60,7 +60,8 @@ class AdaptiveSchedulerSimpleITCase {
 
         configuration.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);
         configuration.set(
-                JobManagerOptions.RESOURCE_STABILIZATION_TIMEOUT, Duration.ofMillis(100L));
+                JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_STABILIZATION_TIMEOUT,
+                Duration.ofMillis(100L));
 
         return configuration;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AutoRescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/AutoRescalingITCase.java
@@ -173,7 +173,9 @@ public class AutoRescalingITCase extends TestLogger {
 
             config.set(JobManagerOptions.SCHEDULER, JobManagerOptions.SchedulerType.Adaptive);
             // Disable the scaling cooldown to speed up the test
-            config.set(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN, Duration.ofMillis(0));
+            config.set(
+                    JobManagerOptions.SCHEDULER_EXECUTING_COOLDOWN_AFTER_RESCALING,
+                    Duration.ofMillis(0));
 
             // speed the test suite up
             // - lower refresh interval -> controls how fast we invalidate ExecutionGraphCache

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -115,7 +115,9 @@ abstract class AbstractTaskManagerProcessFailureRecoveryTest {
         config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
         config.set(TaskManagerOptions.CPU_CORES, 1.0);
         config.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
-        config.set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, Duration.ofSeconds(30L));
+        config.set(
+                JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_WAIT_TIMEOUT,
+                Duration.ofSeconds(30L));
         config.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay");
         config.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
         config.set(

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
@@ -93,7 +93,9 @@ public class TaskManagerDisconnectOnShutdownITCase {
         config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
         config.set(TaskManagerOptions.CPU_CORES, 1.0);
         config.set(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
-        config.set(JobManagerOptions.RESOURCE_WAIT_TIMEOUT, Duration.ofSeconds(30L));
+        config.set(
+                JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_WAIT_TIMEOUT,
+                Duration.ofSeconds(30L));
 
         // check that we run this test only if the java command
         // is available on this machine

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/RescaleOnCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/RescaleOnCheckpointITCase.java
@@ -91,10 +91,12 @@ class RescaleOnCheckpointITCase {
 
         // rescale shouldn't be triggered due to the timeout
         configuration.set(
-                JobManagerOptions.MAXIMUM_DELAY_FOR_SCALE_TRIGGER, TestingUtils.infiniteDuration());
+                JobManagerOptions.SCHEDULER_RESCALE_TRIGGER_MAX_DELAY,
+                TestingUtils.infiniteDuration());
 
         // no cooldown to avoid delaying the test even more
-        configuration.set(JobManagerOptions.SCHEDULER_SCALING_INTERVAL_MIN, Duration.ZERO);
+        configuration.set(
+                JobManagerOptions.SCHEDULER_EXECUTING_COOLDOWN_AFTER_RESCALING, Duration.ZERO);
 
         return configuration;
     }

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -829,7 +829,8 @@ public abstract class YarnTestBase {
             final String confDirPath = flinkConfDirPath.getParentFile().getAbsolutePath();
             globalConfiguration = GlobalConfiguration.loadConfiguration(confDirPath);
             globalConfiguration.set(
-                    JobManagerOptions.RESOURCE_WAIT_TIMEOUT, Duration.ofSeconds(30));
+                    JobManagerOptions.SCHEDULER_SUBMISSION_RESOURCE_WAIT_TIMEOUT,
+                    Duration.ofSeconds(30));
 
             // copy conf dir to test temporary workspace location
             tempConfPathForSecureRun = tmp.toPath().resolve("conf").toFile();


### PR DESCRIPTION

## What is the purpose of the change

This PR aligns the configuration naming for parameters used in the Adaptive Scheduler in different states.  


## Brief change log

- Parameter `jobmanager.adaptive-scheduler.resource-wait-timeout` was renamed to the `jobmanager.adaptive-scheduler.submission.resource-wait-timeout`
 - Parameter `jobmanager.adaptive-scheduler.resource-stabilization-timeout`   was renamed to the `jobmanager.adaptive-scheduler.submission.resource-stabilization-timeout`
 - Parameter `jobmanager.adaptive-scheduler.scaling-interval.min`  was renamed to the `jobmanager.adaptive-scheduler.executing.cooldown-after-rescaling`
 - Parameter `jobmanager.adaptive-scheduler.scaling-interval.max` was renamed to the `jobmanager.adaptive-scheduler.executing.resource-stabilization-timeout` with a default value of 60s. 
 - Parameter `jobmanager.adaptive-scheduler.min-parallelism-increase` was removed without a direct replacement. 
 - Parameter `jobmanager.adaptive-scheduler.max-delay-for-scale-trigger` was renamed to the `jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures`
 - Parameter `jobmanager.adaptive-scheduler.scale-on-failed-checkpoints-count` was renamed to the `jobmanager.adaptive-scheduler.rescale-trigger.max-checkpoint-failures`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  yes
  - The serializer: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? unsure
  - If yes, how is the feature documented?  docs
