### PR TITLE
[FLINK-28770][table-planner] CREATE TABLE AS SELECT supports explain

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -2738,13 +2738,25 @@ SqlNode SqlRichExplain() :
     <EXPLAIN>
     )
     (
+        stmt = SqlReplaceTable()
+        |
         stmt = SqlStatementSet()
         |
         stmt = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
         |
         stmt = RichSqlInsert()
+        |
+        stmt = SqlCreate()
     )
     {
+        if ((stmt instanceof SqlCreate)
+                && !(stmt instanceof SqlCreateTableAs)
+                && !(stmt instanceof SqlReplaceTableAs)) {
+            throw SqlUtil.newContextException(
+                getPos(),
+                ParserResource.RESOURCE.explainCreateOrReplaceStatementUnsupported());
+        }
+
         return new SqlRichExplain(getPos(), stmt, explainDetails);
     }
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/utils/ParserResource.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/utils/ParserResource.java
@@ -41,6 +41,10 @@ public interface ParserResource {
     @Resources.BaseMessage("Duplicate EXPLAIN DETAIL is not allowed.")
     Resources.ExInst<ParseException> explainDetailIsDuplicate();
 
+    @Resources.BaseMessage(
+            "Unsupported CREATE OR REPLACE statement for EXPLAIN. The statement must define a query using the AS clause (i.e. CTAS/RTAS statements).")
+    Resources.ExInst<ParseException> explainCreateOrReplaceStatementUnsupported();
+
     @Resources.BaseMessage("CREATE FUNCTION USING JAR syntax is not applicable to {0} language.")
     Resources.ExInst<ParseException> createFunctionUsingJar(String language);
 

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -2857,6 +2857,31 @@ class FlinkSqlParserImplTest extends SqlParserTest {
     }
 
     @Test
+    void testExplainCreateTableNoSupported() {
+        this.sql("EXPLAIN CREATE TABLE t (id int^)^")
+                .fails(
+                        "Unsupported CREATE OR REPLACE statement for EXPLAIN\\. The statement must define a query using the AS clause \\(i\\.e\\. CTAS/RTAS statements\\)\\.");
+    }
+
+    @Test
+    void testExplainCreateTableAsSelect() {
+        this.sql("EXPLAIN CREATE TABLE t AS SELECT * FROM b")
+                .ok("EXPLAIN CREATE TABLE `T`\nAS\nSELECT *\nFROM `B`");
+    }
+
+    @Test
+    void testExplainCreateOrReplaceTableAsSelect() {
+        this.sql("EXPLAIN CREATE OR REPLACE TABLE t AS SELECT * FROM b")
+                .ok("EXPLAIN CREATE OR REPLACE TABLE `T`\nAS\nSELECT *\nFROM `B`");
+    }
+
+    @Test
+    void testExplainReplaceTableAsSelect() {
+        this.sql("EXPLAIN REPLACE TABLE t AS SELECT * FROM b")
+                .ok("EXPLAIN REPLACE TABLE `T`\nAS\nSELECT *\nFROM `B`");
+    }
+
+    @Test
     void testCreateTableAsSelectWithoutOptions() {
         sql("CREATE TABLE t AS SELECT * FROM b").ok("CREATE TABLE `T`\nAS\nSELECT *\nFROM `B`");
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CreateTableASOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CreateTableASOperation.java
@@ -56,6 +56,14 @@ public class CreateTableASOperation implements ModifyOperation {
         return createTableOperation;
     }
 
+    public Map<String, String> getSinkModifyStaticPartitions() {
+        return sinkModifyStaticPartitions;
+    }
+
+    public boolean getSinkModifyOverwrite() {
+        return sinkModifyOverwrite;
+    }
+
     public SinkModifyOperation toSinkModifyOperation(CatalogManager catalogManager) {
         return new SinkModifyOperation(
                 catalogManager.getTableOrError(createTableOperation.getTableIdentifier()),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlNodeToOperationConversion.java
@@ -45,6 +45,7 @@ import org.apache.flink.sql.parser.ddl.SqlDropFunction;
 import org.apache.flink.sql.parser.ddl.SqlDropTable;
 import org.apache.flink.sql.parser.ddl.SqlDropView;
 import org.apache.flink.sql.parser.ddl.SqlRemoveJar;
+import org.apache.flink.sql.parser.ddl.SqlReplaceTableAs;
 import org.apache.flink.sql.parser.ddl.SqlReset;
 import org.apache.flink.sql.parser.ddl.SqlSet;
 import org.apache.flink.sql.parser.ddl.SqlStopJob;
@@ -973,6 +974,16 @@ public class SqlNodeToOperationConversion {
             operation = convertSqlStatementSet((SqlStatementSet) sqlNode);
         } else if (sqlNode.getKind().belongsTo(SqlKind.QUERY)) {
             operation = convertSqlQuery(sqlExplain.getStatement());
+        } else if ((sqlNode instanceof SqlCreateTableAs)
+                || (sqlNode instanceof SqlReplaceTableAs)) {
+            operation =
+                    convert(flinkPlanner, catalogManager, sqlNode)
+                            .orElseThrow(
+                                    () ->
+                                            new ValidationException(
+                                                    String.format(
+                                                            "EXPLAIN statement doesn't support %s",
+                                                            sqlNode.getKind())));
         } else {
             throw new ValidationException(
                     String.format("EXPLAIN statement doesn't support %s", sqlNode.getKind()));

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExplainCtas.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExplainCtas.out
@@ -1,0 +1,14 @@
+== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.MyCtasTable], fields=[a, b])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.MyCtasTable], fields=[a, b])
++- Calc(select=[a, b])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.MyCtasTable], fields=[a, b])
++- Calc(select=[a, b])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])

--- a/flink-table/flink-table-planner/src/test/resources/explain/testExplainCtasWithColumnsInCreateAndQueryParts.out
+++ b/flink-table/flink-table-planner/src/test/resources/explain/testExplainCtasWithColumnsInCreateAndQueryParts.out
@@ -1,0 +1,14 @@
+== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.MyCtasTable], fields=[EXPR$0, a, b])
++- LogicalProject(EXPR$0=[null:INTEGER], a=[$0], b=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.MyCtasTable], fields=[EXPR$0, a, b])
++- Calc(select=[null:INTEGER AS EXPR$0, a, b])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.MyCtasTable], fields=[EXPR$0, a, b])
++- Calc(select=[null:INTEGER AS EXPR$0, a, b])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])


### PR DESCRIPTION
## What is the purpose of the change

Add `EXPLAIN` support for CTAS and RTAS statements.

i.e.
```
EXPLAIN CREATE TABLE t2 
WITH ('format'='csv', 'connector'='filesystem', 'path'='/tmp/t2.dat') 
AS SELECT * FROM t1;
```

Result:
```
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|  result                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| == Abstract Syntax Tree ==
LogicalSink(table=[default_catalog.default_database.t2], fields=[])
+- LogicalProject
   +- LogicalTableScan(table=[[default_catalog, default_database, t1]])

== Optimized Physical Plan ==
Sink(table=[default_catalog.default_database.t2], fields=[])
+- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[])

== Optimized Execution Plan ==
Sink(table=[default_catalog.default_database.t2], fields=[])
+- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[])
 |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set

```

## Brief change log

  - *Added support for CTAS & RTAS on Explain statements*


## Verifying this change

- *Added unit tests*
- *Added IT tests*
- *Verified manually on SQL client*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable