### PR TITLE
[FLINK-35411] Optimize buffer triggering of async state requests

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
@@ -351,7 +351,11 @@ public class AsyncExecutionController<K> implements StateRequestHandler {
         try {
             while (inFlightRecordNum.get() > targetNum) {
                 if (!mailboxExecutor.tryYield()) {
-                    triggerIfNeeded(true);
+                    // We force trigger the buffer if targetNum == 0 (for draining) or the state
+                    // executor is not fully loaded.
+                    if (targetNum == 0 || !stateExecutor.fullyLoaded()) {
+                        triggerIfNeeded(true);
+                    }
                     Thread.sleep(1);
                 }
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateExecutor.java
@@ -45,6 +45,14 @@ public interface StateExecutor {
      */
     StateRequestContainer createStateRequestContainer();
 
+    /**
+     * Check if this executor is fully loaded. Will be invoked to determine whether to give more
+     * requests to run or wait for a while.
+     *
+     * @return the count.
+     */
+    boolean fullyLoaded();
+
     /** Shutdown the StateExecutor, and new committed state execution requests will be rejected. */
     void shutdown();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateFutureFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateFutureFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.asyncprocessing;
 
-import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.core.state.InternalStateFuture;
 import org.apache.flink.core.state.StateFutureImpl.AsyncFrameworkExceptionHandler;
 
@@ -34,10 +33,10 @@ public class StateFutureFactory<K> {
 
     StateFutureFactory(
             AsyncExecutionController<K> asyncExecutionController,
-            MailboxExecutor mailboxExecutor,
+            BatchCallbackRunner callbackRunner,
             AsyncFrameworkExceptionHandler exceptionHandler) {
         this.asyncExecutionController = asyncExecutionController;
-        this.callbackRunner = new BatchCallbackRunner(mailboxExecutor);
+        this.callbackRunner = callbackRunner;
         this.exceptionHandler = exceptionHandler;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestBuffer.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.runtime.asyncprocessing;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -43,7 +46,7 @@ import java.util.function.Supplier;
  * @param <K> the type of the key
  */
 @NotThreadSafe
-public class StateRequestBuffer<K> {
+public class StateRequestBuffer<K> implements Closeable {
 
     /** All StateRequestBuffer in the same task manager share one ScheduledExecutorService. */
     private static final ScheduledThreadPoolExecutor DELAYER =
@@ -75,44 +78,68 @@ public class StateRequestBuffer<K> {
     /** The timeout of {@link #activeQueue} triggering in milliseconds. */
     final long bufferTimeout;
 
+    /** The interval of periodic buffer timeout check. */
+    final long bufferTimeoutCheckInterval;
+
     /** The handler to trigger when timeout. */
     final Consumer<Long> timeoutHandler;
 
     /** The executor service that schedules and calls the triggers of this task. */
-    ScheduledExecutorService scheduledExecutor;
+    final ScheduledExecutorService scheduledExecutor;
 
     /**
      * The current scheduled future, when the next scheduling occurs, the previous one that has not
      * yet been executed will be canceled.
      */
-    ScheduledFuture<Void> currentScheduledFuture;
+    ScheduledFuture<?> currentScheduledFuture;
 
     /**
      * The current scheduled trigger sequence number, a timeout trigger is scheduled only if {@code
      * scheduledSeq} is less than {@code currentSeq}.
      */
-    AtomicLong scheduledSeq;
+    volatile Tuple2<Long, Long> seqAndTimeout = null;
 
     /**
      * The current trigger sequence number, used to distinguish different triggers. Every time a
      * trigger occurs, {@code currentSeq} increases by 1.
      */
-    AtomicLong currentSeq;
+    final AtomicLong currentSeq;
 
-    public StateRequestBuffer(long bufferTimeout, Consumer<Long> timeoutHandler) {
+    public StateRequestBuffer(
+            long bufferTimeout, long bufferTimeoutCheckInterval, Consumer<Long> timeoutHandler) {
         this.activeQueue = new LinkedList<>();
         this.blockingQueue = new HashMap<>();
         this.blockingQueueSize = 0;
         this.bufferTimeout = bufferTimeout;
+        this.bufferTimeoutCheckInterval = bufferTimeoutCheckInterval;
         this.timeoutHandler = timeoutHandler;
-        this.scheduledSeq = new AtomicLong(-1);
         this.currentSeq = new AtomicLong(0);
         if (bufferTimeout > 0) {
             this.scheduledExecutor = DELAYER;
+            initPeriodicTimeoutCheck();
+        } else {
+            this.scheduledExecutor = null;
         }
     }
 
+    private void initPeriodicTimeoutCheck() {
+        currentScheduledFuture =
+                scheduledExecutor.scheduleAtFixedRate(
+                        () -> {
+                            final Tuple2<Long, Long> theSeqAndTimeout = seqAndTimeout;
+                            if (theSeqAndTimeout != null
+                                    && theSeqAndTimeout.f0 == currentSeq.get()
+                                    && theSeqAndTimeout.f1 <= System.currentTimeMillis()) {
+                                timeoutHandler.accept(theSeqAndTimeout.f0);
+                            }
+                        },
+                        bufferTimeout,
+                        bufferTimeoutCheckInterval,
+                        TimeUnit.MILLISECONDS);
+    }
+
     void advanceSeq() {
+        seqAndTimeout = null;
         currentSeq.incrementAndGet();
     }
 
@@ -125,24 +152,9 @@ public class StateRequestBuffer<K> {
             request.getFuture().complete(null);
         } else {
             activeQueue.add(request);
-            if (bufferTimeout > 0 && currentSeq.get() > scheduledSeq.get()) {
-                if (currentScheduledFuture != null
-                        && !currentScheduledFuture.isDone()
-                        && !currentScheduledFuture.isCancelled()) {
-                    currentScheduledFuture.cancel(false);
-                }
-                final long thisScheduledSeq = currentSeq.get();
-                scheduledSeq.set(thisScheduledSeq);
-                currentScheduledFuture =
-                        (ScheduledFuture<Void>)
-                                scheduledExecutor.schedule(
-                                        () -> {
-                                            if (thisScheduledSeq == currentSeq.get()) {
-                                                timeoutHandler.accept(thisScheduledSeq);
-                                            }
-                                        },
-                                        bufferTimeout,
-                                        TimeUnit.MILLISECONDS);
+            if (bufferTimeout > 0 && seqAndTimeout == null) {
+                seqAndTimeout =
+                        Tuple2.of(currentSeq.get(), System.currentTimeMillis() + bufferTimeout);
             }
         }
     }
@@ -212,5 +224,13 @@ public class StateRequestBuffer<K> {
             stateRequestContainer.offer(activeQueue.pop());
         }
         return Optional.of(stateRequestContainer);
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        if (currentScheduledFuture != null) {
+            currentScheduledFuture.cancel(true);
+            currentScheduledFuture = null;
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -316,4 +316,10 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
     RecordContext getCurrentProcessingContext() {
         return currentProcessingContext;
     }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        asyncExecutionController.close();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
@@ -253,4 +253,10 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
     public RecordContext getCurrentProcessingContext() {
         return currentProcessingContext;
     }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        asyncExecutionController.close();
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AbstractStateIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AbstractStateIteratorTest.java
@@ -202,6 +202,11 @@ public class AbstractStateIteratorTest {
         }
 
         @Override
+        public boolean fullyLoaded() {
+            return false;
+        }
+
+        @Override
         public void shutdown() {}
 
         static class TestIterator extends AbstractStateIterator<Integer> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.core.state.StateFutureImpl.AsyncFrameworkExceptionHandle
 import org.apache.flink.core.state.StateFutureUtils;
 import org.apache.flink.runtime.asyncprocessing.EpochManager.Epoch;
 import org.apache.flink.runtime.asyncprocessing.EpochManager.ParallelMode;
-import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
@@ -46,7 +45,6 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -527,7 +525,7 @@ class AsyncExecutionControllerTest {
     }
 
     @Test
-    void testBufferTimeout() throws IOException {
+    void testBufferTimeout() throws Exception {
         int batchSize = 5;
         int timeout = 1000;
         CloseableRegistry resourceRegistry = new CloseableRegistry();
@@ -538,11 +536,11 @@ class AsyncExecutionControllerTest {
                 new SyncMailboxExecutor(),
                 new TestAsyncFrameworkExceptionHandler(),
                 resourceRegistry);
-        ManuallyTriggeredScheduledExecutorService scheduledExecutor =
-                new ManuallyTriggeredScheduledExecutorService();
-        aec.stateRequestsBuffer.scheduledExecutor = scheduledExecutor;
+
         Runnable userCode = () -> valueState.asyncValue();
 
+        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(0L);
+        assertThat(aec.stateRequestsBuffer.seqAndTimeout).isNull();
         // ------------ basic timeout -------------------
         for (int i = 0; i < batchSize - 1; i++) {
             String record = String.format("key%d-r%d", i, i);
@@ -551,127 +549,47 @@ class AsyncExecutionControllerTest {
             aec.setCurrentContext(recordContext);
             userCode.run();
         }
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(0);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(0);
+        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(0L);
+        assertThat(aec.stateRequestsBuffer.seqAndTimeout.f0).isEqualTo(0L);
         assertThat(aec.stateRequestsBuffer.currentScheduledFuture.isDone()).isFalse();
         assertThat(aec.inFlightRecordNum.get()).isEqualTo(batchSize - 1);
         assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(batchSize - 1);
         assertThat(aec.stateRequestsBuffer.blockingQueueSize()).isEqualTo(0);
 
         // buffer timeout, trigger
-        scheduledExecutor.triggerNonPeriodicScheduledTasks();
+        Thread.sleep(2000);
         assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(0);
-        assertThat(aec.stateRequestsBuffer.currentScheduledFuture.isDone()).isTrue();
-        assertThat(aec.inFlightRecordNum.get()).isEqualTo(0);
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(0);
-
-        // ----------------- oldest state request timeout ------------------
-        // r5 and r6 should be triggered due to r5 exceeding timeout
-        String record5 = "key5-r5";
-        String key5 = "key5";
-        RecordContext<String> recordContext5 = aec.buildContext(record5, key5);
-        aec.setCurrentContext(recordContext5);
-        // execute user code
-        userCode.run();
-        assertThat(aec.inFlightRecordNum.get()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(1);
         assertThat(aec.stateRequestsBuffer.currentScheduledFuture.isDone()).isFalse();
-        ScheduledFuture<Void> scheduledFuture = aec.stateRequestsBuffer.currentScheduledFuture;
-        String record6 = "key6-r6";
-        String key6 = "key6";
-        RecordContext<String> recordContext6 = aec.buildContext(record6, key6);
-        aec.setCurrentContext(recordContext6);
-        // execute user code
-        userCode.run();
-        assertThat(aec.inFlightRecordNum.get()).isEqualTo(2);
-        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(2);
-
-        assertThat(scheduledExecutor.getActiveNonPeriodicScheduledTask().size()).isEqualTo(1);
-        assertThat(scheduledExecutor.getAllNonPeriodicScheduledTask().size()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(1);
-        scheduledExecutor.triggerNonPeriodicScheduledTasks();
-
         assertThat(aec.inFlightRecordNum.get()).isEqualTo(0);
-        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(0);
-        assertThat(scheduledFuture).isEqualTo(aec.stateRequestsBuffer.currentScheduledFuture);
-        assertThat(scheduledFuture.isDone()).isTrue();
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(2);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(1);
+        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(1L);
+        assertThat(aec.stateRequestsBuffer.seqAndTimeout).isNull();
 
-        resourceRegistry.close();
-    }
-
-    @Test
-    void testBufferTimeoutSkip() throws IOException {
-        int batchSize = 3;
-        int timeout = 1000;
-        CloseableRegistry resourceRegistry = new CloseableRegistry();
-        setup(
-                batchSize,
-                timeout,
-                1000,
-                new SyncMailboxExecutor(),
-                new TestAsyncFrameworkExceptionHandler(),
-                resourceRegistry);
-        ManuallyTriggeredScheduledExecutorService scheduledExecutor =
-                new ManuallyTriggeredScheduledExecutorService();
-        aec.stateRequestsBuffer.scheduledExecutor = scheduledExecutor;
-        Runnable userCode = () -> valueState.asyncValue();
-
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(0);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(-1);
-        // register r1 timeout
-        RecordContext<String> recordContext = aec.buildContext("record1", "key1");
-        aec.setCurrentContext(recordContext);
-        userCode.run();
-        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(1);
-        assertThat(aec.inFlightRecordNum.get()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(0);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(0);
-
-        // before r1 timeout execute, the active buffer size reach batch size.
-        RecordContext<String> recordContext2 = aec.buildContext("record2", "key2");
-        aec.setCurrentContext(recordContext2);
-        userCode.run();
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(0);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(0);
-        RecordContext<String> recordContext3 = aec.buildContext("record3", "key3");
-        aec.setCurrentContext(recordContext3);
-        userCode.run();
-        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(0);
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(0);
-
-        // r1 timeout executes, but r1 is already triggered in [r1,r2,r3], so r1 timeout should skip
-        assertThat(scheduledExecutor.getActiveNonPeriodicScheduledTask().size()).isEqualTo(1);
-        assertThat(scheduledExecutor.getAllNonPeriodicScheduledTask().size()).isEqualTo(1);
-        scheduledExecutor.triggerNonPeriodicScheduledTask();
-        assertThat(aec.stateRequestsBuffer.currentScheduledFuture.isDone()).isTrue();
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(0);
-
-        RecordContext<String> recordContext4 = aec.buildContext("record4", "key4");
-        aec.setCurrentContext(recordContext4);
-        userCode.run();
-
-        // register r4 timeout, set new currentScheduledFuture
-        assertThat(scheduledExecutor.getActiveNonPeriodicScheduledTask().size()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(1);
-        assertThat(aec.inFlightRecordNum.get()).isEqualTo(1);
+        // ---------- buffer full before timeout ------------------
+        for (int i = 0; i < batchSize - 1; i++) {
+            String record = String.format("key%d-r%d", i, i);
+            String key = String.format("key%d", batchSize + i);
+            RecordContext<String> recordContext = aec.buildContext(record, key);
+            aec.setCurrentContext(recordContext);
+            userCode.run();
+        }
+        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(1L);
+        assertThat(aec.stateRequestsBuffer.seqAndTimeout.f0).isEqualTo(1L);
         assertThat(aec.stateRequestsBuffer.currentScheduledFuture.isDone()).isFalse();
-        assertThat(aec.stateRequestsBuffer.currentScheduledFuture.isCancelled()).isFalse();
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(1);
-
-        // r4 timeout
-        scheduledExecutor.triggerNonPeriodicScheduledTask();
+        assertThat(aec.inFlightRecordNum.get()).isEqualTo(batchSize - 1);
+        assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(batchSize - 1);
+        assertThat(aec.stateRequestsBuffer.blockingQueueSize()).isEqualTo(0);
+        for (int i = batchSize - 1; i < batchSize; i++) {
+            String record = String.format("key%d-r%d", i, i);
+            String key = String.format("key%d", batchSize + i);
+            RecordContext<String> recordContext = aec.buildContext(record, key);
+            aec.setCurrentContext(recordContext);
+            userCode.run();
+        }
         assertThat(aec.stateRequestsBuffer.activeQueueSize()).isEqualTo(0);
+        assertThat(aec.stateRequestsBuffer.currentScheduledFuture.isDone()).isFalse();
         assertThat(aec.inFlightRecordNum.get()).isEqualTo(0);
-        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(2);
-        assertThat(aec.stateRequestsBuffer.scheduledSeq.get()).isEqualTo(1);
-        assertThat(aec.stateRequestsBuffer.currentScheduledFuture.isDone()).isTrue();
+        assertThat(aec.stateRequestsBuffer.currentSeq.get()).isEqualTo(2L);
+        assertThat(aec.stateRequestsBuffer.seqAndTimeout).isNull();
 
         resourceRegistry.close();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -921,6 +921,11 @@ class AsyncExecutionControllerTest {
         }
 
         @Override
+        public boolean fullyLoaded() {
+            return false;
+        }
+
+        @Override
         public void shutdown() {}
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/MockStateExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/MockStateExecutor.java
@@ -42,5 +42,10 @@ public class MockStateExecutor implements StateExecutor {
     }
 
     @Override
+    public boolean fullyLoaded() {
+        return false;
+    }
+
+    @Override
     public void shutdown() {}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
@@ -221,6 +221,11 @@ public class AbstractKeyedStateTestBase {
         }
 
         @Override
+        public boolean fullyLoaded() {
+            return false;
+        }
+
+        @Override
         public void shutdown() {}
 
         static class TestStateRequestContainer implements StateRequestContainer {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
@@ -184,6 +184,11 @@ public class AbstractReducingStateTest extends AbstractKeyedStateTestBase {
         }
 
         @Override
+        public boolean fullyLoaded() {
+            return false;
+        }
+
+        @Override
         public void shutdown() {}
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStConfigurableOptions.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStConfigurableOptions.java
@@ -40,6 +40,7 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
 import static org.apache.flink.configuration.description.TextElement.code;
 import static org.apache.flink.state.forst.ForStOptions.EXECUTOR_READ_IO_PARALLELISM;
+import static org.apache.flink.state.forst.ForStOptions.EXECUTOR_WRITE_IO_INLINE;
 import static org.apache.flink.state.forst.ForStOptions.EXECUTOR_WRITE_IO_PARALLELISM;
 import static org.rocksdb.CompactionStyle.FIFO;
 import static org.rocksdb.CompactionStyle.LEVEL;
@@ -325,6 +326,7 @@ public class ForStConfigurableOptions implements Serializable {
     static final ConfigOption<?>[] CANDIDATE_CONFIGS =
             new ConfigOption<?>[] {
                 // configurable forst executor
+                EXECUTOR_WRITE_IO_INLINE,
                 EXECUTOR_WRITE_IO_PARALLELISM,
                 EXECUTOR_READ_IO_PARALLELISM,
                 // configurable DBOptions

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBOperation.java
@@ -36,4 +36,11 @@ public interface ForStDBOperation {
      * @return The future which indicates whether the operation is completed.
      */
     CompletableFuture<Void> process();
+
+    /**
+     * The count of sub-processes. Each sub-process is an atomic operation in one single thread.
+     *
+     * @return the count.
+     */
+    int subProcessCount();
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStGeneralMultiGetOperation.java
@@ -38,11 +38,22 @@ public class ForStGeneralMultiGetOperation implements ForStDBOperation {
 
     private final Executor executor;
 
+    private final Runnable subProcessFinished;
+
     ForStGeneralMultiGetOperation(
             RocksDB db, List<ForStDBGetRequest<?, ?, ?, ?>> batchRequest, Executor executor) {
+        this(db, batchRequest, executor, null);
+    }
+
+    ForStGeneralMultiGetOperation(
+            RocksDB db,
+            List<ForStDBGetRequest<?, ?, ?, ?>> batchRequest,
+            Executor executor,
+            Runnable subProcessFinished) {
         this.db = db;
         this.batchRequest = batchRequest;
         this.executor = executor;
+        this.subProcessFinished = subProcessFinished;
     }
 
     @Override
@@ -76,9 +87,17 @@ public class ForStGeneralMultiGetOperation implements ForStDBOperation {
                                     && !future.isCompletedExceptionally()) {
                                 future.complete(null);
                             }
+                            if (subProcessFinished != null) {
+                                subProcessFinished.run();
+                            }
                         }
                     });
         }
         return future;
+    }
+
+    @Override
+    public int subProcessCount() {
+        return batchRequest.size();
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStIterateOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStIterateOperation.java
@@ -39,11 +39,22 @@ public class ForStIterateOperation implements ForStDBOperation {
 
     private final Executor executor;
 
+    private final Runnable subProcessFinished;
+
     ForStIterateOperation(
             RocksDB db, List<ForStDBIterRequest<?, ?, ?, ?, ?>> batchRequest, Executor executor) {
+        this(db, batchRequest, executor, null);
+    }
+
+    ForStIterateOperation(
+            RocksDB db,
+            List<ForStDBIterRequest<?, ?, ?, ?, ?>> batchRequest,
+            Executor executor,
+            Runnable subProcessFinished) {
         this.db = db;
         this.batchRequest = batchRequest;
         this.executor = executor;
+        this.subProcessFinished = subProcessFinished;
     }
 
     @Override
@@ -75,9 +86,17 @@ public class ForStIterateOperation implements ForStDBOperation {
                                     && !future.isCompletedExceptionally()) {
                                 future.complete(null);
                             }
+                            if (subProcessFinished != null) {
+                                subProcessFinished.run();
+                            }
                         }
                     });
         }
         return future;
+    }
+
+    @Override
+    public int subProcessCount() {
+        return batchRequest.size();
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -276,6 +276,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
             }
             StateExecutor stateExecutor =
                     new ForStStateExecutor(
+                            optionsContainer.isWriteInline(),
                             optionsContainer.getReadIoParallelism(),
                             optionsContainer.getWriteIoParallelism(),
                             db,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOptions.java
@@ -157,17 +157,27 @@ public class ForStOptions {
                                             + "of rocksdb timer service, but consumes more heap memory at the same time.",
                                     TIMER_SERVICE_FACTORY.key(), ForStDB.name()));
 
+    public static final ConfigOption<Boolean> EXECUTOR_WRITE_IO_INLINE =
+            ConfigOptions.key("state.backend.forst.executor.inline-write")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to let write requests executed within the coordinator thread.");
+
     public static final ConfigOption<Integer> EXECUTOR_READ_IO_PARALLELISM =
-            ConfigOptions.key("state.backend.forst.memory.executor-read-io-parallelism")
+            ConfigOptions.key("state.backend.forst.executor.read-io-parallelism")
                     .intType()
                     .defaultValue(3)
                     .withDescription(
                             "The number of threads used for read IO operations in the executor.");
 
     public static final ConfigOption<Integer> EXECUTOR_WRITE_IO_PARALLELISM =
-            ConfigOptions.key("state.backend.forst.memory.executor-write-io-parallelism")
+            ConfigOptions.key("state.backend.forst.executor.write-io-parallelism")
                     .intType()
                     .defaultValue(1)
                     .withDescription(
-                            "The number of threads used for write IO operations in the executor.");
+                            "The number of threads used for write IO operations in the executor."
+                                    + " Only valid when '"
+                                    + EXECUTOR_WRITE_IO_INLINE.key()
+                                    + "' is false.");
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
@@ -277,6 +277,10 @@ public final class ForStResourceContainer implements AutoCloseable {
         }
     }
 
+    public boolean isWriteInline() {
+        return configuration.get(ForStOptions.EXECUTOR_WRITE_IO_INLINE);
+    }
+
     public int getReadIoParallelism() {
         return configuration.get(ForStOptions.EXECUTOR_READ_IO_PARALLELISM);
     }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateRequestClassifier.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateRequestClassifier.java
@@ -135,4 +135,8 @@ public class ForStStateRequestClassifier implements StateRequestContainer {
     public List<ForStDBIterRequest<?, ?, ?, ?, ?>> pollDbIterRequests() {
         return dbIterRequests;
     }
+
+    public long size() {
+        return dbGetRequests.size() + dbPutRequests.size() + dbIterRequests.size();
+    }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStWriteBatchOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStWriteBatchOperation.java
@@ -37,15 +37,27 @@ public class ForStWriteBatchOperation implements ForStDBOperation {
 
     private final Executor executor;
 
+    private final Runnable subProcessFinished;
+
     ForStWriteBatchOperation(
             RocksDB db,
             List<ForStDBPutRequest<?, ?, ?>> batchRequest,
             WriteOptions writeOptions,
             Executor executor) {
+        this(db, batchRequest, writeOptions, executor, null);
+    }
+
+    ForStWriteBatchOperation(
+            RocksDB db,
+            List<ForStDBPutRequest<?, ?, ?>> batchRequest,
+            WriteOptions writeOptions,
+            Executor executor,
+            Runnable subProcessFinished) {
         this.db = db;
         this.batchRequest = batchRequest;
         this.writeOptions = writeOptions;
         this.executor = executor;
+        this.subProcessFinished = subProcessFinished;
     }
 
     @Override
@@ -69,8 +81,17 @@ public class ForStWriteBatchOperation implements ForStDBOperation {
                         }
                         // fail the whole batch operation
                         throw new CompletionException(msg, e);
+                    } finally {
+                        if (subProcessFinished != null) {
+                            subProcessFinished.run();
+                        }
                     }
                 },
                 executor);
+    }
+
+    @Override
+    public int subProcessCount() {
+        return batchRequest.size();
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
@@ -47,7 +47,7 @@ class ForStStateExecutorTest extends ForStDBOperationTestBase {
     @SuppressWarnings("unchecked")
     void testExecuteValueStateRequest() throws Exception {
         ForStStateExecutor forStStateExecutor =
-                new ForStStateExecutor(3, 1, db, new WriteOptions());
+                new ForStStateExecutor(false, 3, 1, db, new WriteOptions());
         ForStValueState<Integer, VoidNamespace, String> state1 =
                 buildForStValueState("value-state-1");
         ForStValueState<Integer, VoidNamespace, String> state2 =
@@ -131,7 +131,7 @@ class ForStStateExecutorTest extends ForStDBOperationTestBase {
     @Test
     void testExecuteMapStateRequest() throws Exception {
         ForStStateExecutor forStStateExecutor =
-                new ForStStateExecutor(3, 1, db, new WriteOptions());
+                new ForStStateExecutor(false, 3, 1, db, new WriteOptions());
         ForStMapState<Integer, VoidNamespace, String, String> state =
                 buildForStMapState("map-state");
         StateRequestContainer stateRequestContainer =


### PR DESCRIPTION
## What is the purpose of the change

This PR optimize the trigger logic of `AEC`. Including draining and timeout trigger.

## Brief change log


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
