### PR TITLE
[FLINK-36330] Session Window TVFs with named parameters don't support column expansion

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkCalciteSqlValidator.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.planner.catalog.CatalogSchemaTable;
+import org.apache.flink.table.planner.functions.sql.SqlSessionTableFunction;
 import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
 import org.apache.flink.table.types.logical.DecimalType;
@@ -355,14 +356,15 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
             @PolyNull SqlNode node, boolean underFrom) {
 
         // Special case for window TVFs like:
-        // TUMBLE(TABLE t, DESCRIPTOR(metadata_virtual), INTERVAL '1' MINUTE))
+        // TUMBLE(TABLE t, DESCRIPTOR(metadata_virtual), INTERVAL '1' MINUTE)) or
+        // SESSION(TABLE t PARTITION BY a, DESCRIPTOR(metadata_virtual), INTERVAL '1' MINUTE))
         //
         // "TABLE t" is translated into an implicit "SELECT * FROM t". This would ignore columns
         // that are not expanded by default. However, the descriptor explicitly states the need
         // for this column. Therefore, explicit table expressions (for window TVFs at most one)
         // are captured before rewriting and replaced with a "marker" SqlSelect that contains the
         // descriptor information. The "marker" SqlSelect is considered during column expansion.
-        final List<SqlIdentifier> explicitTableArgs = getExplicitTableOperands(node);
+        final List<SqlIdentifier> tableArgs = getTableOperands(node);
 
         final SqlNode rewritten = super.performUnconditionalRewrites(node, underFrom);
 
@@ -373,20 +375,30 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
         final SqlOperator operator = call.getOperator();
 
         if (operator instanceof SqlWindowTableFunction) {
-            if (explicitTableArgs.stream().allMatch(Objects::isNull)) {
+            if (tableArgs.stream().allMatch(Objects::isNull)) {
                 return rewritten;
             }
 
+            final boolean isSessionWindow = isSessionWindow(operator);
             final List<SqlIdentifier> descriptors =
                     call.getOperandList().stream()
                             .flatMap(FlinkCalciteSqlValidator::extractDescriptors)
                             .collect(Collectors.toList());
 
             for (int i = 0; i < call.operandCount(); i++) {
-                final SqlIdentifier tableArg = explicitTableArgs.get(i);
+                final SqlIdentifier tableArg = tableArgs.get(i);
                 if (tableArg != null) {
                     final SqlNode opReplacement = new ExplicitTableSqlSelect(tableArg, descriptors);
-                    if (call.operand(i).getKind() == SqlKind.ARGUMENT_ASSIGNMENT) {
+                    if (isSessionWindow) {
+                        if (call.operand(i).getKind() == SqlKind.SET_SEMANTICS_TABLE) {
+                            final SqlCall setSemanticsTable = call.operand(i);
+                            setSemanticsTable.setOperand(0, opReplacement);
+                        } else if (call.operand(i).getKind() == SqlKind.ARGUMENT_ASSIGNMENT) {
+                            final SqlCall assignment = call.operand(i);
+                            final SqlCall setSemanticsTable = assignment.operand(i);
+                            setSemanticsTable.setOperand(0, opReplacement);
+                        }
+                    } else if (call.operand(i).getKind() == SqlKind.ARGUMENT_ASSIGNMENT) {
                         // for TUMBLE(DATA => TABLE t3, ...)
                         final SqlCall assignment = call.operand(i);
                         assignment.setOperand(0, opReplacement);
@@ -447,10 +459,11 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
     }
 
     /**
-     * Returns all {@link SqlKind#EXPLICIT_TABLE} operands within TVF operands. A list entry is
-     * {@code null} if the operand is not an {@link SqlKind#EXPLICIT_TABLE}.
+     * Returns all {@link SqlKind#EXPLICIT_TABLE} and {@link SqlKind#SET_SEMANTICS_TABLE} operands
+     * within TVF operands. A list entry is {@code null} if the operand is not an {@link
+     * SqlKind#EXPLICIT_TABLE} or {@link SqlKind#SET_SEMANTICS_TABLE}.
      */
-    private static List<SqlIdentifier> getExplicitTableOperands(SqlNode node) {
+    private static List<SqlIdentifier> getTableOperands(SqlNode node) {
         if (!(node instanceof SqlBasicCall)) {
             return null;
         }
@@ -466,21 +479,28 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
         }
 
         return call.getOperandList().stream()
-                .map(FlinkCalciteSqlValidator::extractExplicitTable)
+                .map(FlinkCalciteSqlValidator::extractTableOperand)
                 .collect(Collectors.toList());
     }
 
-    private static @Nullable SqlIdentifier extractExplicitTable(SqlNode op) {
+    private static @Nullable SqlIdentifier extractTableOperand(SqlNode op) {
         if (op.getKind() == SqlKind.EXPLICIT_TABLE) {
             final SqlBasicCall opCall = (SqlBasicCall) op;
             if (opCall.operandCount() == 1 && opCall.operand(0) instanceof SqlIdentifier) {
                 // for TUMBLE(TABLE t3, ...)
                 return opCall.operand(0);
             }
+        } else if (op.getKind() == SqlKind.SET_SEMANTICS_TABLE) {
+            // for SESSION windows
+            final SqlBasicCall opCall = (SqlBasicCall) op;
+            final SqlCall setSemanticsTable = opCall.operand(0);
+            if (setSemanticsTable.operand(0) instanceof SqlIdentifier) {
+                return setSemanticsTable.operand(0);
+            }
         } else if (op.getKind() == SqlKind.ARGUMENT_ASSIGNMENT) {
             // for TUMBLE(DATA => TABLE t3, ...)
             final SqlBasicCall opCall = (SqlBasicCall) op;
-            return extractExplicitTable(opCall.operand(0));
+            return extractTableOperand(opCall.operand(0));
         }
         return null;
     }
@@ -492,6 +512,13 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
             return opCall.getOperandList().stream()
                     .filter(SqlIdentifier.class::isInstance)
                     .map(SqlIdentifier.class::cast);
+        } else if (op.getKind() == SqlKind.SET_SEMANTICS_TABLE) {
+            // for SESSION windows
+            final SqlBasicCall opCall = (SqlBasicCall) op;
+            return ((SqlNodeList) opCall.operand(1))
+                    .stream()
+                            .filter(SqlIdentifier.class::isInstance)
+                            .map(SqlIdentifier.class::cast);
         } else if (op.getKind() == SqlKind.ARGUMENT_ASSIGNMENT) {
             // for TUMBLE(..., TIMECOL => DESCRIPTOR(col), ...)
             final SqlBasicCall opCall = (SqlBasicCall) op;
@@ -503,5 +530,9 @@ public final class FlinkCalciteSqlValidator extends SqlValidatorImpl {
     private static boolean isTableFunction(SqlFunction function) {
         return function instanceof SqlTableFunction
                 || function.getFunctionType() == SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION;
+    }
+
+    private boolean isSessionWindow(final SqlOperator operator) {
+        return operator instanceof SqlSessionTableFunction;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

* Adds column expansion for Session Windows in FlinkCalciteSqlValidator.

## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - Added tests in ColumnExpansionTest.
  - Existing tests verify compiled plans for SESSION Windows.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
