### PR TITLE
[FLINK-36338] Properly handle KeyContext when using AsyncKeyedStateBackendAdaptor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -95,7 +95,8 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
                             maxParallelism,
                             asyncBufferSize,
                             asyncBufferTimeout,
-                            inFlightRecordsLimit);
+                            inFlightRecordsLimit,
+                            asyncKeyedStateBackend);
             asyncKeyedStateBackend.setup(asyncExecutionController);
         } else if (stateHandler.getKeyedStateBackend() != null) {
             throw new UnsupportedOperationException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
@@ -92,7 +92,8 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
                             maxParallelism,
                             asyncBufferSize,
                             asyncBufferTimeout,
-                            inFlightRecordsLimit);
+                            inFlightRecordsLimit,
+                            asyncKeyedStateBackend);
             asyncKeyedStateBackend.setup(asyncExecutionController);
         } else if (stateHandler.getKeyedStateBackend() != null) {
             throw new UnsupportedOperationException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -250,6 +250,13 @@ public abstract class AbstractKeyedStateBackend<K>
                 KeyGroupRangeAssignment.assignToKeyGroup(newKey, numberOfKeyGroups));
     }
 
+    @Override
+    public void setCurrentKeyAndKeyGroup(K newKey, int newKeyGroupIndex) {
+        notifyKeySelected(newKey);
+        this.keyContext.setCurrentKey(newKey);
+        this.keyContext.setCurrentKeyGroupIndex(newKeyGroupIndex);
+    }
+
     private void notifyKeySelected(K newKey) {
         // we prefer a for-loop over other iteration schemes for performance reasons here.
         for (int i = 0; i < keySelectionListeners.size(); ++i) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.InternalCheckpointListener;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
+import org.apache.flink.runtime.asyncprocessing.RecordContext;
 import org.apache.flink.runtime.asyncprocessing.StateExecutor;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.state.v2.StateDescriptor;
@@ -36,11 +38,12 @@ import java.io.Closeable;
  * in batch.
  */
 @Internal
-public interface AsyncKeyedStateBackend
+public interface AsyncKeyedStateBackend<K>
         extends Snapshotable<SnapshotResult<KeyedStateHandle>>,
                 InternalCheckpointListener,
                 Disposable,
-                Closeable {
+                Closeable,
+                AsyncExecutionController.SwitchContextListener<K> {
 
     /**
      * Initializes with some contexts.
@@ -79,6 +82,10 @@ public interface AsyncKeyedStateBackend
      */
     @Nonnull
     StateExecutor createStateExecutor();
+
+    /** By default, a state backend does nothing when a key is switched in async processing. */
+    @Override
+    default void switchContext(RecordContext<K> context) {}
 
     @Override
     void dispose();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateBackend.java
@@ -45,6 +45,9 @@ public interface KeyedStateBackend<K>
     /** @return Current key. */
     K getCurrentKey();
 
+    /** Act as a fast path for {@link #setCurrentKey} when the key group is known. */
+    void setCurrentKeyAndKeyGroup(K newKey, int newKeyGroupIndex);
+
     /** @return Serializer of the key. */
     TypeSerializer<K> getKeySerializer();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateBackend.java
@@ -117,7 +117,7 @@ public interface StateBackend extends java.io.Serializable {
      *     backend.
      */
     @Experimental
-    default <K> AsyncKeyedStateBackend createAsyncKeyedStateBackend(
+    default <K> AsyncKeyedStateBackend<K> createAsyncKeyedStateBackend(
             KeyedStateBackendParameters<K> parameters) throws Exception {
         throw new UnsupportedOperationException(
                 "Don't support createAsyncKeyedStateBackend by default");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStoreV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStoreV2.java
@@ -33,7 +33,7 @@ import javax.annotation.Nonnull;
 /** Default implementation of KeyedStateStoreV2. */
 public class DefaultKeyedStateStoreV2 implements KeyedStateStoreV2 {
 
-    private final AsyncKeyedStateBackend asyncKeyedStateBackend;
+    private final AsyncKeyedStateBackend<?> asyncKeyedStateBackend;
 
     public DefaultKeyedStateStoreV2(@Nonnull AsyncKeyedStateBackend asyncKeyedStateBackend) {
         this.asyncKeyedStateBackend = Preconditions.checkNotNull(asyncKeyedStateBackend);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.InternalCheckpointListener;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.asyncprocessing.RecordContext;
 import org.apache.flink.runtime.asyncprocessing.StateExecutor;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -49,7 +50,7 @@ import java.util.concurrent.RunnableFuture;
  *
  * @param <K> The key by which state is keyed.
  */
-public class AsyncKeyedStateBackendAdaptor<K> implements AsyncKeyedStateBackend {
+public class AsyncKeyedStateBackendAdaptor<K> implements AsyncKeyedStateBackend<K> {
     private final CheckpointableKeyedStateBackend<K> keyedStateBackend;
 
     public AsyncKeyedStateBackendAdaptor(CheckpointableKeyedStateBackend<K> keyedStateBackend) {
@@ -93,6 +94,11 @@ public class AsyncKeyedStateBackendAdaptor<K> implements AsyncKeyedStateBackend 
     @Override
     public StateExecutor createStateExecutor() {
         return null;
+    }
+
+    @Override
+    public void switchContext(RecordContext<K> context) {
+        keyedStateBackend.setCurrentKeyAndKeyGroup(context.getKey(), context.getKeyGroup());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -83,7 +83,7 @@ public class StreamOperatorStateHandler {
 
     protected static final Logger LOG = LoggerFactory.getLogger(StreamOperatorStateHandler.class);
 
-    @Nullable private final AsyncKeyedStateBackend asyncKeyedStateBackend;
+    @Nullable private final AsyncKeyedStateBackend<?> asyncKeyedStateBackend;
 
     @Nullable private final KeyedStateStoreV2 keyedStateStoreV2;
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -126,6 +126,11 @@ public class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedSt
     }
 
     @Override
+    public void setCurrentKeyAndKeyGroup(K newKey, int newKeyGroupIndex) {
+        setCurrentKey(newKey);
+    }
+
+    @Override
     public TypeSerializer<K> getKeySerializer() {
         return keySerializer;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AbstractStateIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AbstractStateIteratorTest.java
@@ -46,7 +46,14 @@ public class AbstractStateIteratorTest {
         TestIteratorStateExecutor stateExecutor = new TestIteratorStateExecutor(100, 3);
         AsyncExecutionController aec =
                 new AsyncExecutionController(
-                        new SyncMailboxExecutor(), (a, b) -> {}, stateExecutor, 1, 100, 1000, 1);
+                        new SyncMailboxExecutor(),
+                        (a, b) -> {},
+                        stateExecutor,
+                        1,
+                        100,
+                        1000,
+                        1,
+                        null);
         stateExecutor.bindAec(aec);
         RecordContext<String> recordContext = aec.buildContext("1", "key1");
         aec.setCurrentContext(recordContext);
@@ -77,7 +84,14 @@ public class AbstractStateIteratorTest {
         TestIteratorStateExecutor stateExecutor = new TestIteratorStateExecutor(100, 3);
         AsyncExecutionController aec =
                 new AsyncExecutionController(
-                        new SyncMailboxExecutor(), (a, b) -> {}, stateExecutor, 1, 100, 1000, 1);
+                        new SyncMailboxExecutor(),
+                        (a, b) -> {},
+                        stateExecutor,
+                        1,
+                        100,
+                        1000,
+                        1,
+                        null);
         stateExecutor.bindAec(aec);
         RecordContext<String> recordContext = aec.buildContext("1", "key1");
         aec.setCurrentContext(recordContext);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -55,7 +55,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /** Test for {@link AsyncExecutionController}. */
 class AsyncExecutionControllerTest {
-    AsyncExecutionController aec;
+    AsyncExecutionController<String> aec;
     AtomicInteger output;
     TestValueState valueState;
 
@@ -90,7 +90,7 @@ class AsyncExecutionControllerTest {
         StateBackend testAsyncStateBackend =
                 StateBackendTestUtils.buildAsyncStateBackend(stateSupplier, stateExecutor);
         assertThat(testAsyncStateBackend.supportsAsyncKeyedStateBackend()).isTrue();
-        AsyncKeyedStateBackend asyncKeyedStateBackend;
+        AsyncKeyedStateBackend<String> asyncKeyedStateBackend;
         try {
             asyncKeyedStateBackend = testAsyncStateBackend.createAsyncKeyedStateBackend(null);
         } catch (Exception e) {
@@ -106,7 +106,8 @@ class AsyncExecutionControllerTest {
                         128,
                         batchSize,
                         timeout,
-                        maxInFlight);
+                        maxInFlight,
+                        null);
         asyncKeyedStateBackend.setup(aec);
 
         try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -110,7 +110,7 @@ public class StateBackendTestUtils {
         }
     }
 
-    private static class TestAsyncKeyedStateBackend implements AsyncKeyedStateBackend {
+    private static class TestAsyncKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
 
         private final Supplier<org.apache.flink.api.common.state.v2.State> innerStateSupplier;
         private final StateExecutor stateExecutor;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
@@ -75,7 +75,8 @@ public class AbstractKeyedStateTestBase {
                         1,
                         1,
                         1000,
-                        1);
+                        1,
+                        null);
         exception = new AtomicReference<>(null);
     }
 
@@ -124,9 +125,9 @@ public class AbstractKeyedStateTestBase {
         }
 
         @Override
-        public <K> AsyncKeyedStateBackend createAsyncKeyedStateBackend(
+        public <K> AsyncKeyedStateBackend<K> createAsyncKeyedStateBackend(
                 KeyedStateBackendParameters<K> parameters) {
-            return new AsyncKeyedStateBackend() {
+            return new AsyncKeyedStateBackend<K>() {
                 @Nonnull
                 @Override
                 public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
@@ -79,15 +79,16 @@ public class AbstractReducingStateTest extends AbstractKeyedStateTestBase {
         ReduceFunction<Integer> reducer = Integer::sum;
         ReducingStateDescriptor<Integer> descriptor =
                 new ReducingStateDescriptor<>("testState", reducer, BasicTypeInfo.INT_TYPE_INFO);
-        AsyncExecutionController aec =
-                new AsyncExecutionController(
+        AsyncExecutionController<String> aec =
+                new AsyncExecutionController<>(
                         new SyncMailboxExecutor(),
                         (a, b) -> {},
                         new ReducingStateExecutor(),
                         1,
                         100,
                         10000,
-                        1);
+                        1,
+                        null);
         AbstractReducingState<String, String, Integer> reducingState =
                 new AbstractReducingState<>(aec, descriptor);
         aec.setCurrentContext(aec.buildContext("test", "test"));

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link InternalTimerServiceAsyncImpl}. */
 class InternalTimerServiceAsyncImplTest {
-    private AsyncExecutionController asyncExecutionController;
+    private AsyncExecutionController<String> asyncExecutionController;
     private TestKeyContext keyContext;
     private TestProcessingTimeService processingTimeService;
     private InternalTimerServiceAsyncImpl<Integer, String> service;
@@ -59,14 +59,15 @@ class InternalTimerServiceAsyncImplTest {
     @BeforeEach
     void setup() throws Exception {
         asyncExecutionController =
-                new AsyncExecutionController(
+                new AsyncExecutionController<>(
                         new SyncMailboxExecutor(),
                         exceptionHandler,
                         new MockStateExecutor(),
                         128,
                         2,
                         1000L,
-                        10);
+                        10,
+                        null);
         // ensure arbitrary key is in the key group
         int totalKeyGroups = 128;
         KeyGroupRange testKeyGroupList = new KeyGroupRange(0, totalKeyGroups - 1);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -299,6 +299,11 @@ public class ChangelogKeyedStateBackend<K>
     }
 
     @Override
+    public void setCurrentKeyAndKeyGroup(K newKey, int newKeyGroupIndex) {
+        keyedStateBackend.setCurrentKeyAndKeyGroup(newKey, newKeyGroupIndex);
+    }
+
+    @Override
     public TypeSerializer<K> getKeySerializer() {
         return keyedStateBackend.getKeySerializer();
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogMigrationRestoreTarget.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogMigrationRestoreTarget.java
@@ -202,6 +202,11 @@ public class ChangelogMigrationRestoreTarget<K> implements ChangelogRestoreTarge
             }
 
             @Override
+            public void setCurrentKeyAndKeyGroup(K newKey, int newKeyGroupIndex) {
+                keyedStateBackend.setCurrentKeyAndKeyGroup(newKey, newKeyGroupIndex);
+            }
+
+            @Override
             public void notifyCheckpointComplete(long checkpointId) throws Exception {
                 keyedStateBackend.notifyCheckpointComplete(checkpointId);
             }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -69,7 +69,7 @@ import static org.apache.flink.runtime.state.SnapshotExecutionType.ASYNCHRONOUS;
  * A KeyedStateBackend that stores its state in {@code ForSt}. This state backend can store very
  * large state that exceeds memory even disk to remote storage.
  */
-public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend {
+public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ForStKeyedStateBackend.class);
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackend.java
@@ -431,6 +431,12 @@ public class ForStSyncKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> 
         sharedRocksKeyBuilder.setKeyAndKeyGroup(getCurrentKey(), getCurrentKeyGroupIndex());
     }
 
+    @Override
+    public void setCurrentKeyAndKeyGroup(K newKey, int newKeyGroupIndex) {
+        super.setCurrentKeyAndKeyGroup(newKey, newKeyGroupIndex);
+        sharedRocksKeyBuilder.setKeyAndKeyGroup(getCurrentKey(), getCurrentKeyGroupIndex());
+    }
+
     /** Should only be called by one thread, and only after all accesses to the DB happened. */
     @Override
     public void dispose() {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -448,6 +448,12 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
         sharedRocksKeyBuilder.setKeyAndKeyGroup(getCurrentKey(), getCurrentKeyGroupIndex());
     }
 
+    @Override
+    public void setCurrentKeyAndKeyGroup(K newKey, int newKeyGroupIndex) {
+        super.setCurrentKeyAndKeyGroup(newKey, newKeyGroupIndex);
+        sharedRocksKeyBuilder.setKeyAndKeyGroup(getCurrentKey(), getCurrentKeyGroupIndex());
+    }
+
     /** Should only be called by one thread, and only after all accesses to the DB happened. */
     @Override
     public void dispose() {


### PR DESCRIPTION
## What is the purpose of the change

After [FLINK-36117](https://issues.apache.org/jira/browse/FLINK-36117), we port old state backends implementation to new api using AsyncKeyedStateBackendAdaptor, but it cannot work because the KeyContext is not properly handled. This PR fixes this.


## Brief change log

 - Add a listener for state context switch, make all `AsyncKeyedStateBackend` implement it.
 - For `AsyncKeyedStateBackendAdaptor`, set current key when a context switched.

## Verifying this change

This change is without any test coverage, since it is difficult to be covered by a UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
