### PR TITLE
[FLINK-36293][state] make sure register is closed before verification in testAsyncCancellation

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/AbstractAutoCloseableRegistry.java
+++ b/flink-core/src/main/java/org/apache/flink/util/AbstractAutoCloseableRegistry.java
@@ -137,13 +137,13 @@ public abstract class AbstractAutoCloseableRegistry<
 
     /**
      * Does the actual registration of the closeable with the registry map. This should not do any
-     * long running or potentially blocking operations as is is executed under the registry's lock.
+     * long running or potentially blocking operations as it is executed under the registry's lock.
      */
     protected abstract void doRegister(@Nonnull C closeable, @Nonnull Map<R, T> closeableMap);
 
     /**
      * Does the actual un-registration of the closeable from the registry map. This should not do
-     * any long running or potentially blocking operations as is is executed under the registry's
+     * any long running or potentially blocking operations as it is executed under the registry's
      * lock.
      */
     protected abstract boolean doUnRegister(@Nonnull C closeable, @Nonnull Map<R, T> closeableMap);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Saw this flaky `testAsyncCancellation` test failed with
```
org.apache.flink.contrib.streaming.state.RocksDBWriteBatchWrapperTest.testAsyncCancellation -- Time elapsed: 0.121 s <<< ERROR!
Sep 16 02:20:08 java.lang.Exception: Unexpected exception, expected<org.apache.flink.runtime.execution.CancelTaskException> but was<java.lang.AssertionError>
Sep 16 02:20:08 Caused by: java.lang.AssertionError: 
Sep 16 02:20:08 Expecting actual:
Sep 16 02:20:08   2
Sep 16 02:20:08 to be less than:
Sep 16 02:20:08   2 
Sep 16 02:20:08 	at org.apache.flink.contrib.streaming.state.RocksDBWriteBatchWrapperTest.testAsyncCancellation(RocksDBWriteBatchWrapperTest.java:98)
```
After investigation, I found this is because the slow async `register.close()` causes the main verification failure. Because the `register.close` is slow, the infinite loop will go beyond `cancellationCheckInterval * 2`. To make this test reliable, we can make sure the register is completely closed after 1st run of `writeBatchWrapper.put`, so that we can still verify we can tolerate some delay of cancellation propagation.

## Brief change log

Make `testAsyncCancellation` test reliable by making sure register is closed before verification

## Verifying this change

This change is already covered by existing tests, such as testAsyncCancellation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable
