### PR TITLE
[FLINK-36295] [runtime] Test `testCheckpointStatsPersistedAcrossRescale` waits until the desired parallelism is reached

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
@@ -109,11 +109,13 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
 
     @Override
     public void onChange() {
+        LOG.debug("OnChange event received in phase {}.", getPhase());
         phase.onChange();
     }
 
     @Override
     public void onTrigger() {
+        LOG.debug("OnTrigger event received in phase {}.", getPhase());
         phase.onTrigger();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
@@ -103,7 +103,14 @@ interface State extends LabeledGlobalFailureHandler {
             Class<? extends T> clazz, ThrowingConsumer<T, E> action, String debugMessage) throws E {
         tryRun(
                 clazz,
-                action,
+                x -> {
+                    getLogger()
+                            .debug(
+                                    "Running '{}' in state {}.",
+                                    debugMessage,
+                                    this.getClass().getSimpleName());
+                    ThrowingConsumer.unchecked(action).accept(x);
+                },
                 logger ->
                         logger.debug(
                                 "Cannot run '{}' because the actual state is {} and not {}.",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
@@ -258,6 +258,11 @@ public class AdaptiveSchedulerClusterITCase {
         public Future<Void> notifyCheckpointCompleteAsync(long checkpointId) {
             return CompletableFuture.completedFuture(null);
         }
+
+        @Override
+        public Future<Void> notifyCheckpointSubsumedAsync(long checkpointId) {
+            return CompletableFuture.completedFuture(null);
+        }
     }
 
     private JobGraph createBlockingJobGraph(int parallelism) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveSchedulerClusterITCase.java
@@ -187,6 +187,12 @@ public class AdaptiveSchedulerClusterITCase {
 
         miniCluster.submitJob(jobGraph).join();
 
+        // wait until the desired parallelism is reached
+        waitUntilParallelismForVertexReached(
+                jobGraph.getJobID(),
+                JOB_VERTEX_ID,
+                NUMBER_SLOTS_PER_TASK_MANAGER * NUMBER_TASK_MANAGERS);
+
         // wait until some checkpoints have been completed
         CommonTestUtils.waitUntilCondition(
                 () ->


### PR DESCRIPTION
## What is the purpose of the change

Flaky test fix and additional logging in Adaptive Scheduler.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
