### PR TITLE
[FLINK-3992][core] Do not implement deprecated Key interface

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/DoubleValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/DoubleValue.java
@@ -32,8 +32,7 @@ import java.io.IOException;
 public class DoubleValue
         implements Comparable<DoubleValue>,
                 ResettableValue<DoubleValue>,
-                CopyableValue<DoubleValue>,
-                Key<DoubleValue> {
+                CopyableValue<DoubleValue> {
     private static final long serialVersionUID = 1L;
 
     private double value;

--- a/flink-core/src/main/java/org/apache/flink/types/FloatValue.java
+++ b/flink-core/src/main/java/org/apache/flink/types/FloatValue.java
@@ -30,10 +30,7 @@ import java.io.IOException;
  */
 @Public
 public class FloatValue
-        implements Comparable<FloatValue>,
-                ResettableValue<FloatValue>,
-                CopyableValue<FloatValue>,
-                Key<FloatValue> {
+        implements Comparable<FloatValue>, ResettableValue<FloatValue>, CopyableValue<FloatValue> {
     private static final long serialVersionUID = 1L;
 
     private float value;

--- a/flink-core/src/main/java/org/apache/flink/types/NormalizableKey.java
+++ b/flink-core/src/main/java/org/apache/flink/types/NormalizableKey.java
@@ -34,7 +34,7 @@ import org.apache.flink.core.memory.MemorySegment;
  * normalized key length.
  */
 @Public
-public interface NormalizableKey<T> extends Comparable<T>, Key<T> {
+public interface NormalizableKey<T> extends Comparable<T> {
 
     /**
      * Gets the maximal length of normalized keys that the data type would produce to determine the

--- a/pom.xml
+++ b/pom.xml
@@ -2395,6 +2395,10 @@ under the License.
 								<exclude>
 									org.apache.flink.api.common.functions.RuntimeContext#getExecutionConfig()
 								</exclude>
+								<!-- FLINK-3992 Do not implement deprecated Key interface in flink 2.0 -->
+								<exclude>org.apache.flink.types.DoubleValue</exclude>
+								<exclude>org.apache.flink.types.FloatValue</exclude>
+								<exclude>org.apache.flink.types.NormalizableKey</exclude>
 								<!-- FLINK-5336 Remove IOReadableWritable from Path in flink-2.0. -->
 								<exclude>org.apache.flink.core.fs.Path</exclude>
 								<!-- The following exclusions are due to the flink-hadoop-compatibility_${scala.binary.version} module has renamed to flink-hadoop-compatibility. -->


### PR DESCRIPTION
## What is the purpose of the change

*Remove deprecated Key interface*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
