### PR TITLE
[FLINK-36349][tests] Fix ClosureCleanerITCase fail in the AdaptiveScheduler test profile

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/api/functions/ClosureCleanerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/functions/ClosureCleanerITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.api.functions;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.connector.file.sink.FileSink;
@@ -86,6 +87,7 @@ class ClosureCleanerITCase {
             NonSerializable nonSer = new NonSerializable();
             int x = 5;
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.setRuntimeMode(RuntimeExecutionMode.BATCH);
             DataStreamSource<Long> nums = env.fromSequence(1, 4);
             nums.map(num -> num + x)
                     .setParallelism(1)
@@ -111,6 +113,7 @@ class ClosureCleanerITCase {
         public void run(String resultPath) throws Exception {
             NonSerializable nonSer = new NonSerializable();
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.setRuntimeMode(RuntimeExecutionMode.BATCH);
             DataStreamSource<Long> nums = env.fromSequence(1, 4);
             nums.map(num -> num + getX())
                     .setParallelism(1)
@@ -138,6 +141,7 @@ class ClosureCleanerITCase {
             NonSerializable nonSer2 = new NonSerializable();
             int x = 5;
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.setRuntimeMode(RuntimeExecutionMode.BATCH);
             DataStreamSource<Long> nums = env.fromSequence(1, 4);
             nums.map(num -> num + x)
                     .setParallelism(1)
@@ -159,6 +163,7 @@ class ClosureCleanerITCase {
             NonSerializable nonSer2 = new NonSerializable();
             int x = 5;
             StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.setRuntimeMode(RuntimeExecutionMode.BATCH);
             DataStreamSource<Long> nums = env.fromSequence(1, 4);
             nums.map(num -> num + x)
                     .setParallelism(1)


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the `org.apache.flink.api.functions.ClosureCleanerITCase` failed in the AdaptiveScheduler test profile. 

In pull request #25324, the `ClosureCleanerITCase` was updated to use Java language and the DataStream API. This test case employs the `fullWindowPartition` operator while running in streaming job mode. 

The `fullWindowPartition` operator will sets jobEdge blocking, which leads the AdaptiveScheduler fail to check whether the job edge can be pipelined (`org.apache.flink.runtime.scheduler.adaptive.AdaptiveScheduler#assertPreconditions`).


## Brief change log
- modify the test case in `org.apache.flink.api.functions.ClosureCleanerITCase` to run in batch mode


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
