### PR TITLE
[FLINK-36355][runtime] Remove miscellaneous deprecated interfaces related to DataStream

### DIFF
--- a/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-file-sink-test/src/main/java/org/apache/flink/connector/file/sink/FileSinkProgram.java
@@ -91,7 +91,7 @@ public enum FileSinkProgram {
                             .withRollingPolicy(OnCheckpointRollingPolicy.build())
                             .build();
 
-            source.keyBy(0).addSink(sink);
+            source.keyBy(x -> x.f0).addSink(sink);
         } else if (sinkToTest.equalsIgnoreCase("FileSink")) {
             FileSink<Tuple2<Integer, Integer>> sink =
                     FileSink.forRowFormat(
@@ -104,7 +104,7 @@ public enum FileSinkProgram {
                             .withBucketAssigner(new KeyBucketAssigner())
                             .withRollingPolicy(OnCheckpointRollingPolicy.build())
                             .build();
-            source.keyBy(0).sinkTo(sink);
+            source.keyBy(x -> x.f0).sinkTo(sink);
         } else {
             throw new UnsupportedOperationException("Unsupported sink type: " + sinkToTest);
         }

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/AbstractQueryableStateTestBase.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.QueryableStateStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.source.legacy.RichParallelSourceFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -799,7 +800,7 @@ public abstract class AbstractQueryableStateTestBase {
                             }
                         })
                 .process(
-                        new ProcessFunction<Tuple2<Integer, Long>, Object>() {
+                        new KeyedProcessFunction<Integer, Tuple2<Integer, Long>, Object>() {
                             private static final long serialVersionUID = -805125545438296619L;
 
                             private transient MapState<Integer, Tuple2<Integer, Long>> mapState;
@@ -812,7 +813,11 @@ public abstract class AbstractQueryableStateTestBase {
 
                             @Override
                             public void processElement(
-                                    Tuple2<Integer, Long> value, Context ctx, Collector<Object> out)
+                                    Tuple2<Integer, Long> value,
+                                    KeyedProcessFunction<Integer, Tuple2<Integer, Long>, Object>
+                                                    .Context
+                                            ctx,
+                                    Collector<Object> out)
                                     throws Exception {
                                 Tuple2<Integer, Long> v = mapState.get(value.f0);
                                 if (v == null) {
@@ -900,7 +905,7 @@ public abstract class AbstractQueryableStateTestBase {
                             }
                         })
                 .process(
-                        new ProcessFunction<Tuple2<Integer, Long>, Object>() {
+                        new KeyedProcessFunction<Integer, Tuple2<Integer, Long>, Object>() {
                             private static final long serialVersionUID = -805125545438296619L;
 
                             private transient ListState<Long> listState;

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
@@ -20,6 +20,9 @@ package org.apache.flink.streaming.api.datastream;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.operators.Keys;
+import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
@@ -38,6 +41,7 @@ import org.apache.flink.streaming.api.operators.co.CoStreamMap;
 import org.apache.flink.streaming.api.operators.co.KeyedCoProcessOperator;
 import org.apache.flink.streaming.api.operators.co.LegacyKeyedCoProcessOperator;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.streaming.util.keys.KeySelectorUtil;
 import org.apache.flink.util.Utils;
 
 import static java.util.Objects.requireNonNull;
@@ -117,30 +121,36 @@ public class ConnectedStreams<IN1, IN2> {
      * KeyBy operation for connected data stream. Assigns keys to the elements of input1 and input2
      * according to keyPosition1 and keyPosition2.
      *
+     * @deprecated use {@link #keyBy(KeySelector, KeySelector)}
      * @param keyPosition1 The field used to compute the hashcode of the elements in the first input
      *     stream.
      * @param keyPosition2 The field used to compute the hashcode of the elements in the second
      *     input stream.
      * @return The grouped {@link ConnectedStreams}
      */
+    @Deprecated
     public ConnectedStreams<IN1, IN2> keyBy(int keyPosition1, int keyPosition2) {
         return new ConnectedStreams<>(
                 this.environment,
-                inputStream1.keyBy(keyPosition1),
-                inputStream2.keyBy(keyPosition2));
+                keyBy(inputStream1, keyPosition1),
+                keyBy(inputStream2, keyPosition2));
     }
 
     /**
      * KeyBy operation for connected data stream. Assigns keys to the elements of input1 and input2
      * according to keyPositions1 and keyPositions2.
      *
+     * @deprecated use {@link #keyBy(KeySelector, KeySelector)}
      * @param keyPositions1 The fields used to group the first input stream.
      * @param keyPositions2 The fields used to group the second input stream.
      * @return The grouped {@link ConnectedStreams}
      */
+    @Deprecated
     public ConnectedStreams<IN1, IN2> keyBy(int[] keyPositions1, int[] keyPositions2) {
         return new ConnectedStreams<>(
-                environment, inputStream1.keyBy(keyPositions1), inputStream2.keyBy(keyPositions2));
+                environment,
+                keyBy(inputStream1, keyPositions1),
+                keyBy(inputStream2, keyPositions2));
     }
 
     /**
@@ -149,13 +159,15 @@ public class ConnectedStreams<IN1, IN2> {
      * a public field or a getter method with parentheses of the {@link DataStream}S underlying
      * type. A dot can be used to drill down into objects, as in {@code "field1.getInnerField2()" }.
      *
+     * @deprecated use {@link #keyBy(KeySelector, KeySelector)}
      * @param field1 The grouping expression for the first input
      * @param field2 The grouping expression for the second input
      * @return The grouped {@link ConnectedStreams}
      */
+    @Deprecated
     public ConnectedStreams<IN1, IN2> keyBy(String field1, String field2) {
         return new ConnectedStreams<>(
-                environment, inputStream1.keyBy(field1), inputStream2.keyBy(field2));
+                environment, keyBy(inputStream1, field1), keyBy(inputStream2, field2));
     }
 
     /**
@@ -164,13 +176,30 @@ public class ConnectedStreams<IN1, IN2> {
      * field or a getter method with parentheses of the {@link DataStream}S underlying type. A dot
      * can be used to drill down into objects, as in {@code "field1.getInnerField2()" } .
      *
+     * @deprecated use {@link #keyBy(KeySelector, KeySelector)}
      * @param fields1 The grouping expressions for the first input
      * @param fields2 The grouping expressions for the second input
      * @return The grouped {@link ConnectedStreams}
      */
+    @Deprecated
     public ConnectedStreams<IN1, IN2> keyBy(String[] fields1, String[] fields2) {
         return new ConnectedStreams<>(
-                environment, inputStream1.keyBy(fields1), inputStream2.keyBy(fields2));
+                environment, keyBy(inputStream1, fields1), keyBy(inputStream2, fields2));
+    }
+
+    private static <T> DataStream<T> keyBy(DataStream<T> inputStream, int... keyPositions) {
+        if (inputStream.getType() instanceof BasicArrayTypeInfo
+                || inputStream.getType() instanceof PrimitiveArrayTypeInfo) {
+            return inputStream.keyBy(
+                    KeySelectorUtil.getSelectorForArray(keyPositions, inputStream.getType()));
+        } else {
+            return inputStream.keyBy(
+                    new Keys.ExpressionKeys<>(keyPositions, inputStream.getType()));
+        }
+    }
+
+    private static <T> DataStream<T> keyBy(DataStream<T> inputStream, String... fields) {
+        return inputStream.keyBy(new Keys.ExpressionKeys<>(fields, inputStream.getType()));
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -38,8 +38,6 @@ import org.apache.flink.api.common.operators.Keys;
 import org.apache.flink.api.common.operators.ResourceSpec;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.state.MapStateDescriptor;
-import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
-import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.connector.sink2.Sink;
@@ -295,40 +293,7 @@ public class DataStream<T> {
         return new KeyedStream<>(this, clean(key), keyType);
     }
 
-    /**
-     * Partitions the operator state of a {@link DataStream} by the given key positions.
-     *
-     * @deprecated Use {@link DataStream#keyBy(KeySelector)}.
-     * @param fields The position of the fields on which the {@link DataStream} will be grouped.
-     * @return The {@link DataStream} with partitioned state (i.e. KeyedStream)
-     */
-    @Deprecated
-    public KeyedStream<T, Tuple> keyBy(int... fields) {
-        if (getType() instanceof BasicArrayTypeInfo
-                || getType() instanceof PrimitiveArrayTypeInfo) {
-            return keyBy(KeySelectorUtil.getSelectorForArray(fields, getType()));
-        } else {
-            return keyBy(new Keys.ExpressionKeys<>(fields, getType()));
-        }
-    }
-
-    /**
-     * Partitions the operator state of a {@link DataStream} using field expressions. A field
-     * expression is either the name of a public field or a getter method with parentheses of the
-     * {@link DataStream}'s underlying type. A dot can be used to drill down into objects, as in
-     * {@code "field1.getInnerField2()" }.
-     *
-     * @deprecated Use {@link DataStream#keyBy(KeySelector)}.
-     * @param fields One or more field expressions on which the state of the {@link DataStream}
-     *     operators will be partitioned.
-     * @return The {@link DataStream} with partitioned state (i.e. KeyedStream)
-     */
-    @Deprecated
-    public KeyedStream<T, Tuple> keyBy(String... fields) {
-        return keyBy(new Keys.ExpressionKeys<>(fields, getType()));
-    }
-
-    private KeyedStream<T, Tuple> keyBy(Keys<T> keys) {
+    protected KeyedStream<T, Tuple> keyBy(Keys<T> keys) {
         return new KeyedStream<>(
                 this,
                 clean(KeySelectorUtil.getSelectorForKeys(keys, getType(), getExecutionConfig())));

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -300,42 +300,6 @@ public class DataStream<T> {
     }
 
     /**
-     * Partitions a tuple DataStream on the specified key fields using a custom partitioner. This
-     * method takes the key position to partition on, and a partitioner that accepts the key type.
-     *
-     * <p>Note: This method works only on single field keys.
-     *
-     * @deprecated use {@link DataStream#partitionCustom(Partitioner, KeySelector)}.
-     * @param partitioner The partitioner to assign partitions to keys.
-     * @param field The field index on which the DataStream is partitioned.
-     * @return The partitioned DataStream.
-     */
-    @Deprecated
-    public <K> DataStream<T> partitionCustom(Partitioner<K> partitioner, int field) {
-        Keys.ExpressionKeys<T> outExpressionKeys =
-                new Keys.ExpressionKeys<>(new int[] {field}, getType());
-        return partitionCustom(partitioner, outExpressionKeys);
-    }
-
-    /**
-     * Partitions a POJO DataStream on the specified key fields using a custom partitioner. This
-     * method takes the key expression to partition on, and a partitioner that accepts the key type.
-     *
-     * <p>Note: This method works only on single field keys.
-     *
-     * @deprecated use {@link DataStream#partitionCustom(Partitioner, KeySelector)}.
-     * @param partitioner The partitioner to assign partitions to keys.
-     * @param field The expression for the field on which the DataStream is partitioned.
-     * @return The partitioned DataStream.
-     */
-    @Deprecated
-    public <K> DataStream<T> partitionCustom(Partitioner<K> partitioner, String field) {
-        Keys.ExpressionKeys<T> outExpressionKeys =
-                new Keys.ExpressionKeys<>(new String[] {field}, getType());
-        return partitionCustom(partitioner, outExpressionKeys);
-    }
-
-    /**
      * Partitions a DataStream on the key returned by the selector, using a custom partitioner. This
      * method takes the key selector to get the key to partition on, and a partitioner that accepts
      * the key type.
@@ -350,16 +314,6 @@ public class DataStream<T> {
      */
     public <K> DataStream<T> partitionCustom(
             Partitioner<K> partitioner, KeySelector<T, K> keySelector) {
-        return setConnectionType(
-                new CustomPartitionerWrapper<>(clean(partitioner), clean(keySelector)));
-    }
-
-    //	private helper method for custom partitioning
-    private <K> DataStream<T> partitionCustom(Partitioner<K> partitioner, Keys<T> keys) {
-        KeySelector<T, K> keySelector =
-                KeySelectorUtil.getSelectorForOneKey(
-                        keys, partitioner, getType(), getExecutionConfig());
-
         return setConnectionType(
                 new CustomPartitionerWrapper<>(clean(partitioner), clean(keySelector)));
     }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -35,7 +35,6 @@ import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.TupleTypeInfoBase;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
-import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.aggregation.AggregationFunction;
 import org.apache.flink.streaming.api.functions.aggregation.ComparableAggregator;
 import org.apache.flink.streaming.api.functions.aggregation.SumAggregator;
@@ -45,7 +44,6 @@ import org.apache.flink.streaming.api.functions.query.QueryableValueStateOperato
 import org.apache.flink.streaming.api.functions.sink.legacy.SinkFunction;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
-import org.apache.flink.streaming.api.operators.LegacyKeyedProcessOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.co.IntervalJoinOperator;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
@@ -297,68 +295,6 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
         result.getLegacyTransformation().setStateKeySelector(keySelector);
         result.getLegacyTransformation().setStateKeyType(keyType);
         return result;
-    }
-
-    /**
-     * Applies the given {@link ProcessFunction} on the input stream, thereby creating a transformed
-     * output stream.
-     *
-     * <p>The function will be called for every element in the input streams and can produce zero or
-     * more output elements. Contrary to the {@link DataStream#flatMap(FlatMapFunction)} function,
-     * this function can also query the time and set timers. When reacting to the firing of set
-     * timers the function can directly emit elements and/or register yet more timers.
-     *
-     * @param processFunction The {@link ProcessFunction} that is called for each element in the
-     *     stream.
-     * @param <R> The type of elements emitted by the {@code ProcessFunction}.
-     * @return The transformed {@link DataStream}.
-     * @deprecated Use {@link KeyedStream#process(KeyedProcessFunction)}
-     */
-    @Deprecated
-    @Override
-    @PublicEvolving
-    public <R> SingleOutputStreamOperator<R> process(ProcessFunction<T, R> processFunction) {
-
-        TypeInformation<R> outType =
-                TypeExtractor.getUnaryOperatorReturnType(
-                        processFunction,
-                        ProcessFunction.class,
-                        0,
-                        1,
-                        TypeExtractor.NO_INDEX,
-                        getType(),
-                        Utils.getCallLocationName(),
-                        true);
-
-        return process(processFunction, outType);
-    }
-
-    /**
-     * Applies the given {@link ProcessFunction} on the input stream, thereby creating a transformed
-     * output stream.
-     *
-     * <p>The function will be called for every element in the input streams and can produce zero or
-     * more output elements. Contrary to the {@link DataStream#flatMap(FlatMapFunction)} function,
-     * this function can also query the time and set timers. When reacting to the firing of set
-     * timers the function can directly emit elements and/or register yet more timers.
-     *
-     * @param processFunction The {@link ProcessFunction} that is called for each element in the
-     *     stream.
-     * @param outputType {@link TypeInformation} for the result type of the function.
-     * @param <R> The type of elements emitted by the {@code ProcessFunction}.
-     * @return The transformed {@link DataStream}.
-     * @deprecated Use {@link KeyedStream#process(KeyedProcessFunction, TypeInformation)}
-     */
-    @Deprecated
-    @Override
-    @Internal
-    public <R> SingleOutputStreamOperator<R> process(
-            ProcessFunction<T, R> processFunction, TypeInformation<R> outputType) {
-
-        LegacyKeyedProcessOperator<KEY, T, R> operator =
-                new LegacyKeyedProcessOperator<>(clean(processFunction));
-
-        return transform("Process", outputType, operator);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -250,10 +250,4 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
     public int getPort() {
         return configuration.get(JobManagerOptions.PORT);
     }
-
-    /** @deprecated This method is going to be removed in the next releases. */
-    @Deprecated
-    public Configuration getClientConfiguration() {
-        return configuration;
-    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -150,14 +150,6 @@ public class StreamExecutionEnvironment implements AutoCloseable {
         collectIterators.add(iterator);
     }
 
-    /**
-     * The default name to use for a streaming job if no other name has been specified.
-     *
-     * @deprecated This constant does not fit well to batch runtime mode.
-     */
-    @Deprecated
-    public static final String DEFAULT_JOB_NAME = StreamGraphGenerator.DEFAULT_STREAMING_JOB_NAME;
-
     /** The time characteristic that is used if none other is set. */
     private static final TimeCharacteristic DEFAULT_TIME_CHARACTERISTIC =
             TimeCharacteristic.EventTime;

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TimeWindowTranslationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/TimeWindowTranslationTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.operators.windowing;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ReducingStateDescriptor;
-import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -64,7 +63,7 @@ class TimeWindowTranslationTest {
         DummyReducer reducer = new DummyReducer();
 
         DataStream<Tuple2<String, Integer>> window1 =
-                source.keyBy(0)
+                source.keyBy(x -> x.f0)
                         .window(
                                 TumblingProcessingTimeWindows.of(
                                         Duration.ofMillis(1000), Duration.ofMillis(100)))
@@ -78,17 +77,17 @@ class TimeWindowTranslationTest {
         assertThat(operator1).isInstanceOf(WindowOperator.class);
 
         DataStream<Tuple2<String, Integer>> window2 =
-                source.keyBy(0)
+                source.keyBy(x -> x.f0)
                         .window(TumblingProcessingTimeWindows.of(Duration.ofMillis(1000)))
                         .apply(
                                 new WindowFunction<
                                         Tuple2<String, Integer>,
                                         Tuple2<String, Integer>,
-                                        Tuple,
+                                        String,
                                         TimeWindow>() {
                                     @Override
                                     public void apply(
-                                            Tuple key,
+                                            String str,
                                             TimeWindow window,
                                             Iterable<Tuple2<String, Integer>> values,
                                             Collector<Tuple2<String, Integer>> out) {}
@@ -112,7 +111,7 @@ class TimeWindowTranslationTest {
                 env.fromData(Tuple2.of("hello", 1), Tuple2.of("hello", 2));
 
         DataStream<Tuple2<String, Integer>> window1 =
-                source.keyBy(0)
+                source.keyBy(x -> x.f0)
                         .window(
                                 SlidingEventTimeWindows.of(
                                         Duration.ofMillis(1000), Duration.ofMillis(100)))
@@ -140,17 +139,17 @@ class TimeWindowTranslationTest {
                 env.fromData(Tuple2.of("hello", 1), Tuple2.of("hello", 2));
 
         DataStream<Tuple2<String, Integer>> window1 =
-                source.keyBy(0)
+                source.keyBy(x -> x.f0)
                         .window(TumblingEventTimeWindows.of(Duration.ofMillis(1000)))
                         .apply(
                                 new WindowFunction<
                                         Tuple2<String, Integer>,
                                         Tuple2<String, Integer>,
-                                        Tuple,
+                                        String,
                                         TimeWindow>() {
                                     @Override
                                     public void apply(
-                                            Tuple key,
+                                            String str,
                                             TimeWindow window,
                                             Iterable<Tuple2<String, Integer>> values,
                                             Collector<Tuple2<String, Integer>> out) {}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -360,8 +360,8 @@ class DataStreamTest {
 
     /**
      * Tests that {@link DataStream#keyBy(KeySelector)} and {@link
-     * DataStream#partitionCustom(Partitioner, int)} result in different and correct topologies.
-     * Does the some for the {@link ConnectedStreams}.
+     * DataStream#partitionCustom(Partitioner, KeySelector)} result in different and correct
+     * topologies. Does the some for the {@link ConnectedStreams}.
      */
     @Test
     void testPartitioning() {
@@ -422,9 +422,10 @@ class DataStreamTest {
                     }
                 };
 
-        DataStream<Tuple2<Long, Long>> customPartition1 = src1.partitionCustom(longPartitioner, 0);
+        DataStream<Tuple2<Long, Long>> customPartition1 =
+                src1.partitionCustom(longPartitioner, x -> x.f0);
         DataStream<Tuple2<Long, Long>> customPartition3 =
-                src1.partitionCustom(longPartitioner, "f0");
+                src1.partitionCustom(longPartitioner, x -> x.f0);
         DataStream<Tuple2<Long, Long>> customPartition4 =
                 src1.partitionCustom(longPartitioner, new FirstSelector());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -179,7 +179,7 @@ class StreamingJobGraphGeneratorTest {
                                 });
 
         DataStream<Tuple2<String, String>> result =
-                input.keyBy(0)
+                input.keyBy(x -> x.f0)
                         .map(
                                 new MapFunction<Tuple2<String, String>, Tuple2<String, String>>() {
 
@@ -559,7 +559,7 @@ class StreamingJobGraphGeneratorTest {
         opMethod.invoke(filter, resource3);
 
         DataStream<Tuple2<Integer, Integer>> reduce =
-                filter.keyBy(0)
+                filter.keyBy(x -> x.f0)
                         .reduce(
                                 new ReduceFunction<Tuple2<Integer, Integer>>() {
                                     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowTranslationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowTranslationTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.common.state.ReducingStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -91,7 +90,7 @@ class WindowTranslationTest {
 
         assertThatThrownBy(
                         () ->
-                                source.keyBy(0)
+                                source.keyBy(x -> x.f0)
                                         .window(
                                                 SlidingEventTimeWindows.of(
                                                         Duration.ofSeconds(1),
@@ -122,7 +121,7 @@ class WindowTranslationTest {
 
         assertThatThrownBy(
                         () ->
-                                source.keyBy(0)
+                                source.keyBy(x -> x.f0)
                                         .window(
                                                 SlidingEventTimeWindows.of(
                                                         Duration.ofSeconds(1),
@@ -1071,7 +1070,7 @@ class WindowTranslationTest {
         DummyReducer reducer = new DummyReducer();
 
         DataStream<Tuple2<String, Integer>> window1 =
-                source.keyBy(0)
+                source.keyBy(x -> x.f0)
                         .window(
                                 SlidingEventTimeWindows.of(
                                         Duration.ofSeconds(1), Duration.ofMillis(100)))
@@ -1212,7 +1211,7 @@ class WindowTranslationTest {
         DummyReducer reducer = new DummyReducer();
 
         DataStream<Tuple2<String, Integer>> window1 =
-                source.keyBy(0)
+                source.keyBy(x -> x.f0)
                         .window(
                                 SlidingEventTimeWindows.of(
                                         Duration.ofSeconds(1), Duration.ofMillis(100)))
@@ -1250,7 +1249,7 @@ class WindowTranslationTest {
         DummyReducer reducer = new DummyReducer();
 
         DataStream<Tuple2<String, Integer>> window1 =
-                source.keyBy(0)
+                source.keyBy(x -> x.f0)
                         .window(
                                 SlidingEventTimeWindows.of(
                                         Duration.ofSeconds(1), Duration.ofMillis(100)))
@@ -1260,11 +1259,11 @@ class WindowTranslationTest {
                                 new ProcessWindowFunction<
                                         Tuple2<String, Integer>,
                                         Tuple2<String, Integer>,
-                                        Tuple,
+                                        String,
                                         TimeWindow>() {
                                     @Override
                                     public void process(
-                                            Tuple tuple,
+                                            String str,
                                             Context context,
                                             Iterable<Tuple2<String, Integer>> elements,
                                             Collector<Tuple2<String, Integer>> out)

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CoStreamCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CoStreamCheckpointingITCase.java
@@ -95,7 +95,7 @@ public class CoStreamCheckpointingITCase extends AbstractTestBaseJUnit4 {
                 .map(new StatefulCounterFunction())
 
                 // -------------- fourth vertex - reducer (failing) and the sink ----------------
-                .keyBy("prefix")
+                .keyBy(x -> x.prefix)
                 .reduce(new OnceFailingReducer(NUM_STRINGS))
                 .addSink(
                         new SinkFunction<PrefixCount>() {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
-import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
@@ -293,13 +292,13 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                                     new KeyedEventTimeGenerator(numKeys, windowSize),
                                     numElementsPerKey))
                     .rebalance()
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .window(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
                     .apply(
                             new RichWindowFunction<
                                     Tuple2<Long, IntType>,
                                     Tuple4<Long, Long, Long, IntType>,
-                                    Tuple,
+                                    Long,
                                     TimeWindow>() {
 
                                 private boolean open = false;
@@ -316,7 +315,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
                                 @Override
                                 public void apply(
-                                        Tuple tuple,
+                                        Long l,
                                         TimeWindow window,
                                         Iterable<Tuple2<Long, IntType>> values,
                                         Collector<Tuple4<Long, Long, Long, IntType>> out) {
@@ -384,13 +383,13 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                                     new KeyedEventTimeGenerator(numKeys, windowSize),
                                     numElementsPerKey))
                     .rebalance()
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .window(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
                     .apply(
                             new RichWindowFunction<
                                     Tuple2<Long, IntType>,
                                     Tuple4<Long, Long, Long, IntType>,
-                                    Tuple,
+                                    Long,
                                     TimeWindow>() {
 
                                 private boolean open = false;
@@ -414,7 +413,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
                                 @Override
                                 public void apply(
-                                        Tuple tuple,
+                                        Long l,
                                         TimeWindow window,
                                         Iterable<Tuple2<Long, IntType>> values,
                                         Collector<Tuple4<Long, Long, Long, IntType>> out)
@@ -423,7 +422,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                                     // the window count state starts with the key, so that we get
                                     // different count results for each key
                                     if (count.value() == 0) {
-                                        count.update(tuple.<Long>getField(0).intValue());
+                                        count.update(l.intValue());
                                     }
 
                                     // validate that the function has been opened properly
@@ -432,7 +431,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                                     count.update(count.value() + 1);
                                     out.collect(
                                             new Tuple4<>(
-                                                    tuple.<Long>getField(0),
+                                                    l,
                                                     window.getStart(),
                                                     window.getEnd(),
                                                     new IntType(count.value())));
@@ -473,7 +472,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                                     new KeyedEventTimeGenerator(numKeys, windowSlide),
                                     numElementsPerKey))
                     .rebalance()
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .window(
                             SlidingEventTimeWindows.of(
                                     Duration.ofMillis(windowSize), Duration.ofMillis(windowSlide)))
@@ -481,7 +480,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                             new RichWindowFunction<
                                     Tuple2<Long, IntType>,
                                     Tuple4<Long, Long, Long, IntType>,
-                                    Tuple,
+                                    Long,
                                     TimeWindow>() {
 
                                 private boolean open = false;
@@ -498,7 +497,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
                                 @Override
                                 public void apply(
-                                        Tuple tuple,
+                                        Long l,
                                         TimeWindow window,
                                         Iterable<Tuple2<Long, IntType>> values,
                                         Collector<Tuple4<Long, Long, Long, IntType>> out) {
@@ -555,7 +554,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                                     new KeyedEventTimeGenerator(numKeys, windowSize),
                                     numElementsPerKey))
                     .rebalance()
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .window(TumblingEventTimeWindows.of(Duration.ofMillis(windowSize)))
                     .reduce(
                             new ReduceFunction<Tuple2<Long, IntType>>() {
@@ -569,7 +568,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                             new RichWindowFunction<
                                     Tuple2<Long, IntType>,
                                     Tuple4<Long, Long, Long, IntType>,
-                                    Tuple,
+                                    Long,
                                     TimeWindow>() {
 
                                 private boolean open = false;
@@ -586,7 +585,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
                                 @Override
                                 public void apply(
-                                        Tuple tuple,
+                                        Long l,
                                         TimeWindow window,
                                         Iterable<Tuple2<Long, IntType>> input,
                                         Collector<Tuple4<Long, Long, Long, IntType>> out) {
@@ -639,7 +638,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                                     new KeyedEventTimeGenerator(numKeys, windowSlide),
                                     numElementsPerKey))
                     .rebalance()
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .window(
                             SlidingEventTimeWindows.of(
                                     Duration.ofMillis(windowSize), Duration.ofMillis(windowSlide)))
@@ -657,7 +656,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
                             new RichWindowFunction<
                                     Tuple2<Long, IntType>,
                                     Tuple4<Long, Long, Long, IntType>,
-                                    Tuple,
+                                    Long,
                                     TimeWindow>() {
 
                                 private boolean open = false;
@@ -674,7 +673,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
 
                                 @Override
                                 public void apply(
-                                        Tuple tuple,
+                                        Long l,
                                         TimeWindow window,
                                         Iterable<Tuple2<Long, IntType>> input,
                                         Collector<Tuple4<Long, Long, Long, IntType>> out) {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/KeyedStateCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/KeyedStateCheckpointingITCase.java
@@ -167,7 +167,7 @@ public class KeyedStateCheckpointingITCase extends TestLogger {
         stream1.union(stream2)
                 .keyBy(new IdentityKeySelector<Integer>())
                 .map(new OnceFailingPartitionedSum(failurePos))
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .addSink(new CounterSink());
 
         env.execute();

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ProcessingTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ProcessingTimeWindowCheckpointingITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.test.checkpointing;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.ReduceFunction;
-import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
@@ -94,13 +93,13 @@ public class ProcessingTimeWindowCheckpointingITCase extends TestLogger {
 
             env.addSource(new FailingSource(new Generator(), numElements, true))
                     .rebalance()
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .window(TumblingProcessingTimeWindows.of(Duration.ofMillis(100)))
                     .apply(
                             new RichWindowFunction<
                                     Tuple2<Long, IntType>,
                                     Tuple2<Long, IntType>,
-                                    Tuple,
+                                    Long,
                                     TimeWindow>() {
 
                                 private boolean open = false;
@@ -117,7 +116,7 @@ public class ProcessingTimeWindowCheckpointingITCase extends TestLogger {
 
                                 @Override
                                 public void apply(
-                                        Tuple tuple,
+                                        Long l,
                                         TimeWindow window,
                                         Iterable<Tuple2<Long, IntType>> values,
                                         Collector<Tuple2<Long, IntType>> out) {
@@ -155,7 +154,7 @@ public class ProcessingTimeWindowCheckpointingITCase extends TestLogger {
                     new SinkValidatorUpdaterAndChecker(numElements, 3);
             env.addSource(new FailingSource(new Generator(), numElements, true))
                     .rebalance()
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .window(
                             SlidingProcessingTimeWindows.of(
                                     Duration.ofMillis(150), Duration.ofMillis(50)))
@@ -163,7 +162,7 @@ public class ProcessingTimeWindowCheckpointingITCase extends TestLogger {
                             new RichWindowFunction<
                                     Tuple2<Long, IntType>,
                                     Tuple2<Long, IntType>,
-                                    Tuple,
+                                    Long,
                                     TimeWindow>() {
 
                                 private boolean open = false;
@@ -180,7 +179,7 @@ public class ProcessingTimeWindowCheckpointingITCase extends TestLogger {
 
                                 @Override
                                 public void apply(
-                                        Tuple tuple,
+                                        Long l,
                                         TimeWindow window,
                                         Iterable<Tuple2<Long, IntType>> values,
                                         Collector<Tuple2<Long, IntType>> out) {
@@ -226,7 +225,7 @@ public class ProcessingTimeWindowCheckpointingITCase extends TestLogger {
                                 }
                             })
                     .rebalance()
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .window(TumblingProcessingTimeWindows.of(Duration.ofMillis(100)))
                     .reduce(
                             new ReduceFunction<Tuple2<Long, IntType>>() {
@@ -269,7 +268,7 @@ public class ProcessingTimeWindowCheckpointingITCase extends TestLogger {
                                 }
                             })
                     .rebalance()
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .window(
                             SlidingProcessingTimeWindows.of(
                                     Duration.ofMillis(150), Duration.ofMillis(50)))

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -462,7 +462,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 
         env.addSource(new NotifyingInfiniteTupleSource(10_000))
                 .assignTimestampsAndWatermarks(IngestionTimeWatermarkStrategy.create())
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .window(TumblingEventTimeWindows.of(Duration.ofSeconds(3)))
                 .reduce((value1, value2) -> Tuple2.of(value1.f0, value1.f1 + value2.f1))
                 .filter(value -> value.f0.startsWith("Tuple 0"));

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StateCheckpointedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StateCheckpointedITCase.java
@@ -95,7 +95,7 @@ public class StateCheckpointedITCase extends StreamFaultToleranceTestBase {
                 .map(new StatefulCounterFunction())
 
                 // -------------- third vertex - reducer and the sink ----------------
-                .keyBy("prefix")
+                .keyBy(x -> x.prefix)
                 .flatMap(new OnceFailingAggregator(failurePos))
                 .addSink(new ValidatingSink());
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StatefulJobSnapshotMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StatefulJobSnapshotMigrationITCase.java
@@ -25,7 +25,10 @@ import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.state.StateBackendLoader;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -210,11 +213,11 @@ public class StatefulJobSnapshotMigrationITCase extends SnapshotMigrationTestBas
 
         env.addSource(nonParallelSource)
                 .uid("CheckpointingSource1")
-                .keyBy(0)
+                .keyBy(x -> (Tuple) Tuple1.of(x.f0), Types.TUPLE(Types.LONG))
                 .flatMap(flatMap)
                 .startNewChain()
                 .uid("CheckpointingKeyedStateFlatMap1")
-                .keyBy(0)
+                .keyBy(x -> (Tuple) Tuple1.of(x.f0), Types.TUPLE(Types.LONG))
                 .transform(
                         "timely_stateful_operator",
                         new TypeHint<Tuple2<Long, Long>>() {}.getTypeInfo(),
@@ -224,11 +227,11 @@ public class StatefulJobSnapshotMigrationITCase extends SnapshotMigrationTestBas
 
         env.addSource(parallelSource)
                 .uid("CheckpointingSource2")
-                .keyBy(0)
+                .keyBy(x -> (Tuple) Tuple1.of(x.f0), Types.TUPLE(Types.LONG))
                 .flatMap(flatMap)
                 .startNewChain()
                 .uid("CheckpointingKeyedStateFlatMap2")
-                .keyBy(0)
+                .keyBy(x -> (Tuple) Tuple1.of(x.f0), Types.TUPLE(Types.LONG))
                 .transform(
                         "timely_stateful_operator",
                         new TypeHint<Tuple2<Long, Long>>() {}.getTypeInfo(),

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointNotifierITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointNotifierITCase.java
@@ -112,7 +112,7 @@ public class StreamCheckpointNotifierITCase extends AbstractTestBaseJUnit4 {
                     .startNewChain()
 
                     // -------------- fourth vertex - reducer and the sink ----------------
-                    .keyBy(0)
+                    .keyBy(x -> x.f0)
                     .reduce(new OnceFailingReducer(numElements))
                     .sinkTo(new DiscardingSink<>());
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamCheckpointingITCase.java
@@ -72,7 +72,7 @@ public class StreamCheckpointingITCase extends StreamFaultToleranceTestBase {
                 .map(new StatefulCounterFunction())
 
                 // -------------- third vertex - counter and the sink ----------------
-                .keyBy("prefix")
+                .keyBy(x -> x.prefix)
                 .map(new OnceFailingPrefixCounter(NUM_STRINGS))
                 .addSink(
                         new SinkFunction<PrefixCount>() {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UdfStreamOperatorCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UdfStreamOperatorCheckpointingITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.test.checkpointing;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
@@ -61,15 +60,15 @@ public class UdfStreamOperatorCheckpointingITCase extends StreamFaultToleranceTe
     public void testProgram(StreamExecutionEnvironment env) {
 
         // base stream
-        KeyedStream<Tuple2<Integer, Long>, Tuple> stream =
-                env.addSource(new StatefulMultipleSequence()).keyBy(0);
+        KeyedStream<Tuple2<Integer, Long>, Integer> stream =
+                env.addSource(new StatefulMultipleSequence()).keyBy(x -> x.f0);
 
         stream
                 // testing built-in aggregate
                 .min(1)
                 // failure generation
                 .map(new OnceFailingIdentityMapFunction(NUM_INPUT))
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .addSink(new MinEvictingQueueSink());
 
         stream
@@ -83,7 +82,7 @@ public class UdfStreamOperatorCheckpointingITCase extends StreamFaultToleranceTe
                                 return Tuple2.of(value1.f0, value1.f1 + value2.f1);
                             }
                         })
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .addSink(new SumEvictingQueueSink());
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingProgram.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/classloading/jar/StreamingProgram.java
@@ -19,6 +19,9 @@
 package org.apache.flink.test.classloading.jar;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
@@ -36,7 +39,10 @@ public class StreamingProgram {
 
         DataStream<String> text = env.fromData(WordCountData.TEXT).rebalance();
 
-        DataStream<Word> counts = text.flatMap(new Tokenizer()).keyBy("word").sum("frequency");
+        DataStream<Word> counts =
+                text.flatMap(new Tokenizer())
+                        .keyBy(x -> (Tuple) Tuple1.of(x.word), Types.TUPLE(Types.STRING))
+                        .sum("frequency");
 
         counts.sinkTo(new DiscardingSink<>());
 

--- a/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/manual/StreamingScalabilityAndLatency.java
@@ -85,7 +85,7 @@ public class StreamingScalabilityAndLatency {
 
         env.addSource(new TimeStampingSource())
                 .map(new IdMapper<Tuple2<Long, Long>>())
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .addSink(new TimestampingSink());
 
         env.execute("Partitioning Program");

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/FastFailuresITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/FastFailuresITCase.java
@@ -67,7 +67,7 @@ public class FastFailuresITCase extends AbstractTestBaseJUnit4 {
                             public void cancel() {}
                         });
 
-        input.keyBy(0)
+        input.keyBy(x -> x.f0)
                 .map(
                         new MapFunction<Tuple2<Integer, Integer>, Integer>() {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/state/ManualWindowSpeedITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ManualWindowSpeedITCase.java
@@ -70,7 +70,7 @@ public class ManualWindowSpeedITCase extends AbstractTestBaseJUnit4 {
 
         env.addSource(new InfiniteTupleSource(1_000))
                 .assignTimestampsAndWatermarks(IngestionTimeWatermarkStrategy.create())
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .window(TumblingEventTimeWindows.of(Duration.ofSeconds(3)))
                 .reduce(
                         new ReduceFunction<Tuple2<String, Integer>>() {
@@ -110,7 +110,7 @@ public class ManualWindowSpeedITCase extends AbstractTestBaseJUnit4 {
 
         env.addSource(new InfiniteTupleSource(10_000))
                 .assignTimestampsAndWatermarks(IngestionTimeWatermarkStrategy.create())
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .window(TumblingEventTimeWindows.of(Duration.ofSeconds(3)))
                 .allowedLateness(Duration.ofSeconds(1))
                 .reduce(
@@ -148,7 +148,7 @@ public class ManualWindowSpeedITCase extends AbstractTestBaseJUnit4 {
 
         env.addSource(new InfiniteTupleSource(10_000))
                 .assignTimestampsAndWatermarks(IngestionTimeWatermarkStrategy.create())
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .window(TumblingEventTimeWindows.of(Duration.ofSeconds(3)))
                 .reduce(
                         new ReduceFunction<Tuple2<String, Integer>>() {
@@ -185,7 +185,7 @@ public class ManualWindowSpeedITCase extends AbstractTestBaseJUnit4 {
 
         env.addSource(new InfiniteTupleSource(10_000))
                 .assignTimestampsAndWatermarks(IngestionTimeWatermarkStrategy.create())
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .window(TumblingEventTimeWindows.of(Duration.ofSeconds(3)))
                 .allowedLateness(Duration.ofSeconds(1))
                 .reduce(

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/KeyedJob.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/KeyedJob.java
@@ -22,7 +22,9 @@ import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple;
+import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
@@ -96,7 +98,7 @@ public class KeyedJob {
 
     public static SingleOutputStreamOperator<Integer> createWindowFunction(
             ExecutionMode mode, DataStream<Tuple2<Integer, Integer>> input) {
-        return input.keyBy(0)
+        return input.keyBy(x -> (Tuple) Tuple1.of(x.f0), Types.TUPLE(Types.INT))
                 .countWindow(1)
                 .apply(new StatefulWindowFunction(mode))
                 .setParallelism(4)

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/ReinterpretDataStreamAsKeyedStreamITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/datastream/ReinterpretDataStreamAsKeyedStreamITCase.java
@@ -99,7 +99,7 @@ public class ReinterpretDataStreamAsKeyedStreamITCase {
         }
 
         env.addSource(new RandomTupleSource(numEventsPerInstance, numUniqueKeys))
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .addSink(new ToPartitionFileSink(partitionFiles));
 
         env.execute();

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/DataStreamPojoITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/DataStreamPojoITCase.java
@@ -18,7 +18,10 @@
 package org.apache.flink.test.streaming.runtime;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.CompositeType;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.test.util.AbstractTestBaseJUnit4;
@@ -57,9 +60,13 @@ public class DataStreamPojoITCase extends AbstractTestBaseJUnit4 {
 
         DataStream<Data> summedStream =
                 dataStream
-                        .keyBy("aaa", "abc", "wxyz")
+                        .keyBy(
+                                x -> Tuple3.of(x.aaa, x.abc, x.wxyz),
+                                Types.TUPLE(Types.INT, Types.INT, Types.LONG))
                         .sum("sum")
-                        .keyBy("aaa", "abc", "wxyz")
+                        .keyBy(
+                                x -> Tuple3.of(x.aaa, x.abc, x.wxyz),
+                                Types.TUPLE(Types.INT, Types.INT, Types.LONG))
                         .flatMap(
                                 new FlatMapFunction<Data, Data>() {
                                     private static final long serialVersionUID =
@@ -109,9 +116,13 @@ public class DataStreamPojoITCase extends AbstractTestBaseJUnit4 {
 
         DataStream<Data> summedStream =
                 dataStream
-                        .keyBy("aaa", "stats.count")
+                        .keyBy(
+                                x -> Tuple2.of(x.aaa, x.stats.count),
+                                Types.TUPLE(Types.INT, Types.LONG))
                         .sum("sum")
-                        .keyBy("aaa", "stats.count")
+                        .keyBy(
+                                x -> Tuple2.of(x.aaa, x.stats.count),
+                                Types.TUPLE(Types.INT, Types.LONG))
                         .flatMap(
                                 new FlatMapFunction<Data, Data>() {
                                     private static final long serialVersionUID =
@@ -164,9 +175,9 @@ public class DataStreamPojoITCase extends AbstractTestBaseJUnit4 {
 
         DataStream<Data> summedStream =
                 dataStream
-                        .keyBy("aaa")
+                        .keyBy(x -> x.aaa)
                         .sum("stats.count")
-                        .keyBy("aaa")
+                        .keyBy(x -> x.aaa)
                         .flatMap(
                                 new FlatMapFunction<Data, Data>() {
                                     Data[] first = new Data[3];
@@ -199,7 +210,9 @@ public class DataStreamPojoITCase extends AbstractTestBaseJUnit4 {
         StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
 
         DataStream<Data> dataStream = see.fromData(elements);
-        dataStream.keyBy("aaa", "stats.count").sum("stats.nonExistingField");
+        dataStream
+                .keyBy(x -> Tuple2.of(x.aaa, x.stats.count), Types.TUPLE(Types.INT, Types.LONG))
+                .sum("stats.nonExistingField");
     }
 
     /** POJO. */

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
@@ -102,7 +102,7 @@ public class PartitionerITCase extends AbstractTestBaseJUnit4 {
                 env.fromData(INPUT.stream().map(Tuple1::of).collect(Collectors.toList()));
 
         // partition by hash
-        src.keyBy(0).map(new SubtaskIndexAssigner()).addSink(hashPartitionResultSink);
+        src.keyBy(x -> x.f0).map(new SubtaskIndexAssigner()).addSink(hashPartitionResultSink);
 
         // partition custom
         DataStream<Tuple2<Integer, String>> partitionCustom =

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/PartitionerITCase.java
@@ -117,7 +117,7 @@ public class PartitionerITCase extends AbstractTestBaseJUnit4 {
                                         }
                                     }
                                 },
-                                0)
+                                x -> x.f0)
                         .map(new SubtaskIndexAssigner());
 
         partitionCustom.addSink(customPartitionResultSink);

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SideOutputITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.streaming.api.functions.co.CoProcessFunction;
 import org.apache.flink.streaming.api.functions.co.KeyedCoProcessFunction;
@@ -552,13 +553,13 @@ public class SideOutputITCase extends AbstractTestBaseJUnit4 implements Serializ
                                     }
                                 })
                         .process(
-                                new ProcessFunction<Integer, Integer>() {
-                                    private static final long serialVersionUID = 1L;
-
+                                new KeyedProcessFunction<Integer, Integer, Integer>() {
                                     @Override
                                     public void processElement(
-                                            Integer value, Context ctx, Collector<Integer> out)
-                                            throws Exception {
+                                            Integer value,
+                                            KeyedProcessFunction<Integer, Integer, Integer>.Context
+                                                    ctx,
+                                            Collector<Integer> out) {
                                         out.collect(value);
                                         ctx.output(
                                                 sideOutputTag, "sideout-" + String.valueOf(value));

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/StateBackendITCase.java
@@ -62,7 +62,7 @@ public class StateBackendITCase extends AbstractTestBaseJUnit4 {
         RestartStrategyUtils.configureNoRestartStrategy(see);
 
         see.fromData(new Tuple2<>("Hello", 1))
-                .keyBy(0)
+                .keyBy(x -> x.f0)
                 .map(
                         new RichMapFunction<Tuple2<String, Integer>, String>() {
                             private static final long serialVersionUID = 1L;

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -703,7 +703,7 @@ public class TimestampITCase extends TestLogger {
         DataStream<Tuple2<String, Integer>> source1 =
                 env.fromData(new Tuple2<>("a", 1), new Tuple2<>("b", 2));
 
-        source1.keyBy(0)
+        source1.keyBy(x -> x.f0)
                 .window(TumblingEventTimeWindows.of(Duration.ofSeconds(5)))
                 .reduce(
                         new ReduceFunction<Tuple2<String, Integer>>() {
@@ -733,7 +733,7 @@ public class TimestampITCase extends TestLogger {
         DataStream<Tuple2<String, Integer>> source1 =
                 env.fromData(new Tuple2<>("a", 1), new Tuple2<>("b", 2));
 
-        source1.keyBy(0)
+        source1.keyBy(x -> x.f0)
                 .window(TumblingEventTimeWindows.of(Duration.ofSeconds(5)))
                 .reduce(
                         new ReduceFunction<Tuple2<String, Integer>>() {


### PR DESCRIPTION
## What is the purpose of the change

Remove part of the deprecated interfaces related to DataStream

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
