### PR TITLE
[FLINK-36355][runtime] Remove deprecated xxxStreams#with

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -364,12 +364,8 @@ public class CoGroupedStreams<T1, T2> {
         /**
          * Completes the co-group operation with the user function that is executed for windowed
          * groups.
-         *
-         * <p>Note: This method's return type does not support setting an operator-specific
-         * parallelism. Due to binary backwards compatibility, this cannot be altered. Use the
-         * {@link #with(CoGroupFunction)} method to set an operator-specific parallelism.
          */
-        public <T> DataStream<T> apply(CoGroupFunction<T1, T2, T> function) {
+        public <T> SingleOutputStreamOperator<T> apply(CoGroupFunction<T1, T2, T> function) {
 
             TypeInformation<T> resultType =
                     TypeExtractor.getCoGroupReturnTypes(
@@ -381,30 +377,8 @@ public class CoGroupedStreams<T1, T2> {
         /**
          * Completes the co-group operation with the user function that is executed for windowed
          * groups.
-         *
-         * <p><b>Note:</b> This is a temporary workaround while the {@link #apply(CoGroupFunction)}
-         * method has the wrong return type and hence does not allow one to set an operator-specific
-         * parallelism
-         *
-         * @deprecated This method will be removed once the {@link #apply(CoGroupFunction)} method
-         *     is fixed in the next major version of Flink (2.0).
          */
-        @PublicEvolving
-        @Deprecated
-        public <T> SingleOutputStreamOperator<T> with(CoGroupFunction<T1, T2, T> function) {
-            return (SingleOutputStreamOperator<T>) apply(function);
-        }
-
-        /**
-         * Completes the co-group operation with the user function that is executed for windowed
-         * groups.
-         *
-         * <p>Note: This method's return type does not support setting an operator-specific
-         * parallelism. Due to binary backwards compatibility, this cannot be altered. Use the
-         * {@link #with(CoGroupFunction, TypeInformation)} method to set an operator-specific
-         * parallelism.
-         */
-        public <T> DataStream<T> apply(
+        public <T> SingleOutputStreamOperator<T> apply(
                 CoGroupFunction<T1, T2, T> function, TypeInformation<T> resultType) {
             // clean the closure
             function = input1.getExecutionEnvironment().clean(function);
@@ -444,24 +418,6 @@ public class CoGroupedStreams<T1, T2> {
 
             return windowedStream.apply(
                     new CoGroupWindowFunction<T1, T2, T, KEY, W>(function), resultType);
-        }
-
-        /**
-         * Completes the co-group operation with the user function that is executed for windowed
-         * groups.
-         *
-         * <p><b>Note:</b> This is a temporary workaround while the {@link #apply(CoGroupFunction,
-         * TypeInformation)} method has the wrong return type and hence does not allow one to set an
-         * operator-specific parallelism
-         *
-         * @deprecated This method will be removed once the {@link #apply(CoGroupFunction,
-         *     TypeInformation)} method is fixed in the next major version of Flink (2.0).
-         */
-        @PublicEvolving
-        @Deprecated
-        public <T> SingleOutputStreamOperator<T> with(
-                CoGroupFunction<T1, T2, T> function, TypeInformation<T> resultType) {
-            return (SingleOutputStreamOperator<T>) apply(function, resultType);
         }
 
         /** @deprecated Use {@link #getAllowedLatenessDuration()} */

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/JoinedStreams.java
@@ -355,12 +355,8 @@ public class JoinedStreams<T1, T2> {
         /**
          * Completes the join operation with the user function that is executed for each combination
          * of elements with the same key in a window.
-         *
-         * <p>Note: This method's return type does not support setting an operator-specific
-         * parallelism. Due to binary backwards compatibility, this cannot be altered. Use the
-         * {@link #with(JoinFunction)} method to set an operator-specific parallelism.
          */
-        public <T> DataStream<T> apply(JoinFunction<T1, T2, T> function) {
+        public <T> SingleOutputStreamOperator<T> apply(JoinFunction<T1, T2, T> function) {
             TypeInformation<T> resultType =
                     TypeExtractor.getBinaryOperatorReturnType(
                             function,
@@ -380,30 +376,8 @@ public class JoinedStreams<T1, T2> {
         /**
          * Completes the join operation with the user function that is executed for each combination
          * of elements with the same key in a window.
-         *
-         * <p><b>Note:</b> This is a temporary workaround while the {@link #apply(JoinFunction)}
-         * method has the wrong return type and hence does not allow one to set an operator-specific
-         * parallelism
-         *
-         * @deprecated This method will be removed once the {@link #apply(JoinFunction)} method is
-         *     fixed in the next major version of Flink (2.0).
          */
-        @PublicEvolving
-        @Deprecated
-        public <T> SingleOutputStreamOperator<T> with(JoinFunction<T1, T2, T> function) {
-            return (SingleOutputStreamOperator<T>) apply(function);
-        }
-
-        /**
-         * Completes the join operation with the user function that is executed for each combination
-         * of elements with the same key in a window.
-         *
-         * <p>Note: This method's return type does not support setting an operator-specific
-         * parallelism. Due to binary backwards compatibility, this cannot be altered. Use the
-         * {@link #with(JoinFunction, TypeInformation)}, method to set an operator-specific
-         * parallelism.
-         */
-        public <T> DataStream<T> apply(
+        public <T> SingleOutputStreamOperator<T> apply(
                 FlatJoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
             // clean the closure
             function = input1.getExecutionEnvironment().clean(function);
@@ -424,31 +398,8 @@ public class JoinedStreams<T1, T2> {
         /**
          * Completes the join operation with the user function that is executed for each combination
          * of elements with the same key in a window.
-         *
-         * <p><b>Note:</b> This is a temporary workaround while the {@link #apply(JoinFunction,
-         * TypeInformation)} method has the wrong return type and hence does not allow one to set an
-         * operator-specific parallelism
-         *
-         * @deprecated This method will be replaced by {@link #apply(FlatJoinFunction,
-         *     TypeInformation)} in Flink 2.0. So use the {@link #apply(FlatJoinFunction,
-         *     TypeInformation)} in the future.
          */
-        @PublicEvolving
-        @Deprecated
-        public <T> SingleOutputStreamOperator<T> with(
-                FlatJoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
-            return (SingleOutputStreamOperator<T>) apply(function, resultType);
-        }
-
-        /**
-         * Completes the join operation with the user function that is executed for each combination
-         * of elements with the same key in a window.
-         *
-         * <p>Note: This method's return type does not support setting an operator-specific
-         * parallelism. Due to binary backwards compatibility, this cannot be altered. Use the
-         * {@link #with(FlatJoinFunction)}, method to set an operator-specific parallelism.
-         */
-        public <T> DataStream<T> apply(FlatJoinFunction<T1, T2, T> function) {
+        public <T> SingleOutputStreamOperator<T> apply(FlatJoinFunction<T1, T2, T> function) {
             TypeInformation<T> resultType =
                     TypeExtractor.getBinaryOperatorReturnType(
                             function,
@@ -468,30 +419,8 @@ public class JoinedStreams<T1, T2> {
         /**
          * Completes the join operation with the user function that is executed for each combination
          * of elements with the same key in a window.
-         *
-         * <p><b>Note:</b> This is a temporary workaround while the {@link #apply(FlatJoinFunction)}
-         * method has the wrong return type and hence does not allow one to set an operator-specific
-         * parallelism.
-         *
-         * @deprecated This method will be removed once the {@link #apply(FlatJoinFunction)} method
-         *     is fixed in the next major version of Flink (2.0).
          */
-        @PublicEvolving
-        @Deprecated
-        public <T> SingleOutputStreamOperator<T> with(FlatJoinFunction<T1, T2, T> function) {
-            return (SingleOutputStreamOperator<T>) apply(function);
-        }
-
-        /**
-         * Completes the join operation with the user function that is executed for each combination
-         * of elements with the same key in a window.
-         *
-         * <p>Note: This method's return type does not support setting an operator-specific
-         * parallelism. Due to binary backwards compatibility, this cannot be altered. Use the
-         * {@link #with(JoinFunction, TypeInformation)}, method to set an operator-specific
-         * parallelism.
-         */
-        public <T> DataStream<T> apply(
+        public <T> SingleOutputStreamOperator<T> apply(
                 JoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
             // clean the closure
             function = input1.getExecutionEnvironment().clean(function);
@@ -506,24 +435,6 @@ public class JoinedStreams<T1, T2> {
                             .allowedLateness(allowedLateness);
 
             return coGroupedWindowedStream.apply(new JoinCoGroupFunction<>(function), resultType);
-        }
-
-        /**
-         * Completes the join operation with the user function that is executed for each combination
-         * of elements with the same key in a window.
-         *
-         * <p><b>Note:</b> This is a temporary workaround while the {@link #apply(FlatJoinFunction,
-         * TypeInformation)} method has the wrong return type and hence does not allow one to set an
-         * operator-specific parallelism
-         *
-         * @deprecated This method will be removed once the {@link #apply(JoinFunction,
-         *     TypeInformation)} method is fixed in the next major version of Flink (2.0).
-         */
-        @PublicEvolving
-        @Deprecated
-        public <T> SingleOutputStreamOperator<T> with(
-                JoinFunction<T1, T2, T> function, TypeInformation<T> resultType) {
-            return (SingleOutputStreamOperator<T>) apply(function, resultType);
         }
 
         /** @deprecated Use {@link #getAllowedLatenessDuration()}} */


### PR DESCRIPTION
## What is the purpose of the change

Remove deprecated xxxStreams#with

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
