### PR TITLE
[FLINK-36325][statebackend] Implement basic restore from checkpoint for ForStStateBackend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
@@ -26,14 +26,17 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.AsyncStateException;
 import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.v2.StateDescriptor;
 import org.apache.flink.runtime.state.v2.adaptor.AsyncKeyedStateBackendAdaptor;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.operators.Triggerable;
@@ -50,6 +53,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+
+import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -203,6 +208,25 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
         if (isAsyncStateProcessingEnabled()) {
             asyncExecutionController.drainInflightRecords(0);
         }
+    }
+
+    @Override
+    public OperatorSnapshotFutures snapshotState(
+            long checkpointId,
+            long timestamp,
+            CheckpointOptions checkpointOptions,
+            CheckpointStreamFactory factory)
+            throws Exception {
+        return stateHandler.snapshotState(
+                this,
+                Optional.ofNullable(timeServiceManager),
+                getOperatorName(),
+                checkpointId,
+                timestamp,
+                checkpointOptions,
+                factory,
+                isUsingCustomRawKeyedState(),
+                true);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -400,7 +400,8 @@ public abstract class AbstractStreamOperator<OUT>
                 timestamp,
                 checkpointOptions,
                 factory,
-                isUsingCustomRawKeyedState());
+                isUsingCustomRawKeyedState(),
+                false);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -317,7 +317,8 @@ public abstract class AbstractStreamOperatorV2<OUT>
                 timestamp,
                 checkpointOptions,
                 factory,
-                isUsingCustomRawKeyedState());
+                isUsingCustomRawKeyedState(),
+                false);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/StateBackendTestV2Base.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/StateBackendTestV2Base.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.v2;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.state.v2.ValueState;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.state.StateFutureImpl;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
+import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.state.AbstractStateBackend;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.CheckpointStorageAccess;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedStateBackendParametersImpl;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.util.IOUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.RunnableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@link AsyncKeyedStateBackend} produced by various {@link StateBackend}s.
+ *
+ * <p>NOTE: Please ensure to close and dispose any created keyed state backend in tests.
+ */
+@SuppressWarnings("serial")
+public abstract class StateBackendTestV2Base<B extends AbstractStateBackend> {
+
+    protected MockEnvironment env;
+
+    // lazily initialized stream storage
+    private CheckpointStreamFactory checkpointStreamFactory;
+
+    @BeforeEach
+    void before() throws Exception {
+        env = buildMockEnv();
+    }
+
+    private MockEnvironment buildMockEnv() throws Exception {
+        MockEnvironment mockEnvironment =
+                MockEnvironment.builder().setTaskStateManager(getTestTaskStateManager()).build();
+        mockEnvironment.setCheckpointStorageAccess(getCheckpointStorageAccess());
+        return mockEnvironment;
+    }
+
+    protected TestTaskStateManager getTestTaskStateManager() throws IOException {
+        return TestTaskStateManager.builder().build();
+    }
+
+    @AfterEach
+    void after() {
+        IOUtils.closeQuietly(env);
+    }
+
+    protected abstract ConfigurableStateBackend getStateBackend() throws Exception;
+
+    protected CheckpointStorage getCheckpointStorage() throws Exception {
+        ConfigurableStateBackend stateBackend = getStateBackend();
+        if (stateBackend instanceof CheckpointStorage) {
+            return (CheckpointStorage) stateBackend;
+        }
+
+        throw new IllegalStateException(
+                "The state backend under test does not implement CheckpointStorage."
+                        + "Please override 'createCheckpointStorage' and provide an appropriate"
+                        + "checkpoint storage instance");
+    }
+
+    protected CheckpointStorageAccess getCheckpointStorageAccess() throws Exception {
+        return getCheckpointStorage().createCheckpointStorage(new JobID());
+    }
+
+    protected CheckpointStreamFactory createStreamFactory() throws Exception {
+        if (checkpointStreamFactory == null) {
+            checkpointStreamFactory =
+                    getCheckpointStorage()
+                            .createCheckpointStorage(new JobID())
+                            .resolveCheckpointStorageLocation(
+                                    1L, CheckpointStorageLocationReference.getDefault());
+        }
+
+        return checkpointStreamFactory;
+    }
+
+    protected <K> AsyncKeyedStateBackend<K> createAsyncKeyedBackend(
+            TypeSerializer<K> keySerializer, int numberOfKeyGroups, Environment env)
+            throws Exception {
+
+        env.setCheckpointStorageAccess(getCheckpointStorageAccess());
+
+        return getStateBackend()
+                .createAsyncKeyedStateBackend(
+                        new KeyedStateBackendParametersImpl<>(
+                                env,
+                                new JobID(),
+                                "test_op",
+                                keySerializer,
+                                numberOfKeyGroups,
+                                new KeyGroupRange(0, numberOfKeyGroups - 1),
+                                env.getTaskKvStateRegistry(),
+                                TtlTimeProvider.DEFAULT,
+                                getMetricGroup(),
+                                getCustomInitializationMetrics(),
+                                Collections.emptyList(),
+                                new CloseableRegistry(),
+                                1.0d));
+    }
+
+    protected StateBackend.CustomInitializationMetrics getCustomInitializationMetrics() {
+        return (name, value) -> {};
+    }
+
+    protected <K> AsyncKeyedStateBackend<K> restoreAsyncKeyedBackend(
+            TypeSerializer<K> keySerializer,
+            int numberOfKeyGroups,
+            List<KeyedStateHandle> state,
+            Environment env)
+            throws Exception {
+
+        return getStateBackend()
+                .createAsyncKeyedStateBackend(
+                        new KeyedStateBackendParametersImpl<>(
+                                env,
+                                new JobID(),
+                                "test_op",
+                                keySerializer,
+                                numberOfKeyGroups,
+                                new KeyGroupRange(0, numberOfKeyGroups - 1),
+                                env.getTaskKvStateRegistry(),
+                                TtlTimeProvider.DEFAULT,
+                                getMetricGroup(),
+                                getCustomInitializationMetrics(),
+                                state,
+                                new CloseableRegistry(),
+                                1.0d));
+    }
+
+    protected MetricGroup getMetricGroup() {
+        return new UnregisteredMetricsGroup();
+    }
+
+    @TestTemplate
+    void testAsyncKeyedStateBackendSnapshot() throws Exception {
+        int mockRecordCount = 20;
+
+        int jobMaxParallelism = 128;
+        int aecBatchSize = 1;
+        long aecBufferTimeout = 1;
+        int aecMaxInFlightRecords = 1000;
+
+        ArrayList<RecordContext<Integer>> recordContexts = new ArrayList<>(mockRecordCount);
+
+        AsyncKeyedStateBackend<Integer> backend = null;
+        AsyncExecutionController<Integer> aec;
+
+        TestAsyncFrameworkExceptionHandler testExceptionHandler =
+                new TestAsyncFrameworkExceptionHandler();
+
+        KeyedStateHandle stateHandle;
+
+        try {
+            backend = createAsyncKeyedBackend(IntSerializer.INSTANCE, jobMaxParallelism, env);
+            aec =
+                    new AsyncExecutionController<>(
+                            new SyncMailboxExecutor(),
+                            testExceptionHandler,
+                            backend.createStateExecutor(),
+                            jobMaxParallelism,
+                            aecBatchSize,
+                            aecBufferTimeout,
+                            aecMaxInFlightRecords,
+                            null);
+            backend.setup(aec);
+
+            ValueStateDescriptor<Integer> stateDescriptor =
+                    new ValueStateDescriptor<>("test", BasicTypeInfo.INT_TYPE_INFO);
+
+            ValueState<Integer> valueState =
+                    backend.createState(
+                            VoidNamespace.INSTANCE,
+                            VoidNamespaceSerializer.INSTANCE,
+                            stateDescriptor);
+
+            for (int i = 0; i < mockRecordCount; i++) {
+                recordContexts.add(aec.buildContext(i, i));
+                recordContexts.get(i).retain();
+            }
+
+            for (int i = 0; i < mockRecordCount; i++) {
+                aec.setCurrentContext(recordContexts.get(i));
+                valueState.update(i);
+            }
+
+            // verify state value before snapshot and release record contexts
+            for (int i = 0; i < mockRecordCount; i++) {
+                aec.setCurrentContext(recordContexts.get(i));
+                assertThat(valueState.value()).isEqualTo(i);
+                recordContexts.get(i).release();
+            }
+
+            aec.drainInflightRecords(0);
+
+            RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot =
+                    backend.snapshot(
+                            1L,
+                            System.currentTimeMillis(),
+                            createStreamFactory(),
+                            CheckpointOptions.forCheckpointWithDefaultLocation());
+
+            if (!snapshot.isDone()) {
+                snapshot.run();
+            }
+            SnapshotResult<KeyedStateHandle> snapshotResult = snapshot.get();
+            stateHandle = snapshotResult.getJobManagerOwnedSnapshot();
+
+            recordContexts.clear();
+            for (int i = 0; i < mockRecordCount; i++) {
+                recordContexts.add(aec.buildContext(i, i));
+                recordContexts.get(i).retain();
+            }
+
+            for (int i = 0; i < mockRecordCount; i++) {
+                aec.setCurrentContext(recordContexts.get(i));
+                valueState.update(i + 1);
+            }
+
+            // verify state value after snapshot and release record contexts
+            for (int i = 0; i < mockRecordCount; i++) {
+                aec.setCurrentContext(recordContexts.get(i));
+                assertThat(valueState.value()).isEqualTo(i + 1);
+                recordContexts.get(i).release();
+            }
+
+        } finally {
+            if (null != backend) {
+                IOUtils.closeQuietly(backend);
+                backend.dispose();
+            }
+        }
+
+        assertThat(stateHandle).isNotNull();
+
+        backend = null;
+
+        try {
+            backend =
+                    restoreAsyncKeyedBackend(
+                            IntSerializer.INSTANCE,
+                            jobMaxParallelism,
+                            Collections.singletonList(stateHandle),
+                            env);
+            aec =
+                    new AsyncExecutionController<>(
+                            new SyncMailboxExecutor(),
+                            testExceptionHandler,
+                            backend.createStateExecutor(),
+                            jobMaxParallelism,
+                            aecBatchSize,
+                            aecBufferTimeout,
+                            aecMaxInFlightRecords,
+                            null);
+            backend.setup(aec);
+
+            ValueStateDescriptor<Integer> stateDescriptor =
+                    new ValueStateDescriptor<>("test", BasicTypeInfo.INT_TYPE_INFO);
+
+            ValueState<Integer> valueState =
+                    backend.createState(
+                            VoidNamespace.INSTANCE,
+                            VoidNamespaceSerializer.INSTANCE,
+                            stateDescriptor);
+
+            recordContexts.clear();
+            for (int i = 0; i < mockRecordCount; i++) {
+                recordContexts.add(aec.buildContext(i, i));
+                recordContexts.get(i).retain();
+            }
+
+            // verify state value after restore from snapshot and release record contexts
+            for (int i = 0; i < mockRecordCount; i++) {
+                aec.setCurrentContext(recordContexts.get(i));
+                assertThat(valueState.value()).isEqualTo(i);
+                recordContexts.get(i).release();
+            }
+        } finally {
+            if (null != backend) {
+                IOUtils.closeQuietly(backend);
+                backend.dispose();
+            }
+        }
+
+        assertThat(testExceptionHandler.exception).isNull();
+    }
+
+    static class TestAsyncFrameworkExceptionHandler
+            implements StateFutureImpl.AsyncFrameworkExceptionHandler {
+        String message = null;
+        Throwable exception = null;
+
+        public void handleException(String message, Throwable exception) {
+            this.message = message;
+            this.exception = exception;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
@@ -162,6 +162,7 @@ class StreamOperatorStateHandlerTest {
                                             new MemCheckpointStreamFactory(1024),
                                             operatorSnapshotResult,
                                             context,
+                                            false,
                                             false))
                     .isInstanceOfSatisfying(
                             CheckpointException.class,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -20,6 +20,8 @@ package org.apache.flink.state.forst;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataInputDeserializer;
@@ -34,6 +36,7 @@ import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.SnapshotStrategyRunner;
+import org.apache.flink.runtime.state.StateSnapshotTransformer;
 import org.apache.flink.runtime.state.v2.AggregatingStateDescriptor;
 import org.apache.flink.runtime.state.v2.ListStateDescriptor;
 import org.apache.flink.runtime.state.v2.ReducingStateDescriptor;
@@ -44,6 +47,7 @@ import org.apache.flink.state.forst.snapshot.ForStSnapshotStrategyBase;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StateMigrationException;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
@@ -186,15 +190,16 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
     public <N, S extends State, SV> S createState(
             @Nonnull N defaultNamespace,
             @Nonnull TypeSerializer<N> namespaceSerializer,
-            @Nonnull StateDescriptor<SV> stateDesc) {
+            @Nonnull StateDescriptor<SV> stateDesc)
+            throws Exception {
         Preconditions.checkNotNull(
                 stateRequestHandler,
                 "A non-null stateRequestHandler must be setup before createState");
-        ColumnFamilyHandle columnFamilyHandle =
-                ForStOperationUtils.createColumnFamilyHandle(
-                        stateDesc.getStateId(), db, columnFamilyOptionsFactory);
 
-        registerKvStateInformation(stateDesc, namespaceSerializer, columnFamilyHandle);
+        Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> registerResult =
+                tryRegisterKvStateInformation(stateDesc, namespaceSerializer);
+
+        ColumnFamilyHandle columnFamilyHandle = registerResult.f0;
 
         switch (stateDesc.getType()) {
             case VALUE:
@@ -260,19 +265,88 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
         }
     }
 
-    private <N, SV> void registerKvStateInformation(
-            @Nonnull StateDescriptor<SV> stateDesc,
-            TypeSerializer<N> namespaceSerializer,
-            ColumnFamilyHandle columnFamilyHandle) {
-        kvStateInformation.put(
-                stateDesc.getStateId(),
-                new ForStKvStateInfo(
-                        columnFamilyHandle,
-                        new RegisteredKeyValueStateBackendMetaInfo<>(
-                                stateDesc.getStateId(),
-                                stateDesc.getType(),
-                                namespaceSerializer,
-                                stateDesc.getSerializer())));
+    private <N, SV>
+            Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>>
+                    tryRegisterKvStateInformation(
+                            StateDescriptor<SV> stateDesc, TypeSerializer<N> namespaceSerializer)
+                            throws Exception {
+
+        ForStKvStateInfo oldStateInfo = kvStateInformation.get(stateDesc.getStateId());
+
+        TypeSerializer<SV> stateSerializer = stateDesc.getSerializer();
+
+        ForStKvStateInfo newStateInfo;
+        RegisteredKeyValueStateBackendMetaInfo<N, SV> newMetaInfo;
+        if (oldStateInfo != null) {
+            @SuppressWarnings("unchecked")
+            RegisteredKeyValueStateBackendMetaInfo<N, SV> castedMetaInfo =
+                    (RegisteredKeyValueStateBackendMetaInfo<N, SV>) oldStateInfo.metaInfo;
+
+            newMetaInfo =
+                    updateRestoredStateMetaInfo(
+                            Tuple2.of(oldStateInfo.columnFamilyHandle, castedMetaInfo),
+                            stateDesc,
+                            stateSerializer,
+                            namespaceSerializer);
+
+            newStateInfo = new ForStKvStateInfo(oldStateInfo.columnFamilyHandle, newMetaInfo);
+            kvStateInformation.put(stateDesc.getStateId(), newStateInfo);
+        } else {
+            newMetaInfo =
+                    new RegisteredKeyValueStateBackendMetaInfo<>(
+                            stateDesc.getStateId(),
+                            stateDesc.getType(),
+                            namespaceSerializer,
+                            stateSerializer,
+                            StateSnapshotTransformer.StateSnapshotTransformFactory.noTransform());
+
+            newStateInfo =
+                    ForStOperationUtils.createStateInfo(
+                            newMetaInfo, db, columnFamilyOptionsFactory);
+            ForStOperationUtils.registerKvStateInformation(
+                    this.kvStateInformation,
+                    this.nativeMetricMonitor,
+                    stateDesc.getStateId(),
+                    newStateInfo);
+        }
+
+        return Tuple2.of(newStateInfo.columnFamilyHandle, newMetaInfo);
+    }
+
+    private <N, SV> RegisteredKeyValueStateBackendMetaInfo<N, SV> updateRestoredStateMetaInfo(
+            Tuple2<ColumnFamilyHandle, RegisteredKeyValueStateBackendMetaInfo<N, SV>> oldStateInfo,
+            StateDescriptor<SV> stateDesc,
+            TypeSerializer<SV> stateSerializer,
+            TypeSerializer<N> namespaceSerializer)
+            throws Exception {
+
+        RegisteredKeyValueStateBackendMetaInfo<N, SV> restoredKvStateMetaInfo = oldStateInfo.f1;
+
+        restoredKvStateMetaInfo.checkStateMetaInfo(stateDesc);
+
+        // fetch current serializer now because if it is incompatible, we can't access it anymore to
+        // improve the error message
+        TypeSerializer<SV> previousStateSerializer = restoredKvStateMetaInfo.getStateSerializer();
+
+        TypeSerializerSchemaCompatibility<SV> newStateSerializerCompatibility =
+                restoredKvStateMetaInfo.updateStateSerializer(stateSerializer);
+
+        if (!stateSerializer.equals(previousStateSerializer)
+                && newStateSerializerCompatibility.isCompatibleAfterMigration()) {
+
+            // TODO: 2024/6/6 wangfeifan - Implement state migration
+            throw new UnsupportedOperationException("State migration not support yet.");
+
+        } else if (newStateSerializerCompatibility.isIncompatible()) {
+            throw new StateMigrationException(
+                    "The new state serializer ("
+                            + stateSerializer
+                            + ") must not be incompatible with the old state serializer ("
+                            + previousStateSerializer
+                            + ").");
+        }
+
+        return restoredKvStateMetaInfo;
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOperationUtils.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStOperationUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.fs.ICloseableRegistry;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
+import org.apache.flink.state.forst.ForStKeyedStateBackend.ForStKvStateInfo;
 import org.apache.flink.state.forst.sync.ForStIteratorWrapper;
 import org.apache.flink.state.forst.sync.ForStSyncKeyedStateBackend;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -343,6 +344,38 @@ public class ForStOperationUtils {
             nativeMetricMonitor.registerColumnFamily(
                     columnFamilyName, registeredColumn.columnFamilyHandle);
         }
+    }
+
+    public static void registerKvStateInformation(
+            Map<String, ForStKvStateInfo> kvStateInformation,
+            ForStNativeMetricMonitor nativeMetricMonitor,
+            String columnFamilyName,
+            ForStKvStateInfo registeredColumn) {
+
+        kvStateInformation.put(columnFamilyName, registeredColumn);
+        if (nativeMetricMonitor != null) {
+            nativeMetricMonitor.registerColumnFamily(
+                    columnFamilyName, registeredColumn.columnFamilyHandle);
+        }
+    }
+
+    public static ForStKvStateInfo createStateInfo(
+            RegisteredStateMetaInfoBase metaInfoBase,
+            RocksDB db,
+            Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory) {
+
+        ColumnFamilyDescriptor columnFamilyDescriptor =
+                createColumnFamilyDescriptor(metaInfoBase.getName(), columnFamilyOptionsFactory);
+
+        final ColumnFamilyHandle columnFamilyHandle;
+        try {
+            columnFamilyHandle = createColumnFamily(columnFamilyDescriptor, db);
+        } catch (Exception ex) {
+            IOUtils.closeQuietly(columnFamilyDescriptor.getOptions());
+            throw new FlinkRuntimeException("Error creating ColumnFamilyHandle.", ex);
+        }
+
+        return new ForStKvStateInfo(columnFamilyHandle, metaInfoBase);
     }
 
     private static void throwExceptionIfPathLengthExceededOnWindows(String path, Exception cause)

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
@@ -65,12 +65,12 @@ import java.util.Collection;
 public final class ForStResourceContainer implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(ForStResourceContainer.class);
 
+    public static final String DB_DIR_STRING = "db";
+
     private static final String FORST_RELOCATE_LOG_SUFFIX = "_LOG";
 
     // the filename length limit is 255 on most operating systems
     private static final int INSTANCE_PATH_LENGTH_LIMIT = 255 - FORST_RELOCATE_LOG_SUFFIX.length();
-
-    private static final String DB_DIR_STRING = "db";
 
     @Nullable private final Path remoteBasePath;
 
@@ -267,6 +267,14 @@ public final class ForStResourceContainer implements AutoCloseable {
     @Nullable
     public Path getRemoteForStPath() {
         return remoteForStPath;
+    }
+
+    public Path getBasePath() {
+        if (remoteBasePath != null) {
+            return remoteBasePath;
+        } else {
+            return Path.fromLocalFile(localBasePath);
+        }
     }
 
     public Path getDbPath() {

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
@@ -355,13 +355,17 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
 
         ForStKeyedStateBackendBuilder<K> builder =
                 new ForStKeyedStateBackendBuilder<>(
+                                parameters.getOperatorIdentifier(),
+                                env.getUserCodeClassLoader().asClassLoader(),
                                 resourceContainer,
                                 stateName -> resourceContainer.getColumnOptions(),
                                 parameters.getKeySerializer(),
                                 parameters.getNumberOfKeyGroups(),
                                 parameters.getKeyGroupRange(),
                                 parameters.getMetricGroup(),
-                                parameters.getStateHandles())
+                                parameters.getCustomInitializationMetrics(),
+                                parameters.getStateHandles(),
+                                parameters.getCancelStreamRegistry())
                         // TODO: remove after support more snapshot strategy
                         .setEnableIncrementalCheckpointing(true)
                         .setNativeMetricOptions(

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/StateHandleTransferSpec.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/StateHandleTransferSpec.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+
+/**
+ * This class represents a transfer specification for the content of one {@link
+ * IncrementalRemoteKeyedStateHandle} to a target {@link Path}.
+ */
+public class StateHandleTransferSpec {
+    /** The state handle to transfer. */
+    private final IncrementalRemoteKeyedStateHandle stateHandle;
+
+    /** The path to which the content of the state handle shall be transferred. */
+    private final Path transferDestination;
+
+    public StateHandleTransferSpec(
+            IncrementalRemoteKeyedStateHandle stateHandle, Path transferDestination) {
+        this.stateHandle = stateHandle;
+        this.transferDestination = transferDestination;
+    }
+
+    public IncrementalRemoteKeyedStateHandle getStateHandle() {
+        return stateHandle;
+    }
+
+    public Path getTransferDestination() {
+        return transferDestination;
+    }
+
+    @Override
+    public String toString() {
+        return "StateHandleTransferSpec(transferDestination = ["
+                + transferDestination
+                + "] stateHandle = ["
+                + stateHandle
+                + "])";
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStHandle.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStHandle.java
@@ -19,6 +19,9 @@
 package org.apache.flink.state.forst.restore;
 
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.state.forst.ForStKeyedStateBackend.ForStKvStateInfo;
 import org.apache.flink.state.forst.ForStNativeMetricMonitor;
 import org.apache.flink.state.forst.ForStNativeMetricOptions;
 import org.apache.flink.state.forst.ForStOperationUtils;
@@ -30,6 +33,7 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.File;
@@ -37,6 +41,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /** Utility for creating a ForSt instance either from scratch or from restored local state. */
@@ -44,9 +49,10 @@ class ForStHandle implements AutoCloseable {
 
     private final Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory;
     private final DBOptions dbOptions;
+    private final Map<String, ForStKvStateInfo> kvStateInformation;
     private final String dbPath;
-    private final List<ColumnFamilyHandle> columnFamilyHandles;
-    private final List<ColumnFamilyDescriptor> columnFamilyDescriptors;
+    private List<ColumnFamilyHandle> columnFamilyHandles;
+    private List<ColumnFamilyDescriptor> columnFamilyDescriptors;
     private final ForStNativeMetricOptions nativeMetricOptions;
     private final MetricGroup metricGroup;
 
@@ -55,11 +61,13 @@ class ForStHandle implements AutoCloseable {
     @Nullable private ForStNativeMetricMonitor nativeMetricMonitor;
 
     protected ForStHandle(
+            Map<String, ForStKvStateInfo> kvStateInformation,
             File instanceRocksDBPath,
             DBOptions dbOptions,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             ForStNativeMetricOptions nativeMetricOptions,
             MetricGroup metricGroup) {
+        this.kvStateInformation = kvStateInformation;
         this.dbPath = instanceRocksDBPath.getAbsolutePath();
         this.dbOptions = dbOptions;
         this.columnFamilyOptionsFactory = columnFamilyOptionsFactory;
@@ -71,6 +79,20 @@ class ForStHandle implements AutoCloseable {
 
     void openDB() throws IOException {
         loadDb();
+    }
+
+    void openDB(
+            @Nonnull List<ColumnFamilyDescriptor> columnFamilyDescriptors,
+            @Nonnull List<StateMetaInfoSnapshot> stateMetaInfoSnapshots)
+            throws IOException {
+        this.columnFamilyDescriptors = columnFamilyDescriptors;
+        this.columnFamilyHandles = new ArrayList<>(columnFamilyDescriptors.size() + 1);
+        loadDb();
+        // Register CF handlers
+        for (int i = 0; i < stateMetaInfoSnapshots.size(); i++) {
+            getOrRegisterStateColumnFamilyHandle(
+                    columnFamilyHandles.get(i), stateMetaInfoSnapshots.get(i));
+        }
     }
 
     private void loadDb() throws IOException {
@@ -92,6 +114,39 @@ class ForStHandle implements AutoCloseable {
                         : null;
     }
 
+    ForStKvStateInfo getOrRegisterStateColumnFamilyHandle(
+            ColumnFamilyHandle columnFamilyHandle, StateMetaInfoSnapshot stateMetaInfoSnapshot) {
+
+        ForStKvStateInfo registeredStateMetaInfoEntry =
+                kvStateInformation.get(stateMetaInfoSnapshot.getName());
+
+        if (null == registeredStateMetaInfoEntry) {
+            // create a meta info for the state on restore;
+            // this allows us to retain the state in future snapshots even if it wasn't accessed
+            RegisteredStateMetaInfoBase stateMetaInfo =
+                    RegisteredStateMetaInfoBase.fromMetaInfoSnapshot(stateMetaInfoSnapshot);
+            if (columnFamilyHandle == null) {
+                registeredStateMetaInfoEntry =
+                        ForStOperationUtils.createStateInfo(
+                                stateMetaInfo, db, columnFamilyOptionsFactory);
+            } else {
+                registeredStateMetaInfoEntry =
+                        new ForStKvStateInfo(columnFamilyHandle, stateMetaInfo);
+            }
+
+            ForStOperationUtils.registerKvStateInformation(
+                    kvStateInformation,
+                    nativeMetricMonitor,
+                    stateMetaInfoSnapshot.getName(),
+                    registeredStateMetaInfoEntry);
+        } else {
+            // TODO: with eager state registration in place, check here for serializer migration
+            // strategies.
+        }
+
+        return registeredStateMetaInfoEntry;
+    }
+
     public RocksDB getDb() {
         return db;
     }
@@ -103,6 +158,10 @@ class ForStHandle implements AutoCloseable {
 
     public ColumnFamilyHandle getDefaultColumnFamilyHandle() {
         return defaultColumnFamilyHandle;
+    }
+
+    public Function<String, ColumnFamilyOptions> getColumnFamilyOptionsFactory() {
+        return columnFamilyOptionsFactory;
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStIncrementalRestoreOperation.java
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.restore;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle;
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyedBackendSerializationProxy;
+import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
+import org.apache.flink.runtime.state.StateBackend.CustomInitializationMetrics;
+import org.apache.flink.runtime.state.StateSerializerProvider;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.state.forst.ForStKeyedStateBackend.ForStKvStateInfo;
+import org.apache.flink.state.forst.ForStNativeMetricOptions;
+import org.apache.flink.state.forst.ForStOperationUtils;
+import org.apache.flink.state.forst.ForStResourceContainer;
+import org.apache.flink.state.forst.ForStStateDataTransfer;
+import org.apache.flink.state.forst.StateHandleTransferSpec;
+import org.apache.flink.state.forst.fs.ForStFlinkFileSystem;
+import org.apache.flink.util.StateMigrationException;
+import org.apache.flink.util.clock.SystemClock;
+import org.apache.flink.util.function.RunnableWithException;
+
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.runtime.metrics.MetricNames.DOWNLOAD_STATE_DURATION;
+import static org.apache.flink.runtime.metrics.MetricNames.RESTORE_STATE_DURATION;
+import static org.apache.flink.state.forst.ForStResourceContainer.DB_DIR_STRING;
+
+/** Encapsulates the process of restoring a ForSt instance from an incremental snapshot. */
+public class ForStIncrementalRestoreOperation<K> implements ForStRestoreOperation {
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(ForStIncrementalRestoreOperation.class);
+
+    private final String operatorIdentifier;
+    private final SortedMap<Long, Collection<HandleAndLocalPath>> restoredSstFiles;
+    private final ForStHandle forstHandle;
+    private final Collection<IncrementalRemoteKeyedStateHandle> restoreStateHandles;
+    private final CloseableRegistry cancelStreamRegistry;
+    private final KeyGroupRange keyGroupRange;
+    private final ForStResourceContainer optionsContainer;
+    private final Path forstBasePath;
+    private final StateSerializerProvider<K> keySerializerProvider;
+    private final ClassLoader userCodeClassLoader;
+    private final CustomInitializationMetrics customInitializationMetrics;
+    private long lastCompletedCheckpointId;
+    private UUID backendUID;
+
+    private boolean isKeySerializerCompatibilityChecked;
+
+    public ForStIncrementalRestoreOperation(
+            String operatorIdentifier,
+            KeyGroupRange keyGroupRange,
+            CloseableRegistry cancelStreamRegistry,
+            ClassLoader userCodeClassLoader,
+            Map<String, ForStKvStateInfo> kvStateInformation,
+            StateSerializerProvider<K> keySerializerProvider,
+            ForStResourceContainer optionsContainer,
+            Path forstBasePath,
+            File instanceRocksDBPath,
+            DBOptions dbOptions,
+            Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
+            ForStNativeMetricOptions nativeMetricOptions,
+            MetricGroup metricGroup,
+            CustomInitializationMetrics customInitializationMetrics,
+            @Nonnull Collection<IncrementalRemoteKeyedStateHandle> restoreStateHandles) {
+
+        this.forstHandle =
+                new ForStHandle(
+                        kvStateInformation,
+                        instanceRocksDBPath,
+                        dbOptions,
+                        columnFamilyOptionsFactory,
+                        nativeMetricOptions,
+                        metricGroup);
+        this.operatorIdentifier = operatorIdentifier;
+        this.restoredSstFiles = new TreeMap<>();
+        this.lastCompletedCheckpointId = -1L;
+        this.backendUID = UUID.randomUUID();
+        this.customInitializationMetrics = customInitializationMetrics;
+        this.restoreStateHandles = restoreStateHandles;
+        this.cancelStreamRegistry = cancelStreamRegistry;
+        this.keyGroupRange = keyGroupRange;
+        this.optionsContainer = optionsContainer;
+        this.forstBasePath = forstBasePath;
+        this.keySerializerProvider = keySerializerProvider;
+        this.userCodeClassLoader = userCodeClassLoader;
+    }
+
+    /**
+     * Root method that branches for different implementations of {@link
+     * IncrementalKeyedStateHandle}.
+     */
+    @Override
+    public ForStRestoreResult restore() throws Exception {
+
+        if (restoreStateHandles == null || restoreStateHandles.isEmpty()) {
+            return null;
+        }
+
+        logger.info(
+                "Starting ForSt incremental recovery in operator {}, target key-group range {}. State Handles={}",
+                operatorIdentifier,
+                keyGroupRange.prettyPrintInterval(),
+                restoreStateHandles);
+
+        List<IncrementalRemoteKeyedStateHandle> otherHandles =
+                new ArrayList<>(restoreStateHandles.size() - 1);
+        IncrementalRemoteKeyedStateHandle mainHandle =
+                chooseMainHandleAndCollectOthers(otherHandles);
+
+        // Use default db directory name as in main db instance
+        StateHandleTransferSpec mainSpec =
+                new StateHandleTransferSpec(mainHandle, new Path(forstBasePath, DB_DIR_STRING));
+
+        List<StateHandleTransferSpec> otherSpecs =
+                otherHandles.stream()
+                        .map(
+                                handle ->
+                                        new StateHandleTransferSpec(
+                                                handle,
+                                                new Path(
+                                                        forstBasePath,
+                                                        UUID.randomUUID().toString())))
+                        .collect(Collectors.toList());
+
+        try {
+            runAndReportDuration(
+                    () -> transferAllStateHandles(mainSpec, otherSpecs),
+                    // TODO: use new metric name, such as "TransferStateDurationMs"
+                    DOWNLOAD_STATE_DURATION);
+
+            runAndReportDuration(
+                    () -> restoreFromTransferredHandles(mainSpec, otherSpecs),
+                    RESTORE_STATE_DURATION);
+
+            return new ForStRestoreResult(
+                    this.forstHandle.getDb(),
+                    this.forstHandle.getDefaultColumnFamilyHandle(),
+                    this.forstHandle.getNativeMetricMonitor(),
+                    lastCompletedCheckpointId,
+                    backendUID,
+                    restoredSstFiles);
+        } finally {
+            // Delete the transfer destination quietly.
+            otherSpecs.stream()
+                    .map(StateHandleTransferSpec::getTransferDestination)
+                    .forEach(
+                            dir -> {
+                                try {
+                                    FileSystem fs = dir.getFileSystem();
+                                    fs.delete(dir, true);
+                                } catch (IOException ignored) {
+
+                                }
+                            });
+        }
+    }
+
+    private IncrementalRemoteKeyedStateHandle chooseMainHandleAndCollectOthers(
+            final List<IncrementalRemoteKeyedStateHandle> otherHandlesCollector) {
+
+        // TODO: When implementing rescale, refer to
+        // RocksDBIncrementalCheckpointUtils.findTheBestStateHandleForInitial to implement this
+        // method. Currently, it can be assumed that there is only one state handle to restore.
+        return restoreStateHandles.iterator().next();
+    }
+
+    private void transferAllStateHandles(
+            StateHandleTransferSpec mainSpecs, List<StateHandleTransferSpec> otherSpecs)
+            throws Exception {
+
+        // TODO: Now not support rescale, so now ignore otherSpecs. Before implement transfer
+        // otherSpecs, we may need reconsider the implementation of ForStFlinkFileSystem.
+
+        FileSystem forStFs =
+                optionsContainer.getRemoteForStPath() != null
+                        ? ForStFlinkFileSystem.get(optionsContainer.getRemoteForStPath().toUri())
+                        : FileSystem.getLocalFileSystem();
+
+        try (ForStStateDataTransfer transfer =
+                new ForStStateDataTransfer(ForStStateDataTransfer.DEFAULT_THREAD_NUM, forStFs)) {
+            transfer.transferAllStateDataToDirectory(
+                    Collections.singleton(mainSpecs), cancelStreamRegistry);
+        }
+    }
+
+    private void restoreFromTransferredHandles(
+            StateHandleTransferSpec mainHandle, List<StateHandleTransferSpec> temporaryHandles)
+            throws Exception {
+
+        restoreFromMainTransferredHandle(mainHandle);
+
+        mergeOtherTransferredHandles(temporaryHandles);
+    }
+
+    private void restoreFromMainTransferredHandle(StateHandleTransferSpec mainHandle)
+            throws Exception {
+        IncrementalRemoteKeyedStateHandle handle = mainHandle.getStateHandle();
+
+        restoreBaseDBFromMainHandle(handle);
+
+        // Check if the key-groups range has changed.
+        if (Objects.equals(handle.getKeyGroupRange(), keyGroupRange)) {
+            // This is the case if we didn't rescale, so we can restore all the info from the
+            // previous backend instance (backend id and incremental checkpoint history).
+            restorePreviousIncrementalFilesStatus(handle);
+        } else {
+            // If the key-groups don't match, this was a scale out, and we need to clip the
+            // key-groups range of the db to the target range for this backend.
+            throw new UnsupportedOperationException("ForStateBackend not support rescale yet.");
+        }
+        logger.info(
+                "Finished opening base ForSt instance in operator {} with target key-group range {}.",
+                operatorIdentifier,
+                keyGroupRange.prettyPrintInterval());
+    }
+
+    private void mergeOtherTransferredHandles(List<StateHandleTransferSpec> otherHandles) {
+        if (otherHandles != null && !otherHandles.isEmpty()) {
+            // TODO: implement rescale
+            throw new UnsupportedOperationException("ForStateBackend not support rescale yet.");
+        }
+    }
+
+    private void restoreBaseDBFromMainHandle(IncrementalRemoteKeyedStateHandle handle)
+            throws Exception {
+        KeyedBackendSerializationProxy<K> serializationProxy =
+                readMetaData(handle.getMetaDataStateHandle());
+        List<StateMetaInfoSnapshot> stateMetaInfoSnapshots =
+                serializationProxy.getStateMetaInfoSnapshots();
+
+        this.forstHandle.openDB(
+                createColumnFamilyDescriptors(stateMetaInfoSnapshots, true),
+                stateMetaInfoSnapshots);
+    }
+
+    /**
+     * Restores the checkpointing status and state for this backend. This can only be done if the
+     * backend was not rescaled and is therefore identical to the source backend in the previous
+     * run.
+     *
+     * @param incrementalHandle the single state handle from which the backend is restored.
+     */
+    private void restorePreviousIncrementalFilesStatus(
+            IncrementalKeyedStateHandle incrementalHandle) {
+        backendUID = incrementalHandle.getBackendIdentifier();
+        restoredSstFiles.put(
+                incrementalHandle.getCheckpointId(), incrementalHandle.getSharedStateHandles());
+        lastCompletedCheckpointId = incrementalHandle.getCheckpointId();
+        logger.info(
+                "Restored previous incremental files status in backend with range {} in operator {}: backend uuid {}, last checkpoint id {}.",
+                keyGroupRange.prettyPrintInterval(),
+                operatorIdentifier,
+                backendUID,
+                lastCompletedCheckpointId);
+    }
+
+    /**
+     * This method recreates and registers all {@link ColumnFamilyDescriptor} from Flink's state
+     * metadata snapshot.
+     */
+    private List<ColumnFamilyDescriptor> createColumnFamilyDescriptors(
+            List<StateMetaInfoSnapshot> stateMetaInfoSnapshots, boolean registerTtlCompactFilter) {
+
+        List<ColumnFamilyDescriptor> columnFamilyDescriptors =
+                new ArrayList<>(stateMetaInfoSnapshots.size());
+
+        for (StateMetaInfoSnapshot stateMetaInfoSnapshot : stateMetaInfoSnapshots) {
+            RegisteredStateMetaInfoBase metaInfoBase =
+                    RegisteredStateMetaInfoBase.fromMetaInfoSnapshot(stateMetaInfoSnapshot);
+
+            ColumnFamilyDescriptor columnFamilyDescriptor =
+                    ForStOperationUtils.createColumnFamilyDescriptor(
+                            metaInfoBase.getName(),
+                            this.forstHandle.getColumnFamilyOptionsFactory());
+
+            columnFamilyDescriptors.add(columnFamilyDescriptor);
+        }
+        return columnFamilyDescriptors;
+    }
+
+    private void runAndReportDuration(RunnableWithException runnable, String metricName)
+            throws Exception {
+        final SystemClock clock = SystemClock.getInstance();
+        final long startTime = clock.relativeTimeMillis();
+        runnable.run();
+        customInitializationMetrics.addMetric(metricName, clock.relativeTimeMillis() - startTime);
+    }
+
+    /** Reads Flink's state meta data file from the state handle. */
+    private KeyedBackendSerializationProxy<K> readMetaData(StreamStateHandle metaStateHandle)
+            throws Exception {
+
+        InputStream inputStream = null;
+
+        try {
+            inputStream = metaStateHandle.openInputStream();
+            cancelStreamRegistry.registerCloseable(inputStream);
+            DataInputView in = new DataInputViewStreamWrapper(inputStream);
+            return readMetaData(in);
+        } finally {
+            if (cancelStreamRegistry.unregisterCloseable(inputStream)) {
+                inputStream.close();
+            }
+        }
+    }
+
+    KeyedBackendSerializationProxy<K> readMetaData(DataInputView dataInputView)
+            throws IOException, StateMigrationException {
+        // isSerializerPresenceRequired flag is set to false, since for the RocksDB state backend,
+        // deserialization of state happens lazily during runtime; we depend on the fact
+        // that the new serializer for states could be compatible, and therefore the restore can
+        // continue
+        // without old serializers required to be present.
+        KeyedBackendSerializationProxy<K> serializationProxy =
+                new KeyedBackendSerializationProxy<>(userCodeClassLoader);
+        serializationProxy.read(dataInputView);
+        if (!isKeySerializerCompatibilityChecked) {
+            // fetch current serializer now because if it is incompatible, we can't access
+            // it anymore to improve the error message
+            TypeSerializer<K> currentSerializer = keySerializerProvider.currentSchemaSerializer();
+            // check for key serializer compatibility; this also reconfigures the
+            // key serializer to be compatible, if it is required and is possible
+            TypeSerializerSchemaCompatibility<K> keySerializerSchemaCompat =
+                    keySerializerProvider.setPreviousSerializerSnapshotForRestoredState(
+                            serializationProxy.getKeySerializerSnapshot());
+            if (keySerializerSchemaCompat.isCompatibleAfterMigration()
+                    || keySerializerSchemaCompat.isIncompatible()) {
+                throw new StateMigrationException(
+                        "The new key serializer ("
+                                + currentSerializer
+                                + ") must be compatible with the previous key serializer ("
+                                + keySerializerProvider.previousSchemaSerializer()
+                                + ").");
+            }
+
+            isKeySerializerCompatibilityChecked = true;
+        }
+
+        return serializationProxy;
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.forstHandle.close();
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStNoneRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStNoneRestoreOperation.java
@@ -19,12 +19,14 @@
 package org.apache.flink.state.forst.restore;
 
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.state.forst.ForStKeyedStateBackend.ForStKvStateInfo;
 import org.apache.flink.state.forst.ForStNativeMetricOptions;
 
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 
 import java.io.File;
+import java.util.Map;
 import java.util.function.Function;
 
 /** Encapsulates the process of initiating a ForSt instance without restore. */
@@ -32,6 +34,7 @@ public class ForStNoneRestoreOperation implements ForStRestoreOperation {
     private final ForStHandle rocksHandle;
 
     public ForStNoneRestoreOperation(
+            Map<String, ForStKvStateInfo> kvStateInformation,
             File instanceRocksDBPath,
             DBOptions dbOptions,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
@@ -39,6 +42,7 @@ public class ForStNoneRestoreOperation implements ForStRestoreOperation {
             MetricGroup metricGroup) {
         this.rocksHandle =
                 new ForStHandle(
+                        kvStateInformation,
                         instanceRocksDBPath,
                         dbOptions,
                         columnFamilyOptionsFactory,
@@ -52,7 +56,10 @@ public class ForStNoneRestoreOperation implements ForStRestoreOperation {
         return new ForStRestoreResult(
                 this.rocksHandle.getDb(),
                 this.rocksHandle.getDefaultColumnFamilyHandle(),
-                this.rocksHandle.getNativeMetricMonitor());
+                this.rocksHandle.getNativeMetricMonitor(),
+                -1,
+                null,
+                null);
     }
 
     @Override

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStRestoreResult.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStRestoreResult.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.state.forst.restore;
 
+import org.apache.flink.runtime.state.IncrementalKeyedStateHandle.HandleAndLocalPath;
 import org.apache.flink.state.forst.ForStNativeMetricMonitor;
 
 import org.rocksdb.ColumnFamilyHandle;
@@ -25,23 +26,50 @@ import org.rocksdb.RocksDB;
 
 import javax.annotation.Nullable;
 
+import java.util.Collection;
+import java.util.SortedMap;
+import java.util.UUID;
+
 /** Entity holding result of ForSt instance restore. */
 public class ForStRestoreResult {
     private final RocksDB db;
     private final ColumnFamilyHandle defaultColumnFamilyHandle;
     @Nullable private final ForStNativeMetricMonitor nativeMetricMonitor;
 
+    // fields only for incremental restore
+    private final long lastCompletedCheckpointId;
+    private final UUID backendUID;
+    private final SortedMap<Long, Collection<HandleAndLocalPath>> restoredSstFiles;
+
     public ForStRestoreResult(
             RocksDB db,
             ColumnFamilyHandle defaultColumnFamilyHandle,
-            ForStNativeMetricMonitor nativeMetricMonitor) {
+            @Nullable ForStNativeMetricMonitor nativeMetricMonitor,
+            long lastCompletedCheckpointId,
+            UUID backendUID,
+            SortedMap<Long, Collection<HandleAndLocalPath>> restoredSstFiles) {
         this.db = db;
         this.defaultColumnFamilyHandle = defaultColumnFamilyHandle;
         this.nativeMetricMonitor = nativeMetricMonitor;
+        this.lastCompletedCheckpointId = lastCompletedCheckpointId;
+        this.backendUID = backendUID;
+        this.restoredSstFiles = restoredSstFiles;
     }
 
     public RocksDB getDb() {
         return db;
+    }
+
+    public long getLastCompletedCheckpointId() {
+        return lastCompletedCheckpointId;
+    }
+
+    public UUID getBackendUID() {
+        return backendUID;
+    }
+
+    public SortedMap<Long, Collection<HandleAndLocalPath>> getRestoredSstFiles() {
+        return restoredSstFiles;
     }
 
     public ColumnFamilyHandle getDefaultColumnFamilyHandle() {

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStIncrementalSnapshotStrategy.java
@@ -376,7 +376,7 @@ public class ForStIncrementalSnapshotStrategy<K>
             HandleAndLocalPath currentFileWriteResult =
                     stateTransfer.writeFileToCheckpointFs(
                             CURRENT_FILE_NAME,
-                            snapshotResources.manifestFileName,
+                            snapshotResources.getCurrentFileContent(),
                             checkpointStreamFactory,
                             stateScope,
                             snapshotCloseableRegistry,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/snapshot/ForStSnapshotStrategyBase.java
@@ -328,6 +328,11 @@ public abstract class ForStSnapshotStrategyBase<K, R extends SnapshotResources>
             this.previousSnapshot = previousSnapshot;
         }
 
+        public String getCurrentFileContent() {
+            // RocksDB require CURRENT file end with a new line
+            return manifestFileName + "\n";
+        }
+
         @Override
         public void release() {
             // make sure only release once

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackend.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
+import org.apache.flink.runtime.state.DoneFuture;
 import org.apache.flink.runtime.state.HeapPriorityQueuesManager;
 import org.apache.flink.runtime.state.InternalKeyContext;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
@@ -585,7 +586,9 @@ public class ForStSyncKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> 
             @Nonnull final CheckpointStreamFactory streamFactory,
             @Nonnull CheckpointOptions checkpointOptions)
             throws Exception {
-        throw new UnsupportedOperationException("This method is not supported.");
+
+        // TODO: implement snapshot on sync keyed state backend later, skip now.
+        return DoneFuture.of(SnapshotResult.empty());
     }
 
     @Nonnull
@@ -596,12 +599,12 @@ public class ForStSyncKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> 
 
     @Override
     public void notifyCheckpointComplete(long completedCheckpointId) throws Exception {
-        throw new UnsupportedOperationException("This method is not supported.");
+        // TODO: maybe do some thing when implement checkpoint
     }
 
     @Override
     public void notifyCheckpointAborted(long checkpointId) throws Exception {
-        throw new UnsupportedOperationException("This method is not supported.");
+        // TODO: maybe do some thing when implement checkpoint
     }
 
     /**

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackendBuilder.java
@@ -52,7 +52,6 @@ import org.apache.flink.state.forst.ForStResourceContainer;
 import org.apache.flink.state.forst.restore.ForStNoneRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStRestoreResult;
-import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
@@ -60,7 +59,6 @@ import org.apache.flink.util.ResourceGuard;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
-import org.rocksdb.DBOptions;
 import org.rocksdb.RocksDB;
 
 import javax.annotation.Nonnull;
@@ -69,6 +67,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -407,16 +406,15 @@ public class ForStSyncKeyedStateBackendBuilder<K> extends AbstractKeyedStateBack
             LinkedHashMap<String, ForStSyncKeyedStateBackend.ForStDbKvStateInfo> kvStateInformation,
             LinkedHashMap<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates,
             ForStDBTtlCompactFiltersManager ttlCompactFiltersManager) {
-        DBOptions dbOptions = optionsContainer.getDbOptions();
-        if (CollectionUtil.isEmptyOrAllElementsNull(restoreStateHandles)) {
-            return new ForStNoneRestoreOperation(
-                    instanceForStDBPath,
-                    optionsContainer.getDbOptions(),
-                    columnFamilyOptionsFactory,
-                    nativeMetricOptions,
-                    metricGroup);
-        }
-        throw new UnsupportedOperationException("Not support restoring yet for ForStStateBackend");
+
+        //  skip restore until ForStSyncKeyedStateBackend implement checkpoint
+        return new ForStNoneRestoreOperation(
+                Collections.emptyMap(),
+                instanceForStDBPath,
+                optionsContainer.getDbOptions(),
+                columnFamilyOptionsFactory,
+                nativeMetricOptions,
+                metricGroup);
     }
 
     private PriorityQueueSetFactory initPriorityQueueFactory(

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendTestV2.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendTestV2.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.CheckpointStorage;
+import org.apache.flink.runtime.state.ConfigurableStateBackend;
+import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage;
+import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
+import org.apache.flink.runtime.state.v2.StateBackendTestV2Base;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
+import org.apache.flink.util.function.SupplierWithException;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.state.forst.ForStOptions.LOCAL_DIRECTORIES;
+import static org.apache.flink.state.forst.ForStOptions.REMOTE_DIRECTORY;
+
+/** Tests for the async keyed state backend part of {@link ForStStateBackend}. */
+@ExtendWith(ParameterizedTestExtension.class)
+class ForStStateBackendTestV2 extends StateBackendTestV2Base<ForStStateBackend> {
+
+    @TempDir private static java.nio.file.Path tempFolder;
+    @TempDir private static java.nio.file.Path tempFolderForForStLocal;
+    @TempDir private static java.nio.file.Path tempFolderForForstRemote;
+
+    private static final SupplierWithException<CheckpointStorage, IOException>
+            jobManagerCheckpointStorage = JobManagerCheckpointStorage::new;
+
+    private static final SupplierWithException<CheckpointStorage, IOException>
+            filesystemCheckpointStorage =
+                    () -> {
+                        String checkpointPath =
+                                TempDirUtils.newFolder(tempFolder).toURI().toString();
+                        return new FileSystemCheckpointStorage(new Path(checkpointPath), 0, -1);
+                    };
+
+    @Parameters(name = "CheckpointStorage: {0}, hasLocalDir: {1}, hasRemoteDir: {2}")
+    public static List<Object[]> modes() {
+        return Arrays.asList(
+                new Object[][] {
+                    {jobManagerCheckpointStorage, true, false},
+                    {filesystemCheckpointStorage, true, false},
+                    {filesystemCheckpointStorage, false, true},
+                    {filesystemCheckpointStorage, true, true}
+                });
+    }
+
+    @Parameter public SupplierWithException<CheckpointStorage, IOException> storageSupplier;
+
+    @Parameter(1)
+    public boolean hasLocalDir;
+
+    @Parameter(2)
+    public boolean hasRemoteDir;
+
+    @Override
+    protected CheckpointStorage getCheckpointStorage() throws Exception {
+        return storageSupplier.get();
+    }
+
+    @Override
+    protected ConfigurableStateBackend getStateBackend() throws Exception {
+        ForStStateBackend backend = new ForStStateBackend();
+        Configuration config = new Configuration();
+        if (hasLocalDir) {
+            config.set(LOCAL_DIRECTORIES, tempFolderForForStLocal.toString());
+        }
+        if (hasRemoteDir) {
+            config.set(REMOTE_DIRECTORY, tempFolderForForstRemote.toString());
+        }
+        backend.configure(config, Thread.currentThread().getContextClassLoader());
+        return new ForStStateBackend();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Impletement basic restore from checkpoint in `ForStStateBackend`, the checkpoint implement in [FLINK-35510](https://issues.apache.org/jira/browse/FLINK-35510).
Note that `ForStStateBackend` now support sync and async two kind keyed state backend, we make async one support checkpoint and restore first.

## Brief change log

  - Introduce `ForStIncrementalRestoreOperation`
  - Implement restore from checkpoint in `ForStKeyedStateBackendBuilder`


## Verifying this change

This change added tests and can be verified as follows:

  - Add new test case in `ForStStateDataTransferTest`
  - Add `StateBackendTestV2Base` & `ForStStateBackendTestV2` to verify the snapshot & restore of `ForStKeyedStatebackend`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)