### PR TITLE
[FLINK-36344][runtime/metrics] Introduce lastCheckpointCompletedTimestamp metric

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1313,6 +1313,11 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>lastCheckpointCompletedTimestamp</td>
+      <td>The timestamp of the last completed checkpoint (in milliseconds).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>lastCheckpointFullSize</td>
       <td>The full size of the last checkpoint (in bytes).</td>
       <td>Gauge</td>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1303,6 +1303,11 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>lastCheckpointCompletedTimestamp</td>
+      <td>The timestamp of the last completed checkpoint (in milliseconds).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>lastCheckpointFullSize</td>
       <td>The full size of the last checkpoint (in bytes).</td>
       <td>Gauge</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTracker.java
@@ -434,6 +434,9 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
     @VisibleForTesting
     static final String LATEST_COMPLETED_CHECKPOINT_ID_METRIC = "lastCompletedCheckpointId";
 
+    @VisibleForTesting
+    static final String LATEST_CHECKPOINT_COMPLETED_TIMESTAMP = "lastCheckpointCompletedTimestamp";
+
     /**
      * Register the exposed metrics.
      *
@@ -468,6 +471,9 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
                 new LatestCompletedCheckpointExternalPathGauge());
         metricGroup.gauge(
                 LATEST_COMPLETED_CHECKPOINT_ID_METRIC, new LatestCompletedCheckpointIdGauge());
+        metricGroup.gauge(
+                LATEST_CHECKPOINT_COMPLETED_TIMESTAMP,
+                new LatestCheckpointCompletedTimestampGauge());
     }
 
     private class CheckpointsCounter implements Gauge<Long> {
@@ -585,6 +591,18 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
             CompletedCheckpointStats completed = latestCompletedCheckpoint;
             if (completed != null) {
                 return completed.getCheckpointId();
+            } else {
+                return -1L;
+            }
+        }
+    }
+
+    private class LatestCheckpointCompletedTimestampGauge implements Gauge<Long> {
+        @Override
+        public Long getValue() {
+            CompletedCheckpointStats completed = latestCompletedCheckpoint;
+            if (completed != null) {
+                return completed.getLatestAckTimestamp();
             } else {
                 return -1L;
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTrackerTest.java
@@ -534,9 +534,10 @@ class DefaultCheckpointStatsTrackerTest {
                                         .LATEST_COMPLETED_CHECKPOINT_PERSISTED_DATA_METRIC,
                                 DefaultCheckpointStatsTracker
                                         .LATEST_COMPLETED_CHECKPOINT_EXTERNAL_PATH_METRIC,
+                                DefaultCheckpointStatsTracker.LATEST_COMPLETED_CHECKPOINT_ID_METRIC,
                                 DefaultCheckpointStatsTracker
-                                        .LATEST_COMPLETED_CHECKPOINT_ID_METRIC));
-        assertThat(registeredGaugeNames).hasSize(12);
+                                        .LATEST_CHECKPOINT_COMPLETED_TIMESTAMP));
+        assertThat(registeredGaugeNames).hasSize(13);
     }
 
     /**
@@ -565,7 +566,7 @@ class DefaultCheckpointStatsTrackerTest {
         CheckpointStatsTracker stats = new DefaultCheckpointStatsTracker(0, metricGroup);
 
         // Make sure to adjust this test if metrics are added/removed
-        assertThat(registeredGauges).hasSize(12);
+        assertThat(registeredGauges).hasSize(13);
 
         // Check initial values
         Gauge<Long> numCheckpoints =
@@ -626,6 +627,11 @@ class DefaultCheckpointStatsTrackerTest {
                         registeredGauges.get(
                                 DefaultCheckpointStatsTracker
                                         .LATEST_COMPLETED_CHECKPOINT_ID_METRIC);
+        Gauge<Long> latestCompletedTimestamp =
+                (Gauge<Long>)
+                        registeredGauges.get(
+                                DefaultCheckpointStatsTracker
+                                        .LATEST_CHECKPOINT_COMPLETED_TIMESTAMP);
 
         assertThat(numCheckpoints.getValue()).isZero();
         assertThat(numInProgressCheckpoints.getValue()).isZero();
@@ -639,6 +645,7 @@ class DefaultCheckpointStatsTrackerTest {
         assertThat(latestPersistedData.getValue()).isEqualTo(-1);
         assertThat(latestCompletedExternalPath.getValue()).isEqualTo("n/a");
         assertThat(latestCompletedId.getValue()).isEqualTo(-1);
+        assertThat(latestCompletedTimestamp.getValue()).isEqualTo(-1);
 
         PendingCheckpointStats pending =
                 stats.reportPendingCheckpoint(
@@ -694,6 +701,7 @@ class DefaultCheckpointStatsTrackerTest {
         assertThat(latestCompletedDuration.getValue()).isEqualTo(ackTimestamp);
         assertThat(latestCompletedExternalPath.getValue()).isEqualTo(externalPath);
         assertThat(latestCompletedId.getValue()).isZero();
+        assertThat(latestCompletedTimestamp.getValue()).isEqualTo(ackTimestamp);
 
         // Check failed
         PendingCheckpointStats nextPending =


### PR DESCRIPTION
## What is the purpose of the change

Introduce the lastCheckpointCompletedTimestamp metric


## Brief change log

Register `LatestCompletedCheckpointTimestampGauge` named "lastCheckpointCompletedTimestamp" to `CheckpointStatsTracker`


## Verifying this change

This change is already covered by existing tests, such as CheckpointStatsTrackerTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
