### PR TITLE
[FLINK-36378][table] Fix type extraction bug between java BigDecimal …

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ValueDataTypeConverter.java
@@ -126,6 +126,10 @@ public final class ValueDataTypeConverter {
             // negative scale is not supported, normalize it
             return DataTypes.DECIMAL(precision - scale, 0);
         }
+
+        if (scale > precision) {
+            return DataTypes.DECIMAL(precision + scale, scale);
+        }
         return DataTypes.DECIMAL(precision, scale);
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/ValueDataTypeConverterTest.java
@@ -57,6 +57,7 @@ class ValueDataTypeConverterTest {
                 of(BigDecimal.ZERO, DataTypes.DECIMAL(1, 0)),
                 of(new BigDecimal("12.123"), DataTypes.DECIMAL(5, 3)),
                 of(new BigDecimal("1E+36"), DataTypes.DECIMAL(37, 0)),
+                of(new BigDecimal("0.000"), DataTypes.DECIMAL(4, 3)),
                 of(12, DataTypes.INT()),
                 of(LocalTime.of(13, 24, 25, 1000), DataTypes.TIME(6)),
                 of(LocalTime.of(13, 24, 25, 0), DataTypes.TIME(0)),


### PR DESCRIPTION
## What is the purpose of the change

Fix type extraction bug between java BigDecimal and sql decimal.

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
