### PR TITLE
[FLINK-36181][build] Bump target Java version to 11 and drop support for Java 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
     name: "Pre-compile Checks"
     uses: ./.github/workflows/template.pre-compile-checks.yml
   ci:
-    name: "Default (Java 8)"
+    name: "Default (Java 11)"
     uses: ./.github/workflows/template.flink-ci.yml
     with:
       environment: 'PROFILE="-Dinclude_hadoop_aws"'
-      jdk_version: 8
+      jdk_version: 11
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,17 +28,6 @@ jobs:
     name: "Pre-compile Checks"
     uses: ./.github/workflows/template.pre-compile-checks.yml
 
-  java8:
-    name: "Java 8"
-    uses: ./.github/workflows/template.flink-ci.yml
-    with:
-      workflow-caller-id: java8
-      environment: 'PROFILE="-Dinclude_hadoop_aws"'
-      jdk_version: 8
-    secrets:
-      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
-      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
-      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
   java11:
     name: "Java 11"
     uses: ./.github/workflows/template.flink-ci.yml
@@ -78,7 +67,7 @@ jobs:
     with:
       workflow-caller-id: hadoop313
       environment: 'PROFILE="-Dflink.hadoop.version=3.2.3 -Phadoop3-tests,hive3"'
-      jdk_version: 8
+      jdk_version: 11
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
@@ -89,7 +78,7 @@ jobs:
     with:
       workflow-caller-id: adaptive-scheduler
       environment: 'PROFILE="-Penable-adaptive-scheduler"'
-      jdk_version: 8
+      jdk_version: 11
     secrets:
       s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
       s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}

--- a/.github/workflows/template.flink-ci.yml
+++ b/.github/workflows/template.flink-ci.yml
@@ -30,7 +30,7 @@ on:
         type: string
       jdk_version:
         description: "The Java version to use."
-        default: 8
+        default: 11
         type: number
     secrets:
       s3_bucket:

--- a/.github/workflows/template.pre-compile-checks.yml
+++ b/.github/workflows/template.pre-compile-checks.yml
@@ -23,15 +23,15 @@ on:
     inputs:
       jdk_version:
         description: "The JDK version that shall be used as a default within the Flink CI Docker container."
-        default: "8"
+        default: "11"
         type: choice
-        options: ["8", "11", "17", "21"]
+        options: ["11", "17", "21"]
 
   workflow_call:
     inputs:
       jdk_version:
         description: "The JDK version that shall be used as a default within the Flink CI Docker container."
-        default: 8
+        default: 11
         type: number
 
 permissions: read-all

--- a/docs/content.zh/docs/deployment/java_compatibility.md
+++ b/docs/content.zh/docs/deployment/java_compatibility.md
@@ -26,11 +26,6 @@ under the License.
 
 This page lists which Java versions Flink supports and what limitations apply (if any).
 
-## Java 8 (deprecated)
-
-Support for Java 8 has been deprecated in 1.15.0.
-It is recommended to migrate to Java 11.
-
 ## Java 11
 
 Support for Java 11 was added in 1.10.0 and is the recommended Java version to run Flink on.

--- a/docs/content/docs/deployment/java_compatibility.md
+++ b/docs/content/docs/deployment/java_compatibility.md
@@ -26,11 +26,6 @@ under the License.
 
 This page lists which Java versions Flink supports and what limitations apply (if any).
 
-## Java 8 (deprecated)
-
-Support for Java 8 has been deprecated in 1.15.0.
-It is recommended to migrate to Java 11.
-
 ## Java 11
 
 Support for Java 11 was added in 1.10.0 and is the recommended Java version to run Flink on.

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -433,6 +433,17 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<!-- flink-table-planner throws NPE in JDK 11 when we specify ignore-source-errors.
+					See https://bugs.openjdk.org/browse/JDK-8268582. We get around this exception by not
+					generating the class hierarchy pages. -->
+					<notree>true</notree>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ under the License.
 		<flink.shaded.jackson.version>2.15.3</flink.shaded.jackson.version>
 		<flink.shaded.jsonpath.version>2.7.0</flink.shaded.jsonpath.version>
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
-		<target.java.version>1.8</target.java.version>
+		<target.java.version>11</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<log4j.version>2.17.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
@@ -1062,40 +1062,8 @@ under the License.
 								</excludedGroups>
 							</configuration>
 						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-javadoc-plugin</artifactId>
-							<configuration>
-								<additionalJOptions>
-									<additionalJOption>--add-exports=java.base/sun.net.util=ALL-UNNAMED</additionalJOption>
-									<additionalJOption>--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED</additionalJOption>
-								</additionalJOptions>
-							</configuration>
-						</plugin>
 					</plugins>
 				</pluginManagement>
-			</build>
-		</profile>
-
-		<profile>
-			<id>java11-target</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<configuration>
-							<source>11</source>
-							<target>11</target>
-							<compilerArgs combine.children="append">
-								<arg>--add-exports=java.base/sun.net.util=ALL-UNNAMED</arg>
-								<arg>--add-exports=java.management/sun.management=ALL-UNNAMED</arg>
-								<arg>--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED</arg>
-								<arg>--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED</arg>
-							</compilerArgs>
-						</configuration>
-					</plugin>
-				</plugins>
 			</build>
 		</profile>
 
@@ -1431,7 +1399,7 @@ under the License.
 				</property>
 			</activation>
 			<properties>
-				<target.java.version>1.8</target.java.version>
+				<target.java.version>11</target.java.version>
 			</properties>
 			<build>
 				<plugins>
@@ -1463,7 +1431,7 @@ under the License.
 										<!-- versions for certain build tools are enforced to match the CI setup -->
 										<!-- the rules below should stay in sync with Flink Release wiki documentation and the CI scripts -->
 										<requireJavaVersion>
-											<version>[1.8.0,1.8.1)</version>
+											<version>[11.0.0,11.1.0)</version>
 										</requireJavaVersion>
 									</rules>
 								</configuration>
@@ -2127,6 +2095,10 @@ under the License.
 						<compilerArgs>
 							<!-- Prevents recompilation due to missing package-info.class, see MCOMPILER-205 -->
 							<arg>-Xpkginfo:always</arg>
+							<arg>--add-exports=java.base/sun.net.util=ALL-UNNAMED</arg>
+							<arg>--add-exports=java.management/sun.management=ALL-UNNAMED</arg>
+							<arg>--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED</arg>
+							<arg>--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED</arg>
 						</compilerArgs>
 					</configuration>
 				</plugin>
@@ -2216,9 +2188,12 @@ under the License.
 					<configuration>
 						<quiet>true</quiet>
 						<detectOfflineLinks>false</detectOfflineLinks>
+						<release>11</release>
 						<additionalJOptions>
 							<additionalJOption>-Xdoclint:none</additionalJOption>
 							<additionalJOption>--allow-script-in-comments</additionalJOption>
+							<!-- Suppress the error that is accepted by JDK 8 but not by JDK 11. -->
+							<additionalJOption>--ignore-source-errors</additionalJOption>
 						</additionalJOptions>
 					</configuration>
 				</plugin>
@@ -2294,7 +2269,6 @@ under the License.
 					<configuration>
 						<args>
 							<arg>-nobootcp</arg>
-							<arg>-target:jvm-${target.java.version}</arg>
 						</args>
 						<jvmArgs>
 							<arg>-Xss2m</arg>


### PR DESCRIPTION
## What is the purpose of the change

Bump target Java version to 11 and drop support for Java 8.

## Brief change log

- Update the default target Java version to 11.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
