### PR TITLE
Detect base href dynamically

### DIFF
--- a/flink-runtime-web/web-dashboard/src/index.html
+++ b/flink-runtime-web/web-dashboard/src/index.html
@@ -23,6 +23,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Apache Flink Web Dashboard</title>
+    <script>
+      (function () {
+        var base = document.location.pathname;
+        document.write('<base href="' + base + '" />');
+      })();
+    </script>
     <link rel="apple-touch-icon" sizes="180x180" href="assets/favicon/apple-touch-icon.png" />
     <link rel="icon" type="image/png" href="assets/favicon/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="assets/favicon/favicon-16x16.png" sizes="16x16" />
@@ -31,7 +37,6 @@
     <link rel="shortcut icon" href="assets/favicon/favicon.ico" />
     <meta name="msapplication-config" content="assets/favicon/browserconfig.xml" />
     <meta name="theme-color" content="#ffffff" />
-    <base href="/" />
   </head>
   <body>
     <flink-root></flink-root>

--- a/flink-runtime-web/web-dashboard/src/main.ts
+++ b/flink-runtime-web/web-dashboard/src/main.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { registerLocaleData } from '@angular/common';
+import { APP_BASE_HREF, registerLocaleData } from '@angular/common';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import en from '@angular/common/locales/en';
 import { APP_INITIALIZER, enableProdMode, importProvidersFrom, Injector } from '@angular/core';
@@ -51,6 +51,10 @@ export function AppInitServiceFactory(
   };
 }
 
+export function getWindowLocationPath() {
+  return window.location.pathname;
+}
+
 const ngZorroConfig: NzConfig = {
   notification: { nzMaxStack: 1 }
 };
@@ -79,6 +83,10 @@ bootstrapApplication(AppComponent, {
       useFactory: AppInitServiceFactory,
       deps: [StatusService, Injector],
       multi: true
+    },
+    {
+      provide: APP_BASE_HREF,
+      useFactory: getWindowLocationPath
     },
     importProvidersFrom(HttpClientModule),
     importProvidersFrom(BrowserAnimationsModule),


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes flink-runtime-web project detect the base href dynamically so that it can work with paths like http://foo.bar/my-flink-dashboard


## Brief change log

  - Dynamically insert the `<base href="" />` tag based on the current path instead of hard coded `<base href="/" />`
  - Added provider for `APP_BASE_HREF` which points to `window.location.pathname`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
