### PR TITLE
[FLINK-36389][security] Add check in DelegationTokenReceiverRepository for DT enabled flag

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepository.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepository.java
@@ -80,8 +80,9 @@ public class DelegationTokenReceiverRepository {
                                     receiver.serviceName());
                             checkState(
                                     !receivers.containsKey(receiver.serviceName()),
-                                    "Delegation token receiver with service name {} has multiple implementations",
-                                    receiver.serviceName());
+                                    "Delegation token receiver with service name "
+                                            + receiver.serviceName()
+                                            + " has multiple implementations");
                             receivers.put(receiver.serviceName(), receiver);
                         } else {
                             LOG.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepository.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepository.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.security.token;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.security.token.DelegationTokenReceiver;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -57,7 +59,11 @@ public class DelegationTokenReceiverRepository {
             Configuration configuration, @Nullable PluginManager pluginManager) {
         this.configuration = checkNotNull(configuration, "Flink configuration must not be null");
         this.pluginManager = pluginManager;
-        this.delegationTokenReceivers = loadReceivers();
+        if (configuration.get(SecurityOptions.DELEGATION_TOKENS_ENABLED)) {
+            this.delegationTokenReceivers = loadReceivers();
+        } else {
+            this.delegationTokenReceivers = Collections.emptyMap();
+        }
     }
 
     private Map<String, DelegationTokenReceiver> loadReceivers() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepositoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepositoryTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.security.token;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -77,9 +78,10 @@ class DelegationTokenReceiverRepositoryTest {
     @Test
     public void testDelegationTokenDisabled() {
         Configuration configuration = new Configuration();
-        configuration.setBoolean("security.delegation.tokens.enabled", false);
+        configuration.set(SecurityOptions.DELEGATION_TOKENS_ENABLED, false);
         DelegationTokenReceiverRepository delegationTokenReceiverRepository =
                 new DelegationTokenReceiverRepository(configuration, null);
+
         assertEquals(0, delegationTokenReceiverRepository.delegationTokenReceivers.size());
         assertFalse(delegationTokenReceiverRepository.isReceiverLoaded("hadoopfs"));
         assertFalse(delegationTokenReceiverRepository.isReceiverLoaded("hbase"));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepositoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepositoryTest.java
@@ -73,4 +73,18 @@ class DelegationTokenReceiverRepositoryTest {
         assertTrue(ExceptionThrowingDelegationTokenReceiver.constructed.get());
         assertFalse(delegationTokenReceiverRepository.isReceiverLoaded("throw"));
     }
+
+    @Test
+    public void testDelegationTokenDisabled() {
+        Configuration configuration = new Configuration();
+        configuration.setBoolean("security.delegation.tokens.enabled", false);
+        DelegationTokenReceiverRepository delegationTokenReceiverRepository =
+                new DelegationTokenReceiverRepository(configuration, null);
+        assertEquals(0, delegationTokenReceiverRepository.delegationTokenReceivers.size());
+        assertFalse(delegationTokenReceiverRepository.isReceiverLoaded("hadoopfs"));
+        assertFalse(delegationTokenReceiverRepository.isReceiverLoaded("hbase"));
+        assertFalse(delegationTokenReceiverRepository.isReceiverLoaded("test"));
+        assertFalse(ExceptionThrowingDelegationTokenReceiver.constructed.get());
+        assertFalse(delegationTokenReceiverRepository.isReceiverLoaded("throw"));
+    }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
[FLINK-36389](https://issues.apache.org/jira/browse/FLINK-36389)
This PR fixes an issue where the `DelegationTokenReceiverRepository` does not check the `DELEGATION_TOKENS_ENABLED` flag before initializing delegation token receivers, leading to the following error in nearline Flink jobs:

> `java.lang.IllegalStateException: Delegation token receiver with service name {} has multiple implementations [hadoopfs]
`
## Brief change log
When the `DELEGATION_TOKENS_ENABLED` config is disabled, receiver is not expected to load external services.

## Verifying this change

Added unit test to verify if the `DELEGATION_TOKENS_ENABLED` config is set to false, none of the services got loaded by the receiver.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
