### PR TITLE
[FLINK-36395][state/forst] Graceful quit for Forst StateBackend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -332,6 +332,12 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
     }
 
     @Override
+    public void finish() throws Exception {
+        super.finish();
+        asyncExecutionController.drainInflightRecords(0);
+    }
+
+    @Override
     public void close() throws Exception {
         super.close();
         asyncExecutionController.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
@@ -269,6 +269,12 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
     }
 
     @Override
+    public void finish() throws Exception {
+        super.finish();
+        asyncExecutionController.drainInflightRecords(0);
+    }
+
+    @Override
     public void close() throws Exception {
         super.close();
         asyncExecutionController.close();

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -138,11 +138,8 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
     @GuardedBy("lock")
     private final Set<StateExecutor> managedStateExecutors;
 
-    /** The flag indicating whether ForStKeyedStateBackend is closed. */
+    /** Mark whether this backend is already disposed and prevent duplicate disposing. */
     @GuardedBy("lock")
-    private boolean closed = false;
-
-    // mark whether this backend is already disposed and prevent duplicate disposing
     private boolean disposed = false;
 
     public ForStKeyedStateBackend(
@@ -270,7 +267,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
     @Nonnull
     public StateExecutor createStateExecutor() {
         synchronized (lock) {
-            if (closed) {
+            if (disposed) {
                 throw new FlinkRuntimeException(
                         "Attempt to create StateExecutor after ForStKeyedStateBackend is disposed.");
             }
@@ -326,51 +323,49 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
     /** Should only be called by one thread, and only after all accesses to the DB happened. */
     @Override
     public void dispose() {
-        if (this.disposed) {
-            return;
-        }
         synchronized (lock) {
-            if (!closed) {
-                IOUtils.closeQuietly(this);
+            if (this.disposed) {
+                return;
             }
-        }
-
-        // IMPORTANT: null reference to signal potential async checkpoint workers that the db was
-        // disposed, as
-        // working on the disposed object results in SEGFAULTS.
-        if (db != null) {
-
-            // Metric collection occurs on a background thread. When this method returns
-            // it is guaranteed that thr ForSt reference has been invalidated
-            // and no more metric collection will be attempted against the database.
-            if (nativeMetricMonitor != null) {
-                nativeMetricMonitor.close();
+            for (StateExecutor executor : managedStateExecutors) {
+                executor.shutdown();
             }
+            // IMPORTANT: null reference to signal potential async checkpoint workers that the db
+            // was disposed, as working on the disposed object results in SEGFAULTS.
+            if (db != null) {
 
-            IOUtils.closeQuietly(defaultColumnFamily);
+                // Metric collection occurs on a background thread. When this method returns
+                // it is guaranteed that thr ForSt reference has been invalidated
+                // and no more metric collection will be attempted against the database.
+                if (nativeMetricMonitor != null) {
+                    nativeMetricMonitor.close();
+                }
 
-            // ... and finally close the DB instance ...
-            IOUtils.closeQuietly(db);
+                IOUtils.closeQuietly(defaultColumnFamily);
 
-            LOG.info(
-                    "Closed ForSt State Backend. Cleaning up ForSt local working directory {}, remote working directory {}.",
-                    optionsContainer.getLocalBasePath(),
-                    optionsContainer.getRemoteBasePath());
+                // ... and finally close the DB instance ...
+                IOUtils.closeQuietly(db);
 
-            try {
-                optionsContainer.clearDirectories();
-            } catch (Exception ex) {
-                LOG.warn(
-                        "Could not delete ForSt local working directory {}, remote working directory {}.",
+                LOG.info(
+                        "Closed ForSt State Backend. Cleaning up ForSt local working directory {}, remote working directory {}.",
                         optionsContainer.getLocalBasePath(),
-                        optionsContainer.getRemoteBasePath(),
-                        ex);
-            }
+                        optionsContainer.getRemoteBasePath());
 
-            IOUtils.closeQuietly(optionsContainer);
+                try {
+                    optionsContainer.clearDirectories();
+                } catch (Exception ex) {
+                    LOG.warn(
+                            "Could not delete ForSt local working directory {}, remote working directory {}.",
+                            optionsContainer.getLocalBasePath(),
+                            optionsContainer.getRemoteBasePath(),
+                            ex);
+                }
+
+                IOUtils.closeQuietly(optionsContainer);
+            }
+            IOUtils.closeQuietly(snapshotStrategy);
+            this.disposed = true;
         }
-        IOUtils.closeQuietly(snapshotStrategy);
-        this.disposed = true;
     }
 
     @VisibleForTesting
@@ -385,15 +380,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
 
     @Override
     public void close() throws IOException {
-        synchronized (lock) {
-            if (closed) {
-                return;
-            }
-            closed = true;
-            for (StateExecutor executor : managedStateExecutors) {
-                executor.shutdown();
-            }
-        }
+        dispose();
     }
 
     /** ForSt specific information about the k/v states. */

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateExecutor.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateExecutor.java
@@ -236,11 +236,12 @@ public class ForStStateExecutor implements StateExecutor {
 
     @Override
     public void shutdown() {
+        // Coordinator should be shutdown before others, since it submit jobs to others.
+        coordinatorThread.shutdown();
         readThreads.shutdown();
         if (!sharedWriteThread) {
             writeThreads.shutdown();
         }
-        coordinatorThread.shutdown();
         LOG.info("Shutting down the ForStStateExecutor.");
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateExecutor.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateExecutor.java
@@ -85,7 +85,7 @@ public class ForStStateExecutor implements StateExecutor {
             this.coordinatorThread =
                     coordinatorInline
                             ? org.apache.flink.util.concurrent.Executors.newDirectExecutorService()
-                            : Executors.newSingleThreadScheduledExecutor(
+                            : Executors.newSingleThreadExecutor(
                                     new ExecutorThreadFactory(
                                             "ForSt-StateExecutor-Coordinator-And-Write"));
             this.readThreadCount = readIoParallelism;
@@ -101,7 +101,7 @@ public class ForStStateExecutor implements StateExecutor {
             this.coordinatorThread =
                     coordinatorInline
                             ? org.apache.flink.util.concurrent.Executors.newDirectExecutorService()
-                            : Executors.newSingleThreadScheduledExecutor(
+                            : Executors.newSingleThreadExecutor(
                                     new ExecutorThreadFactory("ForSt-StateExecutor-Coordinator"));
             if (readIoParallelism <= 0 || writeIoParallelism <= 0) {
                 this.readThreadCount = Math.max(readIoParallelism, writeIoParallelism);

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
@@ -48,14 +48,15 @@ public class ForStFlinkFileSystem extends FileSystem {
 
     private static final Map<String, String> remoteLocalMapping = new ConcurrentHashMap<>();
     private static final Function<String, Boolean> miscFileFilter = s -> !s.endsWith(".sst");
-    private static final FileSystem localFS = FileSystem.getLocalFileSystem();
 
+    private final FileSystem localFS;
     private final FileSystem delegateFS;
     private final String remoteBase;
     private final Function<String, Boolean> localFileFilter;
     private final String localBase;
 
     public ForStFlinkFileSystem(FileSystem delegateFS, String remoteBase, String localBase) {
+        this.localFS = FileSystem.getLocalFileSystem();
         this.delegateFS = delegateFS;
         this.localFileFilter = miscFileFilter;
         this.remoteBase = remoteBase;

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStInitITCase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStInitITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -52,7 +53,8 @@ public class ForStInitITCase {
                     tempFolder.getAbsolutePath(),
                     () -> {
                         throw new ExpectedTestException();
-                    });
+                    },
+                    Executors.directExecutor());
             fail("Not throwing expected exception.");
         } catch (IOException ignored) {
             // ignored

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStMultiClassLoaderTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStMultiClassLoaderTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.util.FlinkUserCodeClassLoaders;
+import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,6 +28,7 @@ import org.rocksdb.RocksDB;
 
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.concurrent.Executor;
 
 import static org.apache.flink.util.FlinkUserCodeClassLoader.NOOP_EXCEPTION_HANDLER;
 import static org.junit.Assert.assertNotEquals;
@@ -76,13 +78,15 @@ public class ForStMultiClassLoaderTest {
 
         final String tempDir = tmp.newFolder().getAbsolutePath();
 
-        final Method meth1 = clazz1.getDeclaredMethod("ensureForStIsLoaded", String.class);
-        final Method meth2 = clazz2.getDeclaredMethod("ensureForStIsLoaded", String.class);
+        final Method meth1 =
+                clazz1.getDeclaredMethod("ensureForStIsLoaded", String.class, Executor.class);
+        final Method meth2 =
+                clazz2.getDeclaredMethod("ensureForStIsLoaded", String.class, Executor.class);
         meth1.setAccessible(true);
         meth2.setAccessible(true);
 
         // if all is well, these methods can both complete successfully
-        meth1.invoke(instance1, tempDir);
-        meth2.invoke(instance2, tempDir);
+        meth1.invoke(instance1, tempDir, Executors.directExecutor());
+        meth2.invoke(instance2, tempDir, Executors.directExecutor());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

There are many threads in forst statebackends. This PR makes them quit gracefully when task stop.


## Brief change log

 - Change the order of thread quit to avoid error
 - Use async thread to load library and allow interrupt in task thread.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
