### PR TITLE
[FLINK-36355][runtime] Remove deprecated metrics

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1270,11 +1270,6 @@ Whether these metrics are reported depends on the [metrics.job.status.enable]({{
       <td>Gauge</td>
     </tr>
     <tr>
-      <td>fullRestarts</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <b>numRestarts</b>.</td>
-      <td>Gauge</td>
-    </tr>
-    <tr>
       <td>numRestarts</td>
       <td>The total number of restarts since this job was submitted, including full restarts and fine-grained restarts.</td>
       <td>Gauge</td>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1261,11 +1261,6 @@ Whether these metrics are reported depends on the [metrics.job.status.enable]({{
       <td>Gauge</td>
     </tr>
     <tr>
-      <td>fullRestarts</td>
-      <td><span class="label label-danger">Attention:</span> deprecated, use <b>numRestarts</b>.</td>
-      <td>Gauge</td>
-    </tr>
-    <tr>
       <td>numRestarts</td>
       <td>The total number of restarts since this job was submitted, including full restarts and fine-grained restarts.</td>
       <td>Gauge</td>

--- a/flink-end-to-end-tests/flink-metrics-availability-test/src/test/java/org/apache/flink/metrics/tests/MetricsAvailabilityITCase.java
+++ b/flink-end-to-end-tests/flink-metrics-availability-test/src/test/java/org/apache/flink/metrics/tests/MetricsAvailabilityITCase.java
@@ -145,13 +145,13 @@ public class MetricsAvailabilityITCase extends TestLogger {
                 headers.getUnresolvedMessageParameters();
         parameters.taskManagerIdParameter.resolve(taskManagerId);
         parameters.metricsFilterParameter.resolve(
-                Collections.singletonList("Status.Network.TotalMemorySegments"));
+                Collections.singletonList("Status.Shuffle.Netty.TotalMemorySegments"));
 
         fetchMetric(
                 () ->
                         restClient.sendRequest(
                                 HOST, PORT, headers, parameters, EmptyRequestBody.getInstance()),
-                getMetricNamePredicate("Status.Network.TotalMemorySegments"),
+                getMetricNamePredicate("Status.Shuffle.Netty.TotalMemorySegments"),
                 deadline);
     }
 

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
@@ -225,7 +225,7 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 
                 checkMetricAvailability(client, "flink_jobmanager_numRegisteredTaskManagers");
                 checkMetricAvailability(
-                        client, "flink_taskmanager_Status_Network_TotalMemorySegments");
+                        client, "flink_taskmanager_Status_Shuffle_Netty_TotalMemorySegments");
             }
         }
     }

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -878,7 +878,7 @@ function wait_for_restart_to_complete {
     while [[ ${current_num_restarts} -lt ${expected_num_restarts} ]]; do
         echo "Still waiting for restarts. Expected: $expected_num_restarts Current: $current_num_restarts"
         sleep 5
-        current_num_restarts=$(get_job_metric ${jobid} "fullRestarts")
+        current_num_restarts=$(get_job_metric ${jobid} "numRestarts")
         if [[ -z ${current_num_restarts} ]]; then
             current_num_restarts=${base_num_restarts}
         fi

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -89,7 +89,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
         final String name =
                 this.useLogicalIdentifier
                         ? "flink."
-                                + ((LogicalScopeProvider) group)
+                                + LogicalScopeProvider.castFrom(group)
                                         .getLogicalScope(CharacterFilter.NO_OP_FILTER)
                                 + "."
                                 + metricName

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -27,16 +27,13 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.PartitionInfo;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
-import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
-import org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionFactory;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
-import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGateID;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory;
@@ -306,23 +303,6 @@ public class NettyShuffleEnvironment
             registerInputMetrics(config.isNetworkDetailedMetrics(), networkInputGroup, inputGates);
             return Arrays.asList(inputGates);
         }
-    }
-
-    /**
-     * Registers legacy network metric groups before shuffle service refactoring.
-     *
-     * <p>Registers legacy metric groups if shuffle service implementation is original default one.
-     *
-     * @deprecated should be removed in future
-     */
-    @SuppressWarnings("DeprecatedIsStillUsed")
-    @Deprecated
-    public void registerLegacyNetworkMetrics(
-            MetricGroup metricGroup,
-            ResultPartitionWriter[] producedPartitions,
-            InputGate[] inputGates) {
-        NettyShuffleMetricFactory.registerLegacyNetworkMetrics(
-                config.isNetworkDetailedMetrics(), metricGroup, producedPartitions, inputGates);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -53,8 +53,6 @@ public class MetricNames {
 
     public static final String NUM_RESTARTS = "numRestarts";
 
-    @Deprecated public static final String FULL_RESTARTS = "fullRestarts";
-
     public static final String MEMORY_USED = "Used";
     public static final String MEMORY_COMMITTED = "Committed";
     public static final String MEMORY_MAX = "Max";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -39,8 +39,6 @@ public class MetricNames {
     public static final String IO_NUM_BUFFERS_OUT_RATE = IO_NUM_BUFFERS_OUT + SUFFIX_RATE;
 
     public static final String IO_CURRENT_INPUT_WATERMARK = "currentInputWatermark";
-    @Deprecated public static final String IO_CURRENT_INPUT_1_WATERMARK = "currentInput1Watermark";
-    @Deprecated public static final String IO_CURRENT_INPUT_2_WATERMARK = "currentInput2Watermark";
     public static final String IO_CURRENT_INPUT_WATERMARK_PATERN = "currentInput%dWatermark";
     public static final String IO_CURRENT_OUTPUT_WATERMARK = "currentOutputWatermark";
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -86,17 +86,13 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
         return Collections.unmodifiableMap(allVariables);
     }
 
-    /** @deprecated work against the LogicalScopeProvider interface instead. */
     @Override
-    @Deprecated
     public String getLogicalScope(CharacterFilter filter) {
         return parentMetricGroup.getLogicalScope(
                 getDelimiterFilter(this.settings, filter), this.settings.getDelimiter());
     }
 
-    /** @deprecated work against the LogicalScopeProvider interface instead. */
     @Override
-    @Deprecated
     public String getLogicalScope(CharacterFilter filter, char delimiter) {
         return parentMetricGroup.getLogicalScope(
                 getDelimiterFilter(this.settings, filter),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStore.java
@@ -285,12 +285,6 @@ public class MetricStore {
         return unmodifiableMap(taskManagers);
     }
 
-    /** @deprecated Use semantically equivalent {@link #getJobManagerMetricStore()}. */
-    @Deprecated
-    public synchronized ComponentMetricStore getJobManager() {
-        return ComponentMetricStore.unmodifiable(jobManager);
-    }
-
     @VisibleForTesting
     public void add(MetricDump metric) {
         try {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -660,7 +660,6 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         metrics.gauge(DownTimeGauge.METRIC_NAME, new DownTimeGauge(jobStatusProvider));
         metrics.gauge(UpTimeGauge.METRIC_NAME, new UpTimeGauge(jobStatusProvider));
         metrics.gauge(MetricNames.NUM_RESTARTS, numberOfRestarts::getValue);
-        metrics.gauge(MetricNames.FULL_RESTARTS, numberOfRestarts::getValue);
 
         final JobStatusMetrics jobStatusMetrics =
                 new JobStatusMetrics(initializationTimestamp, jobStatusMetricsSettings);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -54,7 +54,6 @@ import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.externalresource.ExternalResourceInfoProvider;
 import org.apache.flink.runtime.filecache.FileCache;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
@@ -431,13 +430,6 @@ public class Task
             inputGates[counter++] =
                     new InputGateWithMetrics(
                             gate, metrics.getIOMetricGroup().getNumBytesInCounter());
-        }
-
-        if (shuffleEnvironment instanceof NettyShuffleEnvironment) {
-            //noinspection deprecation
-            ((NettyShuffleEnvironment) shuffleEnvironment)
-                    .registerLegacyNetworkMetrics(
-                            metrics.getIOMetricGroup(), resultPartitionWriters, gates);
         }
 
         invokableHasBeenCanceled = new AtomicBoolean(false);

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
@@ -87,12 +87,6 @@ public abstract class AbstractTwoInputStreamTask<IN1, IN2, OUT>
         mainOperator
                 .getMetricGroup()
                 .gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge);
-        mainOperator
-                .getMetricGroup()
-                .gauge(MetricNames.IO_CURRENT_INPUT_1_WATERMARK, input1WatermarkGauge);
-        mainOperator
-                .getMetricGroup()
-                .gauge(MetricNames.IO_CURRENT_INPUT_2_WATERMARK, input2WatermarkGauge);
         // wrap watermark gauge since registered metrics must be unique
         getEnvironment()
                 .getMetricGroup()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroupTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.LogicalScopeProvider;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -252,13 +253,11 @@ class AbstractMetricGroupTest {
                     .withFailMessage("Reporters were not properly instantiated")
                     .hasSize(2);
             assertThat(
-                            ((FrontMetricGroup<AbstractMetricGroup<?>>)
-                                            reporter1.findAdded(counterName).group)
+                            LogicalScopeProvider.castFrom(reporter1.findAdded(counterName).group)
                                     .getLogicalScope(reporter1, '-'))
                     .isEqualTo("taskmanager-X-C");
             assertThat(
-                            ((FrontMetricGroup<AbstractMetricGroup<?>>)
-                                            reporter2.findAdded(counterName).group)
+                            LogicalScopeProvider.castFrom(reporter2.findAdded(counterName).group)
                                     .getLogicalScope(reporter2, ','))
                     .isEqualTo("taskmanager,B,X");
         } finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/metrics/AbstractMetricsHandlerTest.java
@@ -197,7 +197,7 @@ class AbstractMetricsHandlerTest {
         @Override
         protected MetricStore.ComponentMetricStore getComponentMetricStore(
                 HandlerRequest<EmptyRequestBody> request, MetricStore metricStore) {
-            return returnComponentMetricStore ? metricStore.getJobManager() : null;
+            return returnComponentMetricStore ? metricStore.getJobManagerMetricStore() : null;
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
@@ -133,7 +133,7 @@ class MetricStoreTest {
         store.add(cd);
 
         // -----verify that no side effects occur
-        assertThat(store.getJobManager().metrics).isEmpty();
+        assertThat(store.getJobManagerMetricStore().metrics).isEmpty();
         assertThat(store.getTaskManagers()).isEmpty();
         assertThat(store.getJobs()).isEmpty();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -242,8 +242,6 @@ class TaskManagerRunnerStartupTest {
                         ".taskmanager..Status.JVM.Threads.Count",
                         ".taskmanager..Status.JVM.CPU.Load",
                         ".taskmanager..Status.JVM.CPU.Time",
-                        ".taskmanager..Status.Network.TotalMemorySegments",
-                        ".taskmanager..Status.Network.AvailableMemorySegments",
                         ".taskmanager..Status.Shuffle.Netty.TotalMemorySegments",
                         ".taskmanager..Status.Shuffle.Netty.TotalMemory",
                         ".taskmanager..Status.Shuffle.Netty.AvailableMemorySegments",

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -635,10 +635,6 @@ class TwoInputStreamTaskTest {
 
         Gauge<Long> taskInputWatermarkGauge =
                 (Gauge<Long>) taskMetricGroup.get(MetricNames.IO_CURRENT_INPUT_WATERMARK);
-        Gauge<Long> headInput1WatermarkGauge =
-                (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.IO_CURRENT_INPUT_1_WATERMARK);
-        Gauge<Long> headInput2WatermarkGauge =
-                (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.IO_CURRENT_INPUT_2_WATERMARK);
         Gauge<Long> headInputWatermarkGauge =
                 (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.IO_CURRENT_INPUT_WATERMARK);
         Gauge<Long> headOutputWatermarkGauge =
@@ -654,19 +650,15 @@ class TwoInputStreamTaskTest {
                         new HashSet<>(
                                 Arrays.asList(
                                         taskInputWatermarkGauge,
-                                        headInput1WatermarkGauge,
-                                        headInput2WatermarkGauge,
                                         headInputWatermarkGauge,
                                         headOutputWatermarkGauge,
                                         chainedInputWatermarkGauge,
                                         chainedOutputWatermarkGauge)))
                 .as("A metric was registered multiple times.")
-                .hasSize(7);
+                .hasSize(5);
 
         assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
         assertThat(headInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
-        assertThat(headInput1WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
-        assertThat(headInput2WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
         assertThat(headOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
         assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
         assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
@@ -675,8 +667,6 @@ class TwoInputStreamTaskTest {
         testHarness.waitForInputProcessing();
         assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
         assertThat(headInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
-        assertThat(headInput1WatermarkGauge.getValue()).isOne();
-        assertThat(headInput2WatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
         assertThat(headOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
         assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
         assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(Long.MIN_VALUE);
@@ -685,8 +675,6 @@ class TwoInputStreamTaskTest {
         testHarness.waitForInputProcessing();
         assertThat(taskInputWatermarkGauge.getValue()).isOne();
         assertThat(headInputWatermarkGauge.getValue()).isOne();
-        assertThat(headInput1WatermarkGauge.getValue()).isOne();
-        assertThat(headInput2WatermarkGauge.getValue()).isEqualTo(2L);
         assertThat(headOutputWatermarkGauge.getValue()).isOne();
         assertThat(chainedInputWatermarkGauge.getValue()).isOne();
         assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(2L);
@@ -695,8 +683,6 @@ class TwoInputStreamTaskTest {
         testHarness.waitForInputProcessing();
         assertThat(taskInputWatermarkGauge.getValue()).isEqualTo(2L);
         assertThat(headInputWatermarkGauge.getValue()).isEqualTo(2L);
-        assertThat(headInput1WatermarkGauge.getValue()).isEqualTo(3L);
-        assertThat(headInput2WatermarkGauge.getValue()).isEqualTo(2L);
         assertThat(headOutputWatermarkGauge.getValue()).isEqualTo(2L);
         assertThat(chainedInputWatermarkGauge.getValue()).isEqualTo(2L);
         assertThat(chainedOutputWatermarkGauge.getValue()).isEqualTo(4L);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -434,7 +434,7 @@ class YARNHighAvailabilityITCase extends YarnTestBase {
             final RestClusterClient<ApplicationId> restClusterClient, final JobID jobId)
             throws Exception {
 
-        return getJobMetric(restClusterClient, jobId, "fullRestarts")
+        return getJobMetric(restClusterClient, jobId, "numRestarts")
                 .map(Metric::getValue)
                 .map(Integer::parseInt)
                 .orElse(0);


### PR DESCRIPTION
## What is the purpose of the change

Remove deprecated metrics

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
