### PR TITLE
[FLINK-36355][runtime] Remove deprecated CLI options

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
@@ -157,7 +157,7 @@ bin/start-cluster.sh
 #### 添加 JobManager
 
 ```bash
-bin/jobmanager.sh ((start|start-foreground) [args] [webui-port])|stop|stop-all
+bin/jobmanager.sh ((start|start-foreground) [args])|stop|stop-all
 ```
 
 <a name="adding-a-taskmanager"></a>

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterConfiguration.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterConfiguration.java
@@ -44,13 +44,11 @@ final class StandaloneApplicationClusterConfiguration extends EntrypointClusterC
             @Nonnull String configDir,
             @Nonnull Properties dynamicProperties,
             @Nonnull String[] args,
-            @Nullable String hostname,
-            int restPort,
             @Nonnull SavepointRestoreSettings savepointRestoreSettings,
             @Nullable JobID jobId,
             @Nullable String jobClassName,
             @Nullable String[] jars) {
-        super(configDir, dynamicProperties, args, hostname, restPort);
+        super(configDir, dynamicProperties, args);
         this.savepointRestoreSettings =
                 requireNonNull(savepointRestoreSettings, "savepointRestoreSettings");
         this.jobId = jobId;

--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterConfigurationParserFactory.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterConfigurationParserFactory.java
@@ -35,8 +35,6 @@ import java.util.Properties;
 
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
-import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.HOST_OPTION;
-import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.REST_PORT_OPTION;
 
 /**
  * Parser factory which generates a {@link StandaloneApplicationClusterConfiguration} from a given
@@ -78,11 +76,9 @@ public class StandaloneApplicationClusterConfigurationParserFactory
         final Options options = new Options();
         options.addOption(CONFIG_DIR_OPTION);
         options.addOption(JARS_OPTION);
-        options.addOption(REST_PORT_OPTION);
         options.addOption(JOB_CLASS_NAME_OPTION);
         options.addOption(JOB_ID_OPTION);
         options.addOption(DYNAMIC_PROPERTY_OPTION);
-        options.addOption(HOST_OPTION);
         options.addOption(CliFrontendParser.SAVEPOINT_PATH_OPTION);
         options.addOption(CliFrontendParser.SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
 
@@ -95,8 +91,6 @@ public class StandaloneApplicationClusterConfigurationParserFactory
         final String configDir = commandLine.getOptionValue(CONFIG_DIR_OPTION.getOpt());
         final Properties dynamicProperties =
                 commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
-        final int restPort = getRestPort(commandLine);
-        final String hostname = commandLine.getOptionValue(HOST_OPTION.getOpt());
         final SavepointRestoreSettings savepointRestoreSettings =
                 CliFrontendParser.createSavepointRestoreSettings(commandLine);
         final JobID jobId = getJobId(commandLine);
@@ -107,21 +101,10 @@ public class StandaloneApplicationClusterConfigurationParserFactory
                 configDir,
                 dynamicProperties,
                 commandLine.getArgs(),
-                hostname,
-                restPort,
                 savepointRestoreSettings,
                 jobId,
                 jobClassName,
                 jarFiles);
-    }
-
-    private int getRestPort(CommandLine commandLine) throws FlinkParseException {
-        final String restPortString = commandLine.getOptionValue(REST_PORT_OPTION.getOpt(), "-1");
-        try {
-            return Integer.parseInt(restPortString);
-        } catch (NumberFormatException e) {
-            throw createFlinkParseException(REST_PORT_OPTION, e);
-        }
     }
 
     @Nullable

--- a/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterConfigurationParserFactoryTest.java
+++ b/flink-container/src/test/java/org/apache/flink/container/entrypoint/StandaloneApplicationClusterConfigurationParserFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
@@ -85,8 +86,8 @@ class StandaloneApplicationClusterConfigurationParserFactoryTest {
             "--fromSavepoint",
             savepointRestoreSettings.getRestorePath(),
             "--allowNonRestoredState",
-            "--webui-port",
-            String.valueOf(restPort),
+            "-D",
+            "rest.port=" + restPort,
             "--job-classname",
             JOB_CLASS_NAME,
             "--jars",
@@ -143,8 +144,8 @@ class StandaloneApplicationClusterConfigurationParserFactoryTest {
         final String[] args = {
             "--configDir",
             confDirPath,
-            "--webui-port",
-            String.valueOf(restPort),
+            "-D",
+            "rest.port=" + restPort,
             "--job-classname",
             JOB_CLASS_NAME,
             String.format("-D%s=%s", key, value),
@@ -154,10 +155,13 @@ class StandaloneApplicationClusterConfigurationParserFactoryTest {
 
         final StandaloneApplicationClusterConfiguration clusterConfiguration =
                 commandLineParser.parse(args);
+        final Configuration configuration =
+                StandaloneApplicationClusterEntryPoint.loadConfigurationFromClusterConfig(
+                        clusterConfiguration);
 
         assertThat(clusterConfiguration.getConfigDir()).isEqualTo(confDirPath);
         assertThat(clusterConfiguration.getJobClassName()).isEqualTo(JOB_CLASS_NAME);
-        assertThat(clusterConfiguration.getRestPort()).isEqualTo(restPort);
+        assertThat(configuration.get(RestOptions.PORT)).isEqualTo(restPort);
         final Properties dynamicProperties = clusterConfiguration.getDynamicProperties();
 
         assertThat(dynamicProperties).containsEntry(key, value);
@@ -177,11 +181,15 @@ class StandaloneApplicationClusterConfigurationParserFactoryTest {
         final StandaloneApplicationClusterConfiguration clusterConfiguration =
                 commandLineParser.parse(args);
 
+        final Configuration configuration =
+                StandaloneApplicationClusterEntryPoint.loadConfigurationFromClusterConfig(
+                        clusterConfiguration);
+
         assertThat(clusterConfiguration.getConfigDir()).isEqualTo(confDirPath);
         assertThat(clusterConfiguration.getDynamicProperties()).isEqualTo(new Properties());
         assertThat(clusterConfiguration.getArgs()).isEqualTo(new String[0]);
-        assertThat(clusterConfiguration.getRestPort()).isEqualTo(-1);
-        assertThat(clusterConfiguration.getHostname()).isNull();
+        assertThat(configuration.get(RestOptions.PORT)).isEqualTo(8081);
+        assertThat(configuration.get(JobManagerOptions.ADDRESS)).isNull();
         assertThat(clusterConfiguration.getSavepointRestoreSettings())
                 .isEqualTo(SavepointRestoreSettings.none());
         assertThat(clusterConfiguration.getJobId()).isNull();
@@ -280,11 +288,21 @@ class StandaloneApplicationClusterConfigurationParserFactoryTest {
     void testHostOption() throws FlinkParseException {
         final String hostName = "user-specified-hostname";
         final String[] args = {
-            "--configDir", confDirPath, "--job-classname", "foobar", "--host", hostName
+            "--configDir",
+            confDirPath,
+            "--job-classname",
+            "foobar",
+            "-D",
+            "jobmanager.rpc.address=" + hostName
         };
         final StandaloneApplicationClusterConfiguration applicationClusterConfiguration =
                 commandLineParser.parse(args);
-        assertThat(applicationClusterConfiguration.getHostname()).isEqualTo(hostName);
+
+        final Configuration configuration =
+                StandaloneApplicationClusterEntryPoint.loadConfigurationFromClusterConfig(
+                        applicationClusterConfiguration);
+
+        assertThat(configuration.get(JobManagerOptions.ADDRESS)).isEqualTo(hostName);
     }
 
     @Test

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -55,13 +55,13 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
 
     args=("--configDir" "${FLINK_CONF_DIR}" "--executionMode" "cluster" "${args[@]}")
     if [ ! -z $HOST ]; then
-        args+=("--host")
-        args+=("${HOST}")
+        args+=("-D")
+        args+=("jobmanager.rpc.address=${HOST}")
     fi
 
     if [ ! -z $WEBUIPORT ]; then
-        args+=("--webui-port")
-        args+=("${WEBUIPORT}")
+        args+=("-D")
+        args+=("rest.port=${WEBUIPORT}")
     fi
 
     if [ ! -z "${DYNAMIC_PARAMETERS}" ]; then

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -53,7 +53,7 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     export FLINK_ENV_JAVA_OPTS="${FLINK_ENV_JAVA_OPTS} ${FLINK_ENV_JAVA_OPTS_JM}"
     parseJmArgsAndExportLogs "${args[@]}"
 
-    args=("--configDir" "${FLINK_CONF_DIR}" "--executionMode" "cluster" "${args[@]}")
+    args=("--configDir" "${FLINK_CONF_DIR}" "${args[@]}")
     if [ ! -z $HOST ]; then
         args+=("-D")
         args+=("jobmanager.rpc.address=${HOST}")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -30,7 +30,6 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JMXServerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.failure.FailureEnricher;
@@ -704,24 +703,6 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
         final Configuration configuration =
                 GlobalConfiguration.loadConfiguration(
                         entrypointClusterConfiguration.getConfigDir(), dynamicProperties);
-
-        final int restPort = entrypointClusterConfiguration.getRestPort();
-
-        if (restPort >= 0) {
-            LOG.warn(
-                    "The 'webui-port' parameter of 'jobmanager.sh' has been deprecated. Please use '-D {}=<port> instead.",
-                    RestOptions.PORT);
-            configuration.set(RestOptions.PORT, restPort);
-        }
-
-        final String hostname = entrypointClusterConfiguration.getHostname();
-
-        if (hostname != null) {
-            LOG.warn(
-                    "The 'host' parameter of 'jobmanager.sh' has been deprecated. Please use '-D {}=<host> instead.",
-                    JobManagerOptions.ADDRESS);
-            configuration.set(JobManagerOptions.ADDRESS, hostname);
-        }
 
         return configuration;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfiguration.java
@@ -19,34 +19,16 @@
 package org.apache.flink.runtime.entrypoint;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.util.Properties;
 
 /** Basic {@link ClusterConfiguration} for entry points. */
 public class EntrypointClusterConfiguration extends ClusterConfiguration {
 
-    @Nullable private final String hostname;
-
-    private final int restPort;
-
     public EntrypointClusterConfiguration(
             @Nonnull String configDir,
             @Nonnull Properties dynamicProperties,
-            @Nonnull String[] args,
-            @Nullable String hostname,
-            int restPort) {
+            @Nonnull String[] args) {
         super(configDir, dynamicProperties, args);
-        this.hostname = hostname;
-        this.restPort = restPort;
-    }
-
-    public int getRestPort() {
-        return restPort;
-    }
-
-    @Nullable
-    public String getHostname() {
-        return hostname;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactory.java
@@ -30,8 +30,6 @@ import java.util.Properties;
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.EXECUTION_MODE_OPTION;
-import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.HOST_OPTION;
-import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.REST_PORT_OPTION;
 
 /** Parser factory for {@link EntrypointClusterConfiguration}. */
 public class EntrypointClusterConfigurationParserFactory
@@ -41,9 +39,7 @@ public class EntrypointClusterConfigurationParserFactory
     public Options getOptions() {
         final Options options = new Options();
         options.addOption(CONFIG_DIR_OPTION);
-        options.addOption(REST_PORT_OPTION);
         options.addOption(DYNAMIC_PROPERTY_OPTION);
-        options.addOption(HOST_OPTION);
         options.addOption(EXECUTION_MODE_OPTION);
 
         return options;
@@ -54,11 +50,8 @@ public class EntrypointClusterConfigurationParserFactory
         final String configDir = commandLine.getOptionValue(CONFIG_DIR_OPTION.getOpt());
         final Properties dynamicProperties =
                 commandLine.getOptionProperties(DYNAMIC_PROPERTY_OPTION.getOpt());
-        final String restPortStr = commandLine.getOptionValue(REST_PORT_OPTION.getOpt(), "-1");
-        final int restPort = Integer.parseInt(restPortStr);
-        final String hostname = commandLine.getOptionValue(HOST_OPTION.getOpt());
 
         return new EntrypointClusterConfiguration(
-                configDir, dynamicProperties, commandLine.getArgs(), hostname, restPort);
+                configDir, dynamicProperties, commandLine.getArgs());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactory.java
@@ -29,7 +29,6 @@ import java.util.Properties;
 
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.CONFIG_DIR_OPTION;
 import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.DYNAMIC_PROPERTY_OPTION;
-import static org.apache.flink.runtime.entrypoint.parser.CommandLineOptions.EXECUTION_MODE_OPTION;
 
 /** Parser factory for {@link EntrypointClusterConfiguration}. */
 public class EntrypointClusterConfigurationParserFactory
@@ -40,7 +39,6 @@ public class EntrypointClusterConfigurationParserFactory
         final Options options = new Options();
         options.addOption(CONFIG_DIR_OPTION);
         options.addOption(DYNAMIC_PROPERTY_OPTION);
-        options.addOption(EXECUTION_MODE_OPTION);
 
         return options;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
@@ -32,34 +32,12 @@ public class CommandLineOptions {
                     .desc("Directory which contains the configuration file flink-conf.yml.")
                     .build();
 
-    /** @deprecated subsumed by dynamic properties */
-    @Deprecated
-    public static final Option REST_PORT_OPTION =
-            Option.builder("r")
-                    .longOpt("webui-port")
-                    .required(false)
-                    .hasArg(true)
-                    .argName("rest port")
-                    .desc("Port for the rest endpoint and the web UI.")
-                    .build();
-
     public static final Option DYNAMIC_PROPERTY_OPTION =
             Option.builder("D")
                     .argName("property=value")
                     .numberOfArgs(2)
                     .valueSeparator('=')
                     .desc("use value for given property")
-                    .build();
-
-    /** @deprecated subsumed by dynamic properties */
-    @Deprecated
-    public static final Option HOST_OPTION =
-            Option.builder("h")
-                    .longOpt("host")
-                    .required(false)
-                    .hasArg(true)
-                    .argName("hostname")
-                    .desc("Hostname for the RPC service.")
                     .build();
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
@@ -40,19 +40,5 @@ public class CommandLineOptions {
                     .desc("use value for given property")
                     .build();
 
-    /**
-     * @deprecated exists only for compatibility with legacy mode. Remove once legacy mode and
-     *     execution mode option has been removed.
-     */
-    @Deprecated
-    public static final Option EXECUTION_MODE_OPTION =
-            Option.builder("x")
-                    .longOpt("executionMode")
-                    .required(false)
-                    .hasArg(true)
-                    .argName("execution mode")
-                    .desc("Deprecated option")
-                    .build();
-
     private CommandLineOptions() {}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactoryTest.java
@@ -51,8 +51,6 @@ public class EntrypointClusterConfigurationParserFactoryTest extends TestLogger 
         final String[] args = {
             "--configDir",
             configDir,
-            "--executionMode",
-            "cluster",
             "-D",
             "jobmanager.rpc.address=localhost",
             "-D",

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/entrypoint/EntrypointClusterConfigurationParserFactoryTest.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.runtime.entrypoint;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
 import org.apache.flink.util.TestLogger;
 
@@ -50,19 +53,21 @@ public class EntrypointClusterConfigurationParserFactoryTest extends TestLogger 
             configDir,
             "--executionMode",
             "cluster",
-            "--host",
-            "localhost",
-            "-r",
-            String.valueOf(restPort),
+            "-D",
+            "jobmanager.rpc.address=localhost",
+            "-D",
+            "rest.port=" + restPort,
             String.format("-D%s=%s", key, value),
             arg1,
             arg2
         };
 
         final EntrypointClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+        final Configuration dynamicPropertiesConfig =
+                ConfigurationUtils.createConfiguration(clusterConfiguration.getDynamicProperties());
 
         assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
-        assertThat(clusterConfiguration.getRestPort(), is(equalTo(restPort)));
+        assertThat(dynamicPropertiesConfig.get(RestOptions.PORT), is(equalTo(restPort)));
         final Properties dynamicProperties = clusterConfiguration.getDynamicProperties();
 
         assertThat(dynamicProperties, hasEntry(key, value));
@@ -76,9 +81,11 @@ public class EntrypointClusterConfigurationParserFactoryTest extends TestLogger 
         final String[] args = {"--configDir", configDir};
 
         final EntrypointClusterConfiguration clusterConfiguration = commandLineParser.parse(args);
+        final Configuration dynamicProperties =
+                ConfigurationUtils.createConfiguration(clusterConfiguration.getDynamicProperties());
 
         assertThat(clusterConfiguration.getConfigDir(), is(equalTo(configDir)));
-        assertThat(clusterConfiguration.getRestPort(), is(equalTo(-1)));
+        assertThat(dynamicProperties.get(RestOptions.PORT), is(equalTo(8081)));
     }
 
     @Test(expected = FlinkParseException.class)


### PR DESCRIPTION
## What is the purpose of the change

Remove deprecated CLI options

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
