### PR TITLE
[FLINK-36369][table] Replace all class annotations in the legacy package with Internal in table modules (table-common, table-api-java and table-api-java-bridge)

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/connector/source/SourceFunctionProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/connector/source/SourceFunctionProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.connector.source;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.connector.source.ScanTableSource;
@@ -37,7 +37,7 @@ import java.util.Optional;
  *     removed. Use {@link org.apache.flink.table.connector.source.SourceProvider} instead.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface SourceFunctionProvider
         extends ScanTableSource.ScanRuntimeProvider, ParallelismProvider {
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/descriptors/RowtimeValidator.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/descriptors/RowtimeValidator.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.descriptors;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.DescriptorProperties;
@@ -59,8 +59,8 @@ import static org.apache.flink.table.legacy.descriptors.Rowtime.ROWTIME_WATERMAR
  *
  * @deprecated See {@link Rowtime} for details.
  */
-@PublicEvolving
 @Deprecated
+@Internal
 public class RowtimeValidator implements DescriptorValidator {
 
     private final boolean supportsSourceTimestamps;

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/descriptors/SchemaValidator.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/descriptors/SchemaValidator.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.descriptors;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -59,8 +59,8 @@ import static org.apache.flink.table.legacy.descriptors.Schema.SCHEMA_TYPE;
  *
  * @deprecated See {@link Schema} for details.
  */
-@PublicEvolving
 @Deprecated
+@Internal
 public class SchemaValidator implements DescriptorValidator {
 
     private final boolean isStreamEnvironment;

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/factories/StreamTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/factories/StreamTableSinkFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.factories;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.legacy.table.sinks.StreamTableSink;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -37,7 +37,7 @@ import java.util.Map;
  *     interface creates instances of {@link DynamicTableSink}. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface StreamTableSinkFactory<T> extends TableSinkFactory<T> {
 
     /**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/factories/StreamTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/factories/StreamTableSourceFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.factories;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.legacy.table.sources.StreamTableSource;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -37,7 +37,7 @@ import java.util.Map;
  *     interface creates instances of {@link DynamicTableSource}. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface StreamTableSourceFactory<T> extends TableSourceFactory<T> {
 
     /**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/AppendStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/AppendStreamTableSink.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.sinks;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableException;
@@ -36,5 +36,5 @@ import org.apache.flink.table.legacy.sinks.TableSink;
  *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface AppendStreamTableSink<T> extends StreamTableSink<T> {}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/OutputFormatTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/OutputFormatTableSink.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.sinks;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -35,7 +35,7 @@ import org.apache.flink.table.legacy.sinks.TableSink;
  *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
-@Experimental
+@Internal
 public abstract class OutputFormatTableSink<T> implements StreamTableSink<T> {
 
     /** Returns an {@link OutputFormat} for writing the data of the table. */

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/RetractStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/RetractStreamTableSink.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.sinks;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -44,7 +44,7 @@ import org.apache.flink.table.legacy.sinks.TableSink;
  *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface RetractStreamTableSink<T> extends StreamTableSink<Tuple2<Boolean, T>> {
 
     /** Returns the requested record type. */

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/StreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/StreamTableSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.legacy.table.sinks;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -31,6 +32,7 @@ import org.apache.flink.table.legacy.sinks.TableSink;
  *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
+@Internal
 public interface StreamTableSink<T> extends TableSink<T> {
 
     /**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/UpsertStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sinks/UpsertStreamTableSink.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.sinks;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -55,7 +55,7 @@ import org.apache.flink.table.legacy.sinks.TableSink;
  *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface UpsertStreamTableSink<T> extends StreamTableSink<Tuple2<Boolean, T>> {
 
     /**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sources/InputFormatTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sources/InputFormatTableSource.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.legacy.table.sources;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -36,7 +36,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToL
  *     produces internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
-@Experimental
+@Internal
 public abstract class InputFormatTableSource<T> implements StreamTableSource<T> {
 
     /** Returns an {@link InputFormat} for reading the data of the table. */

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sources/StreamTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/legacy/table/sources/StreamTableSource.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.legacy.table.sources;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -31,6 +32,7 @@ import org.apache.flink.table.legacy.sources.TableSource;
  *     produces internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
+@Internal
 public interface StreamTableSource<T> extends TableSource<T> {
 
     /**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/legacy/operations/ddl/AlterTableOptionsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/legacy/operations/ddl/AlterTableOptionsOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.legacy.operations.ddl;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.internal.TableResultImpl;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
  * @deprecated Please use {@link AlterTableChangeOperation} instead.
  */
 @Deprecated
+@Internal
 public class AlterTableOptionsOperation extends AlterTableOperation {
     private final CatalogTable catalogTable;
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/legacy/sources/tsextractors/ExistingField.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/legacy/sources/tsextractors/ExistingField.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources.tsextractors;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.expressions.CallExpression;
@@ -48,7 +48,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public final class ExistingField extends TimestampExtractor {
 
     private static final long serialVersionUID = 1L;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/legacy/sources/tsextractors/StreamRecordTimestamp.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/legacy/sources/tsextractors/StreamRecordTimestamp.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources.tsextractors;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.expressions.ApiExpressionUtils;
 import org.apache.flink.table.expressions.Expression;
@@ -40,7 +40,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.STREAM
  *     information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public final class StreamRecordTimestamp extends TimestampExtractor {
 
     private static final long serialVersionUID = 1L;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/TableColumn.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/TableColumn.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.api;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.types.DataType;
@@ -38,7 +38,7 @@ import java.util.Optional;
  * @deprecated See {@link ResolvedSchema} and {@link Column}.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public abstract class TableColumn {
 
     private final String name;
@@ -182,7 +182,7 @@ public abstract class TableColumn {
     // --------------------------------------------------------------------------------------------
 
     /** Representation of a physical column. */
-    @PublicEvolving
+    @Internal
     public static class PhysicalColumn extends TableColumn {
 
         private PhysicalColumn(String name, DataType type) {
@@ -206,7 +206,7 @@ public abstract class TableColumn {
     }
 
     /** Representation of a computed column. */
-    @PublicEvolving
+    @Internal
     public static class ComputedColumn extends TableColumn {
 
         private final String expression;
@@ -257,7 +257,7 @@ public abstract class TableColumn {
     }
 
     /** Representation of a metadata column. */
-    @PublicEvolving
+    @Internal
     public static class MetadataColumn extends TableColumn {
 
         private final @Nullable String metadataAlias;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/TableSchema.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.api;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeType;
 import org.apache.flink.table.api.DataTypes;
@@ -72,7 +72,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
  *     validation.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public class TableSchema {
 
     private static final String ATOMIC_TYPE_FIELD_NAME = "f0";
@@ -627,7 +627,7 @@ public class TableSchema {
     // --------------------------------------------------------------------------------------------
 
     /** Builder for creating a {@link TableSchema}. */
-    @PublicEvolving
+    @Internal
     public static class Builder {
 
         private List<TableColumn> columns;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/Types.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/Types.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.legacy.api;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.MapTypeInfo;
@@ -42,6 +43,7 @@ import java.util.Map;
  *     information.
  */
 @Deprecated
+@Internal
 public final class Types {
 
     // we use SQL-like naming for types and avoid Java keyword clashes

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/WatermarkSpec.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/WatermarkSpec.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.legacy.api;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.types.DataType;
 
@@ -37,6 +38,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * @deprecated See {@link ResolvedSchema} and {@link org.apache.flink.table.catalog.WatermarkSpec}.
  */
 @Deprecated
+@Internal
 public class WatermarkSpec {
 
     private final String rowtimeAttribute;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/constraints/Constraint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/constraints/Constraint.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.api.constraints;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.ResolvedSchema;
 
 /**
@@ -28,7 +28,7 @@ import org.apache.flink.table.catalog.ResolvedSchema;
  * @deprecated See {@link ResolvedSchema} and {@link org.apache.flink.table.catalog.Constraint}.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface Constraint {
     String getName();
 
@@ -59,7 +59,7 @@ public interface Constraint {
      *       defined for a Table.
      * </ul>
      */
-    @PublicEvolving
+    @Internal
     enum ConstraintType {
         PRIMARY_KEY,
         UNIQUE_KEY

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/constraints/UniqueConstraint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/api/constraints/UniqueConstraint.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.api.constraints;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.ResolvedSchema;
 
 import java.util.List;
@@ -34,7 +34,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     org.apache.flink.table.catalog.UniqueConstraint}.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public final class UniqueConstraint extends AbstractConstraint {
     private final List<String> columns;
     private final ConstraintType type;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/connector/sink/SinkProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/connector/sink/SinkProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.connector.sink;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.table.connector.ParallelismProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -39,7 +39,7 @@ import java.util.Optional;
  *     {@link SinkV2Provider}.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface SinkProvider extends DynamicTableSink.SinkRuntimeProvider, ParallelismProvider {
 
     /** Helper method for creating a static provider. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/connector/source/AsyncTableFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/connector/source/AsyncTableFunctionProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.connector.source;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.lookup.AsyncLookupFunctionProvider;
 import org.apache.flink.table.data.RowData;
@@ -42,8 +42,8 @@ import org.apache.flink.types.Row;
  * @deprecated Please use {@link AsyncLookupFunctionProvider} to implement asynchronous lookup
  *     table.
  */
-@PublicEvolving
 @Deprecated
+@Internal
 public interface AsyncTableFunctionProvider<T> extends LookupTableSource.LookupRuntimeProvider {
 
     /** Helper method for creating a static provider. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/connector/source/TableFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/connector/source/TableFunctionProvider.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.connector.source;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
 import org.apache.flink.table.data.RowData;
@@ -41,8 +41,8 @@ import org.apache.flink.types.Row;
  *
  * @deprecated Please use {@link LookupFunctionProvider} to implement synchronous lookup table.
  */
-@PublicEvolving
 @Deprecated
+@Internal
 public interface TableFunctionProvider<T> extends LookupTableSource.LookupRuntimeProvider {
 
     /** Helper method for creating a static provider. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/descriptors/Descriptor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/descriptors/Descriptor.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.descriptors;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 
 import java.util.Map;
 
@@ -35,8 +35,8 @@ import java.util.Map;
  * @deprecated {@link Descriptor} was primarily used for the legacy connector stack and have been
  *     deprecated. Use {@code TableDescriptor} for creating sources and sinks from the Table API.
  */
-@PublicEvolving
 @Deprecated
+@Internal
 public interface Descriptor {
 
     /** Converts this descriptor into a set of properties. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/descriptors/Rowtime.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/descriptors/Rowtime.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.descriptors;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.legacy.sources.tsextractors.TimestampExtractor;
@@ -31,8 +31,8 @@ import java.util.Map;
  *
  * @deprecated This class was used for legacy connectors using {@link Descriptor}.
  */
-@PublicEvolving
 @Deprecated
+@Internal
 public class Rowtime implements Descriptor {
 
     private final DescriptorProperties internalProperties = new DescriptorProperties(true);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/descriptors/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/descriptors/Schema.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.descriptors;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.DescriptorProperties;
@@ -43,8 +43,8 @@ import java.util.Map;
  *
  * @deprecated This class was used for legacy connectors using {@link Descriptor}.
  */
-@PublicEvolving
 @Deprecated
+@Internal
 public class Schema implements Descriptor {
 
     public static final String SCHEMA = "schema";

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/factories/TableFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/factories/TableFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.factories;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.factories.Factory;
 
 import java.util.List;
@@ -37,7 +37,7 @@ import java.util.Map;
  * @deprecated This interface has been replaced by {@link Factory}.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface TableFactory {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/factories/TableSinkFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/factories/TableSinkFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.factories;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -38,7 +38,7 @@ import java.util.Map;
  *     interface consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface TableSinkFactory<T> extends TableFactory {
 
     /**
@@ -79,7 +79,7 @@ public interface TableSinkFactory<T> extends TableFactory {
     }
 
     /** Context of table sink creation. Contains table information and environment information. */
-    @PublicEvolving
+    @Internal
     interface Context {
 
         /** @return full identifier of the given {@link CatalogTable}. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/factories/TableSourceFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/factories/TableSourceFactory.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.factories;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -37,7 +37,7 @@ import java.util.Map;
  *     interface produces internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface TableSourceFactory<T> extends TableFactory {
 
     /**
@@ -79,7 +79,7 @@ public interface TableSourceFactory<T> extends TableFactory {
     }
 
     /** Context of table source creation. Contains table information and environment information. */
-    @PublicEvolving
+    @Internal
     interface Context {
 
         /** @return full identifier of the given {@link CatalogTable}. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sinks/OverwritableTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sinks/OverwritableTableSink.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sinks;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
 
@@ -31,7 +31,7 @@ import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
  *     DynamicTableSink}. Use {@link SupportsOverwrite} instead. See FLIP-95 for more information.
  */
 @Deprecated
-@Experimental
+@Internal
 public interface OverwritableTableSink {
 
     /** Configures whether the insert should overwrite existing data or not. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sinks/PartitionableTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sinks/PartitionableTableSink.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sinks;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
 
@@ -67,7 +67,7 @@ import java.util.Map;
  *     information.
  */
 @Deprecated
-@Experimental
+@Internal
 public interface PartitionableTableSink {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sinks/TableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sinks/TableSink.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sinks;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
@@ -38,7 +38,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
  *     consumes internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface TableSink<T> {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/DefinedFieldMapping.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/DefinedFieldMapping.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.legacy.api.TableSchema;
 import org.apache.flink.table.types.DataType;
@@ -45,7 +45,7 @@ import java.util.Map;
  *     DynamicTableSource}. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface DefinedFieldMapping {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/DefinedProctimeAttribute.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/DefinedProctimeAttribute.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.legacy.api.TableSchema;
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
  *     information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface DefinedProctimeAttribute {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/DefinedRowtimeAttributes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/DefinedRowtimeAttributes.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.legacy.api.TableSchema;
@@ -34,7 +34,7 @@ import java.util.List;
  *     information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface DefinedRowtimeAttributes {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/FieldComputer.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/FieldComputer.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.expressions.Expression;
@@ -34,7 +34,7 @@ import org.apache.flink.table.expressions.ResolvedFieldReference;
  *     information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface FieldComputer<T> {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/FilterableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/FilterableTableSource.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.expressions.Expression;
@@ -33,6 +34,7 @@ import java.util.List;
  *     information.
  */
 @Deprecated
+@Internal
 public interface FilterableTableSource<T> {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/LimitableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/LimitableTableSource.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 
@@ -34,7 +34,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
  *     information.
  */
 @Deprecated
-@Experimental
+@Internal
 public interface LimitableTableSource<T> {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/LookupableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/LookupableTableSource.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
 import org.apache.flink.table.functions.AsyncTableFunction;
@@ -34,7 +34,7 @@ import org.apache.flink.table.functions.TableFunction;
  *     DynamicTableSource}. Use {@link LookupTableSource} instead. See FLIP-95 for more information.
  */
 @Deprecated
-@Experimental
+@Internal
 public interface LookupableTableSource<T> extends TableSource<T> {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/NestedFieldsProjectableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/NestedFieldsProjectableTableSource.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 
@@ -34,7 +34,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
  *     information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface NestedFieldsProjectableTableSource<T> {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/PartitionableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/PartitionableTableSource.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
 
@@ -41,7 +41,7 @@ import java.util.Map;
  *     information.
  */
 @Deprecated
-@Experimental
+@Internal
 public interface PartitionableTableSource {
 
     /** Returns all the partitions of this {@link PartitionableTableSource}. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/ProjectableTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/ProjectableTableSource.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
 
@@ -34,7 +34,7 @@ import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushD
  *     information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface ProjectableTableSource<T> {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/RowtimeAttributeDescriptor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/RowtimeAttributeDescriptor.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.legacy.sources.tsextractors.TimestampExtractor;
 import org.apache.flink.table.sources.wmstrategies.WatermarkStrategy;
@@ -32,6 +33,7 @@ import java.util.Objects;
  *     information.
  */
 @Deprecated
+@Internal
 public final class RowtimeAttributeDescriptor {
 
     private final String attributeName;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/TableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/TableSource.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
@@ -45,7 +45,7 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
  *     produces internal data structures. See FLIP-95 for more information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public interface TableSource<T> {
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/tsextractors/TimestampExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/sources/tsextractors/TimestampExtractor.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.sources.tsextractors;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -39,7 +39,7 @@ import java.util.Map;
  *     information.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public abstract class TimestampExtractor implements FieldComputer<Long>, Serializable, Descriptor {
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/types/logical/TypeInformationRawType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/types/logical/TypeInformationRawType.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.legacy.types.logical;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
@@ -53,8 +52,8 @@ import java.util.Set;
  *
  * @deprecated Use {@link RawType} instead.
  */
-@PublicEvolving
 @Deprecated
+@Internal
 public final class TypeInformationRawType<T> extends LogicalType {
     private static final long serialVersionUID = 1L;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/utils/TypeStringUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/legacy/utils/TypeStringUtils.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.legacy.utils;
 
-import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.InvalidTypesException;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -48,7 +48,7 @@ import java.util.List;
  *     LogicalTypeParser} instead.
  */
 @Deprecated
-@PublicEvolving
+@Internal
 public class TypeStringUtils {
 
     private static final String VARCHAR = "VARCHAR";


### PR DESCRIPTION
## What is the purpose of the change

*This is an addition to the previous PR(https://github.com/apache/flink/pull/25400). All annotations of classes under the legacy package in table modules should be replaced to `Internal`*


## Brief change log

  - *Replace all class annotations in the legacy package with Internal in table modules (table-common, table-api-java and table-api-java-bridge)*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
