### PR TITLE
 [FLINK-35202][table] Support the execution of alter materialized table set freshness

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpoint.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.gateway.api.endpoint.SqlGatewayEndpoint;
 import org.apache.flink.table.gateway.rest.handler.materializedtable.RefreshMaterializedTableHandler;
 import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowHandler;
 import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.DeleteEmbeddedSchedulerWorkflowHandler;
+import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.ModifyEmbeddedSchedulerWorkflowCronExpressionHandler;
 import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowHandler;
 import org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler.SuspendEmbeddedSchedulerWorkflowHandler;
 import org.apache.flink.table.gateway.rest.handler.operation.CancelOperationHandler;
@@ -46,6 +47,7 @@ import org.apache.flink.table.gateway.rest.handler.util.GetInfoHandler;
 import org.apache.flink.table.gateway.rest.header.materializedtable.RefreshMaterializedTableHeaders;
 import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.CreateEmbeddedSchedulerWorkflowHeaders;
 import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.DeleteEmbeddedSchedulerWorkflowHeaders;
+import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.ModifyEmbeddedSchedulerWorkflowCronExpressionHeaders;
 import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.ResumeEmbeddedSchedulerWorkflowHeaders;
 import org.apache.flink.table.gateway.rest.header.materializedtable.scheduler.SuspendEmbeddedSchedulerWorkflowHeaders;
 import org.apache.flink.table.gateway.rest.header.operation.CancelOperationHeaders;
@@ -243,6 +245,18 @@ public class SqlGatewayRestEndpoint extends RestServerEndpoint implements SqlGat
                         DeleteEmbeddedSchedulerWorkflowHeaders.getInstance());
         handlers.add(
                 Tuple2.of(DeleteEmbeddedSchedulerWorkflowHeaders.getInstance(), deleteHandler));
+
+        // modify cron expression handler
+        ModifyEmbeddedSchedulerWorkflowCronExpressionHandler modifyCronExpressionHandler =
+                new ModifyEmbeddedSchedulerWorkflowCronExpressionHandler(
+                        service,
+                        quartzScheduler,
+                        responseHeaders,
+                        ModifyEmbeddedSchedulerWorkflowCronExpressionHeaders.getInstance());
+        handlers.add(
+                Tuple2.of(
+                        ModifyEmbeddedSchedulerWorkflowCronExpressionHeaders.getInstance(),
+                        modifyCronExpressionHandler));
     }
 
     private void addMaterializedTableRelatedHandlers(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/ModifyEmbeddedSchedulerWorkflowCronExpressionHandler.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/handler/materializedtable/scheduler/ModifyEmbeddedSchedulerWorkflowCronExpressionHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.handler.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.table.gateway.api.SqlGatewayService;
+import org.apache.flink.table.gateway.rest.handler.AbstractSqlGatewayRestHandler;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody;
+import org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion;
+import org.apache.flink.table.gateway.workflow.scheduler.EmbeddedQuartzScheduler;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/** Handler for modifying the cron expression of a workflow in the embedded scheduler. */
+public class ModifyEmbeddedSchedulerWorkflowCronExpressionHandler
+        extends AbstractSqlGatewayRestHandler<
+                ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody,
+                EmptyResponseBody,
+                EmptyMessageParameters> {
+
+    private final EmbeddedQuartzScheduler quartzScheduler;
+
+    public ModifyEmbeddedSchedulerWorkflowCronExpressionHandler(
+            SqlGatewayService service,
+            EmbeddedQuartzScheduler quartzScheduler,
+            Map<String, String> responseHeaders,
+            MessageHeaders<
+                            ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody,
+                            EmptyResponseBody,
+                            EmptyMessageParameters>
+                    messageHeaders) {
+        super(service, responseHeaders, messageHeaders);
+
+        this.quartzScheduler = quartzScheduler;
+    }
+
+    @Override
+    protected CompletableFuture<EmptyResponseBody> handleRequest(
+            @Nullable SqlGatewayRestAPIVersion version,
+            @Nonnull
+                    HandlerRequest<ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody>
+                            request)
+            throws RestHandlerException {
+
+        String workflowName = request.getRequestBody().getWorkflowName();
+        String workflowGroup = request.getRequestBody().getWorkflowGroup();
+        String cronExpression = request.getRequestBody().getCronExpression();
+
+        try {
+            quartzScheduler.modifyScheduleWorkflowCronExpression(
+                    workflowName, workflowGroup, cronExpression);
+
+            return CompletableFuture.completedFuture(EmptyResponseBody.getInstance());
+        } catch (Exception e) {
+            throw new RestHandlerException(
+                    e.getMessage(), HttpResponseStatus.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/ModifyEmbeddedSchedulerWorkflowCronExpressionHeaders.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/header/materializedtable/scheduler/ModifyEmbeddedSchedulerWorkflowCronExpressionHeaders.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.header.materializedtable.scheduler;
+
+import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.versioning.RestAPIVersion;
+import org.apache.flink.table.gateway.rest.header.SqlGatewayMessageHeaders;
+import org.apache.flink.table.gateway.rest.message.materializedtable.scheduler.ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.table.gateway.rest.util.SqlGatewayRestAPIVersion.V3;
+
+/** Message headers for modifying cron expression in embedded scheduler. */
+@Documentation.ExcludeFromDocumentation("The embedded rest api.")
+public class ModifyEmbeddedSchedulerWorkflowCronExpressionHeaders
+        implements SqlGatewayMessageHeaders<
+                ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody,
+                EmptyResponseBody,
+                EmptyMessageParameters> {
+
+    private static final ModifyEmbeddedSchedulerWorkflowCronExpressionHeaders INSTANCE =
+            new ModifyEmbeddedSchedulerWorkflowCronExpressionHeaders();
+
+    public static final String URL = "/workflow/embedded-scheduler/modify-cron-expression";
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.DELETE;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public Class<EmptyResponseBody> getResponseClass() {
+        return EmptyResponseBody.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Modify workflow cron expression";
+    }
+
+    @Override
+    public String operationId() {
+        return "modifyCronExpression";
+    }
+
+    @Override
+    public Class<ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody> getRequestClass() {
+        return ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody.class;
+    }
+
+    @Override
+    public EmptyMessageParameters getUnresolvedMessageParameters() {
+        return EmptyMessageParameters.getInstance();
+    }
+
+    @Override
+    public Collection<? extends RestAPIVersion<?>> getSupportedAPIVersions() {
+        return Collections.singleton(V3);
+    }
+
+    public static ModifyEmbeddedSchedulerWorkflowCronExpressionHeaders getInstance() {
+        return INSTANCE;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/rest/message/materializedtable/scheduler/ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.gateway.rest.message.materializedtable.scheduler;
+
+import org.apache.flink.runtime.rest.messages.RequestBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Request body for modifying the cron expression of a workflow. */
+public class ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody implements RequestBody {
+
+    private static final String FIELD_NAME_WORKFLOW_NAME = "workflowName";
+    private static final String FIELD_NAME_WORKFLOW_GROUP = "workflowGroup";
+    private static final String FIELD_NAME_CRON_EXPRESSION = "cronExpression";
+
+    @JsonProperty(FIELD_NAME_WORKFLOW_NAME)
+    private final String workflowName;
+
+    @JsonProperty(FIELD_NAME_WORKFLOW_GROUP)
+    private final String workflowGroup;
+
+    @JsonProperty(FIELD_NAME_CRON_EXPRESSION)
+    private final String cronExpression;
+
+    public ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody(
+            @JsonProperty(FIELD_NAME_WORKFLOW_NAME) String workflowName,
+            @JsonProperty(FIELD_NAME_WORKFLOW_GROUP) String workflowGroup,
+            @JsonProperty(FIELD_NAME_CRON_EXPRESSION) String cronExpression) {
+        this.workflowName = workflowName;
+        this.workflowGroup = workflowGroup;
+        this.cronExpression = cronExpression;
+    }
+
+    public String getWorkflowName() {
+        return workflowName;
+    }
+
+    public String getWorkflowGroup() {
+        return workflowGroup;
+    }
+
+    public String getCronExpression() {
+        return cronExpression;
+    }
+}

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/materializedtable/MaterializedTableManager.java
@@ -49,6 +49,7 @@ import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
 import org.apache.flink.table.operations.command.DescribeJobOperation;
 import org.apache.flink.table.operations.command.StopJobOperation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableChangeOperation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableFreshnessOperation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableRefreshOperation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableResumeOperation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableSuspendOperation;
@@ -60,10 +61,12 @@ import org.apache.flink.table.refresh.ContinuousRefreshHandlerSerializer;
 import org.apache.flink.table.refresh.RefreshHandler;
 import org.apache.flink.table.refresh.RefreshHandlerSerializer;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.utils.RefreshModeUtils;
 import org.apache.flink.table.workflow.CreatePeriodicRefreshWorkflow;
 import org.apache.flink.table.workflow.CreateRefreshWorkflow;
 import org.apache.flink.table.workflow.DeleteRefreshWorkflow;
 import org.apache.flink.table.workflow.ModifyRefreshWorkflow;
+import org.apache.flink.table.workflow.ModifyRefreshWorkflowCronExpression;
 import org.apache.flink.table.workflow.ResumeRefreshWorkflow;
 import org.apache.flink.table.workflow.SuspendRefreshWorkflow;
 import org.apache.flink.table.workflow.WorkflowScheduler;
@@ -95,6 +98,7 @@ import static org.apache.flink.configuration.ExecutionOptions.RUNTIME_MODE;
 import static org.apache.flink.configuration.PipelineOptions.NAME;
 import static org.apache.flink.configuration.StateRecoveryOptions.SAVEPOINT_PATH;
 import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.DATE_FORMATTER;
+import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.MATERIALIZED_TABLE_FRESHNESS_THRESHOLD;
 import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.PARTITION_FIELDS;
 import static org.apache.flink.table.api.config.MaterializedTableConfigOptions.SCHEDULE_TIME_DATE_FORMATTER_DEFAULT;
 import static org.apache.flink.table.api.internal.TableResultInternal.TABLE_RESULT_OK;
@@ -174,6 +178,9 @@ public class MaterializedTableManager {
         } else if (op instanceof DropMaterializedTableOperation) {
             return callDropMaterializedTableOperation(
                     operationExecutor, handle, (DropMaterializedTableOperation) op);
+        } else if (op instanceof AlterMaterializedTableFreshnessOperation) {
+            return callAlterMaterializedTableFreshnessOperation(
+                    operationExecutor, handle, (AlterMaterializedTableFreshnessOperation) op);
         }
 
         throw new SqlExecutionException(
@@ -212,13 +219,22 @@ public class MaterializedTableManager {
                 createMaterializedTableOperation.getCatalogMaterializedTable();
 
         try {
-            executeContinuousRefreshJob(
+            ContinuousRefreshHandler continuousRefreshHandler =
+                    executeContinuousRefreshJob(
+                            operationExecutor,
+                            handle,
+                            catalogMaterializedTable,
+                            materializedTableIdentifier,
+                            Collections.emptyMap(),
+                            Optional.empty());
+
+            updateContinuousModeRefreshHandler(
                     operationExecutor,
                     handle,
-                    catalogMaterializedTable,
                     materializedTableIdentifier,
-                    Collections.emptyMap(),
-                    Optional.empty());
+                    catalogMaterializedTable,
+                    CatalogMaterializedTable.RefreshStatus.ACTIVATED,
+                    continuousRefreshHandler);
         } catch (Exception e) {
             // drop materialized table while submit flink streaming job occur exception. Thus, weak
             // atomicity is guaranteed
@@ -248,6 +264,38 @@ public class MaterializedTableManager {
         CatalogMaterializedTable catalogMaterializedTable =
                 createMaterializedTableOperation.getCatalogMaterializedTable();
 
+        try {
+            RefreshHandler refreshHandler =
+                    createPeriodicRefreshWorkflow(
+                            operationExecutor,
+                            materializedTableIdentifier,
+                            catalogMaterializedTable);
+
+            updateFullModeRefreshHandler(
+                    operationExecutor,
+                    handle,
+                    materializedTableIdentifier,
+                    catalogMaterializedTable,
+                    CatalogMaterializedTable.RefreshStatus.ACTIVATED,
+                    refreshHandler);
+        } catch (Exception e) {
+            // drop materialized table while create refresh workflow occur exception. Thus, weak
+            // atomicity is guaranteed
+            operationExecutor.callExecutableOperation(
+                    handle, new DropMaterializedTableOperation(materializedTableIdentifier, true));
+            throw new SqlExecutionException(
+                    String.format(
+                            "Failed to create refresh workflow for materialized table %s.",
+                            materializedTableIdentifier),
+                    e);
+        }
+    }
+
+    private RefreshHandler createPeriodicRefreshWorkflow(
+            OperationExecutor operationExecutor,
+            ObjectIdentifier materializedTableIdentifier,
+            CatalogMaterializedTable catalogMaterializedTable)
+            throws Exception {
         // convert duration to cron expression
         String cronExpression =
                 convertFreshnessToCron(catalogMaterializedTable.getDefinitionFreshness());
@@ -261,32 +309,9 @@ public class MaterializedTableManager {
                         Collections.emptyMap(),
                         restEndpointUrl);
 
-        try {
-            RefreshHandler refreshHandler =
-                    workflowScheduler.createRefreshWorkflow(createRefreshWorkflow);
-            RefreshHandlerSerializer refreshHandlerSerializer =
-                    workflowScheduler.getRefreshHandlerSerializer();
-            byte[] serializedRefreshHandler = refreshHandlerSerializer.serialize(refreshHandler);
-
-            updateRefreshHandler(
-                    operationExecutor,
-                    handle,
-                    materializedTableIdentifier,
-                    catalogMaterializedTable,
-                    CatalogMaterializedTable.RefreshStatus.ACTIVATED,
-                    refreshHandler.asSummaryString(),
-                    serializedRefreshHandler);
-        } catch (Exception e) {
-            // drop materialized table while create refresh workflow occur exception. Thus, weak
-            // atomicity is guaranteed
-            operationExecutor.callExecutableOperation(
-                    handle, new DropMaterializedTableOperation(materializedTableIdentifier, true));
-            throw new SqlExecutionException(
-                    String.format(
-                            "Failed to create refresh workflow for materialized table %s.",
-                            materializedTableIdentifier),
-                    e);
-        }
+        RefreshHandler refreshHandler =
+                workflowScheduler.createRefreshWorkflow(createRefreshWorkflow);
+        return refreshHandler;
     }
 
     private ResultFetcher callAlterMaterializedTableSuspend(
@@ -307,100 +332,100 @@ public class MaterializedTableManager {
         }
 
         if (CatalogMaterializedTable.RefreshMode.CONTINUOUS == materializedTable.getRefreshMode()) {
-            suspendContinuousRefreshJob(
-                    operationExecutor, handle, tableIdentifier, materializedTable);
+            try {
+                if (CatalogMaterializedTable.RefreshStatus.SUSPENDED
+                        == materializedTable.getRefreshStatus()) {
+                    ContinuousRefreshHandler refreshHandler =
+                            deserializeContinuousHandler(
+                                    materializedTable.getSerializedRefreshHandler());
+                    throw new SqlExecutionException(
+                            String.format(
+                                    "Materialized table %s continuous refresh job has been suspended, jobId is %s.",
+                                    tableIdentifier, refreshHandler.getJobId()));
+                }
+
+                ContinuousRefreshHandler continuousRefreshHandler =
+                        suspendContinuousRefreshJob(operationExecutor, handle, materializedTable);
+
+                updateContinuousModeRefreshHandler(
+                        operationExecutor,
+                        handle,
+                        tableIdentifier,
+                        materializedTable,
+                        CatalogMaterializedTable.RefreshStatus.SUSPENDED,
+                        continuousRefreshHandler);
+            } catch (Exception e) {
+                throw new SqlExecutionException(
+                        String.format(
+                                "Failed to suspend the continuous refresh job for materialized table %s.",
+                                tableIdentifier),
+                        e);
+            }
         } else {
-            suspendRefreshWorkflow(operationExecutor, handle, tableIdentifier, materializedTable);
+            try {
+                if (CatalogMaterializedTable.RefreshStatus.SUSPENDED
+                        == materializedTable.getRefreshStatus()) {
+                    throw new SqlExecutionException(
+                            String.format(
+                                    "Materialized table %s refresh workflow has been suspended.",
+                                    tableIdentifier));
+                }
+
+                if (workflowScheduler == null) {
+                    throw new SqlExecutionException(
+                            "The workflow scheduler must be configured when suspending materialized table in full refresh mode.");
+                }
+
+                RefreshHandler refreshHandler = suspendRefreshWorkflow(materializedTable);
+
+                updateFullModeRefreshHandler(
+                        operationExecutor,
+                        handle,
+                        tableIdentifier,
+                        materializedTable,
+                        CatalogMaterializedTable.RefreshStatus.SUSPENDED,
+                        refreshHandler);
+            } catch (Exception e) {
+                throw new SqlExecutionException(
+                        String.format(
+                                "Failed to suspend the refresh workflow for materialized table %s.",
+                                tableIdentifier),
+                        e);
+            }
         }
         return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
     }
 
-    private void suspendContinuousRefreshJob(
+    private ContinuousRefreshHandler suspendContinuousRefreshJob(
             OperationExecutor operationExecutor,
             OperationHandle handle,
-            ObjectIdentifier tableIdentifier,
             CatalogMaterializedTable materializedTable) {
-        try {
-            ContinuousRefreshHandler refreshHandler =
-                    deserializeContinuousHandler(materializedTable.getSerializedRefreshHandler());
+        ContinuousRefreshHandler refreshHandler =
+                deserializeContinuousHandler(materializedTable.getSerializedRefreshHandler());
 
-            if (CatalogMaterializedTable.RefreshStatus.SUSPENDED
-                    == materializedTable.getRefreshStatus()) {
-                throw new SqlExecutionException(
-                        String.format(
-                                "Materialized table %s continuous refresh job has been suspended, jobId is %s.",
-                                tableIdentifier, refreshHandler.getJobId()));
-            }
+        String savepointPath =
+                stopJobWithSavepoint(operationExecutor, handle, refreshHandler.getJobId());
 
-            String savepointPath =
-                    stopJobWithSavepoint(operationExecutor, handle, refreshHandler.getJobId());
+        ContinuousRefreshHandler updateRefreshHandler =
+                new ContinuousRefreshHandler(
+                        refreshHandler.getExecutionTarget(),
+                        refreshHandler.getJobId(),
+                        savepointPath);
 
-            ContinuousRefreshHandler updateRefreshHandler =
-                    new ContinuousRefreshHandler(
-                            refreshHandler.getExecutionTarget(),
-                            refreshHandler.getJobId(),
-                            savepointPath);
-
-            updateRefreshHandler(
-                    operationExecutor,
-                    handle,
-                    tableIdentifier,
-                    materializedTable,
-                    CatalogMaterializedTable.RefreshStatus.SUSPENDED,
-                    updateRefreshHandler.asSummaryString(),
-                    serializeContinuousHandler(updateRefreshHandler));
-        } catch (Exception e) {
-            throw new SqlExecutionException(
-                    String.format(
-                            "Failed to suspend the continuous refresh job for materialized table %s.",
-                            tableIdentifier),
-                    e);
-        }
+        return updateRefreshHandler;
     }
 
-    private void suspendRefreshWorkflow(
-            OperationExecutor operationExecutor,
-            OperationHandle handle,
-            ObjectIdentifier tableIdentifier,
-            CatalogMaterializedTable materializedTable) {
-        if (CatalogMaterializedTable.RefreshStatus.SUSPENDED
-                == materializedTable.getRefreshStatus()) {
-            throw new SqlExecutionException(
-                    String.format(
-                            "Materialized table %s refresh workflow has been suspended.",
-                            tableIdentifier));
-        }
+    private RefreshHandler suspendRefreshWorkflow(CatalogMaterializedTable materializedTable)
+            throws Exception {
+        RefreshHandlerSerializer<?> refreshHandlerSerializer =
+                workflowScheduler.getRefreshHandlerSerializer();
+        RefreshHandler refreshHandler =
+                refreshHandlerSerializer.deserialize(
+                        materializedTable.getSerializedRefreshHandler(), userCodeClassLoader);
+        ModifyRefreshWorkflow modifyRefreshWorkflow = new SuspendRefreshWorkflow(refreshHandler);
+        workflowScheduler.modifyRefreshWorkflow(modifyRefreshWorkflow);
 
-        if (workflowScheduler == null) {
-            throw new SqlExecutionException(
-                    "The workflow scheduler must be configured when suspending materialized table in full refresh mode.");
-        }
-
-        try {
-            RefreshHandlerSerializer<?> refreshHandlerSerializer =
-                    workflowScheduler.getRefreshHandlerSerializer();
-            RefreshHandler refreshHandler =
-                    refreshHandlerSerializer.deserialize(
-                            materializedTable.getSerializedRefreshHandler(), userCodeClassLoader);
-            ModifyRefreshWorkflow modifyRefreshWorkflow =
-                    new SuspendRefreshWorkflow(refreshHandler);
-            workflowScheduler.modifyRefreshWorkflow(modifyRefreshWorkflow);
-
-            updateRefreshHandler(
-                    operationExecutor,
-                    handle,
-                    tableIdentifier,
-                    materializedTable,
-                    CatalogMaterializedTable.RefreshStatus.SUSPENDED,
-                    refreshHandler.asSummaryString(),
-                    materializedTable.getSerializedRefreshHandler());
-        } catch (Exception e) {
-            throw new SqlExecutionException(
-                    String.format(
-                            "Failed to suspend the refresh workflow for materialized table %s.",
-                            tableIdentifier),
-                    e);
-        }
+        return refreshHandler;
     }
 
     private ResultFetcher callAlterMaterializedTableResume(
@@ -429,12 +454,38 @@ public class MaterializedTableManager {
                     catalogMaterializedTable,
                     op.getDynamicOptions());
         } else {
-            resumeRefreshWorkflow(
-                    operationExecutor,
-                    handle,
-                    tableIdentifier,
-                    catalogMaterializedTable,
-                    op.getDynamicOptions());
+            // Repeated resume refresh workflow is not supported
+            if (CatalogMaterializedTable.RefreshStatus.ACTIVATED
+                    == catalogMaterializedTable.getRefreshStatus()) {
+                throw new SqlExecutionException(
+                        String.format(
+                                "Materialized table %s refresh workflow has been resumed.",
+                                tableIdentifier));
+            }
+
+            if (workflowScheduler == null) {
+                throw new SqlExecutionException(
+                        "The workflow scheduler must be configured when resuming materialized table in full refresh mode.");
+            }
+
+            try {
+                RefreshHandler refreshHandler =
+                        resumeRefreshWorkflow(catalogMaterializedTable, op.getDynamicOptions());
+
+                updateFullModeRefreshHandler(
+                        operationExecutor,
+                        handle,
+                        tableIdentifier,
+                        catalogMaterializedTable,
+                        CatalogMaterializedTable.RefreshStatus.ACTIVATED,
+                        refreshHandler);
+            } catch (Exception e) {
+                throw new SqlExecutionException(
+                        String.format(
+                                "Failed to resume the refresh workflow for materialized table %s.",
+                                tableIdentifier),
+                        e);
+            }
         }
 
         return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
@@ -464,13 +515,22 @@ public class MaterializedTableManager {
 
         Optional<String> restorePath = refreshHandler.getRestorePath();
         try {
-            executeContinuousRefreshJob(
+            ContinuousRefreshHandler continuousRefreshHandler =
+                    executeContinuousRefreshJob(
+                            operationExecutor,
+                            handle,
+                            catalogMaterializedTable,
+                            tableIdentifier,
+                            dynamicOptions,
+                            restorePath);
+
+            updateContinuousModeRefreshHandler(
                     operationExecutor,
                     handle,
-                    catalogMaterializedTable,
                     tableIdentifier,
-                    dynamicOptions,
-                    restorePath);
+                    catalogMaterializedTable,
+                    CatalogMaterializedTable.RefreshStatus.ACTIVATED,
+                    continuousRefreshHandler);
         } catch (Exception e) {
             throw new SqlExecutionException(
                     String.format(
@@ -480,54 +540,24 @@ public class MaterializedTableManager {
         }
     }
 
-    private void resumeRefreshWorkflow(
-            OperationExecutor operationExecutor,
-            OperationHandle handle,
-            ObjectIdentifier tableIdentifier,
-            CatalogMaterializedTable catalogMaterializedTable,
-            Map<String, String> dynamicOptions) {
+    private RefreshHandler resumeRefreshWorkflow(
+            CatalogMaterializedTable catalogMaterializedTable, Map<String, String> dynamicOptions)
+            throws Exception {
         // Repeated resume refresh workflow is not supported
-        if (CatalogMaterializedTable.RefreshStatus.ACTIVATED
-                == catalogMaterializedTable.getRefreshStatus()) {
-            throw new SqlExecutionException(
-                    String.format(
-                            "Materialized table %s refresh workflow has been resumed.",
-                            tableIdentifier));
-        }
+        RefreshHandlerSerializer<?> refreshHandlerSerializer =
+                workflowScheduler.getRefreshHandlerSerializer();
+        RefreshHandler refreshHandler =
+                refreshHandlerSerializer.deserialize(
+                        catalogMaterializedTable.getSerializedRefreshHandler(),
+                        userCodeClassLoader);
+        ModifyRefreshWorkflow modifyRefreshWorkflow =
+                new ResumeRefreshWorkflow(refreshHandler, dynamicOptions);
+        workflowScheduler.modifyRefreshWorkflow(modifyRefreshWorkflow);
 
-        if (workflowScheduler == null) {
-            throw new SqlExecutionException(
-                    "The workflow scheduler must be configured when resuming materialized table in full refresh mode.");
-        }
-        try {
-            RefreshHandlerSerializer<?> refreshHandlerSerializer =
-                    workflowScheduler.getRefreshHandlerSerializer();
-            RefreshHandler refreshHandler =
-                    refreshHandlerSerializer.deserialize(
-                            catalogMaterializedTable.getSerializedRefreshHandler(),
-                            userCodeClassLoader);
-            ModifyRefreshWorkflow modifyRefreshWorkflow =
-                    new ResumeRefreshWorkflow(refreshHandler, dynamicOptions);
-            workflowScheduler.modifyRefreshWorkflow(modifyRefreshWorkflow);
-
-            updateRefreshHandler(
-                    operationExecutor,
-                    handle,
-                    tableIdentifier,
-                    catalogMaterializedTable,
-                    CatalogMaterializedTable.RefreshStatus.ACTIVATED,
-                    refreshHandler.asSummaryString(),
-                    catalogMaterializedTable.getSerializedRefreshHandler());
-        } catch (Exception e) {
-            throw new SqlExecutionException(
-                    String.format(
-                            "Failed to resume the refresh workflow for materialized table %s.",
-                            tableIdentifier),
-                    e);
-        }
+        return refreshHandler;
     }
 
-    private void executeContinuousRefreshJob(
+    private ContinuousRefreshHandler executeContinuousRefreshJob(
             OperationExecutor operationExecutor,
             OperationHandle handle,
             CatalogMaterializedTable catalogMaterializedTable,
@@ -569,18 +599,8 @@ public class MaterializedTableManager {
         List<RowData> results = fetchAllResults(resultFetcher);
         String jobId = results.get(0).getString(0).toString();
         String executeTarget = operationExecutor.getSessionContext().getSessionConf().get(TARGET);
-        ContinuousRefreshHandler continuousRefreshHandler =
-                new ContinuousRefreshHandler(executeTarget, jobId);
-        byte[] serializedBytes = serializeContinuousHandler(continuousRefreshHandler);
 
-        updateRefreshHandler(
-                operationExecutor,
-                handle,
-                materializedTableIdentifier,
-                catalogMaterializedTable,
-                CatalogMaterializedTable.RefreshStatus.ACTIVATED,
-                continuousRefreshHandler.asSummaryString(),
-                serializedBytes);
+        return new ContinuousRefreshHandler(executeTarget, jobId);
     }
 
     private ResultFetcher callAlterMaterializedTableRefreshOperation(
@@ -831,7 +851,19 @@ public class MaterializedTableManager {
         if (CatalogMaterializedTable.RefreshStatus.ACTIVATED == refreshStatus
                 || CatalogMaterializedTable.RefreshStatus.SUSPENDED == refreshStatus) {
             if (CatalogMaterializedTable.RefreshMode.FULL == refreshMode) {
-                deleteRefreshWorkflow(tableIdentifier, materializedTable);
+                if (workflowScheduler == null) {
+                    throw new SqlExecutionException(
+                            "The workflow scheduler must be configured when dropping materialized table in full refresh mode.");
+                }
+                try {
+                    deleteRefreshWorkflow(materializedTable);
+                } catch (Exception e) {
+                    throw new SqlExecutionException(
+                            String.format(
+                                    "Failed to delete the refresh workflow for materialized table %s.",
+                                    tableIdentifier),
+                            e);
+                }
             } else if (CatalogMaterializedTable.RefreshMode.CONTINUOUS == refreshMode
                     && CatalogMaterializedTable.RefreshStatus.ACTIVATED == refreshStatus) {
                 cancelContinuousRefreshJob(
@@ -848,6 +880,404 @@ public class MaterializedTableManager {
         operationExecutor.callExecutableOperation(handle, dropMaterializedTableOperation);
 
         return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
+    }
+
+    private ResultFetcher callAlterMaterializedTableFreshnessOperation(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            AlterMaterializedTableFreshnessOperation alterMaterializedTableFreshnessOperation) {
+        ObjectIdentifier tableIdentifier =
+                alterMaterializedTableFreshnessOperation.getTableIdentifier();
+        CatalogMaterializedTable materializedTable =
+                getCatalogMaterializedTable(operationExecutor, tableIdentifier);
+
+        IntervalFreshness newFreshness =
+                alterMaterializedTableFreshnessOperation.getDefinitionFreshness();
+        CatalogMaterializedTable.RefreshMode newRefreshMode =
+                calculateNewRefreshMode(operationExecutor, materializedTable, newFreshness);
+
+        if (materializedTable.getDefinitionFreshness().equals(newFreshness)
+                && materializedTable.getRefreshMode() == newRefreshMode) {
+            LOG.warn(
+                    "Freshness for materialized table {} is unchanged, skip the alter operation.",
+                    tableIdentifier);
+            return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
+        }
+
+        if ((newRefreshMode == CatalogMaterializedTable.RefreshMode.FULL
+                        || materializedTable.getRefreshMode()
+                                == CatalogMaterializedTable.RefreshMode.FULL)
+                && workflowScheduler == null) {
+            throw new SqlExecutionException(
+                    String.format(
+                            "Cannot alter materialized table %s: either the new or existing refresh mode is FULL, but no workflow scheduler is configured.",
+                            tableIdentifier));
+        }
+
+        RefreshHandler refreshHandler =
+                materializedTable.getRefreshMode() == newRefreshMode
+                        ? modifyExistingRefresh(
+                                operationExecutor,
+                                handle,
+                                tableIdentifier,
+                                materializedTable,
+                                newFreshness)
+                        : switchRefreshMode(
+                                operationExecutor,
+                                handle,
+                                tableIdentifier,
+                                materializedTable,
+                                newFreshness);
+
+        updateRefreshHandler(
+                operationExecutor,
+                handle,
+                tableIdentifier,
+                materializedTable,
+                materializedTable.getRefreshStatus(),
+                refreshHandler,
+                Optional.of(newFreshness),
+                Optional.of(newRefreshMode));
+
+        return ResultFetcher.fromTableResult(handle, TABLE_RESULT_OK, false);
+    }
+
+    private RefreshHandler modifyExistingRefresh(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            ObjectIdentifier tableIdentifier,
+            CatalogMaterializedTable materializedTable,
+            IntervalFreshness newFreshness) {
+        if (materializedTable.getRefreshMode() == CatalogMaterializedTable.RefreshMode.CONTINUOUS) {
+            return modifyContinuousModeFreshness(
+                    operationExecutor, handle, materializedTable, tableIdentifier, newFreshness);
+        } else {
+            return modifyFullModeFreshness(tableIdentifier, materializedTable, newFreshness);
+        }
+    }
+
+    private RefreshHandler switchRefreshMode(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            ObjectIdentifier tableIdentifier,
+            CatalogMaterializedTable materializedTable,
+            IntervalFreshness newFreshness) {
+        if (materializedTable.getRefreshMode() == CatalogMaterializedTable.RefreshMode.CONTINUOUS) {
+            return switchToFullMode(
+                    operationExecutor, handle, tableIdentifier, materializedTable, newFreshness);
+        } else {
+            return switchToContinuousMode(
+                    operationExecutor, handle, tableIdentifier, materializedTable, newFreshness);
+        }
+    }
+
+    private CatalogMaterializedTable.RefreshMode calculateNewRefreshMode(
+            OperationExecutor operationExecutor,
+            CatalogMaterializedTable materializedTable,
+            IntervalFreshness newFreshness) {
+        return RefreshModeUtils.deriveRefreshMode(
+                operationExecutor
+                        .getTableEnvironment()
+                        .getConfig()
+                        .getRootConfiguration()
+                        .get(MATERIALIZED_TABLE_FRESHNESS_THRESHOLD),
+                convertFreshnessToDuration(newFreshness),
+                materializedTable.getLogicalRefreshMode());
+    }
+
+    private RefreshHandler modifyFullModeFreshness(
+            ObjectIdentifier tableIdentifier,
+            CatalogMaterializedTable catalogMaterializedTable,
+            IntervalFreshness freshness) {
+        try {
+            RefreshHandlerSerializer<?> refreshHandlerSerializer =
+                    workflowScheduler.getRefreshHandlerSerializer();
+            RefreshHandler refreshHandler =
+                    refreshHandlerSerializer.deserialize(
+                            catalogMaterializedTable.getSerializedRefreshHandler(),
+                            userCodeClassLoader);
+            ModifyRefreshWorkflow modifyRefreshWorkflow =
+                    new ModifyRefreshWorkflowCronExpression(
+                            refreshHandler, convertFreshnessToCron(freshness));
+            workflowScheduler.modifyRefreshWorkflow(modifyRefreshWorkflow);
+
+            return refreshHandler;
+        } catch (Exception e) {
+            throw new SqlExecutionException(
+                    String.format(
+                            "Failed to alter freshness of materialized table %s: Unable to modify the cron expression for refresh workflow.",
+                            tableIdentifier),
+                    e);
+        }
+    }
+
+    private RefreshHandler modifyContinuousModeFreshness(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            CatalogMaterializedTable materializedTable,
+            ObjectIdentifier tableIdentifier,
+            IntervalFreshness freshness) {
+        ContinuousRefreshHandler continuousRefreshHandler =
+                deserializeContinuousHandler(materializedTable.getSerializedRefreshHandler());
+        JobStatus jobStatus = getJobStatus(operationExecutor, handle, continuousRefreshHandler);
+
+        if (materializedTable.getRefreshStatus() == CatalogMaterializedTable.RefreshStatus.ACTIVATED
+                || jobStatus.isTerminalState()) {
+            if (jobStatus == JobStatus.RUNNING) {
+                // TODO: check the current running job interval, skip restart if currently running
+                // checkpoint interval is the same as checkpoint interval in current session conf.
+
+                // stop the origin continuous refresh job and change the checkpoint interval
+                ContinuousRefreshHandler suspendRefreshHandler;
+                try {
+                    suspendRefreshHandler =
+                            suspendContinuousRefreshJob(
+                                    operationExecutor, handle, materializedTable);
+                } catch (Exception e) {
+                    throw new SqlExecutionException(
+                            String.format(
+                                    "Failed to alter freshness of materialized table %s: Unable to suspend current continuous refresh job.",
+                                    tableIdentifier),
+                            e);
+                }
+
+                CatalogMaterializedTable alterFreshnessMaterializedTable =
+                        materializedTable.copy(
+                                freshness, CatalogMaterializedTable.RefreshMode.CONTINUOUS);
+
+                try {
+                    return executeContinuousRefreshJob(
+                            operationExecutor,
+                            handle,
+                            alterFreshnessMaterializedTable,
+                            tableIdentifier,
+                            Collections.emptyMap(),
+                            suspendRefreshHandler.getRestorePath());
+                } catch (Exception e) {
+                    // rollback to origin continuous refresh job
+                    LOG.warn(
+                            "Failed to start new continuous refresh job with updated checkpoint interval for materialized table {}. Attempting to rollback to previous continuous refresh job.",
+                            tableIdentifier,
+                            e);
+
+                    try {
+                        ContinuousRefreshHandler rollbackRefreshHandler =
+                                executeContinuousRefreshJob(
+                                        operationExecutor,
+                                        handle,
+                                        materializedTable,
+                                        tableIdentifier,
+                                        Collections.emptyMap(),
+                                        suspendRefreshHandler.getRestorePath());
+
+                        updateRefreshHandler(
+                                operationExecutor,
+                                handle,
+                                tableIdentifier,
+                                materializedTable,
+                                materializedTable.getRefreshStatus(),
+                                rollbackRefreshHandler,
+                                Optional.empty(),
+                                Optional.empty());
+                    } catch (Exception rollbackException) {
+                        throw new SqlExecutionException(
+                                String.format(
+                                        "Failed to alter freshness of materialized table %s: Unable to rollback to previous continuous refresh job. Table may be in an inconsistent state.",
+                                        tableIdentifier),
+                                rollbackException);
+                    }
+
+                    throw new SqlExecutionException(
+                            String.format(
+                                    "Failed to alter freshness of materialized table %s: Unable to execute new continuous refresh job with updated checkpoint interval.",
+                                    tableIdentifier),
+                            e);
+                }
+            }
+        } else {
+            throw new SqlExecutionException(
+                    String.format(
+                            "Cannot alter freshness of materialized table %s: Continuous refresh job is neither running nor in a terminal state.",
+                            tableIdentifier));
+        }
+
+        return continuousRefreshHandler;
+    }
+
+    private RefreshHandler switchToFullMode(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            ObjectIdentifier tableIdentifier,
+            CatalogMaterializedTable materializedTable,
+            IntervalFreshness alterFreshness) {
+        ContinuousRefreshHandler refreshHandler =
+                deserializeContinuousHandler(materializedTable.getSerializedRefreshHandler());
+        JobStatus jobStatus = getJobStatus(operationExecutor, handle, refreshHandler);
+
+        // TODO: Support creating workflow in suspended mode
+        if (materializedTable.getRefreshStatus()
+                == CatalogMaterializedTable.RefreshStatus.SUSPENDED) {
+            throw new SqlExecutionException(
+                    String.format(
+                            "Cannot alter freshness of materialized table %s: Creating workflow in SUSPENDED mode is not supported.",
+                            tableIdentifier));
+        }
+
+        CatalogMaterializedTable updatedTable =
+                materializedTable.copy(alterFreshness, CatalogMaterializedTable.RefreshMode.FULL);
+
+        if (jobStatus == JobStatus.RUNNING) {
+            Optional<String> savepointDir;
+            try {
+                savepointDir =
+                        suspendContinuousRefreshJob(operationExecutor, handle, materializedTable)
+                                .getRestorePath();
+            } catch (Exception e) {
+                throw new SqlExecutionException(
+                        String.format(
+                                "Failed to alter freshness of materialized table %s: Unable to suspend ongoing continuous refresh job.",
+                                tableIdentifier),
+                        e);
+            }
+
+            try {
+                return createPeriodicRefreshWorkflow(
+                        operationExecutor, tableIdentifier, updatedTable);
+            } catch (Exception e) {
+                LOG.error(
+                        "Failed to create periodic refresh workflow for materialized table {} during freshness alteration. Attempting to roll back to the previous continuous refresh job.",
+                        tableIdentifier,
+                        e);
+
+                try {
+                    // rollback to continuous mode
+                    RefreshHandler rollbackHandler =
+                            executeContinuousRefreshJob(
+                                    operationExecutor,
+                                    handle,
+                                    materializedTable,
+                                    tableIdentifier,
+                                    Collections.emptyMap(),
+                                    savepointDir);
+
+                    updateRefreshHandler(
+                            operationExecutor,
+                            handle,
+                            tableIdentifier,
+                            materializedTable,
+                            CatalogMaterializedTable.RefreshStatus.ACTIVATED,
+                            rollbackHandler,
+                            Optional.empty(),
+                            Optional.empty());
+                } catch (Exception rollbackException) {
+                    throw new SqlExecutionException(
+                            String.format(
+                                    "Failed to alter freshness of materialized table %s: Unable to rollback to previous continuous refresh job. Table may be in an inconsistent state.",
+                                    tableIdentifier),
+                            rollbackException);
+                }
+
+                throw new SqlExecutionException(
+                        String.format(
+                                "Failed to alter freshness of materialized table %s: Unable to create periodic refresh workflow.",
+                                tableIdentifier),
+                        e);
+            }
+        } else if (jobStatus.isTerminalState()) {
+            try {
+                return createPeriodicRefreshWorkflow(
+                        operationExecutor, tableIdentifier, updatedTable);
+            } catch (Exception e) {
+                throw new SqlExecutionException(
+                        String.format(
+                                "Failed to alter freshness of materialized table %s: Unable to create periodic refresh workflow.",
+                                tableIdentifier),
+                        e);
+            }
+        } else {
+            throw new SqlExecutionException(
+                    String.format(
+                            "Cannot alter freshness of materialized table %s: Continuous refresh job is not in running state.",
+                            tableIdentifier));
+        }
+    }
+
+    private RefreshHandler switchToContinuousMode(
+            OperationExecutor operationExecutor,
+            OperationHandle handle,
+            ObjectIdentifier tableIdentifier,
+            CatalogMaterializedTable materializedTable,
+            IntervalFreshness alterFreshness) {
+        ContinuousRefreshHandler continuousRefreshHandler;
+        if (materializedTable.getRefreshStatus()
+                == CatalogMaterializedTable.RefreshStatus.ACTIVATED) {
+
+            try {
+                // Suspend the current refresh workflow before switching modes
+                suspendRefreshWorkflow(materializedTable);
+            } catch (Exception e) {
+                throw new SqlExecutionException(
+                        String.format(
+                                "Failed to alter freshness of materialized table %s: Unable to suspend current refresh workflow.",
+                                tableIdentifier.asSerializableString()),
+                        e);
+            }
+
+            CatalogMaterializedTable updatedTable =
+                    materializedTable.copy(
+                            alterFreshness, CatalogMaterializedTable.RefreshMode.CONTINUOUS);
+
+            try {
+                // Execute the continuous refresh job with the updated freshness
+                continuousRefreshHandler =
+                        executeContinuousRefreshJob(
+                                operationExecutor,
+                                handle,
+                                updatedTable,
+                                tableIdentifier,
+                                Collections.emptyMap(),
+                                Optional.empty());
+            } catch (Exception e) {
+                LOG.error(
+                        "Failed to execute continuous refresh job for materialized table {} during freshness alteration. Attempting to roll back to previous periodic refresh workflow.",
+                        tableIdentifier,
+                        e);
+
+                // Rollback to full mode if switching to continuous mode fails
+                try {
+                    resumeRefreshWorkflow(materializedTable, Collections.emptyMap());
+                } catch (Exception rollbackException) {
+                    throw new SqlExecutionException(
+                            String.format(
+                                    "Failed to alter freshness of materialized table %s: Unable to rollback to previous periodic refresh workflow. Table may be in an inconsistent state.",
+                                    tableIdentifier),
+                            rollbackException);
+                }
+
+                throw new SqlExecutionException(
+                        String.format(
+                                "Failed to alter freshness of materialized table %s: Unable to execute continuous refresh job.",
+                                tableIdentifier),
+                        e);
+            }
+        } else {
+            String target = operationExecutor.getSessionContext().getSessionConf().get(TARGET);
+
+            // as the table is in suspended mode, we can set an empty job id.
+            continuousRefreshHandler = new ContinuousRefreshHandler(target, "");
+        }
+
+        // Attempt to delete the old workflow (non-critical operation)
+        try {
+            deleteRefreshWorkflow(materializedTable);
+        } catch (Exception e) {
+            // Log the error but don't throw, since the continuous job has already started
+            LOG.warn(
+                    "Non-critical failure during freshness alteration of materialized table {}: Unable to delete old refresh workflow. Continuous refresh job has already started.",
+                    tableIdentifier,
+                    e);
+        }
+        return continuousRefreshHandler;
     }
 
     private void cancelContinuousRefreshJob(
@@ -887,28 +1317,16 @@ public class MaterializedTableManager {
         }
     }
 
-    private void deleteRefreshWorkflow(
-            ObjectIdentifier tableIdentifier, CatalogMaterializedTable catalogMaterializedTable) {
-        if (workflowScheduler == null) {
-            throw new SqlExecutionException(
-                    "The workflow scheduler must be configured when dropping materialized table in full refresh mode.");
-        }
-        try {
-            RefreshHandlerSerializer<?> refreshHandlerSerializer =
-                    workflowScheduler.getRefreshHandlerSerializer();
-            RefreshHandler refreshHandler =
-                    refreshHandlerSerializer.deserialize(
-                            catalogMaterializedTable.getSerializedRefreshHandler(),
-                            userCodeClassLoader);
-            DeleteRefreshWorkflow deleteRefreshWorkflow = new DeleteRefreshWorkflow(refreshHandler);
-            workflowScheduler.deleteRefreshWorkflow(deleteRefreshWorkflow);
-        } catch (Exception e) {
-            throw new SqlExecutionException(
-                    String.format(
-                            "Failed to delete the refresh workflow for materialized table %s.",
-                            tableIdentifier),
-                    e);
-        }
+    private void deleteRefreshWorkflow(CatalogMaterializedTable catalogMaterializedTable)
+            throws Exception {
+        RefreshHandlerSerializer<?> refreshHandlerSerializer =
+                workflowScheduler.getRefreshHandlerSerializer();
+        RefreshHandler refreshHandler =
+                refreshHandlerSerializer.deserialize(
+                        catalogMaterializedTable.getSerializedRefreshHandler(),
+                        userCodeClassLoader);
+        DeleteRefreshWorkflow deleteRefreshWorkflow = new DeleteRefreshWorkflow(refreshHandler);
+        workflowScheduler.deleteRefreshWorkflow(deleteRefreshWorkflow);
     }
 
     /**
@@ -1004,6 +1422,25 @@ public class MaterializedTableManager {
         }
     }
 
+    private byte[] serializeHandler(RefreshHandler refreshHandler) {
+        try {
+            if (refreshHandler instanceof ContinuousRefreshHandler) {
+                return serializeContinuousHandler((ContinuousRefreshHandler) refreshHandler);
+            } else {
+                if (workflowScheduler != null) {
+                    RefreshHandlerSerializer refreshHandlerSerializer =
+                            workflowScheduler.getRefreshHandlerSerializer();
+                    return refreshHandlerSerializer.serialize(refreshHandler);
+                } else {
+                    throw new SqlExecutionException(
+                            "WorkflowScheduler is null, can not serialize RefreshHandler.");
+                }
+            }
+        } catch (IOException e) {
+            throw new SqlExecutionException("Serialize RefreshHandler occur exception.", e);
+        }
+    }
+
     private ResolvedCatalogMaterializedTable getCatalogMaterializedTable(
             OperationExecutor operationExecutor, ObjectIdentifier tableIdentifier) {
         ResolvedCatalogBaseTable<?> resolvedCatalogBaseTable =
@@ -1024,8 +1461,11 @@ public class MaterializedTableManager {
             ObjectIdentifier materializedTableIdentifier,
             CatalogMaterializedTable catalogMaterializedTable,
             CatalogMaterializedTable.RefreshStatus refreshStatus,
-            String refreshHandlerSummary,
-            byte[] serializedRefreshHandler) {
+            RefreshHandler refreshHandler,
+            Optional<IntervalFreshness> freshness,
+            Optional<CatalogMaterializedTable.RefreshMode> refreshMode) {
+        String refreshHandlerSummary = refreshHandler.asSummaryString();
+        byte[] serializedRefreshHandler = serializeHandler(refreshHandler);
         CatalogMaterializedTable updatedMaterializedTable =
                 catalogMaterializedTable.copy(
                         refreshStatus, refreshHandlerSummary, serializedRefreshHandler);
@@ -1033,10 +1473,112 @@ public class MaterializedTableManager {
         tableChanges.add(TableChange.modifyRefreshStatus(refreshStatus));
         tableChanges.add(
                 TableChange.modifyRefreshHandler(refreshHandlerSummary, serializedRefreshHandler));
+
+        if (freshness.isPresent()) {
+            updatedMaterializedTable =
+                    updatedMaterializedTable.copy(
+                            freshness.get(),
+                            refreshMode.orElse(catalogMaterializedTable.getRefreshMode()));
+        }
+
         AlterMaterializedTableChangeOperation alterMaterializedTableChangeOperation =
                 new AlterMaterializedTableChangeOperation(
                         materializedTableIdentifier, tableChanges, updatedMaterializedTable);
         // update RefreshHandler to Catalog
+        operationExecutor.callExecutableOperation(
+                operationHandle, alterMaterializedTableChangeOperation);
+    }
+
+    private void updateFullModeRefreshHandler(
+            OperationExecutor operationExecutor,
+            OperationHandle operationHandle,
+            ObjectIdentifier materializedTableIdentifier,
+            CatalogMaterializedTable catalogMaterializedTable,
+            CatalogMaterializedTable.RefreshStatus refreshStatus,
+            RefreshHandler refreshHandler)
+            throws IOException {
+        String summaryString = refreshHandler.asSummaryString();
+        RefreshHandlerSerializer refreshHandlerSerializer =
+                workflowScheduler.getRefreshHandlerSerializer();
+        byte[] serializedRefreshHandler = refreshHandlerSerializer.serialize(refreshHandler);
+
+        updateMaterializedTable(
+                operationExecutor,
+                operationHandle,
+                materializedTableIdentifier,
+                catalogMaterializedTable,
+                Optional.of(summaryString),
+                Optional.of(serializedRefreshHandler),
+                Optional.of(refreshStatus),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private void updateContinuousModeRefreshHandler(
+            OperationExecutor operationExecutor,
+            OperationHandle operationHandle,
+            ObjectIdentifier materializedTableIdentifier,
+            CatalogMaterializedTable catalogMaterializedTable,
+            CatalogMaterializedTable.RefreshStatus refreshStatus,
+            ContinuousRefreshHandler continuousRefreshHandler)
+            throws IOException {
+
+        String summaryString = continuousRefreshHandler.asSummaryString();
+        byte[] serializedRefreshHandler = serializeContinuousHandler(continuousRefreshHandler);
+
+        updateMaterializedTable(
+                operationExecutor,
+                operationHandle,
+                materializedTableIdentifier,
+                catalogMaterializedTable,
+                Optional.of(summaryString),
+                Optional.of(serializedRefreshHandler),
+                Optional.of(refreshStatus),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    private void updateMaterializedTable(
+            OperationExecutor operationExecutor,
+            OperationHandle operationHandle,
+            ObjectIdentifier materializedTableIdentifier,
+            CatalogMaterializedTable catalogMaterializedTable,
+            Optional<String> refreshHandlerSummary,
+            Optional<byte[]> serializedRefreshHandler,
+            Optional<CatalogMaterializedTable.RefreshStatus> refreshStatus,
+            Optional<IntervalFreshness> freshness,
+            Optional<CatalogMaterializedTable.RefreshMode> refreshMode) {
+        CatalogMaterializedTable updatedMaterializedTable = catalogMaterializedTable;
+        List<TableChange> tableChanges = new ArrayList<>();
+        if (serializedRefreshHandler.isPresent() && refreshHandlerSummary.isPresent()) {
+            updatedMaterializedTable =
+                    updatedMaterializedTable.copy(
+                            refreshStatus.orElse(catalogMaterializedTable.getRefreshStatus()),
+                            refreshHandlerSummary.get(),
+                            serializedRefreshHandler.get());
+            tableChanges.add(
+                    TableChange.modifyRefreshHandler(
+                            refreshHandlerSummary.get(), serializedRefreshHandler.get()));
+            refreshStatus.ifPresent(
+                    status -> tableChanges.add(TableChange.modifyRefreshStatus(status)));
+        }
+        if (freshness.isPresent()) {
+            updatedMaterializedTable =
+                    updatedMaterializedTable.copy(
+                            freshness.get(), catalogMaterializedTable.getRefreshMode());
+            tableChanges.add(TableChange.modifyFreshnessHandler(freshness.get()));
+        }
+        if (refreshMode.isPresent()) {
+            updatedMaterializedTable =
+                    updatedMaterializedTable.copy(
+                            catalogMaterializedTable.getDefinitionFreshness(), refreshMode.get());
+            tableChanges.add(TableChange.modifyRefreshMode(refreshMode.get()));
+        }
+
+        // update materialized table change to catalog.
+        AlterMaterializedTableChangeOperation alterMaterializedTableChangeOperation =
+                new AlterMaterializedTableChangeOperation(
+                        materializedTableIdentifier, tableChanges, updatedMaterializedTable);
         operationExecutor.callExecutableOperation(
                 operationHandle, alterMaterializedTableChangeOperation);
     }

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractMaterializedTableStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractMaterializedTableStatementITCase.java
@@ -209,6 +209,24 @@ public abstract class AbstractMaterializedTableStatementITCase {
                         + "  'rows-per-second' = '10'\n"
                         + ")";
         service.configureSession(sessionHandle, dataGenSource, -1);
+
+        String filesystemSource =
+                "CREATE TABLE filesystemSource (\n"
+                        + "  order_id BIGINT,\n"
+                        + "  order_number VARCHAR(20),\n"
+                        + "  user_id BIGINT,\n"
+                        + "  shop_id BIGINT,\n"
+                        + "  product_id BIGINT,\n"
+                        + "  status BIGINT,\n"
+                        + "  order_type BIGINT,\n"
+                        + "  order_created_at TIMESTAMP,\n"
+                        + "  payment_amount_cents BIGINT\n"
+                        + ") with (\n"
+                        + "  'format' = 'json',\n"
+                        + "  'source.monitor-interval' = '10s'"
+                        + ")";
+        service.configureSession(sessionHandle, filesystemSource, -1);
+
         return sessionHandle;
     }
 

--- a/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
+++ b/flink-table/flink-sql-gateway/src/test/resources/sql_gateway_rest_api_v3.snapshot
@@ -516,6 +516,36 @@
       "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
     }
   }, {
+    "url" : "/workflow/embedded-scheduler/modify-cron-expression",
+    "method" : "DELETE",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:table:gateway:rest:message:materializedtable:scheduler:ModifyEmbeddedSchedulerWorkflowCronExpressionRequestBody",
+      "properties" : {
+        "workflowName" : {
+          "type" : "string"
+        },
+        "workflowGroup" : {
+          "type" : "string"
+        },
+        "cronExpression" : {
+          "type" : "string"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EmptyResponseBody"
+    }
+  }, {
     "url" : "/workflow/embedded-scheduler/resume",
     "method" : "POST",
     "status-code" : "200 OK",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableFreshnessOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableFreshnessOperation.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.IntervalFreshness;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+/**
+ * Operation to describe clause like: ALTER MATERIALIZED TABLE [catalog_name.][db_name.]table_name
+ * SET FRESHNESS = INTERVAL '1' DAY.
+ */
+@Internal
+public class AlterMaterializedTableFreshnessOperation extends AlterMaterializedTableOperation {
+
+    private final IntervalFreshness freshness;
+
+    public AlterMaterializedTableFreshnessOperation(
+            ObjectIdentifier tableIdentifier, IntervalFreshness freshness) {
+        super(tableIdentifier);
+
+        this.freshness = freshness;
+    }
+
+    public IntervalFreshness getDefinitionFreshness() {
+        return freshness;
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        // execute AlterMaterializedTableRefreshOperation in SqlGateway OperationExecutor.
+        // see more at MaterializedTableManager#callAlterMaterializedTableRefreshOperation
+        throw new UnsupportedOperationException(
+                "AlterMaterializedTableFreshnessOperation does not support ExecutableOperation yet.");
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format(
+                "ALTER MATERIALIZED TABLE %s SET FRESHNESS = %s",
+                tableIdentifier.asSummaryString(), freshness.toString());
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogMaterializedTable.java
@@ -97,6 +97,13 @@ public interface CatalogMaterializedTable extends CatalogBaseTable {
             String refreshHandlerDescription,
             byte[] serializedRefreshHandler);
 
+    /**
+     * Returns a copy of this {@code CatalogMaterializedTable} with given interval freshness.
+     *
+     * @return a new copy of this table with replaced interval freshness
+     */
+    CatalogMaterializedTable copy(IntervalFreshness intervalFreshness, RefreshMode refreshMode);
+
     /** Return the snapshot specified for the table. Return Optional.empty() if not specified. */
     Optional<Long> getSnapshot();
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DefaultCatalogMaterializedTable.java
@@ -164,6 +164,23 @@ public class DefaultCatalogMaterializedTable implements CatalogMaterializedTable
     }
 
     @Override
+    public CatalogMaterializedTable copy(IntervalFreshness freshness, RefreshMode refreshMode) {
+        return new DefaultCatalogMaterializedTable(
+                schema,
+                comment,
+                partitionKeys,
+                options,
+                snapshot,
+                definitionQuery,
+                freshness,
+                logicalRefreshMode,
+                refreshMode,
+                refreshStatus,
+                refreshHandlerDescription,
+                serializedRefreshHandler);
+    }
+
+    @Override
     public Optional<String> getDescription() {
         return Optional.of(getComment());
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogMaterializedTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedCatalogMaterializedTable.java
@@ -84,6 +84,13 @@ public class ResolvedCatalogMaterializedTable
     }
 
     @Override
+    public ResolvedCatalogMaterializedTable copy(
+            IntervalFreshness intervalFreshness, RefreshMode refreshMode) {
+        return new ResolvedCatalogMaterializedTable(
+                origin.copy(intervalFreshness, refreshMode), resolvedSchema);
+    }
+
+    @Override
     public Optional<String> getDescription() {
         return origin.getDescription();
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/TableChange.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/TableChange.java
@@ -380,6 +380,26 @@ public interface TableChange {
         return new ModifyRefreshHandler(refreshHandlerDesc, refreshHandlerBytes);
     }
 
+    /**
+     * A table change to modify materialized table freshness.
+     *
+     * @param freshness the modified freshness.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyFreshness modifyFreshnessHandler(IntervalFreshness freshness) {
+        return new ModifyFreshness(freshness);
+    }
+
+    /**
+     * A table change to modify materialized table refresh mode.
+     *
+     * @param refreshMode the modified refresh mode.
+     * @return a TableChange represents the modification.
+     */
+    static ModifyRefreshMode modifyRefreshMode(CatalogMaterializedTable.RefreshMode refreshMode) {
+        return new ModifyRefreshMode(refreshMode);
+    }
+
     // --------------------------------------------------------------------------------------------
     // Add Change
     // --------------------------------------------------------------------------------------------
@@ -1372,6 +1392,68 @@ public interface TableChange {
                     + ", refreshHandlerBytes="
                     + Arrays.toString(refreshHandlerBytes)
                     + '}';
+        }
+    }
+
+    /** A table change to modify materialized table freshness. */
+    @PublicEvolving
+    class ModifyFreshness implements MaterializedTableChange {
+
+        private final IntervalFreshness freshness;
+
+        public ModifyFreshness(IntervalFreshness freshness) {
+            this.freshness = freshness;
+        }
+
+        public IntervalFreshness getFreshness() {
+            return freshness;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ModifyFreshness that = (ModifyFreshness) o;
+            return Objects.equals(freshness, that.freshness);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(freshness);
+        }
+    }
+
+    /** A table change to modify materialized table refresh mode. */
+    class ModifyRefreshMode implements MaterializedTableChange {
+        private final CatalogMaterializedTable.RefreshMode refreshMode;
+
+        public ModifyRefreshMode(CatalogMaterializedTable.RefreshMode refreshMode) {
+            this.refreshMode = refreshMode;
+        }
+
+        public CatalogMaterializedTable.RefreshMode getRefreshMode() {
+            return refreshMode;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ModifyRefreshMode that = (ModifyRefreshMode) o;
+            return Objects.equals(refreshMode, that.refreshMode);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(refreshMode);
         }
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/RefreshModeUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/RefreshModeUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+
+import java.time.Duration;
+
+public class RefreshModeUtils {
+
+    public static CatalogMaterializedTable.RefreshMode deriveRefreshMode(
+            Duration threshold,
+            Duration definedFreshness,
+            CatalogMaterializedTable.LogicalRefreshMode definedRefreshMode) {
+        // If the refresh mode is specified manually, use it directly.
+        if (definedRefreshMode == CatalogMaterializedTable.LogicalRefreshMode.FULL) {
+            return CatalogMaterializedTable.RefreshMode.FULL;
+        } else if (definedRefreshMode == CatalogMaterializedTable.LogicalRefreshMode.CONTINUOUS) {
+            return CatalogMaterializedTable.RefreshMode.CONTINUOUS;
+        }
+
+        // derive the actual refresh mode via defined freshness
+        if (definedFreshness.compareTo(threshold) < 0) {
+            return CatalogMaterializedTable.RefreshMode.CONTINUOUS;
+        } else {
+            return CatalogMaterializedTable.RefreshMode.FULL;
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/ModifyRefreshWorkflowCronExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/workflow/ModifyRefreshWorkflowCronExpression.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.workflow;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.refresh.RefreshHandler;
+
+/**
+ * {@link ModifyRefreshWorkflowCronExpression} is used to modify the cron expression for the refresh
+ * workflow of {@link CatalogMaterializedTable}.
+ *
+ * @param <T> The type of {@link RefreshHandler} used by specific {@link WorkflowScheduler} to
+ *     locate the refresh workflow in scheduler service.
+ */
+@PublicEvolving
+public class ModifyRefreshWorkflowCronExpression<T extends RefreshHandler>
+        implements ModifyRefreshWorkflow<T> {
+
+    private final T refreshHandler;
+    private final String cronExpression;
+
+    public ModifyRefreshWorkflowCronExpression(T refreshHandler, String cronExpression) {
+        this.refreshHandler = refreshHandler;
+        this.cronExpression = cronExpression;
+    }
+
+    @Override
+    public T getRefreshHandler() {
+        return refreshHandler;
+    }
+
+    public String getCronExpression() {
+        return cronExpression;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableFreshnessConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableFreshnessConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableFreshness;
+import org.apache.flink.table.catalog.IntervalFreshness;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableFreshnessOperation;
+import org.apache.flink.table.planner.utils.MaterializedTableUtils;
+
+/** A converter for {@link SqlAlterMaterializedTableFreshness}. */
+public class SqlAlterMaterializedTableFreshnessConverter
+        implements SqlNodeConverter<SqlAlterMaterializedTableFreshness> {
+    @Override
+    public Operation convertSqlNode(
+            SqlAlterMaterializedTableFreshness node, ConvertContext context) {
+        UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(node.fullTableName());
+        ObjectIdentifier identifier =
+                context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+
+        // get freshness
+        IntervalFreshness intervalFreshness =
+                MaterializedTableUtils.getMaterializedTableFreshness(node.getFreshness());
+        return new AlterMaterializedTableFreshnessOperation(identifier, intervalFreshness);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateMaterializedTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlCreateMaterializedTableConverter.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.planner.utils.MaterializedTableUtils;
 import org.apache.flink.table.planner.utils.OperationConverterUtils;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.utils.RefreshModeUtils;
 
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
@@ -103,7 +104,7 @@ public class SqlCreateMaterializedTableConverter
         // only MATERIALIZED_TABLE_FRESHNESS_THRESHOLD configured in flink conf yaml work, so we get
         // it from rootConfiguration instead of table config
         CatalogMaterializedTable.RefreshMode refreshMode =
-                MaterializedTableUtils.deriveRefreshMode(
+                RefreshModeUtils.deriveRefreshMode(
                         context.getTableConfig()
                                 .getRootConfiguration()
                                 .get(MATERIALIZED_TABLE_FRESHNESS_THRESHOLD),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -64,6 +64,7 @@ public class SqlNodeConverters {
         register(new SqlAlterMaterializedTableSuspendConverter());
         register(new SqlAlterMaterializedTableResumeConverter());
         register(new SqlDropMaterializedTableConverter());
+        register(new SqlAlterMaterializedTableFreshnessConverter());
         register(new SqlShowTablesConverter());
         register(new SqlShowViewsConverter());
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/MaterializedTableUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/MaterializedTableUtils.java
@@ -27,8 +27,6 @@ import org.apache.flink.table.catalog.IntervalFreshness;
 import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 
-import java.time.Duration;
-
 /** The utils for materialized table. */
 @Internal
 public class MaterializedTableUtils {
@@ -76,25 +74,6 @@ public class MaterializedTableUtils {
             default:
                 throw new ValidationException(
                         String.format("Unsupported logical refresh mode: %s.", sqlRefreshMode));
-        }
-    }
-
-    public static CatalogMaterializedTable.RefreshMode deriveRefreshMode(
-            Duration threshold,
-            Duration definedFreshness,
-            CatalogMaterializedTable.LogicalRefreshMode definedRefreshMode) {
-        // If the refresh mode is specified manually, use it directly.
-        if (definedRefreshMode == CatalogMaterializedTable.LogicalRefreshMode.FULL) {
-            return CatalogMaterializedTable.RefreshMode.FULL;
-        } else if (definedRefreshMode == CatalogMaterializedTable.LogicalRefreshMode.CONTINUOUS) {
-            return CatalogMaterializedTable.RefreshMode.CONTINUOUS;
-        }
-
-        // derive the actual refresh mode via defined freshness
-        if (definedFreshness.compareTo(threshold) < 0) {
-            return CatalogMaterializedTable.RefreshMode.CONTINUOUS;
-        } else {
-            return CatalogMaterializedTable.RefreshMode.FULL;
         }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlMaterializedTableNodeToOperationConverterTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableFreshnessOperation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableRefreshOperation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableResumeOperation;
 import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableSuspendOperation;
@@ -409,5 +410,21 @@ public class SqlMaterializedTableNodeToOperationConverterTest
         assertThat(operation2.asSummaryString())
                 .isEqualTo(
                         "DROP MATERIALIZED TABLE: (identifier: [`builtin`.`default`.`mtbl1`], IfExists: [true])");
+    }
+
+    @Test
+    void testAlterMaterializedTableFreshness() {
+        final String sql = "ALTER MATERIALIZED TABLE mtbl1 SET FRESHNESS = INTERVAL '1' MINUTES";
+        Operation operation = parse(sql);
+        assertThat(operation).isInstanceOf(AlterMaterializedTableFreshnessOperation.class);
+        assertThat(
+                        ((AlterMaterializedTableFreshnessOperation) operation)
+                                .getDefinitionFreshness()
+                                .toString())
+                .isEqualTo("INTERVAL '1' MINUTE");
+
+        assertThat(operation.asSummaryString())
+                .isEqualTo(
+                        "ALTER MATERIALIZED TABLE builtin.default.mtbl1 SET FRESHNESS = INTERVAL '1' MINUTE");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*Support the execution of alter materialized table set freshness*


## Brief change log

  - *Support convert SqlAlterMaterializedTableFreshness node to operation*
  - *Introduce ModifyRefreshWorkflowCronExpression and Support Modify CronExpression for EmbeddedScheduler*
  - *Support the execution of alter materialized table set freshness*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added ITCase in MaterializedTableStatementITCase to verify the change*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Will be added in a separated pr)
