### PR TITLE
[FLINK-36260][metrics] Fix numBytesInLocal and numBuffersInLocal being reported as remote

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -196,8 +196,8 @@ class UnknownInputChannel extends InputChannel implements ChannelStateHolder {
                 taskEventPublisher,
                 initialBackoff,
                 maxBackoff,
-                metrics.getNumBytesInRemoteCounter(),
-                metrics.getNumBuffersInRemoteCounter(),
+                metrics.getNumBytesInLocalCounter(),
+                metrics.getNumBuffersInLocalCounter(),
                 channelStateWriter == null ? ChannelStateWriter.NO_OP : channelStateWriter);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannelTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link UnknownInputChannel}. */
+class UnknownInputChannelTest {
+    @Test
+    void testMetrics() {
+        SingleInputGateBuilder builder =
+                new SingleInputGateBuilder()
+                        .setNumberOfChannels(1)
+                        .setSingleInputGateIndex(0)
+                        .setResultPartitionType(ResultPartitionType.PIPELINED);
+
+        InputChannelMetrics metrics = new InputChannelMetrics(new UnregisteredMetricsGroup());
+        UnknownInputChannel unknownInputChannel =
+                InputChannelBuilder.newBuilder()
+                        .setMetrics(metrics)
+                        .buildUnknownChannel(builder.build());
+        metrics.getNumBuffersInLocalCounter().inc();
+        LocalInputChannel localInputChannel =
+                unknownInputChannel.toLocalInputChannel(new ResultPartitionID());
+        assertThat(localInputChannel.numBuffersIn.getCount())
+                .isEqualTo(metrics.getNumBuffersInLocalCounter().getCount());
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-36260][metrics] Fix numBytesInLocal and numBuffersInLocal being reported as remote

## Verifying this change

I've tried to find a way how to implement a test, but couldn't find an easy way.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? **(not applicable** / docs / JavaDocs / not documented)
