### PR TITLE
[FLINK-36415][table] ProjectWatermarkAssignerTransposeRule can generate extra casts which do not make sense

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkRexBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkRexBuilder.java
@@ -28,6 +28,8 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.runtime.FlatLists;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.tools.RelBuilder;
@@ -56,8 +58,15 @@ public final class FlinkRexBuilder extends RexBuilder {
     public RexNode makeFieldAccess(RexNode expr, String fieldName, boolean caseSensitive) {
         RexNode field = super.makeFieldAccess(expr, fieldName, caseSensitive);
         if (expr.getType().isNullable() && !field.getType().isNullable()) {
-            return makeCast(
-                    typeFactory.createTypeWithNullability(field.getType(), true), field, true);
+            SqlOperator sqlOperator = ((RexCall) expr).getOperator();
+            if (sqlOperator.getKind() == SqlKind.CAST) {
+                //       return field;
+            }
+            field =
+                    makeCast(
+                            typeFactory.createTypeWithNullability(field.getType(), true),
+                            field,
+                            true);
         }
 
         return field;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkRexBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkRexBuilder.java
@@ -28,8 +28,6 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.runtime.FlatLists;
-import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.tools.RelBuilder;
@@ -58,15 +56,8 @@ public final class FlinkRexBuilder extends RexBuilder {
     public RexNode makeFieldAccess(RexNode expr, String fieldName, boolean caseSensitive) {
         RexNode field = super.makeFieldAccess(expr, fieldName, caseSensitive);
         if (expr.getType().isNullable() && !field.getType().isNullable()) {
-            SqlOperator sqlOperator = ((RexCall) expr).getOperator();
-            if (sqlOperator.getKind() == SqlKind.CAST) {
-                //       return field;
-            }
-            field =
-                    makeCast(
-                            typeFactory.createTypeWithNullability(field.getType(), true),
-                            field,
-                            true);
+            return makeCast(
+                    typeFactory.createTypeWithNullability(field.getType(), true), field, true);
         }
 
         return field;

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/NestedProjectionUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/NestedProjectionUtil.scala
@@ -256,6 +256,7 @@ private class NestedSchemaRewriter(schema: NestedSchema, builder: RexBuilder) ex
     }
   }
 
+  // Extra CASTs should be avoided since only need to copy FieldAccess
   private def copyFieldAccess(
       newExpr: RexNode,
       fieldName: String,

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
@@ -175,6 +175,10 @@ class PushProjectIntoTableSourceScanRuleTest extends TableTestBase {
                         + "    `data_map` MAP<STRING, ROW<`value` BIGINT>>>,\n"
                         + "  `outer_array` ARRAY<INT>,\n"
                         + "  `outer_map` MAP<STRING, STRING>,\n"
+                        + "  `chart` ROW<"
+                        + "    `result` ARRAY<ROW<`meta` ROW<"
+                        + "                         `symbol` STRING NOT NULL> NOT NULL> NOT NULL>"
+                        + "     NOT NULL>,\n"
                         + "   WATERMARK FOR `Timestamp` AS `Timestamp`\n"
                         + ") WITH (\n"
                         + " 'connector' = 'values',\n"
@@ -295,6 +299,11 @@ class PushProjectIntoTableSourceScanRuleTest extends TableTestBase {
                         + "`Result`.`Mid`.data_arr[2].`value`, "
                         + "`Result`.`Mid`.data_arr "
                         + "FROM NestedItemTable");
+    }
+
+    @Test
+    void testNestedProjectFieldAccessWithNestedArrayAndRows() {
+        util.verifyRelPlan("SELECT `chart`.`result`[1].`meta`.`symbol` FROM ItemTable");
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
@@ -186,6 +186,23 @@ LogicalProject(EXPR$0=[ITEM($0, $2).value], EXPR$1=[ITEM($1, _UTF-16LE'item').va
 ]]>
     </Resource>
   </TestCase>
+	<TestCase name="testNestedProjectFieldAccessWithNestedArrayAndRows">
+		<Resource name="sql">
+			<![CDATA[SELECT `chart`.`result`[1].`meta`.`symbol` FROM ItemTable]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(EXPR$0=[CAST(CAST(ITEM($5.result, 1).meta):RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL symbol).symbol):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
++- LogicalTableScan(table=[[default_catalog, default_database, ItemTable]])
+]]>
+		</Resource>
+		<Resource name="optimized rel plan">
+			<![CDATA[
+LogicalProject(EXPR$0=[CAST(CAST(ITEM($0.result, 1).meta):RecordType:peek_no_expand(VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL symbol).symbol):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
++- LogicalTableScan(table=[[default_catalog, default_database, ItemTable, project=[chart], metadata=[]]])
+]]>
+		</Resource>
+	</TestCase>
   <TestCase name="testNestedProjectFieldAccessWithITEMContainsTopLevelAccess">
     <Resource name="sql">
       <![CDATA[SELECT `Result`.`Mid`.data_arr[2].`value`, `Result`.`Mid`.data_arr[ID].`value`, `Result`.`Mid`.data_map['item'].`value`, `Result`.`Mid` FROM NestedItemTable]]>


### PR DESCRIPTION
## What is the purpose of the change

Do not generate not required casts while `ProjectWatermarkAssignerTransposeRule`


## Brief change log

Introduce `NestedSchemaRewriter#copyFieldAccess` which should copy existing field accesses


## Verifying this change

There is a test in `PushProjectIntoTableSourceScanRuleTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
