### PR TITLE
[FLINK-36416][table][runtime] Enable splittable timers for temporal join, temporal sort and windowed aggregation in SQL/Table API

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/BaseTwoInputStreamOperatorWithStateRetention.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/BaseTwoInputStreamOperatorWithStateRetention.java
@@ -81,6 +81,11 @@ public abstract class BaseTwoInputStreamOperatorWithStateRetention
     }
 
     @Override
+    public boolean useSplittableTimers() {
+        return true;
+    }
+
+    @Override
     public void open() throws Exception {
         initializeTimerService();
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/BaseTemporalSortOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/BaseTemporalSortOperator.java
@@ -39,6 +39,11 @@ abstract class BaseTemporalSortOperator extends AbstractStreamOperator<RowData>
     BaseTemporalSortOperator() {}
 
     @Override
+    public boolean useSplittableTimers() {
+        return true;
+    }
+
+    @Override
     public void open() throws Exception {
         InternalTimerService<VoidNamespace> internalTimerService =
                 getInternalTimerService("user-timers", VoidNamespaceSerializer.INSTANCE, this);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/groupwindow/operator/WindowOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/groupwindow/operator/WindowOperator.java
@@ -208,6 +208,11 @@ public abstract class WindowOperator<K, W extends Window> extends AbstractStream
         this.recordCounter = RecordCounter.of(inputCountIndex);
     }
 
+    @Override
+    public boolean useSplittableTimers() {
+        return true;
+    }
+
     WindowOperator(
             GroupWindowAssigner<W> windowAssigner,
             Trigger<W> trigger,


### PR DESCRIPTION
## What is the purpose of the change

This is a follow up for https://cwiki.apache.org/confluence/display/FLINK/FLIP-443%3A+Interruptible+timers+firing . Temporal join, temporal sort and both windowed and table windowed aggregations in Table API/SQL can have large amount of registered/fired time, while at the same time enabling splittable timers shouldn't cause any side effects for those operators.


## Brief change log

N/A

## Verifying this change

N/A


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
