### PR TITLE
[FLINK-36417][table] Add support for hints in WatermarkAssigner

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkRelBuilder.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkRelBuilder.java
@@ -253,7 +253,8 @@ public final class FlinkRelBuilder extends RelBuilder {
     public RelBuilder watermark(int rowtimeFieldIndex, RexNode watermarkExpr) {
         final RelNode input = build();
         final RelNode relNode =
-                LogicalWatermarkAssigner.create(cluster, input, rowtimeFieldIndex, watermarkExpr);
+                LogicalWatermarkAssigner.create(
+                        cluster, input, Collections.emptyList(), rowtimeFieldIndex, watermarkExpr);
         return push(relNode);
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHints.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/hint/FlinkHints.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.hint;
 
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.planner.plan.nodes.calcite.WatermarkAssigner;
 import org.apache.flink.table.planner.plan.rules.logical.WrapJsonAggFunctionArgumentsRule;
 import org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase;
 
@@ -119,7 +120,8 @@ public abstract class FlinkHints {
     public static boolean canTransposeToTableScan(RelNode node) {
         return node instanceof LogicalProject // computed column on table
                 || node instanceof LogicalFilter
-                || node instanceof LogicalSnapshot;
+                || node instanceof LogicalSnapshot
+                || node instanceof WatermarkAssigner;
     }
 
     /** Returns the qualified name of a table scan, otherwise returns empty. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/EventTimeTemporalJoinRewriteRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/EventTimeTemporalJoinRewriteRule.java
@@ -41,6 +41,8 @@ import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
 import org.immutables.value.Value;
 
+import java.util.Collections;
+
 /**
  * Traverses an event time temporal table join {@link RelNode} tree and update the right child to
  * set {@link FlinkLogicalTableSourceScan}'s eventTimeSnapshot property to true which will prevent
@@ -140,7 +142,11 @@ public class EventTimeTemporalJoinRewriteRule
             final RelNode newChild = transmitSnapshotRequirement(child);
             if (newChild != child) {
                 return wma.copy(
-                        wma.getTraitSet(), newChild, wma.rowtimeFieldIndex(), wma.watermarkExpr());
+                        wma.getTraitSet(),
+                        newChild,
+                        Collections.emptyList(),
+                        wma.rowtimeFieldIndex(),
+                        wma.watermarkExpr());
             }
             return wma;
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/EventTimeTemporalJoinRewriteRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/EventTimeTemporalJoinRewriteRule.java
@@ -41,8 +41,6 @@ import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
 import org.immutables.value.Value;
 
-import java.util.Collections;
-
 /**
  * Traverses an event time temporal table join {@link RelNode} tree and update the right child to
  * set {@link FlinkLogicalTableSourceScan}'s eventTimeSnapshot property to true which will prevent
@@ -144,7 +142,7 @@ public class EventTimeTemporalJoinRewriteRule
                 return wma.copy(
                         wma.getTraitSet(),
                         newChild,
-                        Collections.emptyList(),
+                        wma.getHints(),
                         wma.rowtimeFieldIndex(),
                         wma.watermarkExpr());
             }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRule.java
@@ -288,6 +288,7 @@ public class WatermarkAssignerChangelogNormalizeTransposeRule
                 watermark.copy(
                         watermark.getTraitSet().plus(FlinkRelDistribution.DEFAULT()),
                         exchange.getInput(),
+                        Collections.emptyList(),
                         newRowTimeFieldIndex,
                         newWatermarkExpr);
         final RelNode newChangelogNormalize =

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/LogicalWatermarkAssigner.scala
@@ -19,7 +19,10 @@ package org.apache.flink.table.planner.plan.nodes.calcite
 
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rex.RexNode
+
+import java.util
 
 /**
  * Sub-class of [[WatermarkAssigner]] that is a relational operator which generates
@@ -30,16 +33,22 @@ final class LogicalWatermarkAssigner(
     cluster: RelOptCluster,
     traits: RelTraitSet,
     input: RelNode,
+    hints: util.List[RelHint],
     rowtimeFieldIndex: Int,
     watermarkExpr: RexNode)
-  extends WatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkExpr) {
+  extends WatermarkAssigner(cluster, traits, input, hints, rowtimeFieldIndex, watermarkExpr) {
 
   override def copy(
       traitSet: RelTraitSet,
       input: RelNode,
+      hints: util.List[RelHint],
       rowtime: Int,
       watermark: RexNode): RelNode = {
-    new LogicalWatermarkAssigner(cluster, traitSet, input, rowtime, watermark)
+    new LogicalWatermarkAssigner(cluster, traitSet, input, hints, rowtime, watermark)
+  }
+
+  override def withHints(hintList: util.List[RelHint]): RelNode = {
+    new LogicalWatermarkAssigner(cluster, traits, input, hintList, rowtimeFieldIndex, watermarkExpr)
   }
 }
 
@@ -48,9 +57,10 @@ object LogicalWatermarkAssigner {
   def create(
       cluster: RelOptCluster,
       input: RelNode,
+      hints: util.List[RelHint],
       rowtimeFieldIndex: Int,
       watermarkExpr: RexNode): LogicalWatermarkAssigner = {
     val traits = cluster.traitSetOf(Convention.NONE)
-    new LogicalWatermarkAssigner(cluster, traits, input, rowtimeFieldIndex, watermarkExpr)
+    new LogicalWatermarkAssigner(cluster, traits, input, hints, rowtimeFieldIndex, watermarkExpr)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
@@ -26,7 +26,10 @@ import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelNode, RelWriter}
+import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rex.RexNode
+
+import java.util
 
 import scala.collection.JavaConversions._
 
@@ -35,9 +38,10 @@ class StreamPhysicalWatermarkAssigner(
     cluster: RelOptCluster,
     traits: RelTraitSet,
     inputRel: RelNode,
+    hints: util.List[RelHint],
     rowtimeFieldIndex: Int,
     watermarkExpr: RexNode)
-  extends WatermarkAssigner(cluster, traits, inputRel, rowtimeFieldIndex, watermarkExpr)
+  extends WatermarkAssigner(cluster, traits, inputRel, hints, rowtimeFieldIndex, watermarkExpr)
   with StreamPhysicalRel {
 
   override def requireWatermark: Boolean = false
@@ -45,9 +49,10 @@ class StreamPhysicalWatermarkAssigner(
   override def copy(
       traitSet: RelTraitSet,
       input: RelNode,
+      hints: util.List[RelHint],
       rowtime: Int,
       watermark: RexNode): RelNode = {
-    new StreamPhysicalWatermarkAssigner(cluster, traitSet, input, rowtime, watermark)
+    new StreamPhysicalWatermarkAssigner(cluster, traitSet, input, hints, rowtime, watermark)
   }
 
   /** Fully override this method to have a better display name of this RelNode. */
@@ -74,5 +79,16 @@ class StreamPhysicalWatermarkAssigner(
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),
       getRelDetailedDescription)
+  }
+
+  override def withHints(hintList: util.List[RelHint]): RelNode = {
+
+    new StreamPhysicalWatermarkAssigner(
+      cluster,
+      traitSet,
+      input,
+      hints,
+      rowtimeFieldIndex,
+      watermarkExpr)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWatermarkAssigner.scala
@@ -82,7 +82,6 @@ class StreamPhysicalWatermarkAssigner(
   }
 
   override def withHints(hintList: util.List[RelHint]): RelNode = {
-
     new StreamPhysicalWatermarkAssigner(
       cluster,
       traitSet,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalWatermarkAssignerRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalWatermarkAssignerRule.scala
@@ -26,6 +26,8 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rel.convert.ConverterRule.Config
 
+import java.util.Collections
+
 /** Rule that converts [[FlinkLogicalWatermarkAssigner]] to [[StreamPhysicalWatermarkAssigner]]. */
 class StreamPhysicalWatermarkAssignerRule(config: Config) extends ConverterRule(config) {
 
@@ -39,6 +41,7 @@ class StreamPhysicalWatermarkAssignerRule(config: Config) extends ConverterRule(
       watermarkAssigner.getCluster,
       traitSet,
       convertInput,
+      Collections.emptyList(),
       watermarkAssigner.rowtimeFieldIndex,
       watermarkAssigner.watermarkExpr
     )

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/ProjectWatermarkAssignerTransposeRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/ProjectWatermarkAssignerTransposeRuleTest.java
@@ -159,12 +159,4 @@ class ProjectWatermarkAssignerTransposeRuleTest extends TableTestBase {
     void transposeWithWatermarkWithMultipleInput() {
         util.verifyRelPlan("SELECT a FROM UdfTable");
     }
-
-    @Test
-    void transposeWithHints() {
-        util.verifyRelPlan(
-                "SELECT /*+ STATE_TTL('st'='1d', 'vt' = '3d') */ st.* FROM SimpleTable st "
-                        + "LEFT JOIN(SELECT DISTINCT b FROM VirtualTable) vt "
-                        + "ON st.b = vt.b WHERE vt.b IS NOT NULL");
-    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/ProjectWatermarkAssignerTransposeRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/ProjectWatermarkAssignerTransposeRuleTest.java
@@ -159,4 +159,12 @@ class ProjectWatermarkAssignerTransposeRuleTest extends TableTestBase {
     void transposeWithWatermarkWithMultipleInput() {
         util.verifyRelPlan("SELECT a FROM UdfTable");
     }
+
+    @Test
+    void transposeWithHints() {
+        util.verifyRelPlan(
+                "SELECT /*+ STATE_TTL('st'='1d', 'vt' = '3d') */ st.* FROM SimpleTable st "
+                        + "LEFT JOIN(SELECT DISTINCT b FROM VirtualTable) vt "
+                        + "ON st.b = vt.b WHERE vt.b IS NOT NULL");
+    }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/stream/StateTtlHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/stream/StateTtlHintTest.xml
@@ -494,4 +494,82 @@ GroupAggregate(groupBy=[b1], select=[b1, SUM(a1) AS EXPR$1])
 ]]>
     </Resource>
   </TestCase>
+	<TestCase name="testWatermarkAssigner">
+		<Resource name="sql">
+			<![CDATA[
+SELECT /*+ STATE_TTL('tableWithWatermark1'='1d', 'tww2' = '3d') */ tableWithWatermark1.* FROM tableWithWatermark1
+LEFT JOIN(SELECT DISTINCT b FROM tableWithWatermark2) tww2
+ON tableWithWatermark1.b = tww2.b WHERE tww2.b IS NOT NULL]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[IS NOT NULL($3)])
+   +- LogicalJoin(condition=[=($1, $3)], joinType=[left], stateTtlHints=[[[STATE_TTL inheritPath:[0, 0] options:{tww2=3d, tableWithWatermark1=1d}]]])
+      :- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2], hints=[[[ALIAS options:[tableWithWatermark1]]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, tableWithWatermark1]])
+      +- LogicalAggregate(group=[{0}], hints=[[[ALIAS options:[tww2]]]])
+         +- LogicalProject(b=[$1])
+            +- LogicalWatermarkAssigner(rowtime=[d], watermark=[-($3, 5000:INTERVAL SECOND)], hints=[[[ALIAS options:[tableWithWatermark2]]]])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[+($2.c1, 5000:INTERVAL SECOND)])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, tableWithWatermark2]])
+]]>
+		</Resource>
+		<Resource name="optimized rel plan">
+			<![CDATA[
+Calc(select=[a, b, c])
++- Join(joinType=[InnerJoin], where=[=(b, b0)], select=[a, b, c, b0], leftInputSpec=[NoUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], stateTtlHints=[[[STATE_TTL options:{LEFT=1d, RIGHT=3d}]]])
+   :- Exchange(distribution=[hash[b]])
+   :  +- Calc(select=[a, b, CAST(c AS TIMESTAMP(3)) AS c], where=[IS NOT NULL(b)])
+   :     +- WatermarkAssigner(rowtime=[c], watermark=[c])
+   :        +- TableSourceScan(table=[[default_catalog, default_database, tableWithWatermark1]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[b]])
+      +- GroupAggregate(groupBy=[b], select=[b])
+         +- Exchange(distribution=[hash[b]])
+            +- Calc(select=[b], where=[IS NOT NULL(b)])
+               +- WatermarkAssigner(rowtime=[d], watermark=[-(d, 5000:INTERVAL SECOND)])
+                  +- Calc(select=[b, +(c.c1, 5000:INTERVAL SECOND) AS d])
+                     +- TableSourceScan(table=[[default_catalog, default_database, tableWithWatermark2, project=[b, c], metadata=[]]], fields=[b, c])
+]]>
+		</Resource>
+	</TestCase>
+  <TestCase name="testWatermarkAssignerWithAliases">
+		<Resource name="sql">
+			<![CDATA[
+SELECT /*+ STATE_TTL('tww1'='1d', 'tww2' = '3d') */ tww1.* FROM tableWithWatermark1 tww1
+LEFT JOIN(SELECT DISTINCT b FROM tableWithWatermark2) tww2
+ON tww1.b = tww2.b WHERE tww2.b IS NOT NULL]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[IS NOT NULL($3)])
+   +- LogicalJoin(condition=[=($1, $3)], joinType=[left], stateTtlHints=[[[STATE_TTL inheritPath:[0, 0] options:{tww2=3d, tww1=1d}]]])
+      :- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2], hints=[[[ALIAS options:[tww1]]]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, tableWithWatermark1]])
+      +- LogicalAggregate(group=[{0}], hints=[[[ALIAS options:[tww2]]]])
+         +- LogicalProject(b=[$1])
+            +- LogicalWatermarkAssigner(rowtime=[d], watermark=[-($3, 5000:INTERVAL SECOND)], hints=[[[ALIAS options:[tableWithWatermark2]]]])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[+($2.c1, 5000:INTERVAL SECOND)])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, tableWithWatermark2]])
+]]>
+		</Resource>
+		<Resource name="optimized rel plan">
+			<![CDATA[
+Calc(select=[a, b, c])
++- Join(joinType=[InnerJoin], where=[=(b, b0)], select=[a, b, c, b0], leftInputSpec=[NoUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], stateTtlHints=[[[STATE_TTL options:{LEFT=1d, RIGHT=3d}]]])
+   :- Exchange(distribution=[hash[b]])
+   :  +- Calc(select=[a, b, CAST(c AS TIMESTAMP(3)) AS c], where=[IS NOT NULL(b)])
+   :     +- WatermarkAssigner(rowtime=[c], watermark=[c])
+   :        +- TableSourceScan(table=[[default_catalog, default_database, tableWithWatermark1]], fields=[a, b, c])
+   +- Exchange(distribution=[hash[b]])
+      +- GroupAggregate(groupBy=[b], select=[b])
+         +- Exchange(distribution=[hash[b]])
+            +- Calc(select=[b], where=[IS NOT NULL(b)])
+               +- WatermarkAssigner(rowtime=[d], watermark=[-(d, 5000:INTERVAL SECOND)])
+                  +- Calc(select=[b, +(c.c1, 5000:INTERVAL SECOND) AS d])
+                     +- TableSourceScan(table=[[default_catalog, default_database, tableWithWatermark2, project=[b, c], metadata=[]]], fields=[b, c])
+]]>
+		</Resource>
+	</TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ProjectWatermarkAssignerTransposeRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ProjectWatermarkAssignerTransposeRuleTest.xml
@@ -183,6 +183,40 @@ LogicalProject(a=[$0])
 ]]>
     </Resource>
   </TestCase>
+	<TestCase name="transposeWithHints">
+		<Resource name="sql">
+			<![CDATA[SELECT /*+ STATE_TTL('st'='1d', 'vt' = '3d') */ st.* FROM SimpleTable st LEFT JOIN(SELECT DISTINCT b FROM VirtualTable) vt ON st.b = vt.b WHERE vt.b IS NOT NULL]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
++- LogicalFilter(condition=[IS NOT NULL($4)])
+   +- LogicalJoin(condition=[=($1, $4)], joinType=[left], stateTtlHints=[[[STATE_TTL inheritPath:[0, 0] options:{st=1d, vt=3d}]]])
+      :- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, SimpleTable]])
+      +- LogicalAggregate(group=[{0}])
+         +- LogicalProject(b=[$1])
+            +- LogicalWatermarkAssigner(rowtime=[d], watermark=[-($3, 5000:INTERVAL SECOND)])
+               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[+($2.c1, 5000:INTERVAL SECOND)])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+		<Resource name="optimized rel plan">
+			<![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
++- LogicalFilter(condition=[IS NOT NULL($4)])
+   +- LogicalJoin(condition=[=($1, $4)], joinType=[left], stateTtlHints=[[[STATE_TTL options:{LEFT=1d, RIGHT=3d}]]])
+      :- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, SimpleTable]])
+      +- LogicalAggregate(group=[{0}])
+         +- LogicalProject(b=[$0])
+            +- LogicalWatermarkAssigner(rowtime=[d], watermark=[-($1, 5000:INTERVAL SECOND)])
+               +- LogicalProject(b=[$1], d=[$3])
+                  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[+($2.c1, 5000:INTERVAL SECOND)])
+                     +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
+]]>
+		</Resource>
+	</TestCase>
   <TestCase name="transposeWithIncludeComputedRowTime">
     <Resource name="sql">
       <![CDATA[SELECT a, b, d FROM VirtualTable]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ProjectWatermarkAssignerTransposeRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ProjectWatermarkAssignerTransposeRuleTest.xml
@@ -181,40 +181,6 @@ LogicalProject(a=[$0])
    +- LogicalProject(a=[$0], b=[$1], c=[$2])
       +- LogicalTableScan(table=[[default_catalog, default_database, UdfTable]])
 ]]>
-    </Resource>
-  </TestCase>
-	<TestCase name="transposeWithHints">
-		<Resource name="sql">
-			<![CDATA[SELECT /*+ STATE_TTL('st'='1d', 'vt' = '3d') */ st.* FROM SimpleTable st LEFT JOIN(SELECT DISTINCT b FROM VirtualTable) vt ON st.b = vt.b WHERE vt.b IS NOT NULL]]>
-		</Resource>
-		<Resource name="ast">
-			<![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
-+- LogicalFilter(condition=[IS NOT NULL($4)])
-   +- LogicalJoin(condition=[=($1, $4)], joinType=[left], stateTtlHints=[[[STATE_TTL inheritPath:[0, 0] options:{st=1d, vt=3d}]]])
-      :- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2])
-      :  +- LogicalTableScan(table=[[default_catalog, default_database, SimpleTable]])
-      +- LogicalAggregate(group=[{0}])
-         +- LogicalProject(b=[$1])
-            +- LogicalWatermarkAssigner(rowtime=[d], watermark=[-($3, 5000:INTERVAL SECOND)])
-               +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[+($2.c1, 5000:INTERVAL SECOND)])
-                  +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
-]]>
-		</Resource>
-		<Resource name="optimized rel plan">
-			<![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
-+- LogicalFilter(condition=[IS NOT NULL($4)])
-   +- LogicalJoin(condition=[=($1, $4)], joinType=[left], stateTtlHints=[[[STATE_TTL options:{LEFT=1d, RIGHT=3d}]]])
-      :- LogicalWatermarkAssigner(rowtime=[c], watermark=[$2])
-      :  +- LogicalTableScan(table=[[default_catalog, default_database, SimpleTable]])
-      +- LogicalAggregate(group=[{0}])
-         +- LogicalProject(b=[$0])
-            +- LogicalWatermarkAssigner(rowtime=[d], watermark=[-($1, 5000:INTERVAL SECOND)])
-               +- LogicalProject(b=[$1], d=[$3])
-                  +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[+($2.c1, 5000:INTERVAL SECOND)])
-                     +- LogicalTableScan(table=[[default_catalog, default_database, VirtualTable]])
-]]>
 		</Resource>
 	</TestCase>
   <TestCase name="transposeWithIncludeComputedRowTime">

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -1321,6 +1321,7 @@ case class StreamTableTestUtil(
       sourceRel.getCluster,
       sourceRel.getTraitSet,
       sourceRel,
+      Collections.emptyList(),
       rowtimeFieldIdx,
       expr
     )


### PR DESCRIPTION
## What is the purpose of the change
The change is intended to make it possible to run queries like
```sql
SELECT /*+ STATE_TTL('st'='1d', 'vt' = '3d') */ st.* FROM SimpleTable st 
LEFT JOIN(SELECT DISTINCT b FROM VirtualTable) vt 
           ON st.b = vt.b WHERE vt.b IS NOT NULL
```

## Brief change log
Introduce support for hints for WatermarkAssigner


## Verifying this change

ProjectWatermarkAssignerTransposeRuleTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
