### PR TITLE
[FLINK-36181][ci] Use Java 11 to run documentation build

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -18,6 +18,11 @@
 ################################################################################
 set -e
 
+# override env to use Java 11 to for build instead default Java 8
+# path to JDK is taken from https://github.com/apache/flink-connector-shared-utils/blob/ci_utils/docker/base/Dockerfile#L37-L40
+export JAVA_HOME=$JAVA_HOME_11_X64
+export PATH=$JAVA_HOME_11_X64/bin:$PATH
+
 mvn --version
 java -version
 javadoc -J-version


### PR DESCRIPTION
## What is the purpose of the change

Use Java 11 for documentation build to fix failing workflow: https://github.com/apache/flink/actions/runs/11168786218/job/31047996276

## Brief change log
  - Override environment in `.github/workflows/docs.sh` to use JDK 11

## Verifying this change

Running docker command from workflow locally:
```
~ docker run --rm --volume "$PWD:/root/flink" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink && JAVA_HOME=$JAVA_HOME_11_X64 ./.github/workflows/docs.sh"
```
Output before change
```
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: /usr/share/maven
Java version: 1.8.0_292, vendor: Private Build, runtime: /usr/lib/jvm/java-8-openjdk-amd64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1014-azure", arch: "amd64", family: "unix"
openjdk version "1.8.0_292"
OpenJDK Runtime Environment (build 1.8.0_292-8u292-b10-0ubuntu1~16.04.1-b10)
OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
openjdk version "1.8.0_292"
OpenJDK Runtime Environment (build 1.8.0_292-8u292-b10-0ubuntu1~16.04.1-b10)
OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
```

After change:
```
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: /usr/share/maven
Java version: 11.0.19, vendor: Eclipse Adoptium, runtime: /usr/lib/jvm/jdk-11.0.19+7
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.10.4-linuxkit", arch: "amd64", family: "unix"
openjdk version "11.0.19" 2023-04-18
OpenJDK Runtime Environment Temurin-11.0.19+7 (build 11.0.19+7)
OpenJDK 64-Bit Server VM Temurin-11.0.19+7 (build 11.0.19+7, mixed mode)
openjdk version "11.0.19" 2023-04-18
OpenJDK Runtime Environment Temurin-11.0.19+7 (build 11.0.19+7)
OpenJDK 64-Bit Server VM Temurin-11.0.19+7 (build 11.0.19+7, mixed mode)
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
