### PR TITLE
[FLINK-36424][yarn] Update deprecated YARN RM/NM callback handlers in YarnResourceManagerDriver

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/DefaultYarnNodeManagerClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/DefaultYarnNodeManagerClientFactory.java
@@ -33,7 +33,8 @@ public class DefaultYarnNodeManagerClientFactory implements YarnNodeManagerClien
     }
 
     @Override
-    public NMClientAsync createNodeManagerClient(NMClientAsync.CallbackHandler callbackHandler) {
+    public NMClientAsync createNodeManagerClient(
+            NMClientAsync.AbstractCallbackHandler callbackHandler) {
         // create the client to communicate with the node managers
         return NMClientAsync.createNMClientAsync(callbackHandler);
     }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/DefaultYarnResourceManagerClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/DefaultYarnResourceManagerClientFactory.java
@@ -35,7 +35,8 @@ public class DefaultYarnResourceManagerClientFactory implements YarnResourceMana
 
     @Override
     public AMRMClientAsync<AMRMClient.ContainerRequest> createResourceManagerClient(
-            int yarnHeartbeatIntervalMillis, AMRMClientAsync.CallbackHandler callbackHandler) {
+            int yarnHeartbeatIntervalMillis,
+            AMRMClientAsync.AbstractCallbackHandler callbackHandler) {
         return AMRMClientAsync.createAMRMClientAsync(yarnHeartbeatIntervalMillis, callbackHandler);
     }
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnNodeManagerClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnNodeManagerClientFactory.java
@@ -29,5 +29,5 @@ public interface YarnNodeManagerClientFactory {
      * @param callbackHandler which handles the events from YARN NodeManager.
      * @return a {@link NMClientAsync} instance.
      */
-    NMClientAsync createNodeManagerClient(NMClientAsync.CallbackHandler callbackHandler);
+    NMClientAsync createNodeManagerClient(NMClientAsync.AbstractCallbackHandler callbackHandler);
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerClientFactory.java
@@ -33,5 +33,6 @@ public interface YarnResourceManagerClientFactory {
      * @return an {@link AMRMClientAsync} instance.
      */
     AMRMClientAsync<AMRMClient.ContainerRequest> createResourceManagerClient(
-            int yarnHeartbeatIntervalMillis, AMRMClientAsync.CallbackHandler callbackHandler);
+            int yarnHeartbeatIntervalMillis,
+            AMRMClientAsync.AbstractCallbackHandler callbackHandler);
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.yarn.api.records.NodeReport;
 import org.apache.hadoop.yarn.api.records.Priority;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.ResourceRequest;
+import org.apache.hadoop.yarn.api.records.UpdatedContainer;
 import org.apache.hadoop.yarn.client.api.AMRMClient;
 import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
 import org.apache.hadoop.yarn.client.api.async.NMClientAsync;
@@ -181,11 +182,10 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
     @Override
     protected void initializeInternal() throws Exception {
         isRunning = true;
-        final YarnContainerEventHandler yarnContainerEventHandler = new YarnContainerEventHandler();
         try {
             resourceManagerClient =
                     yarnResourceManagerClientFactory.createResourceManagerClient(
-                            yarnHeartbeatIntervalMillis, yarnContainerEventHandler);
+                            yarnHeartbeatIntervalMillis, new AMRMCallbackHandler());
             resourceManagerClient.init(yarnConfig);
             resourceManagerClient.start();
 
@@ -203,7 +203,7 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
         }
 
         nodeManagerClient =
-                yarnNodeManagerClientFactory.createNodeManagerClient(yarnContainerEventHandler);
+                yarnNodeManagerClientFactory.createNodeManagerClient(new NMCallbackHandler());
         nodeManagerClient.init(yarnConfig);
         nodeManagerClient.start();
     }
@@ -652,11 +652,24 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
     }
 
     // ------------------------------------------------------------------------
-    //  Event handlers
+    //  Callback handlers
     // ------------------------------------------------------------------------
 
-    class YarnContainerEventHandler
-            implements AMRMClientAsync.CallbackHandler, NMClientAsync.CallbackHandler {
+    private void runAsyncWithFatalHandler(Runnable runnable) {
+        getMainThreadExecutor()
+                .execute(
+                        () -> {
+                            try {
+                                runnable.run();
+                            } catch (Throwable t) {
+                                if (isRunning) {
+                                    getResourceEventHandler().onError(t);
+                                }
+                            }
+                        });
+    }
+
+    class AMRMCallbackHandler extends AMRMClientAsync.AbstractCallbackHandler {
 
         @Override
         public void onContainersCompleted(List<ContainerStatus> statuses) {
@@ -697,16 +710,9 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
                     });
         }
 
-        private void runAsyncWithFatalHandler(Runnable runnable) {
-            getMainThreadExecutor()
-                    .execute(
-                            () -> {
-                                try {
-                                    runnable.run();
-                                } catch (Throwable t) {
-                                    onError(t);
-                                }
-                            });
+        @Override
+        public void onContainersUpdated(List<UpdatedContainer> updatedContainers) {
+            // We are not interested in container updates
         }
 
         @Override
@@ -732,6 +738,9 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
                 getResourceEventHandler().onError(throwable);
             }
         }
+    }
+
+    class NMCallbackHandler extends NMClientAsync.AbstractCallbackHandler {
 
         @Override
         public void onContainerStarted(ContainerId containerId, Map<String, ByteBuffer> map) {
@@ -763,16 +772,55 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
         }
 
         @Override
+        public void onContainerResourceIncreased(ContainerId containerId, Resource resource) {
+            // ResourceManagerDriver does not support this, but it is still possible via
+            // direct YARN interaction, so it makes sense to log it.
+            log.debug(
+                    "Succeeded to call YARN Node Manager to increase resource for container {} to {}.",
+                    containerId,
+                    resource);
+        }
+
+        @Override
+        public void onContainerResourceUpdated(ContainerId containerId, Resource resource) {
+            // ResourceManagerDriver does not support this, but it is still possible via
+            // direct YARN interaction, so it makes sense to log it.
+            log.debug(
+                    "Succeeded to call YARN Node Manager to update resource for container {} to {}.",
+                    containerId,
+                    resource);
+        }
+
+        @Override
         public void onGetContainerStatusError(ContainerId containerId, Throwable throwable) {
-            // We are not interested in getting container status
+            // We are not interested in container status error
+        }
+
+        @Override
+        public void onIncreaseContainerResourceError(ContainerId containerId, Throwable throwable) {
+            log.debug(
+                    String.format(
+                            "Error while calling YARN Node Manager to increase resource for container %s.",
+                            containerId),
+                    throwable);
+        }
+
+        @Override
+        public void onUpdateContainerResourceError(ContainerId containerId, Throwable throwable) {
+            log.debug(
+                    String.format(
+                            "Error while calling YARN Node Manager to update resource for container %s.",
+                            containerId),
+                    throwable);
         }
 
         @Override
         public void onStopContainerError(ContainerId containerId, Throwable throwable) {
             trackerOfReleasedResources.arriveAndDeregister();
             log.warn(
-                    "Error while calling YARN Node Manager to stop container {}.",
-                    containerId,
+                    String.format(
+                            "Error while calling YARN Node Manager to stop container %s.",
+                            containerId),
                     throwable);
         }
     }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnNodeManagerClientFactory.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnNodeManagerClientFactory.java
@@ -25,17 +25,18 @@ import java.util.function.Function;
 /** A {@link YarnNodeManagerClientFactory} implementation for testing. */
 public class TestingYarnNodeManagerClientFactory implements YarnNodeManagerClientFactory {
 
-    private final Function<NMClientAsync.CallbackHandler, NMClientAsync>
+    private final Function<NMClientAsync.AbstractCallbackHandler, NMClientAsync>
             createNodeManagerClientFunction;
 
     TestingYarnNodeManagerClientFactory(
-            Function<NMClientAsync.CallbackHandler, NMClientAsync>
+            Function<NMClientAsync.AbstractCallbackHandler, NMClientAsync>
                     createNodeManagerClientFunction) {
         this.createNodeManagerClientFunction = createNodeManagerClientFunction;
     }
 
     @Override
-    public NMClientAsync createNodeManagerClient(NMClientAsync.CallbackHandler callbackHandler) {
+    public NMClientAsync createNodeManagerClient(
+            NMClientAsync.AbstractCallbackHandler callbackHandler) {
         return createNodeManagerClientFunction.apply(callbackHandler);
     }
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnResourceManagerClientFactory.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnResourceManagerClientFactory.java
@@ -27,14 +27,14 @@ import java.util.function.BiFunction;
 public class TestingYarnResourceManagerClientFactory implements YarnResourceManagerClientFactory {
     private final BiFunction<
                     Integer,
-                    AMRMClientAsync.CallbackHandler,
+                    AMRMClientAsync.AbstractCallbackHandler,
                     AMRMClientAsync<AMRMClient.ContainerRequest>>
             createResourceManagerClientFunction;
 
     TestingYarnResourceManagerClientFactory(
             BiFunction<
                             Integer,
-                            AMRMClientAsync.CallbackHandler,
+                            AMRMClientAsync.AbstractCallbackHandler,
                             AMRMClientAsync<AMRMClient.ContainerRequest>>
                     createResourceManagerClientFunction) {
         this.createResourceManagerClientFunction = createResourceManagerClientFunction;
@@ -42,7 +42,8 @@ public class TestingYarnResourceManagerClientFactory implements YarnResourceMana
 
     @Override
     public AMRMClientAsync<AMRMClient.ContainerRequest> createResourceManagerClient(
-            int yarnHeartbeatIntervalMillis, AMRMClientAsync.CallbackHandler callbackHandler) {
+            int yarnHeartbeatIntervalMillis,
+            AMRMClientAsync.AbstractCallbackHandler callbackHandler) {
         return createResourceManagerClientFunction.apply(
                 yarnHeartbeatIntervalMillis, callbackHandler);
     }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerDriverTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerDriverTest.java
@@ -702,7 +702,7 @@ public class YarnResourceManagerDriverTest extends ResourceManagerDriverTestBase
     private static Container createTestingContainerWithResource(
             Resource resource, Priority priority, int containerIdx) {
         final ContainerId containerId =
-                ContainerId.newInstance(
+                ContainerId.newContainerId(
                         ApplicationAttemptId.newInstance(
                                 ApplicationId.newInstance(System.currentTimeMillis(), 1), 1),
                         containerIdx);
@@ -729,8 +729,8 @@ public class YarnResourceManagerDriverTest extends ResourceManagerDriverTestBase
         final CompletableFuture<Void> nodeManagerClientStartFuture = new CompletableFuture<>();
         final CompletableFuture<Void> nodeManagerClientStopFuture = new CompletableFuture<>();
 
-        AMRMClientAsync.CallbackHandler resourceManagerClientCallbackHandler;
-        NMClientAsync.CallbackHandler nodeManagerClientCallbackHandler;
+        AMRMClientAsync.AbstractCallbackHandler resourceManagerClientCallbackHandler;
+        NMClientAsync.AbstractCallbackHandler nodeManagerClientCallbackHandler;
         TestingYarnNMClientAsync testingYarnNMClientAsync;
         TestingYarnAMRMClientAsync testingYarnAMRMClientAsync;
         final TestingYarnNMClientAsync.Builder testingYarnNMClientAsyncBuilder =


### PR DESCRIPTION
## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

- Create `AMRMCallbackHandler` that extends `AMRMClientAsync.AbstractCallbackHandler`, keeping the already existing logic from `YarnContainerEventHandler`.
- Create `NMCallbackHandler` that extends `NMClientAsync.AbstractCallbackHandler`, keeping the already existing logic from `YarnContainerEventHandler`.
- Adapt the related code to handle the new separate classes.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
