### PR TITLE
[FLINK-36433][hotfix] Check StreamRecord status to avoid NPE in PartitionReduceOperator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/PartitionReduceOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/PartitionReduceOperator.java
@@ -50,7 +50,9 @@ public class PartitionReduceOperator<IN> extends AbstractUdfStreamOperator<IN, R
 
     @Override
     public void endInput() throws Exception {
-        output.collect(new StreamRecord<>(currentRecord));
+        if (currentRecord != null) {
+            output.collect(new StreamRecord<>(currentRecord));
+        }
     }
 
     @Override


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Non-keyed fullWindowPartition#reduce may throw NPE, this pr is try to check StreamRecord status to avoid NPE in PartitionReduceOperator.

Non-keyed fullWindowPartition#reduce may throw a NullPointerException, so this pull request tries to check the StreamRecord status in order to avoid a NullPointerException in the PartitionReduceOperator.

Non-keyed fullWindowPartition#reduce may throw a NullPointerException, this pull request tries to check the StreamRecord status to avoid NPE in the PartitionReduceOperator.

## Brief change log

- check StreamRecord status in `PartitionReduceOperator#endInput`

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
