### PR TITLE
[FLINK-20092] Bump maven-shade-plugin to 3.5.3 and maven-remote-resource-plugin to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2244,7 +2244,13 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.5.1</version>
+					<version>3.5.3</version>
+				</plugin>
+				<!-- Pin the version of the maven remote resource plugin -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-remote-resources-plugin</artifactId>
+					<version>3.2.0</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
## What is the purpose of the change

The issue is that sometimes `./mvnw clean install -DskipTests -Dscala-2.12 -Pfast -Pskip-webui-build -U -T4`
is hanging while maven-shade-plugin or maven-remote-resource-plugin

there are some concurrency related fixes in maven-shade-plugin like https://issues.apache.org/jira/browse/MSHADE-467

After bumping dependencies the problem disappears 

## Brief change log

pom.xml


## Verifying this change
`./mvnw clean install -DskipTests -Dscala-2.12 -Pfast -Pskip-webui-build -U -T4`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
