### PR TITLE
[FLINK-36435] Fix shaded hadoop S3A with credentials provider end-to-end test failed

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_s3_operations.sh
+++ b/flink-end-to-end-tests/test-scripts/common_s3_operations.sh
@@ -101,18 +101,18 @@ function aws_cli() {
 # Arguments:
 #   $1 - local path to save folder with files
 #   $2 - s3 key full path prefix
-#   $3 - s3 file name prefix w/o directory to filter files by name (optional)
-#   $4 - recursive?
+#   $3 - recursive?
+#   $4 - s3 file name prefix w/o directory to filter files by name (optional)
 # Returns:
 #   None
 ###################################
 function s3_get_by_full_path_and_filename_prefix() {
   local args=
-  if [[ $3 ]]; then
-    args=" --exclude '*' --include '*/${3}[!/]*'"
-  fi
-  if [[ "$4" == true ]]; then
+  if [[ "$3" == true ]]; then
     args="$args --recursive"
+  fi
+  if [[ $4 ]]; then
+    args="$args --exclude '*' --include '*/${4}[!/]*'"
   fi
   local relative_dir=${1#$TEST_INFRA_DIR}
   aws_cli s3 cp --quiet "s3://$IT_CASE_S3_BUCKET/$2" "/hostdir/${relative_dir}" $args

--- a/flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh
+++ b/flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh
@@ -36,7 +36,7 @@ case $INPUT_TYPE in
         ARGS="--execution-mode BATCH --input ${S3_TEST_DATA_WORDS_URI} --output s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
         OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
         on_exit "s3_delete_by_full_path_prefix '$S3_PREFIX'"
-        fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" "" false)
+        fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" true)
     ;;
     (hadoop_minio)
         source "$(dirname "$0")"/common_s3_minio.sh
@@ -50,7 +50,7 @@ case $INPUT_TYPE in
         ARGS="--execution-mode BATCH --input ${S3_TEST_DATA_WORDS_URI} --output s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
         OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
         on_exit "s3_delete_by_full_path_prefix '$S3_PREFIX'"
-        fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" "" false)
+        fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" true)
     ;;
     (presto)
         source "$(dirname "$0")"/common_s3.sh
@@ -58,7 +58,7 @@ case $INPUT_TYPE in
         ARGS="--execution-mode BATCH --input ${S3_TEST_DATA_WORDS_URI} --output s3://$IT_CASE_S3_BUCKET/$S3_PREFIX"
         OUTPUT_PATH="$TEST_DATA_DIR/$S3_PREFIX"
         on_exit "s3_delete_by_full_path_prefix '$S3_PREFIX'"
-        fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" "" false)
+        fetch_complete_result=(s3_get_by_full_path_and_filename_prefix "$OUTPUT_PATH" "${S3_PREFIX}" true)
     ;;
     (presto_minio)
         source "$(dirname "$0")"/common_s3_minio.sh

--- a/flink-end-to-end-tests/test-scripts/test_file_sink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_file_sink.sh
@@ -74,7 +74,7 @@ elif [ "${OUT_TYPE}" == "s3" ]; then
   # overwrites implementation for local runs
   function get_complete_result {
     # copies the data from S3 to the local LOCAL_JOB_OUTPUT_PATH
-    s3_get_by_full_path_and_filename_prefix "$LOCAL_JOB_OUTPUT_PATH" "$S3_DATA_PREFIX" "part-" true
+    s3_get_by_full_path_and_filename_prefix "$LOCAL_JOB_OUTPUT_PATH" "$S3_DATA_PREFIX" true "part-"
 
     # and prints the sorted output
     find "${LOCAL_JOB_OUTPUT_PATH}" -type f \( -iname "part-*" \) -exec cat {} + | sort -g


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix shaded hadoop S3A with credentials provider end-to-end test failed

## Verifying this change

This change is already covered by existing tests, such as *flink-end-to-end-tests/test-scripts/test_batch_wordcount.sh hadoop_with_provider*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
