### PR TITLE
[FLINK-36437][hive] Exclude hive connector

### DIFF
--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -36,7 +36,6 @@ under the License.
 
 	<modules>
 		<module>flink-hadoop-compatibility</module>
-		<module>flink-connector-hive</module>
 		<module>flink-connector-base</module>
 		<module>flink-file-sink-common</module>
 		<module>flink-connector-files</module>
@@ -65,24 +64,6 @@ under the License.
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 	</dependencies>
-
-	<!-- See main pom.xml for explanation of profiles -->
-	<profiles>
-
-		<!-- Create SQL Client uber jars by default -->
-		<profile>
-			<id>sql-jars</id>
-			<activation>
-				<property>
-					<name>!skipSqlJars</name>
-				</property>
-			</activation>
-			<modules>
-				<module>flink-sql-connector-hive-2.3.10</module>
-				<module>flink-sql-connector-hive-3.1.3</module>
-			</modules>
-		</profile>
-	</profiles>
 
 	<build>
 		<plugins>

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -70,7 +70,6 @@ under the License.
 		<module>flink-end-to-end-tests-scala</module>
 		<module>flink-end-to-end-tests-sql</module>
 		<module>flink-end-to-end-tests-jdbc-driver</module>
-		<module>flink-end-to-end-tests-hive</module>
 		<module>flink-end-to-end-tests-restclient</module>
 		<module>flink-failure-enricher-test</module>
     </modules>

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -245,7 +245,7 @@ function run_group_2 {
 
     MVN_LOGGING_OPTIONS="-Dlog.dir=${DEBUG_FILES_OUTPUT_DIR} -DlogBackupDir=${DEBUG_FILES_OUTPUT_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES"
     MVN_COMMON_OPTIONS="-Dfast -Pskip-webui-build"
-    e2e_modules=$(find flink-end-to-end-tests -mindepth 2 -maxdepth 5 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')
+    e2e_modules=$(find flink-end-to-end-tests -mindepth 2 -maxdepth 5 -name 'pom.xml' -not -path "flink-end-to-end-tests/flink-end-to-end-tests-hive/*" -printf '%h\n' | sort -u | tr '\n' ',')
     e2e_modules="${e2e_modules},$(find flink-walkthroughs -mindepth 2 -maxdepth 2 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')"
 
     PROFILE="$PROFILE -Prun-end-to-end-tests"


### PR DESCRIPTION
## What is the purpose of the change

Currently, hive connector doesn't support Java 11. Thus, we have to exclude Hive connector for Flink 2.0 preview as we dropped the support for Java 8 and Hive doesn't support Java 11 at the moment. We will discuss further how to do with the Hive connector later.


## Brief change log

- Exclude hive connector from pom.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
