### PR TITLE
[FLINK-36440] Bump log4j from 2.17.1 to 2.24.1

### DIFF
--- a/docs/content.zh/docs/dev/configuration/overview.md
+++ b/docs/content.zh/docs/dev/configuration/overview.md
@@ -108,7 +108,7 @@ ext {
     flinkVersion = '{{< version >}}'
     scalaBinaryVersion = '{{< scala_version >}}'
     slf4jVersion = '1.7.36'
-    log4jVersion = '2.17.1'
+    log4jVersion = '2.24.1'
 }
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion

--- a/docs/content/docs/dev/configuration/overview.md
+++ b/docs/content/docs/dev/configuration/overview.md
@@ -110,7 +110,7 @@ ext {
     flinkVersion = '{{< version >}}'
     scalaBinaryVersion = '{{< scala_version >}}'
     slf4jVersion = '1.7.36'
-    log4jVersion = '2.17.1'
+    log4jVersion = '2.24.1'
 }
 sourceCompatibility = javaVersion
 targetCompatibility = javaVersion

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@ under the License.
 		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
 		<target.java.version>11</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
-		<log4j.version>2.17.1</log4j.version>
+		<log4j.version>2.24.1</log4j.version>
 		<!-- Overwrite default values from parent pom.
 			 IntelliJ IDEA is (sometimes?) using those values to choose target language level
 			 and thus is changing back to java 1.6 on each maven re-import -->

--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -8,10 +8,10 @@ Copyright 2014-2024 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.logging.log4j:log4j-api:2.17.1
-- org.apache.logging.log4j:log4j-core:2.17.1
-- org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
-- org.apache.logging.log4j:log4j-1.2-api:2.17.1
+- org.apache.logging.log4j:log4j-api:2.24.1
+- org.apache.logging.log4j:log4j-core:2.24.1
+- org.apache.logging.log4j:log4j-slf4j-impl:2.24.1
+- org.apache.logging.log4j:log4j-1.2-api:2.24.1
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.


### PR DESCRIPTION
## What is the purpose of the change

Bump log4j from 2.17.1 to 2.24.1

## Brief change log

Bump log4j version from 2.17.1 to 2.24.1 in pom

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
