### PR TITLE
[hotfix] Fixed flaky-test: StateTtlHintTest#testJoinStateTtlHintWithView

### DIFF
--- a/tools/releasing/create_preview_branch.sh
+++ b/tools/releasing/create_preview_branch.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# check arguments
+MVN=${MVN:-mvn}
+
+if [ -z "${SHORT_RELEASE_VERSION:-}" ]; then
+    echo "SHORT_RELEASE_VERSION was not set."
+    exit 1
+fi
+
+if [ -z "${PREVIEW:-}" ]; then
+    echo "PREVIEW was not set."
+    exit 1
+fi
+
+if [ -z "${RELEASE_CANDIDATE:-}" ]; then
+    echo "RELEASE_CANDIDATE was not set."
+    exit 1
+fi
+
+NEW_VERSION=${SHORT_RELEASE_VERSION}-preview${PREVIEW}
+TARGET_BRANCH=release-${SHORT_RELEASE_VERSION}-preview${PREVIEW}-rc${RELEASE_CANDIDATE}
+
+# fail immediately
+set -o errexit
+set -o nounset
+# print command before executing
+set -o xtrace
+
+CURR_DIR=`pwd`
+if [[ `basename $CURR_DIR` != "tools" ]] ; then
+  echo "You have to call the script from the tools/ dir"
+  exit 1
+fi
+
+###########################
+
+cd ..
+
+# create branch
+git checkout master
+git checkout -b ${TARGET_BRANCH}
+
+# change version in all pom files
+$MVN org.codehaus.mojo:versions-maven-plugin:2.8.1:set -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false --quiet
+
+# change version of documentation
+config_file=docs/config.toml
+
+perl -pi -e "s#^  Version = .*#  Version = \"${NEW_VERSION}\"#" ${config_file}
+perl -pi -e "s#^  VersionTitle = .*#  VersionTitle = \"${NEW_VERSION}\"#" ${config_file}
+perl -pi -e "s#^  Branch = .*#  Branch = \"${TARGET_BRANCH}\"#" ${config_file}
+
+url_base="//nightlies.apache.org/flink/flink-docs-release-"${NEW_VERSION}
+perl -pi -e "s#^baseURL = .*#baseURL = \'${url_base}\'#" ${config_file}
+perl -pi -e "s#^  JavaDocs = .*#  JavaDocs = \"${url_base}/api/java/\"#" ${config_file}
+perl -pi -e "s#^    \[\"JavaDocs\", .*#    \[\"JavaDocs\", \"${url_base}/api/java/\"\],#" ${config_file}
+perl -pi -e "s#^  ScalaDocs = .*#  ScalaDocs = \"${url_base}/api/scala/index.html\#org.apache.flink.api.scala.package\"#" ${config_file}
+perl -pi -e "s#^    \[\"ScalaDocs\", .*#    \[\"ScalaDocs\", \"${url_base}/api/scala/index.html\#org.apache.flink.api.scala.package/\"\],#" ${config_file}
+perl -pi -e "s#^  PyDocs = .*#  PyDocs = \"${url_base}/api/python/\"#" ${config_file}
+perl -pi -e "s#^    \[\"PyDocs\", .*#    \[\"PyDocs\", \"${url_base}/api/python/\"\]#" ${config_file}
+
+perl -pi -e "s#^  PreviousDocs = \[#  PreviousDocs = \[\n    \[\"${NEW_VERSION}\", \"http:${url_base}\"\],#" ${config_file}
+
+perl -pi -e "s#^  IsStable = .*#  IsStable = true#" ${config_file}
+
+# change version of pyflink
+pushd flink-python/pyflink
+perl -pi -e "s#^__version__ = \".*\"#__version__ = \"${NEW_VERSION}\"#" version.py
+popd
+
+# change version for docker
+perl -pi -e "s#dev-master#dev-${SHORT_RELEASE_VERSION}#" flink-end-to-end-tests/test-scripts/common_docker.sh
+
+git commit -am "Commit for release $NEW_VERSION"
+
+RELEASE_HASH=`git rev-parse HEAD`
+echo "Echo created release hash $RELEASE_HASH"
+
+echo "Done. Don't forget to create the signed release tag at the end and push the changes."


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

**This pull request identifies a flaky-test and proposes a fix.**


## Brief change log

The following method asserts a flaky test:
**org.apache.flink.table.planner.plan.hints.stream.StateTtlHintTest#testJoinStateTtlHintWithView**

Failed assertion:
```
expected: <
Join(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, b1, a3, b3], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], stateTtlHints=[[[STATE_TTL options:{LEFT=2d, RIGHT=1d}]]])
:- Exchange(distribution=[hash[a1]])
:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+- Exchange(distribution=[hash[a3]])
   +- TableSourceScan(table=[[default_catalog, default_database, T3]], fields=[a3, b3])
> but was: <
Join(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, b1, a3, b3], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey], stateTtlHints=[[[STATE_TTL options:{RIGHT=1d, LEFT=2d}]]])
:- Exchange(distribution=[hash[a1]])
:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+- Exchange(distribution=[hash[a3]])
   +- TableSourceScan(table=[[default_catalog, default_database, T3]], fields=[a3, b3])
>
```
### Precisely (String comparison failure)
```
Expected: stateTtlHints=[[[STATE_TTL options:{LEFT=2d, RIGHT=1d}]]] 
Actual: stateTtlHints=[[[STATE_TTL options:{RIGHT=1d, LEFT=2d}]]]
```

### FAILURE REASON
RelExplainUtil.scala => hintsToString uses ImmutableMap.toString() function to convert kvOptions to string representation. Map.toString() is unreliable and gives non-deterministic output where sorting of Entries depends on current hashcode generation logic, and could be different for each toString call.

### Fix
Added a method that sorts entries in lexographical order and returns same result as map.toString(). Sorting makes it deterministic.

Confirmed test failure using nondex

### For particular test:
>mvn -pl ./flink-table/flink-table-planner edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.flink.table.planner.plan.hints.stream.StateTtlHintTest#testJoinStateTtlHintWithView -DnondexRuns=10 -Dspotless.check.skip=true

### For entire repo
Suggested command to check flaky tests :
> mvn nondex:nondex

For more information : https://github.com/TestingResearchIllinois/NonDex

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:

- Added fixes in code to generate deterministic output for non-flaky (deterministic) assertion


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no 