### PR TITLE
[FLINK-36421] [fs] [checkpoint] Sync outputStream before returning handle in FsCheckpointStreamFactory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -405,6 +405,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
                         } catch (Exception ignored) {
                         }
 
+                        sync();
                         outStream.close();
 
                         return allowRelativePaths


### PR DESCRIPTION
## What is the purpose of the change

The `FsCheckpointStreamFactory` returns handles to files containing larger serialized data for checkpoint creation. However, these files are not synced persistently to disk via `fsync` before their handles are incorporated into completed checkpoints. Upon e.g. power loss this can cause corruption of a checkpoint as it references files that may now be lost due to missing persistence.  
This PR adds a #sync() call to the `FsCheckpointStreamFactory`'s #closeAndGetHandle() function. This makes sure that the returned handle always points to a file that has been safely persisted. 

## Brief change log

  - *Files written by `FsCheckpointStreamFactory` are now synced before their handle is referenced in checkpoints*

## Verifying this change

There is no easy way to unit- or integration-test these changes. OS tools are required. Correctness has been verified by using `strace`, see discussion at FLINK-36421.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
