### PR TITLE
[BP-1.19][FLINK-36421] [fs] [checkpoint] Sync outputStream before returning handle in FsCheckpointStreamFactory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStreamFactory.java
@@ -401,6 +401,7 @@ public class FsCheckpointStreamFactory implements CheckpointStreamFactory {
                             } catch (Exception ignored) {
                             }
 
+                            sync();
                             outStream.close();
 
                             return allowRelativePaths


### PR DESCRIPTION
Backport of FLINK-36421 for 1.19

Cherry-pick of commit dfb9bfeabac8d3ac289e46a3017ed68c50ba3777 from original PR #25468