### PR TITLE
[FLINK-29797][flink-yarn][backport] Fix fs.default-scheme will accidentally cau…

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1103,7 +1103,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
             fileUploader.registerSingleLocalResource(
                     flinkConfigFileName,
-                    new Path(tmpConfigurationFile.getAbsolutePath()),
+                    new Path(tmpConfigurationFile.toURI()),
                     "",
                     LocalResourceType.FILE,
                     true,


### PR DESCRIPTION
…se temporary flinkConfigFile treated as remote file. also fix [FLINK-33424]


## What is the purpose of the change
If user set fs.default-scheme to hdfs://namenode or s3://any, it will cause /tmp/flink-confxxxx FileNotFoundException.

Fix [FLINK-29797](https://issues.apache.org/jira/browse/FLINK-29797)

also fix [FLINK-33424](https://issues.apache.org/jira/browse/FLINK-33424)


This is a backport PR of https://github.com/apache/flink/pull/24733, for details, please click the link.