### PR TITLE
[hotfix] Fixing flaky tests in flink-table-planner /hints

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/spec/LookupJoinHintTestUtil.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/spec/LookupJoinHintTestUtil.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.planner.hint.JoinStrategy;
 
 import org.apache.calcite.rel.hint.RelHint;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Test util for lookup hint. */
@@ -46,7 +46,7 @@ public class LookupJoinHintTestUtil {
 
     public static Map<String, String> getLookupJoinHintOptions(
             String table, boolean withAsync, boolean withRetry) {
-        Map<String, String> kvOptions = new HashMap<>();
+        Map<String, String> kvOptions = new LinkedHashMap<>();
         kvOptions.put(LookupJoinHintOptions.LOOKUP_TABLE.key(), table);
         if (withAsync) {
             addAsyncOptions(kvOptions);
@@ -59,15 +59,15 @@ public class LookupJoinHintTestUtil {
 
     public static void addAsyncOptions(Map<String, String> kvOptions) {
         kvOptions.put(LookupJoinHintOptions.ASYNC_LOOKUP.key(), "true");
-        kvOptions.put(LookupJoinHintOptions.ASYNC_CAPACITY.key(), "1000");
         kvOptions.put(LookupJoinHintOptions.ASYNC_OUTPUT_MODE.key(), "allow_unordered");
         kvOptions.put(LookupJoinHintOptions.ASYNC_TIMEOUT.key(), "300 s");
+        kvOptions.put(LookupJoinHintOptions.ASYNC_CAPACITY.key(), "1000");
     }
 
     public static void addRetryOptions(Map<String, String> kvOptions) {
-        kvOptions.put(LookupJoinHintOptions.RETRY_PREDICATE.key(), "lookup_miss");
         kvOptions.put(LookupJoinHintOptions.RETRY_STRATEGY.key(), "fixed_delay");
-        kvOptions.put(LookupJoinHintOptions.FIXED_DELAY.key(), "155 ms");
         kvOptions.put(LookupJoinHintOptions.MAX_ATTEMPTS.key(), "10");
+        kvOptions.put(LookupJoinHintOptions.FIXED_DELAY.key(), "155 ms");
+        kvOptions.put(LookupJoinHintOptions.RETRY_PREDICATE.key(), "lookup_miss");
     }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/hint/ClearJoinHintsWithCapitalizeQueryHintsShuttleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/hint/ClearJoinHintsWithCapitalizeQueryHintsShuttleTest.xml
@@ -31,7 +31,7 @@ LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGI
     <Resource name="afterPropagatingHints">
       <![CDATA[
 LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGINT a)]
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[lookUp inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[lookUp inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
    :- LogicalProject(a=[$0], pts=[PROCTIME()]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
    :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a)]
    +- LogicalFilter(condition=[=($cor0.a, $0)]), rowType=[RecordType(BIGINT a)]
@@ -42,7 +42,7 @@ LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGI
     <Resource name="afterCapitalizeJoinHints">
       <![CDATA[
 LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGINT a)]
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
    :- LogicalProject(a=[$0], pts=[PROCTIME()]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
    :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a)]
    +- LogicalFilter(condition=[=($cor0.a, $0)]), rowType=[RecordType(BIGINT a)]
@@ -53,7 +53,7 @@ LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGI
     <Resource name="afterClearingJoinHints">
       <![CDATA[
 LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGINT a)]
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
    :- LogicalProject(a=[$0], pts=[PROCTIME()]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
    :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a)]
    +- LogicalFilter(condition=[=($cor0.a, $0)]), rowType=[RecordType(BIGINT a)]

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/hint/ClearLookupJoinHintsWithInvalidPropagationShuttleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/hint/ClearLookupJoinHintsWithInvalidPropagationShuttleTest.xml
@@ -31,7 +31,7 @@ LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGI
     <Resource name="afterPropagatingHints">
       <![CDATA[
 LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGINT a)]
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
    :- LogicalProject(a=[$0], ds=[$1], pts=[PROCTIME()]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
    :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds)]
    +- LogicalFilter(condition=[=($cor0.a, $0)]), rowType=[RecordType(BIGINT a)]
@@ -42,7 +42,7 @@ LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGI
     <Resource name="afterClearingJoinHints">
       <![CDATA[
 LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGINT a)]
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
    :- LogicalProject(a=[$0], ds=[$1], pts=[PROCTIME()]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
    :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds)]
    +- LogicalFilter(condition=[=($cor0.a, $0)]), rowType=[RecordType(BIGINT a)]
@@ -70,9 +70,9 @@ LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
     <Resource name="afterPropagatingHints">
       <![CDATA[
 LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
-+- LogicalJoin(condition=[=($0, $1)], joinType=[inner], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, retry-strategy=fixed_delay, max-attempts=10, output-mode=allow_unordered, fixed-delay=155 ms, retry-predicate=lookup_miss, table=src, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT a0, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
++- LogicalJoin(condition=[=($0, $1)], joinType=[inner], joinHints=[[[LOOKUP inheritPath:[0] options:{table=src, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000, retry-strategy=fixed_delay, max-attempts=10, fixed-delay=155 ms, retry-predicate=lookup_miss}]]]), rowType=[RecordType(BIGINT a, BIGINT a0, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
    :- LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGINT a)]
-   :  +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}][LOOKUP inheritPath:[0, 0, 0] options:{async=true, retry-strategy=fixed_delay, max-attempts=10, output-mode=allow_unordered, fixed-delay=155 ms, retry-predicate=lookup_miss, table=src, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
+   :  +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}][LOOKUP inheritPath:[0, 0, 0] options:{table=src, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000, retry-strategy=fixed_delay, max-attempts=10, fixed-delay=155 ms, retry-predicate=lookup_miss}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
    :     :- LogicalProject(a=[$0], ds=[$1], pts=[PROCTIME()]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
    :     :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds)]
    :     +- LogicalFilter(condition=[=($cor0.a, $0)]), rowType=[RecordType(BIGINT a)]
@@ -85,9 +85,9 @@ LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
     <Resource name="afterClearingJoinHints">
       <![CDATA[
 LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
-+- LogicalJoin(condition=[=($0, $1)], joinType=[inner], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, retry-strategy=fixed_delay, max-attempts=10, output-mode=allow_unordered, fixed-delay=155 ms, retry-predicate=lookup_miss, table=src, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT a0, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
++- LogicalJoin(condition=[=($0, $1)], joinType=[inner], joinHints=[[[LOOKUP inheritPath:[0] options:{table=src, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000, retry-strategy=fixed_delay, max-attempts=10, fixed-delay=155 ms, retry-predicate=lookup_miss}]]]), rowType=[RecordType(BIGINT a, BIGINT a0, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
    :- LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGINT a)]
-   :  +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
+   :  +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
    :     :- LogicalProject(a=[$0], ds=[$1], pts=[PROCTIME()]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
    :     :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds)]
    :     +- LogicalFilter(condition=[=($cor0.a, $0)]), rowType=[RecordType(BIGINT a)]
@@ -113,7 +113,7 @@ LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
     <Resource name="afterPropagatingHints">
       <![CDATA[
 LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT a0)]
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT a0)]
    :- LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
    :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds)]
    +- Uncollect, rowType=[RecordType(BIGINT a)]
@@ -124,7 +124,7 @@ LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
     <Resource name="afterClearingJoinHints">
       <![CDATA[
 LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT a0)]
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT a0)]
    :- LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
    :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds)]
    +- Uncollect, rowType=[RecordType(BIGINT a)]
@@ -146,7 +146,7 @@ LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
     <Resource name="afterPropagatingHints">
       <![CDATA[
 LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT b)]
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT b)]
    :- LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
    :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds)]
    +- LogicalTableFunctionScan(invocation=[TABLE($cor0.b)], rowType=[RecordType(BIGINT b)]), rowType=[RecordType(BIGINT b)]
@@ -155,7 +155,7 @@ LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
     <Resource name="afterClearingJoinHints">
       <![CDATA[
 LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}], joinHints=[[[LOOKUP inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT b)]
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}], joinHints=[[[LOOKUP inheritPath:[0] options:{table=d, async=true, output-mode=allow_unordered, timeout=300 s, capacity=1000}]]]), rowType=[RecordType(BIGINT a, BIGINT b)]
    :- LogicalProject(a=[$0]), rowType=[RecordType(BIGINT a)]
    :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a, BIGINT ARRAY ds)]
    +- LogicalTableFunctionScan(invocation=[TABLE($cor0.b)], rowType=[RecordType(BIGINT b)]), rowType=[RecordType(BIGINT b)]


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This fix is intended to fix flaky tests in the following classes -
- `org.apache.flink.table.planner.hint.ClearJoinHintsWithCapitalizeQueryHintsShuttleTest`
- `org.apache.flink.table.planner.hint.ClearLookupJoinHintsWithInvalidPropagationShuttleTest`

For example, when the following command is run on one of these tests using the Nondex plugin - 
 `mvn -pl flink-table/flink-table-planner edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.flink.table.planner.hint.ClearJoinHintsWithCapitalizeQueryHintsShuttleTest
`
This error is thrown.

```
[ERROR]   ClearJoinHintsWithCapitalizeQueryHintsShuttleTest.testClearCaseInsensitiveLookupHint:133->ClearQueryHintsWithInvalidPropagationShuttleTestBase.verifyRelPlan:142 afterPropagatingHints ==> expected: <
LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGINT a)]
+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[lookUp inheritPath:[0] options:{async=true, output-mode=allow_unordered, table=d, timeout=300 s, capacity=1000}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
   :- LogicalProject(a=[$0], pts=[PROCTIME()]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
   :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a)]
   +- LogicalFilter(condition=[=($cor0.a, $0)]), rowType=[RecordType(BIGINT a)]
      +- LogicalSnapshot(period=[PROCTIME()]), rowType=[RecordType(BIGINT a)]
         +- LogicalTableScan(table=[[builtin, default, lookup]]), rowType=[RecordType(BIGINT a)]
> but was: <
LogicalProject(a=[$0], hints=[[[ALIAS options:[t1]]]]), rowType=[RecordType(BIGINT a)]
+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}], joinHints=[[[lookUp inheritPath:[0] options:{table=d, timeout=300 s, capacity=1000, output-mode=allow_unordered, async=true}]]], hints=[[[ALIAS inheritPath:[0] options:[t1]]]]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts, BIGINT a0)]
   :- LogicalProject(a=[$0], pts=[PROCTIME()]), rowType=[RecordType(BIGINT a, TIMESTAMP_LTZ(3) *PROCTIME* pts)]
   :  +- LogicalTableScan(table=[[builtin, default, src]]), rowType=[RecordType(BIGINT a)]
   +- LogicalFilter(condition=[=($cor0.a, $0)]), rowType=[RecordType(BIGINT a)]
      +- LogicalSnapshot(period=[PROCTIME()]), rowType=[RecordType(BIGINT a)]
         +- LogicalTableScan(table=[[builtin, default, lookup]]), rowType=[RecordType(BIGINT a)]
```


This flakiness presents itself because the test is doing a direct string comparison over String forms of objects. Since the hintOptions required for these tests are stored in a map (`org.apache.flink.table.planner.plan.nodes.exec.spec.LookupJoinHintTestUtil#getLookupJoinHintOptions`), their ordering is non-deterministic, and thus leads to these tests intermittently failing. Furthermore, the examples that were used to compare these tests with (in files `flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/hint/ClearJoinHintsWithCapitalizeQueryHintsShuttleTest.xml` and `flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/hint/ClearJoinHintsWithCapitalizeQueryHintsShuttleTest.xml` do not have consistent ordering for hintOptions.


The following tests have been fixed with this change - 
- `org.apache.flink.table.planner.hint.ClearJoinHintsWithCapitalizeQueryHintsShuttleTest#testClearCaseInsensitiveLookupHint`
- `org.apache.flink.table.planner.hint.ClearLookupJoinHintsWithInvalidPropagationShuttleTest#testNoNeedToClearLookupHint`
- `org.apache.flink.table.planner.hint.ClearLookupJoinHintsWithInvalidPropagationShuttleTest#testClearLookupHintWithInvalidPropagationToSubQuery`
- `org.apache.flink.table.planner.hint.ClearLookupJoinHintsWithInvalidPropagationShuttleTest#testNoNeedToClearLookupHintWhileJoinWithUnnest`
- `org.apache.flink.table.planner.hint.ClearLookupJoinHintsWithInvalidPropagationShuttleTest#testNoNeedToClearLookupHintWhileJoinWithUDTF`


## Brief change log

- To fix the flakiness in these tests, the hint options (`org.apache.flink.table.planner.plan.nodes.exec.spec.LookupJoinHintTestUtil#getLookupJoinHintOptions`) have been changed to use a LinkedHashMap instead of a HashMap, which will preserve insertion order. 
- The test files `flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/hint/ClearJoinHintsWithCapitalizeQueryHintsShuttleTest.xml` and `flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/hint/ClearLookupJoinHintsWithInvalidPropagationShuttleTest.xml` have been amended to have a consistent ordering for hint options.

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change added tests and can be verified as follows:
  - *Fixed test cases that relied on non-deterministic aspects of a data structure - the ordering within a map and made them reliable.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
