### PR TITLE
[FLINK-35833][clients] Skip trying to create parents for "user.artifacts.base-dir" when fetching a "local://" artifact(s)

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactFetchManager.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactFetchManager.java
@@ -90,7 +90,6 @@ public class ArtifactFetchManager {
     public Result fetchArtifacts(String[] uris) {
         checkArgument(uris != null && uris.length > 0, "At least one URI is required.");
 
-        ArtifactUtils.createMissingParents(baseDir);
         List<File> artifacts =
                 Arrays.stream(uris)
                         .map(FunctionUtils.uncheckedFunction(this::fetchArtifact))
@@ -120,9 +119,7 @@ public class ArtifactFetchManager {
             throws Exception {
         checkArgument(jobUri != null && !jobUri.trim().isEmpty(), "The jobUri is required.");
 
-        ArtifactUtils.createMissingParents(baseDir);
         File jobJar = fetchArtifact(jobUri);
-
         List<File> additionalArtifacts =
                 additionalUris == null
                         ? Collections.emptyList()

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/FsArtifactFetcher.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/FsArtifactFetcher.java
@@ -35,6 +35,8 @@ class FsArtifactFetcher extends ArtifactFetcher {
 
     @Override
     File fetch(String uri, Configuration flinkConf, File targetDir) throws Exception {
+        ArtifactUtils.createMissingParents(targetDir);
+
         Path source = new Path(uri);
         long start = System.currentTimeMillis();
         FileSystem fileSystem = source.getFileSystem();

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/HttpArtifactFetcher.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/HttpArtifactFetcher.java
@@ -39,6 +39,8 @@ class HttpArtifactFetcher extends ArtifactFetcher {
 
     @Override
     File fetch(String uri, Configuration flinkConf, File targetDir) throws IOException {
+        ArtifactUtils.createMissingParents(targetDir);
+
         long start = System.currentTimeMillis();
         URL url = new URL(uri);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();

--- a/flink-clients/src/test/java/org/apache/flink/client/program/artifact/ArtifactFetchManagerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/artifact/ArtifactFetchManagerTest.java
@@ -170,6 +170,21 @@ class ArtifactFetchManagerTest {
     }
 
     @Test
+    void testLocalFetcherNotCreatesBaseDir() throws Exception {
+        Path nonExistingPath =
+                tempDir.resolve("non").resolve("existing").resolve("path").toAbsolutePath();
+        configuration.set(ArtifactFetchOptions.BASE_DIR, nonExistingPath.toString());
+
+        File sourceFile = TestingUtils.getClassFile(getClass());
+        String uriStr = "local://" + sourceFile.toURI().getPath();
+
+        ArtifactFetchManager fetchMgr = new ArtifactFetchManager(configuration);
+        fetchMgr.fetchArtifacts(uriStr, null);
+
+        assertThat(nonExistingPath.getParent().getParent()).doesNotExist();
+    }
+
+    @Test
     void testHttpDisabledError() {
         ArtifactFetchManager fetchMgr = new ArtifactFetchManager(configuration);
         assertThatThrownBy(


### PR DESCRIPTION
## What is the purpose of the change

Fixing the default behavior of the artifact fetcher in case of a read-only K8s FS and `local://` artifacts. Currently, the artifact fetcher always try to create the base parent dirs before actually trying to fetch any artifact, and fail in such scenario.

## Brief change log

- Move the `ArtifactUtils#createMissingParents` calls to the specific fetchers where it makes sense.

## Verifying this change

Added unit test to validate `ArtifactUtils#createMissingParents` is not called if we fetch `local://` artifacts.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
