### PR TITLE
[FLINK-36468][parquet] Use Flink Preconditions util instead of Parquet

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/PositionOutputStreamAdapter.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/PositionOutputStreamAdapter.java
@@ -25,7 +25,7 @@ import org.apache.parquet.io.PositionOutputStream;
 
 import java.io.IOException;
 
-import static org.apache.parquet.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** An adapter to turn Flink's {@link FSDataOutputStream} into a {@link PositionOutputStream}. */
 @Internal

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetFormatStatisticsReportUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetFormatStatisticsReportUtil.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.utils.DateTimeUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.statistics.BinaryStatistics;
 import org.apache.parquet.column.statistics.DoubleStatistics;
 import org.apache.parquet.column.statistics.FloatStatistics;
@@ -63,6 +62,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Utils for Parquet format statistics report. */
 public class ParquetFormatStatisticsReportUtil {
@@ -316,7 +317,7 @@ public class ParquetFormatStatisticsReportUtil {
     }
 
     private static Timestamp binaryToTimestamp(Binary timestamp, boolean utcTimestamp) {
-        Preconditions.checkArgument(timestamp.length() == 12, "Must be 12 bytes");
+        checkArgument(timestamp.length() == 12, "Must be 12 bytes");
         ByteBuffer buf = timestamp.toByteBuffer();
         buf.order(ByteOrder.LITTLE_ENDIAN);
         long timeOfDayNanos = buf.getLong();

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetDecimalVector.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetDecimalVector.java
@@ -32,7 +32,7 @@ import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector
 import org.apache.flink.table.data.columnar.vector.writable.WritableIntVector;
 import org.apache.flink.table.data.columnar.vector.writable.WritableLongVector;
 
-import org.apache.parquet.Preconditions;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Parquet write decimal as int32 and int64 and binary, this class wrap the real vector to provide
@@ -58,7 +58,7 @@ public class ParquetDecimalVector
             return DecimalData.fromUnscaledLong(
                     ((LongColumnVector) vector).getLong(i), precision, scale);
         } else {
-            Preconditions.checkArgument(
+            checkArgument(
                     vector instanceof BytesColumnVector,
                     "Reading decimal type occur unsupported vector type: %s",
                     vector.getClass());

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
@@ -97,7 +97,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.utils.DateTimeUtils.toInternal;
-import static org.apache.parquet.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/AbstractColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/AbstractColumnReader.java
@@ -21,7 +21,6 @@ import org.apache.flink.formats.parquet.vector.ParquetDictionary;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
 import org.apache.flink.table.data.columnar.vector.writable.WritableIntVector;
 
-import org.apache.parquet.Preconditions;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.BytesUtils;
@@ -44,6 +43,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.parquet.column.ValuesType.REPETITION_LEVEL;
 
 /**
@@ -132,7 +132,7 @@ public abstract class AbstractColumnReader<VECTOR extends WritableColumnVector>
     protected void checkTypeName(PrimitiveType.PrimitiveTypeName expectedName) {
         PrimitiveType.PrimitiveTypeName actualName =
                 descriptor.getPrimitiveType().getPrimitiveTypeName();
-        Preconditions.checkArgument(
+        checkArgument(
                 actualName == expectedName,
                 "Expected type name: %s, actual type name: %s",
                 expectedName,

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/RunLengthDecoder.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/RunLengthDecoder.java
@@ -20,7 +20,6 @@ package org.apache.flink.formats.parquet.vector.reader;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
 import org.apache.flink.table.data.columnar.vector.writable.WritableIntVector;
 
-import org.apache.parquet.Preconditions;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.values.bitpacking.BytePacker;
@@ -30,6 +29,8 @@ import org.apache.parquet.io.ParquetDecodingException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Run length decoder for data and dictionary ids. See
@@ -107,8 +108,7 @@ final class RunLengthDecoder {
 
     /** Initializes the internal state for decoding ints of `bitWidth`. */
     private void initWidthAndPacker(int bitWidth) {
-        Preconditions.checkArgument(
-                bitWidth >= 0 && bitWidth <= 32, "bitWidth must be >= 0 and <= 32");
+        checkArgument(bitWidth >= 0 && bitWidth <= 32, "bitWidth must be >= 0 and <= 32");
         this.bitWidth = bitWidth;
         this.bytesWidth = BytesUtils.paddedByteCountFromBits(bitWidth);
         this.packer = Packer.LITTLE_ENDIAN.newBytePacker(bitWidth);

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/TimestampColumnReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/TimestampColumnReader.java
@@ -21,7 +21,6 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.columnar.vector.writable.WritableIntVector;
 import org.apache.flink.table.data.columnar.vector.writable.WritableTimestampVector;
 
-import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.io.api.Binary;
@@ -33,6 +32,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.sql.Timestamp;
 import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Timestamp {@link ColumnReader}. We support INT96 and INT64 now, julianDay(4) + nanosOfDay(8). See
@@ -72,7 +73,7 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
     }
 
     private void checkTypeName() {
-        Preconditions.checkArgument(
+        checkArgument(
                 actualName == PrimitiveType.PrimitiveTypeName.INT96
                         || actualName == PrimitiveType.PrimitiveTypeName.INT64,
                 "Expected type name: %s or %s, actual type name: %s",
@@ -137,8 +138,7 @@ public class TimestampColumnReader extends AbstractColumnReader<WritableTimestam
     public static TimestampData decodeInt96ToTimestamp(
             boolean utcTimestamp, org.apache.parquet.column.Dictionary dictionary, int id) {
         Binary binary = dictionary.decodeToBinary(id);
-        Preconditions.checkArgument(
-                binary.length() == 12, "Timestamp with int96 should be 12 bytes.");
+        checkArgument(binary.length() == 12, "Timestamp with int96 should be 12 bytes.");
         ByteBuffer buffer = binary.toByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
         return int96ToTimestamp(utcTimestamp, buffer.getLong(), buffer.getInt());
     }


### PR DESCRIPTION
## What is the purpose of the change

Use Flink Preconditions util instead of Parquet

## Brief change log

`org.apache.parquet.Preconditions` -> `org.apache.flink.util.Preconditions`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
