### PR TITLE
[hotfix][test] Fix TypeHintITCase if adaptive scheduler enabled

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/operators/TypeHintITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/operators/TypeHintITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.test.operators;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.functions.CoGroupFunction;
 import org.apache.flink.api.common.functions.FlatJoinFunction;
 import org.apache.flink.api.common.functions.FlatMapFunction;
@@ -109,6 +110,7 @@ public class TypeHintITCase extends AbstractTestBaseJUnit4 {
     @Test
     public void testJoinWithTypeInformationTypeHint() throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
 
         DataStreamSource<Tuple3<Integer, Long, String>> ds1 =
                 CollectionDataStreams.getSmall3TupleDataSet(env);
@@ -134,6 +136,7 @@ public class TypeHintITCase extends AbstractTestBaseJUnit4 {
     @Test
     public void testFlatJoinWithTypeInformationTypeHint() throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
 
         DataStreamSource<Tuple3<Integer, Long, String>> ds1 =
                 CollectionDataStreams.getSmall3TupleDataSet(env);
@@ -159,6 +162,7 @@ public class TypeHintITCase extends AbstractTestBaseJUnit4 {
     @Test
     public void testCoGroupWithTypeInformationTypeHint() throws Exception {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
 
         DataStreamSource<Tuple3<Integer, Long, String>> ds1 =
                 CollectionDataStreams.getSmall3TupleDataSet(env);


### PR DESCRIPTION
## What is the purpose of the change

*Fix TypeHintITCase if adaptive scheduler enabled*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
