### PR TITLE
[FLINK-36511] Prevent StackOverflow in FlinkSecurityManager

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/security/FlinkSecurityManager.java
+++ b/flink-core/src/main/java/org/apache/flink/core/security/FlinkSecurityManager.java
@@ -181,6 +181,8 @@ public class FlinkSecurityManager extends SecurityManager {
         // At this point, exit is determined. Halt if defined, otherwise check ended, JVM will call
         // System.exit
         if (haltOnSystemExit) {
+            // null the security manager to prevent infinite recursion
+            System.setSecurityManager(null);
             Runtime.getRuntime().halt(status);
         }
     }


### PR DESCRIPTION
The halt() call in checkExit() will again cause checkExit() to be called since we don't null the security manager, in contrast to how forceProcessExit is implemented.
This is only an issue during the process startup, as at later times we typically initiate the shutdown for forceProcessExit.