### PR TITLE
[BP-1.19][FLINK-35833][clients] Skip trying to create parents for "user.artifacts.base-dir" when fetching a "local://" artifact

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactFetchManager.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/ArtifactFetchManager.java
@@ -90,7 +90,6 @@ public class ArtifactFetchManager {
     public Result fetchArtifacts(String[] uris) {
         checkArgument(uris != null && uris.length > 0, "At least one URI is required.");
 
-        ArtifactUtils.createMissingParents(baseDir);
         List<File> artifacts =
                 Arrays.stream(uris)
                         .map(FunctionUtils.uncheckedFunction(this::fetchArtifact))
@@ -120,9 +119,7 @@ public class ArtifactFetchManager {
             throws Exception {
         checkArgument(jobUri != null && !jobUri.trim().isEmpty(), "The jobUri is required.");
 
-        ArtifactUtils.createMissingParents(baseDir);
         File jobJar = fetchArtifact(jobUri);
-
         List<File> additionalArtifacts =
                 additionalUris == null
                         ? Collections.emptyList()

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/FsArtifactFetcher.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/FsArtifactFetcher.java
@@ -35,6 +35,8 @@ class FsArtifactFetcher extends ArtifactFetcher {
 
     @Override
     File fetch(String uri, Configuration flinkConf, File targetDir) throws Exception {
+        ArtifactUtils.createMissingParents(targetDir);
+
         Path source = new Path(uri);
         long start = System.currentTimeMillis();
         FileSystem fileSystem = source.getFileSystem();

--- a/flink-clients/src/main/java/org/apache/flink/client/program/artifact/HttpArtifactFetcher.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/artifact/HttpArtifactFetcher.java
@@ -39,6 +39,8 @@ class HttpArtifactFetcher extends ArtifactFetcher {
 
     @Override
     File fetch(String uri, Configuration flinkConf, File targetDir) throws IOException {
+        ArtifactUtils.createMissingParents(targetDir);
+
         long start = System.currentTimeMillis();
         URL url = new URL(uri);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();

--- a/flink-clients/src/test/java/org/apache/flink/client/program/artifact/ArtifactFetchManagerTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/artifact/ArtifactFetchManagerTest.java
@@ -172,6 +172,21 @@ class ArtifactFetchManagerTest {
     }
 
     @Test
+    void testLocalFetcherNotCreatesBaseDir() throws Exception {
+        Path nonExistingPath =
+                tempDir.resolve("non").resolve("existing").resolve("path").toAbsolutePath();
+        configuration.set(ArtifactFetchOptions.BASE_DIR, nonExistingPath.toString());
+
+        File sourceFile = getDummyArtifact(getClass());
+        String uriStr = "local://" + sourceFile.toURI().getPath();
+
+        ArtifactFetchManager fetchMgr = new ArtifactFetchManager(configuration);
+        fetchMgr.fetchArtifacts(uriStr, null);
+
+        assertThat(nonExistingPath.getParent().getParent()).doesNotExist();
+    }
+
+    @Test
     void testHttpDisabledError() {
         ArtifactFetchManager fetchMgr = new ArtifactFetchManager(configuration);
         assertThatThrownBy(


### PR DESCRIPTION
1.19 backport of https://github.com/apache/flink/pull/25487