### PR TITLE
[FLINK-35029][state/forst] Store timer in JVM heap when use async state backend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -89,6 +89,7 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
     public void initializeState(StreamTaskStateInitializer streamTaskStateManager)
             throws Exception {
         super.initializeState(streamTaskStateManager);
+        this.timeServiceManager = stateHandler.getAsyncInternalTimerServiceManager();
         getRuntimeContext().setKeyedStateStoreV2(stateHandler.getKeyedStateStoreV2().orElse(null));
         final StreamTask<?, ?> containingTask = checkNotNull(getContainingTask());
         environment = containingTask.getEnvironment();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
@@ -89,6 +89,7 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
     public final void initializeState(StreamTaskStateInitializer streamTaskStateManager)
             throws Exception {
         super.initializeState(streamTaskStateManager);
+        this.timeServiceManager = stateHandler.getAsyncInternalTimerServiceManager();
         getRuntimeContext().setKeyedStateStoreV2(stateHandler.getKeyedStateStoreV2().orElse(null));
 
         final int inFlightRecordsLimit = getExecutionConfig().getAsyncInflightRecordsLimit();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
@@ -26,12 +26,19 @@ import org.apache.flink.runtime.asyncprocessing.RecordContext;
 import org.apache.flink.runtime.asyncprocessing.StateExecutor;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.SnapshotType;
+import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
 import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 import org.apache.flink.runtime.state.internal.InternalAggregatingState;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.runtime.state.internal.InternalMapState;
@@ -97,6 +104,11 @@ public class AsyncKeyedStateBackendAdaptor<K> implements AsyncKeyedStateBackend<
     }
 
     @Override
+    public KeyGroupRange getKeyGroupRange() {
+        return keyedStateBackend.getKeyGroupRange();
+    }
+
+    @Override
     public void switchContext(RecordContext<K> context) {
         keyedStateBackend.setCurrentKeyAndKeyGroup(context.getKey(), context.getKeyGroup());
     }
@@ -138,5 +150,33 @@ public class AsyncKeyedStateBackendAdaptor<K> implements AsyncKeyedStateBackend<
             throws Exception {
         return keyedStateBackend.snapshot(
                 checkpointId, timestamp, streamFactory, checkpointOptions);
+    }
+
+    @Nonnull
+    @Override
+    public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+            KeyGroupedInternalPriorityQueue<T> create(
+                    @Nonnull String stateName,
+                    @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+        return keyedStateBackend.create(stateName, byteOrderedElementSerializer);
+    }
+
+    @Override
+    public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+            KeyGroupedInternalPriorityQueue<T> create(
+                    @Nonnull String stateName,
+                    @Nonnull TypeSerializer<T> byteOrderedElementSerializer,
+                    boolean allowFutureMetadataUpdates) {
+        return keyedStateBackend.create(
+                stateName, byteOrderedElementSerializer, allowFutureMetadataUpdates);
+    }
+
+    @Override
+    public boolean requiresLegacySynchronousTimerSnapshots(SnapshotType checkpointType) {
+        if (keyedStateBackend instanceof AbstractKeyedStateBackend) {
+            return ((AbstractKeyedStateBackend) keyedStateBackend)
+                    .requiresLegacySynchronousTimerSnapshots(checkpointType);
+        }
+        return false;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
@@ -111,6 +112,7 @@ public interface InternalTimeServiceManager<K> {
         <K> InternalTimeServiceManager<K> create(
                 TaskIOMetricGroup taskIOMetricGroup,
                 CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+                AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
                 ClassLoader userClassloader,
                 KeyContext keyContext,
                 ProcessingTimeService processingTimeService,

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -22,10 +22,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
@@ -111,8 +111,8 @@ public interface InternalTimeServiceManager<K> {
     interface Provider extends Serializable {
         <K> InternalTimeServiceManager<K> create(
                 TaskIOMetricGroup taskIOMetricGroup,
-                CheckpointableKeyedStateBackend<K> keyedStatedBackend,
-                AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
+                PriorityQueueSetFactory factory,
+                KeyGroupRange keyGroupRange,
                 ClassLoader userClassloader,
                 KeyContext keyContext,
                 ProcessingTimeService processingTimeService,

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
@@ -25,8 +25,6 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
@@ -102,28 +100,21 @@ public class InternalTimeServiceManagerImpl<K> implements InternalTimeServiceMan
      */
     public static <K> InternalTimeServiceManagerImpl<K> create(
             TaskIOMetricGroup taskIOMetricGroup,
-            CheckpointableKeyedStateBackend<K> keyedStateBackend,
-            AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
+            PriorityQueueSetFactory factory,
+            KeyGroupRange keyGroupRange,
             ClassLoader userClassloader,
             KeyContext keyContext,
             ProcessingTimeService processingTimeService,
             Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
             StreamTaskCancellationContext cancellationContext)
             throws Exception {
-        final KeyGroupRange keyGroupRange =
-                keyedStateBackend != null
-                        ? keyedStateBackend.getKeyGroupRange()
-                        : asyncKeyedStateBackend.getKeyGroupRange();
-
-        final PriorityQueueSetFactory priorityQueueSetFactory =
-                keyedStateBackend != null ? keyedStateBackend : asyncKeyedStateBackend;
 
         final InternalTimeServiceManagerImpl<K> timeServiceManager =
                 new InternalTimeServiceManagerImpl<>(
                         taskIOMetricGroup,
                         keyGroupRange,
                         keyContext,
-                        priorityQueueSetFactory,
+                        factory,
                         processingTimeService,
                         cancellationContext);
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
@@ -102,20 +103,27 @@ public class InternalTimeServiceManagerImpl<K> implements InternalTimeServiceMan
     public static <K> InternalTimeServiceManagerImpl<K> create(
             TaskIOMetricGroup taskIOMetricGroup,
             CheckpointableKeyedStateBackend<K> keyedStateBackend,
+            AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
             ClassLoader userClassloader,
             KeyContext keyContext,
             ProcessingTimeService processingTimeService,
             Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
             StreamTaskCancellationContext cancellationContext)
             throws Exception {
-        final KeyGroupRange keyGroupRange = keyedStateBackend.getKeyGroupRange();
+        final KeyGroupRange keyGroupRange =
+                keyedStateBackend != null
+                        ? keyedStateBackend.getKeyGroupRange()
+                        : asyncKeyedStateBackend.getKeyGroupRange();
+
+        final PriorityQueueSetFactory priorityQueueSetFactory =
+                keyedStateBackend != null ? keyedStateBackend : asyncKeyedStateBackend;
 
         final InternalTimeServiceManagerImpl<K> timeServiceManager =
                 new InternalTimeServiceManagerImpl<>(
                         taskIOMetricGroup,
                         keyGroupRange,
                         keyContext,
-                        keyedStateBackend,
+                        priorityQueueSetFactory,
                         processingTimeService,
                         cancellationContext);
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
@@ -68,6 +68,12 @@ public interface StreamOperatorStateContext {
     InternalTimeServiceManager<?> internalTimerServiceManager();
 
     /**
+     * Returns the internal timer service manager create by async state backend for the stream
+     * operator. This method returns null for non-keyed operators.
+     */
+    InternalTimeServiceManager<?> asyncInternalTimerServiceManager();
+
+    /**
      * Returns an iterable to obtain input streams for previously stored operator state partitions
      * that are assigned to this stream operator.
      */

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -245,7 +245,7 @@ public class StreamOperatorStateHandler {
                                         .requiresLegacySynchronousTimerSnapshots(
                                                 checkpointOptions.getCheckpointType());
                 requiresLegacyRawKeyedStateSnapshots |=
-                        keyedStateBackend instanceof AsyncKeyedStateBackend
+                        useAsyncState
                                 && ((AsyncKeyedStateBackend<?>) keyedStateBackend)
                                         .requiresLegacySynchronousTimerSnapshots(
                                                 checkpointOptions.getCheckpointType());
@@ -462,6 +462,10 @@ public class StreamOperatorStateHandler {
         } else {
             throw new UnsupportedOperationException("Key can only be retrieved on KeyedStream.");
         }
+    }
+
+    public InternalTimeServiceManager<?> getAsyncInternalTimerServiceManager() {
+        return context.asyncInternalTimerServiceManager();
     }
 
     public Optional<KeyedStateStore> getKeyedStateStore() {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -245,7 +245,7 @@ public class StreamOperatorStateHandler {
                                         .requiresLegacySynchronousTimerSnapshots(
                                                 checkpointOptions.getCheckpointType());
                 requiresLegacyRawKeyedStateSnapshots |=
-                        useAsyncState
+                        keyedStateBackend instanceof AsyncKeyedStateBackend
                                 && ((AsyncKeyedStateBackend<?>) keyedStateBackend)
                                         .requiresLegacySynchronousTimerSnapshots(
                                                 checkpointOptions.getCheckpointType());

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -244,6 +244,11 @@ public class StreamOperatorStateHandler {
                                 && ((AbstractKeyedStateBackend<?>) keyedStateBackend)
                                         .requiresLegacySynchronousTimerSnapshots(
                                                 checkpointOptions.getCheckpointType());
+                requiresLegacyRawKeyedStateSnapshots |=
+                        keyedStateBackend instanceof AsyncKeyedStateBackend
+                                && ((AsyncKeyedStateBackend<?>) keyedStateBackend)
+                                        .requiresLegacySynchronousTimerSnapshots(
+                                                checkpointOptions.getCheckpointType());
 
                 if (requiresLegacyRawKeyedStateSnapshots) {
                     checkState(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
@@ -21,11 +21,11 @@ package org.apache.flink.streaming.api.operators.sorted.state;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
-import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.KeyContext;
@@ -107,20 +107,21 @@ public class BatchExecutionInternalTimeServiceManager<K>
 
     public static <K> InternalTimeServiceManager<K> create(
             TaskIOMetricGroup taskIOMetricGroup,
-            CheckpointableKeyedStateBackend<K> keyedStatedBackend,
-            AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
+            PriorityQueueSetFactory factory,
+            KeyGroupRange keyGroupRange,
             ClassLoader userClassloader,
             KeyContext keyContext, // the operator
             ProcessingTimeService processingTimeService,
             Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
             StreamTaskCancellationContext cancellationContext) {
         checkState(
-                keyedStatedBackend instanceof BatchExecutionKeyedStateBackend,
+                factory instanceof BatchExecutionKeyedStateBackend,
                 "Batch execution specific time service can work only with BatchExecutionKeyedStateBackend");
 
         BatchExecutionInternalTimeServiceManager<K> timeServiceManager =
                 new BatchExecutionInternalTimeServiceManager<>(processingTimeService);
-        keyedStatedBackend.registerKeySelectionListener(timeServiceManager);
+        ((BatchExecutionKeyedStateBackend) factory)
+                .registerKeySelectionListener(timeServiceManager);
         return timeServiceManager;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.operators.sorted.state;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateBackend;
@@ -107,6 +108,7 @@ public class BatchExecutionInternalTimeServiceManager<K>
     public static <K> InternalTimeServiceManager<K> create(
             TaskIOMetricGroup taskIOMetricGroup,
             CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+            AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
             ClassLoader userClassloader,
             KeyContext keyContext, // the operator
             ProcessingTimeService processingTimeService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorTest.java
@@ -40,7 +40,6 @@ import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.util.function.ThrowingConsumer;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutorService;
@@ -222,7 +221,6 @@ public class AbstractAsyncStateStreamOperatorTest {
         }
     }
 
-    @Disabled("Support Timer for AsyncKeyedStateBackend")
     @Test
     void testTimerServiceIsAsync() throws Exception {
         try (KeyedOneInputStreamOperatorTestHarness<Integer, Tuple2<Integer, String>, String>

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.util.function.FunctionWithException;
 
 import javax.annotation.Nonnull;
@@ -114,12 +115,14 @@ public class StateBackendTestUtils {
 
         private final Supplier<org.apache.flink.api.common.state.v2.State> innerStateSupplier;
         private final StateExecutor stateExecutor;
+        private final PriorityQueueSetFactory factory;
 
         public TestAsyncKeyedStateBackend(
                 Supplier<org.apache.flink.api.common.state.v2.State> innerStateSupplier,
                 StateExecutor stateExecutor) {
             this.innerStateSupplier = innerStateSupplier;
             this.stateExecutor = stateExecutor;
+            this.factory = new HeapPriorityQueueSetFactory(new KeyGroupRange(0, 127), 128, 128);
         }
 
         @Override
@@ -141,6 +144,11 @@ public class StateBackendTestUtils {
         @Override
         public StateExecutor createStateExecutor() {
             return stateExecutor;
+        }
+
+        @Override
+        public KeyGroupRange getKeyGroupRange() {
+            return new KeyGroupRange(0, 127);
         }
 
         @Override
@@ -172,6 +180,15 @@ public class StateBackendTestUtils {
                 throws Exception {
             // do nothing
             return null;
+        }
+
+        @Nonnull
+        @Override
+        public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+                KeyGroupedInternalPriorityQueue<T> create(
+                        @Nonnull String stateName,
+                        @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+            return factory.create(stateName, byteOrderedElementSerializer);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
@@ -31,10 +31,15 @@ import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateBackend;
+import org.apache.flink.runtime.state.PriorityComparable;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -130,6 +135,18 @@ public class AbstractKeyedStateTestBase {
             return new AsyncKeyedStateBackend<K>() {
                 @Nonnull
                 @Override
+                public <
+                                T extends
+                                        HeapPriorityQueueElement & PriorityComparable<? super T>
+                                                & Keyed<?>>
+                        KeyGroupedInternalPriorityQueue<T> create(
+                                @Nonnull String stateName,
+                                @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+                    throw new UnsupportedOperationException("Not support for test yet.");
+                }
+
+                @Nonnull
+                @Override
                 public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
                         long checkpointId,
                         long timestamp,
@@ -168,6 +185,11 @@ public class AbstractKeyedStateTestBase {
                 @Override
                 public StateExecutor createStateExecutor() {
                     return new TestStateExecutor();
+                }
+
+                @Override
+                public KeyGroupRange getKeyGroupRange() {
+                    return new KeyGroupRange(0, 127);
                 }
 
                 @Override

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -37,8 +37,6 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
-import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
@@ -47,6 +45,7 @@ import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateInitializationContextImpl;
 import org.apache.flink.runtime.state.StatePartitionStreamProvider;
@@ -197,8 +196,8 @@ class StateInitializationContextImplTest {
                             @Override
                             public <K> InternalTimeServiceManager<K> create(
                                     TaskIOMetricGroup taskIOMetricGroup,
-                                    CheckpointableKeyedStateBackend<K> keyedStatedBackend,
-                                    AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
+                                    PriorityQueueSetFactory factory,
+                                    KeyGroupRange keyGroupRange,
                                     ClassLoader userClassloader,
                                     KeyContext keyContext,
                                     ProcessingTimeService processingTimeService,

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.DefaultOperatorStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -197,6 +198,7 @@ class StateInitializationContextImplTest {
                             public <K> InternalTimeServiceManager<K> create(
                                     TaskIOMetricGroup taskIOMetricGroup,
                                     CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+                                    AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
                                     ClassLoader userClassloader,
                                     KeyContext keyContext,
                                     ProcessingTimeService processingTimeService,

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.OperatorStateBackend;
@@ -346,6 +347,7 @@ class StreamTaskStateInitializerImplTest {
                         public <K> InternalTimeServiceManager<K> create(
                                 TaskIOMetricGroup taskIOMetricGroup,
                                 CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+                                AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
                                 ClassLoader userClassloader,
                                 KeyContext keyContext,
                                 ProcessingTimeService processingTimeService,

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -35,12 +35,13 @@ import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
-import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StatePartitionStreamProvider;
@@ -346,8 +347,8 @@ class StreamTaskStateInitializerImplTest {
                         @Override
                         public <K> InternalTimeServiceManager<K> create(
                                 TaskIOMetricGroup taskIOMetricGroup,
-                                CheckpointableKeyedStateBackend<K> keyedStatedBackend,
-                                AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
+                                PriorityQueueSetFactory factory,
+                                KeyGroupRange keyGroupRange,
                                 ClassLoader userClassloader,
                                 KeyContext keyContext,
                                 ProcessingTimeService processingTimeService,

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
@@ -91,6 +91,7 @@ class BatchExecutionInternalTimeServiceTest {
                                         UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
                                                 .getIOMetricGroup(),
                                         stateBackend,
+                                        null,
                                         this.getClass().getClassLoader(),
                                         new DummyKeyContext(),
                                         new TestProcessingTimeService(),
@@ -147,6 +148,7 @@ class BatchExecutionInternalTimeServiceTest {
                         UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
                                 .getIOMetricGroup(),
                         keyedStatedBackend,
+                        null,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         new TestProcessingTimeService(),
@@ -185,6 +187,7 @@ class BatchExecutionInternalTimeServiceTest {
                         UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
                                 .getIOMetricGroup(),
                         keyedStatedBackend,
+                        null,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         new TestProcessingTimeService(),
@@ -216,6 +219,7 @@ class BatchExecutionInternalTimeServiceTest {
                         UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
                                 .getIOMetricGroup(),
                         keyedStatedBackend,
+                        null,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         new TestProcessingTimeService(),
@@ -265,6 +269,7 @@ class BatchExecutionInternalTimeServiceTest {
                         UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
                                 .getIOMetricGroup(),
                         keyedStatedBackend,
+                        null,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         processingTimeService,
@@ -302,6 +307,7 @@ class BatchExecutionInternalTimeServiceTest {
                         UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
                                 .getIOMetricGroup(),
                         keyedStatedBackend,
+                        null,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         processingTimeService,
@@ -344,6 +350,7 @@ class BatchExecutionInternalTimeServiceTest {
                         UnregisteredMetricGroups.createUnregisteredTaskMetricGroup()
                                 .getIOMetricGroup(),
                         keyedStatedBackend,
+                        null,
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         processingTimeService,

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageAccess;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
@@ -153,6 +154,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
                 public <K> InternalTimeServiceManager<K> create(
                         TaskIOMetricGroup taskIOMetricGroup,
                         CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+                        AsyncKeyedStateBackend<K> asyncKeyedStatedBackend,
                         ClassLoader userClassloader,
                         KeyContext keyContext,
                         ProcessingTimeService processingTimeService,
@@ -163,6 +165,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
                             InternalTimeServiceManagerImpl.create(
                                     taskIOMetricGroup,
                                     keyedStatedBackend,
+                                    asyncKeyedStatedBackend,
                                     userClassloader,
                                     keyContext,
                                     processingTimeService,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -31,12 +31,22 @@ import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.runtime.state.HeapPriorityQueuesManager;
+import org.apache.flink.runtime.state.InternalKeyContext;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
+import org.apache.flink.runtime.state.Keyed;
 import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.SnapshotStrategyRunner;
 import org.apache.flink.runtime.state.StateSnapshotTransformer;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSnapshotRestoreWrapper;
 import org.apache.flink.runtime.state.v2.AggregatingStateDescriptor;
 import org.apache.flink.runtime.state.v2.ListStateDescriptor;
 import org.apache.flink.runtime.state.v2.ReducingStateDescriptor;
@@ -62,6 +72,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.RunnableFuture;
@@ -80,6 +91,9 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
 
     /** Number of bytes required to prefix the key groups. */
     private final int keyGroupPrefixBytes;
+
+    /** The key groups which this state backend is responsible for. */
+    private final KeyGroupRange keyGroupRange;
 
     /** The key serializer. */
     protected final TypeSerializer<K> keySerializer;
@@ -110,6 +124,11 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
     private final ColumnFamilyHandle defaultColumnFamily;
 
     private final ForStSnapshotStrategyBase<K, ?> snapshotStrategy;
+
+    /** Factory for priority queue state. */
+    private final PriorityQueueSetFactory priorityQueueFactory;
+
+    private final HeapPriorityQueuesManager heapPriorityQueuesManager;
 
     /**
      * Registry for all opened streams, so they can be closed if the task using this backend is
@@ -157,14 +176,18 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
             Supplier<DataInputDeserializer> valueDeserializerView,
             RocksDB db,
             LinkedHashMap<String, ForStKvStateInfo> kvStateInformation,
+            Map<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             ColumnFamilyHandle defaultColumnFamilyHandle,
             ForStSnapshotStrategyBase<K, ?> snapshotStrategy,
+            PriorityQueueSetFactory priorityQueueFactory,
             CloseableRegistry cancelStreamRegistry,
-            ForStNativeMetricMonitor nativeMetricMonitor) {
+            ForStNativeMetricMonitor nativeMetricMonitor,
+            InternalKeyContext<K> keyContext) {
         this.backendUID = backendUID;
         this.optionsContainer = Preconditions.checkNotNull(optionsContainer);
         this.keyGroupPrefixBytes = keyGroupPrefixBytes;
+        this.keyGroupRange = keyContext.getKeyGroupRange();
         this.keySerializer = keySerializer;
         this.serializedKeyBuilder = serializedKeyBuilder;
         this.valueSerializerView = valueSerializerView;
@@ -177,6 +200,17 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
         this.cancelStreamRegistry = cancelStreamRegistry;
         this.nativeMetricMonitor = nativeMetricMonitor;
         this.managedStateExecutors = new HashSet<>(1);
+        this.priorityQueueFactory = priorityQueueFactory;
+        if (priorityQueueFactory instanceof HeapPriorityQueueSetFactory) {
+            this.heapPriorityQueuesManager =
+                    new HeapPriorityQueuesManager(
+                            registeredPQStates,
+                            (HeapPriorityQueueSetFactory) priorityQueueFactory,
+                            keyContext.getKeyGroupRange(),
+                            keyContext.getNumberOfKeyGroups());
+        } else {
+            this.heapPriorityQueuesManager = null;
+        }
     }
 
     @Override
@@ -370,6 +404,11 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
         }
     }
 
+    @Override
+    public KeyGroupRange getKeyGroupRange() {
+        return keyGroupRange;
+    }
+
     @Nonnull
     @Override
     public RunnableFuture<SnapshotResult<KeyedStateHandle>> snapshot(
@@ -467,6 +506,30 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
     @Override
     public void close() throws IOException {
         dispose();
+    }
+
+    @Nonnull
+    @Override
+    public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+            KeyGroupedInternalPriorityQueue<T> create(
+                    @Nonnull String stateName,
+                    @Nonnull TypeSerializer<T> byteOrderedElementSerializer) {
+        return create(stateName, byteOrderedElementSerializer, false);
+    }
+
+    @Override
+    public <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+            KeyGroupedInternalPriorityQueue<T> create(
+                    @Nonnull String stateName,
+                    @Nonnull TypeSerializer<T> byteOrderedElementSerializer,
+                    boolean allowFutureMetadataUpdates) {
+        if (this.heapPriorityQueuesManager != null) {
+            return this.heapPriorityQueuesManager.createOrUpdate(
+                    stateName, byteOrderedElementSerializer, allowFutureMetadataUpdates);
+        } else {
+            return priorityQueueFactory.create(
+                    stateName, byteOrderedElementSerializer, allowFutureMetadataUpdates);
+        }
     }
 
     /** ForSt specific information about the k/v states. */

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
@@ -27,19 +27,26 @@ import org.apache.flink.runtime.state.BackendBuildingException;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
 import org.apache.flink.runtime.state.IncrementalKeyedStateHandle;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.InternalKeyContext;
+import org.apache.flink.runtime.state.InternalKeyContextImpl;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.SerializedCompositeKeyBuilder;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendBuilder;
 import org.apache.flink.runtime.state.StateSerializerProvider;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSnapshotRestoreWrapper;
 import org.apache.flink.state.forst.fs.ForStFlinkFileSystem;
+import org.apache.flink.state.forst.restore.ForStHeapTimersFullRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStIncrementalRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStNoneRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStRestoreOperation;
 import org.apache.flink.state.forst.restore.ForStRestoreResult;
 import org.apache.flink.state.forst.snapshot.ForStIncrementalSnapshotStrategy;
 import org.apache.flink.state.forst.snapshot.ForStSnapshotStrategyBase;
+import org.apache.flink.state.forst.sync.ForStPriorityQueueConfig;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
@@ -83,6 +90,9 @@ public class ForStKeyedStateBackendBuilder<K>
     /** String that identifies the operator that owns this backend. */
     private final String operatorIdentifier;
 
+    /** The configuration of rocksDB priorityQueue state. */
+    private final ForStPriorityQueueConfig priorityQueueConfig;
+
     protected final ClassLoader userCodeClassLoader;
 
     protected final CloseableRegistry cancelStreamRegistry;
@@ -117,6 +127,7 @@ public class ForStKeyedStateBackendBuilder<K>
             TypeSerializer<K> keySerializer,
             int numberOfKeyGroups,
             KeyGroupRange keyGroupRange,
+            ForStPriorityQueueConfig priorityQueueConfig,
             MetricGroup metricGroup,
             StateBackend.CustomInitializationMetrics customInitializationMetrics,
             @Nonnull Collection<KeyedStateHandle> stateHandles,
@@ -129,6 +140,7 @@ public class ForStKeyedStateBackendBuilder<K>
                 StateSerializerProvider.fromNewRegisteredSerializer(keySerializer);
         this.numberOfKeyGroups = numberOfKeyGroups;
         this.keyGroupRange = keyGroupRange;
+        this.priorityQueueConfig = priorityQueueConfig;
         this.metricGroup = metricGroup;
         this.customInitializationMetrics = customInitializationMetrics;
         this.restoreStateHandles = stateHandles;
@@ -157,6 +169,8 @@ public class ForStKeyedStateBackendBuilder<K>
 
         LinkedHashMap<String, ForStKeyedStateBackend.ForStKvStateInfo> kvStateInformation =
                 new LinkedHashMap<>();
+        LinkedHashMap<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates =
+                new LinkedHashMap<>();
 
         RocksDB db = null;
         ForStRestoreOperation restoreOperation = null;
@@ -183,10 +197,11 @@ public class ForStKeyedStateBackendBuilder<K>
         Supplier<DataInputDeserializer> valueDeserializerView = DataInputDeserializer::new;
 
         UUID backendUID = UUID.randomUUID();
+        PriorityQueueSetFactory priorityQueueFactory;
 
         try {
             optionsContainer.prepareDirectories();
-            restoreOperation = getForStRestoreOperation(kvStateInformation);
+            restoreOperation = getForStRestoreOperation(kvStateInformation, registeredPQStates);
             ForStRestoreResult restoreResult = restoreOperation.restore();
             db = restoreResult.getDb();
             defaultColumnFamilyHandle = restoreResult.getDefaultColumnFamilyHandle();
@@ -208,6 +223,8 @@ public class ForStKeyedStateBackendBuilder<K>
                             backendUID,
                             materializedSstFiles,
                             lastCompletedCheckpointId);
+
+            priorityQueueFactory = createHeapQueueFactory();
 
         } catch (Throwable e) {
             // Do clean up
@@ -237,6 +254,8 @@ public class ForStKeyedStateBackendBuilder<K>
                 throw new BackendBuildingException(errMsg, e);
             }
         }
+        InternalKeyContext<K> keyContext =
+                new InternalKeyContextImpl<>(keyGroupRange, numberOfKeyGroups);
         logger.info(
                 "Finished building ForSt keyed state-backend at local base path: {}, remote base path: {}.",
                 optionsContainer.getLocalBasePath(),
@@ -251,15 +270,19 @@ public class ForStKeyedStateBackendBuilder<K>
                 valueDeserializerView,
                 db,
                 kvStateInformation,
+                registeredPQStates,
                 columnFamilyOptionsFactory,
                 defaultColumnFamilyHandle,
                 snapshotStrategy,
+                priorityQueueFactory,
                 cancelStreamRegistryForBackend,
-                nativeMetricMonitor);
+                nativeMetricMonitor,
+                keyContext);
     }
 
     private ForStRestoreOperation getForStRestoreOperation(
-            LinkedHashMap<String, ForStKeyedStateBackend.ForStKvStateInfo> kvStateInformation) {
+            LinkedHashMap<String, ForStKeyedStateBackend.ForStKvStateInfo> kvStateInformation,
+            LinkedHashMap<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates) {
         // Currently, ForStDB does not support mixing local-dir and remote-dir, and ForStDB will
         // concatenates the dfs directory with the local directory as working dir when using flink
         // env. We expect to directly use the dfs directory in flink env or local directory as
@@ -299,7 +322,27 @@ public class ForStKeyedStateBackendBuilder<K>
                     customInitializationMetrics,
                     CollectionUtil.checkedSubTypeCast(
                             restoreStateHandles, IncrementalRemoteKeyedStateHandle.class));
+        } else if (priorityQueueConfig.getPriorityQueueStateType()
+                == ForStStateBackend.PriorityQueueStateType.HEAP) {
+            // Note: This branch can be touched after ForSt Support canonical savepoint,
+            // Timers are stored as raw keyed state instead of managed keyed state now.
+            return new ForStHeapTimersFullRestoreOperation<>(
+                    keyGroupRange,
+                    numberOfKeyGroups,
+                    userCodeClassLoader,
+                    kvStateInformation,
+                    registeredPQStates,
+                    createHeapQueueFactory(),
+                    keySerializerProvider,
+                    instanceForStPath,
+                    optionsContainer.getDbOptions(),
+                    columnFamilyOptionsFactory,
+                    nativeMetricOptions,
+                    metricGroup,
+                    restoreStateHandles,
+                    cancelStreamRegistry);
         }
+
         // TODO: Support Restoring
         throw new UnsupportedOperationException("Not support restoring yet for ForStStateBackend");
     }
@@ -350,5 +393,9 @@ public class ForStKeyedStateBackendBuilder<K>
             throw new UnsupportedOperationException("Not implemented yet for ForStStateBackend");
         }
         return snapshotStrategy;
+    }
+
+    private HeapPriorityQueueSetFactory createHeapQueueFactory() {
+        return new HeapPriorityQueueSetFactory(keyGroupRange, numberOfKeyGroups, 128);
     }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
@@ -362,6 +362,7 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
                                 parameters.getKeySerializer(),
                                 parameters.getNumberOfKeyGroups(),
                                 parameters.getKeyGroupRange(),
+                                priorityQueueConfig,
                                 parameters.getMetricGroup(),
                                 parameters.getCustomInitializationMetrics(),
                                 parameters.getStateHandles(),

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStHeapTimersFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStHeapTimersFullRestoreOperation.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.restore;
+
+import org.apache.flink.core.fs.ICloseableRegistry;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
+import org.apache.flink.runtime.state.KeyExtractorFunction;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.Keyed;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.PriorityComparable;
+import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
+import org.apache.flink.runtime.state.StateSerializerProvider;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueElement;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSet;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
+import org.apache.flink.runtime.state.heap.HeapPriorityQueueSnapshotRestoreWrapper;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot.BackendStateType;
+import org.apache.flink.runtime.state.restore.FullSnapshotRestoreOperation;
+import org.apache.flink.runtime.state.restore.KeyGroup;
+import org.apache.flink.runtime.state.restore.KeyGroupEntry;
+import org.apache.flink.runtime.state.restore.SavepointRestoreResult;
+import org.apache.flink.runtime.state.restore.ThrowingIterator;
+import org.apache.flink.state.forst.ForStDBWriteBatchWrapper;
+import org.apache.flink.state.forst.ForStKeyedStateBackend;
+import org.apache.flink.state.forst.ForStNativeMetricOptions;
+import org.apache.flink.util.StateMigrationException;
+
+import org.forstdb.ColumnFamilyHandle;
+import org.forstdb.ColumnFamilyOptions;
+import org.forstdb.DBOptions;
+import org.forstdb.RocksDBException;
+
+import javax.annotation.Nonnull;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/** Encapsulates the process of restoring a ForStDB instance from a full snapshot. */
+public class ForStHeapTimersFullRestoreOperation<K> implements ForStRestoreOperation {
+    private final FullSnapshotRestoreOperation<K> savepointRestoreOperation;
+
+    private final LinkedHashMap<String, HeapPriorityQueueSnapshotRestoreWrapper<?>>
+            registeredPQStates;
+    private final HeapPriorityQueueSetFactory priorityQueueFactory;
+    private final int numberOfKeyGroups;
+    private final DataInputDeserializer deserializer = new DataInputDeserializer();
+
+    private final ForStHandle rocksHandle;
+    private final KeyGroupRange keyGroupRange;
+    private final int keyGroupPrefixBytes;
+    private final ICloseableRegistry cancelStreamRegistryForRestore;
+
+    public ForStHeapTimersFullRestoreOperation(
+            KeyGroupRange keyGroupRange,
+            int numberOfKeyGroups,
+            ClassLoader userCodeClassLoader,
+            Map<String, ForStKeyedStateBackend.ForStKvStateInfo> kvStateInformation,
+            LinkedHashMap<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates,
+            HeapPriorityQueueSetFactory priorityQueueFactory,
+            StateSerializerProvider<K> keySerializerProvider,
+            File instanceRocksDBPath,
+            DBOptions dbOptions,
+            Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
+            ForStNativeMetricOptions nativeMetricOptions,
+            MetricGroup metricGroup,
+            @Nonnull Collection<KeyedStateHandle> restoreStateHandles,
+            ICloseableRegistry cancelStreamRegistryForRestore) {
+        this.rocksHandle =
+                new ForStHandle(
+                        kvStateInformation,
+                        instanceRocksDBPath,
+                        dbOptions,
+                        columnFamilyOptionsFactory,
+                        nativeMetricOptions,
+                        metricGroup);
+        this.savepointRestoreOperation =
+                new FullSnapshotRestoreOperation<>(
+                        keyGroupRange,
+                        userCodeClassLoader,
+                        restoreStateHandles,
+                        keySerializerProvider);
+        this.registeredPQStates = registeredPQStates;
+        this.priorityQueueFactory = priorityQueueFactory;
+        this.numberOfKeyGroups = numberOfKeyGroups;
+        this.keyGroupRange = keyGroupRange;
+        this.keyGroupPrefixBytes =
+                CompositeKeySerializationUtils.computeRequiredBytesInKeyGroupPrefix(
+                        numberOfKeyGroups);
+        this.cancelStreamRegistryForRestore = cancelStreamRegistryForRestore;
+    }
+
+    /** Restores all key-groups data that is referenced by the passed state handles. */
+    @Override
+    public ForStRestoreResult restore()
+            throws IOException, StateMigrationException, RocksDBException {
+        rocksHandle.openDB();
+        try (ThrowingIterator<SavepointRestoreResult> restore =
+                savepointRestoreOperation.restore()) {
+            while (restore.hasNext()) {
+                applyRestoreResult(restore.next());
+            }
+        }
+        return new ForStRestoreResult(
+                this.rocksHandle.getDb(),
+                this.rocksHandle.getDefaultColumnFamilyHandle(),
+                this.rocksHandle.getNativeMetricMonitor(),
+                -1,
+                null,
+                null);
+    }
+
+    private void applyRestoreResult(SavepointRestoreResult savepointRestoreResult)
+            throws IOException, RocksDBException, StateMigrationException {
+        List<StateMetaInfoSnapshot> restoredMetaInfos =
+                savepointRestoreResult.getStateMetaInfoSnapshots();
+        Map<Integer, ColumnFamilyHandle> columnFamilyHandles = new HashMap<>();
+        Map<Integer, HeapPriorityQueueSnapshotRestoreWrapper<?>> restoredPQStates = new HashMap<>();
+        for (int i = 0; i < restoredMetaInfos.size(); i++) {
+            StateMetaInfoSnapshot restoredMetaInfo = restoredMetaInfos.get(i);
+            if (restoredMetaInfo.getBackendStateType() == BackendStateType.PRIORITY_QUEUE) {
+                String stateName = restoredMetaInfo.getName();
+                HeapPriorityQueueSnapshotRestoreWrapper<?> queueWrapper =
+                        registeredPQStates.computeIfAbsent(
+                                stateName,
+                                key ->
+                                        createInternal(
+                                                new RegisteredPriorityQueueStateBackendMetaInfo<>(
+                                                        restoredMetaInfo)));
+                restoredPQStates.put(i, queueWrapper);
+            } else {
+                ForStKeyedStateBackend.ForStKvStateInfo registeredStateCFHandle =
+                        this.rocksHandle.getOrRegisterStateColumnFamilyHandle(
+                                null, restoredMetaInfo);
+                columnFamilyHandles.put(i, registeredStateCFHandle.columnFamilyHandle);
+            }
+        }
+
+        try (ThrowingIterator<KeyGroup> keyGroups = savepointRestoreResult.getRestoredKeyGroups()) {
+            restoreKVStateData(keyGroups, columnFamilyHandles, restoredPQStates);
+        }
+    }
+
+    /**
+     * Restore the KV-state / ColumnFamily data for all key-groups referenced by the current state
+     * handle.
+     */
+    private void restoreKVStateData(
+            ThrowingIterator<KeyGroup> keyGroups,
+            Map<Integer, ColumnFamilyHandle> columnFamilies,
+            Map<Integer, HeapPriorityQueueSnapshotRestoreWrapper<?>> restoredPQStates)
+            throws IOException, RocksDBException, StateMigrationException {
+        // for all key-groups in the current state handle...
+        try (ForStDBWriteBatchWrapper writeBatchWrapper =
+                        new ForStDBWriteBatchWrapper(this.rocksHandle.getDb(), 0);
+                Closeable ignored =
+                        cancelStreamRegistryForRestore.registerCloseableTemporarily(
+                                writeBatchWrapper.getCancelCloseable())) {
+            HeapPriorityQueueSnapshotRestoreWrapper<HeapPriorityQueueElement> restoredPQ = null;
+            ColumnFamilyHandle handle = null;
+            while (keyGroups.hasNext()) {
+                KeyGroup keyGroup = keyGroups.next();
+                try (ThrowingIterator<KeyGroupEntry> groupEntries = keyGroup.getKeyGroupEntries()) {
+                    int oldKvStateId = -1;
+                    while (groupEntries.hasNext()) {
+                        KeyGroupEntry groupEntry = groupEntries.next();
+                        int kvStateId = groupEntry.getKvStateId();
+                        if (kvStateId != oldKvStateId) {
+                            oldKvStateId = kvStateId;
+                            handle = columnFamilies.get(kvStateId);
+                            restoredPQ = getRestoredPQ(restoredPQStates, kvStateId);
+                        }
+                        if (restoredPQ != null) {
+                            restoreQueueElement(restoredPQ, groupEntry);
+                        } else if (handle != null) {
+                            writeBatchWrapper.put(
+                                    handle, groupEntry.getKey(), groupEntry.getValue());
+                        } else {
+                            throw new IllegalStateException("Unknown state id: " + kvStateId);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void restoreQueueElement(
+            HeapPriorityQueueSnapshotRestoreWrapper<HeapPriorityQueueElement> restoredPQ,
+            KeyGroupEntry groupEntry)
+            throws IOException {
+        deserializer.setBuffer(groupEntry.getKey());
+        deserializer.skipBytesToRead(keyGroupPrefixBytes);
+        HeapPriorityQueueElement queueElement =
+                restoredPQ.getMetaInfo().getElementSerializer().deserialize(deserializer);
+        restoredPQ.getPriorityQueue().add(queueElement);
+    }
+
+    @SuppressWarnings("unchecked")
+    private HeapPriorityQueueSnapshotRestoreWrapper<HeapPriorityQueueElement> getRestoredPQ(
+            Map<Integer, HeapPriorityQueueSnapshotRestoreWrapper<?>> restoredPQStates,
+            int kvStateId) {
+        return (HeapPriorityQueueSnapshotRestoreWrapper<HeapPriorityQueueElement>)
+                restoredPQStates.get(kvStateId);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <T extends HeapPriorityQueueElement & PriorityComparable<? super T> & Keyed<?>>
+            HeapPriorityQueueSnapshotRestoreWrapper<T> createInternal(
+                    RegisteredPriorityQueueStateBackendMetaInfo metaInfo) {
+
+        final String stateName = metaInfo.getName();
+        final HeapPriorityQueueSet<T> priorityQueue =
+                priorityQueueFactory.create(stateName, metaInfo.getElementSerializer());
+
+        return new HeapPriorityQueueSnapshotRestoreWrapper<>(
+                priorityQueue,
+                metaInfo,
+                KeyExtractorFunction.forKeyedObjects(),
+                keyGroupRange,
+                numberOfKeyGroups);
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.rocksHandle.close();
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractAsyncStateStreamOperatorV2Test.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractAsyncStateStreamOperatorV2Test.java
@@ -38,7 +38,6 @@ import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.util.function.ThrowingConsumer;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -223,7 +222,6 @@ class AbstractAsyncStateStreamOperatorV2Test {
         }
     }
 
-    @Disabled("Support Timer for AsyncKeyedStateBackend")
     @Test
     void testTimerServiceIsAsync() throws Exception {
         try (KeyedOneInputStreamOperatorV2TestHarness<Integer, Tuple2<Integer, String>, String>

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -2362,6 +2362,13 @@ public class StreamTaskTest {
                     }
 
                     @Override
+                    public InternalTimeServiceManager<?> asyncInternalTimerServiceManager() {
+                        InternalTimeServiceManager<?> timeServiceManager =
+                                controller.internalTimerServiceManager();
+                        return timeServiceManager != null ? spy(timeServiceManager) : null;
+                    }
+
+                    @Override
                     public CloseableIterable<StatePartitionStreamProvider>
                             rawOperatorStateInputs() {
                         return replaceWithSpy(controller.rawOperatorStateInputs());

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -37,14 +37,14 @@ import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
-import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.LocalSnapshotDirectoryProvider;
 import org.apache.flink.runtime.state.LocalSnapshotDirectoryProviderImpl;
 import org.apache.flink.runtime.state.OperatorStateCheckpointOutputStream;
+import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StatePartitionStreamProvider;
@@ -240,8 +240,8 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
                     @Override
                     public <K> InternalTimeServiceManager<K> create(
                             TaskIOMetricGroup taskIOMetricGroup,
-                            CheckpointableKeyedStateBackend<K> keyedStatedBackend,
-                            AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
+                            PriorityQueueSetFactory factory,
+                            KeyGroupRange keyGroupRange,
                             ClassLoader userClassloader,
                             KeyContext keyContext,
                             ProcessingTimeService processingTimeService,

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
@@ -240,6 +241,7 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
                     public <K> InternalTimeServiceManager<K> create(
                             TaskIOMetricGroup taskIOMetricGroup,
                             CheckpointableKeyedStateBackend<K> keyedStatedBackend,
+                            AsyncKeyedStateBackend<K> asyncKeyedStateBackend,
                             ClassLoader userClassloader,
                             KeyContext keyContext,
                             ProcessingTimeService processingTimeService,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR supports storing timer in JVM heap when use async state backend. 
Note: Timers are stored as raw keyed state instead of managed keyed state now, the snapshot/restore of jvm timer is managed by `InternalTimeServiceManager`.

## Brief change log
- Implement `ForStKeyedStateBackend#create() -> KeyGroupedInternalPriorityQueue`
- Support using async keyed state backend initializing `timeServiceManager` in `StreamTaskStateInitializerImpl`

## Verifying this change

This change added tests and can be verified as follows:

- `StateBackendTestV2Base#testKeyGroupedInternalPriorityQueue`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
