### PR TITLE
[FLINK-36466][runtime] Change default value of execution.runtime-mode from STREAMING to AUTOMATIC

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ExecutionOptions.java
@@ -41,7 +41,7 @@ public class ExecutionOptions {
     public static final ConfigOption<RuntimeExecutionMode> RUNTIME_MODE =
             ConfigOptions.key("execution.runtime-mode")
                     .enumType(RuntimeExecutionMode.class)
-                    .defaultValue(RuntimeExecutionMode.STREAMING)
+                    .defaultValue(RuntimeExecutionMode.AUTOMATIC)
                     .withDescription(
                             "Runtime execution mode of DataStream programs. Among other things, "
                                     + "this controls task scheduling, network shuffle behavior, and time semantics.");

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+class StreamGraphGeneratorTest {
+
+    @Test
+    void testShouldExecuteInBatchModeWithBoundedSourceAndDefaultMode() {
+        final Configuration configuration = new Configuration();
+        final StreamGraphGenerator streamGraphGenerator =
+                getStreamGraphGeneratorWithBoundedSource(configuration);
+        assertThat(streamGraphGenerator.shouldExecuteInBatchMode()).isTrue();
+    }
+
+    @Test
+    void testShouldExecuteInBatchModeWithBoundedSourceAndBatchMode() {
+        final Configuration configuration =
+                new Configuration() {
+                    {
+                        set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+                    }
+                };
+        final StreamGraphGenerator streamGraphGenerator =
+                getStreamGraphGeneratorWithBoundedSource(configuration);
+        assertThat(streamGraphGenerator.shouldExecuteInBatchMode()).isTrue();
+    }
+
+    @Test
+    void testShouldExecuteInBatchModeWithBoundedSourceAndStreamingMode() {
+        final Configuration configuration =
+                new Configuration() {
+                    {
+                        set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
+                    }
+                };
+        final StreamGraphGenerator streamGraphGenerator =
+                getStreamGraphGeneratorWithBoundedSource(configuration);
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(streamGraphGenerator::shouldExecuteInBatchMode);
+    }
+
+    @Test
+    void testShouldExecuteInBatchModeWithUnBoundedSourceAndDefaultMode() {
+        final Configuration configuration = new Configuration();
+        final StreamGraphGenerator streamGraphGenerator =
+                getStreamGraphGeneratorWithUnBoundedSource(configuration);
+        assertThat(streamGraphGenerator.shouldExecuteInBatchMode()).isFalse();
+    }
+
+    @Test
+    void testShouldExecuteInBatchModeWithUnBoundedSourceAndBatchMode() {
+        final Configuration configuration =
+                new Configuration() {
+                    {
+                        set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+                    }
+                };
+        final StreamGraphGenerator streamGraphGenerator =
+                getStreamGraphGeneratorWithUnBoundedSource(configuration);
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(streamGraphGenerator::shouldExecuteInBatchMode);
+    }
+
+    @Test
+    void testShouldExecuteInBatchModeWithUnBoundedSourceAndStreamingMode() {
+        final Configuration configuration =
+                new Configuration() {
+                    {
+                        set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
+                    }
+                };
+        final StreamGraphGenerator streamGraphGenerator =
+                getStreamGraphGeneratorWithUnBoundedSource(configuration);
+        assertThat(streamGraphGenerator.shouldExecuteInBatchMode()).isFalse();
+    }
+
+    private StreamGraphGenerator getStreamGraphGeneratorWithBoundedSource(
+            final Configuration configuration) {
+        final CheckpointConfig checkpointConfig = new CheckpointConfig(configuration);
+        final ExecutionConfig executionConfig = new ExecutionConfig(configuration);
+
+        final SourceTransformation boundedSourceTransformation =
+                Mockito.mock(SourceTransformation.class);
+        when(boundedSourceTransformation.getBoundedness()).thenReturn(Boundedness.BOUNDED);
+
+        return new StreamGraphGenerator(
+                Lists.newArrayList(boundedSourceTransformation),
+                executionConfig,
+                checkpointConfig,
+                configuration);
+    }
+
+    private StreamGraphGenerator getStreamGraphGeneratorWithUnBoundedSource(
+            final Configuration configuration) {
+        final CheckpointConfig checkpointConfig = new CheckpointConfig(configuration);
+        final ExecutionConfig executionConfig = new ExecutionConfig(configuration);
+
+        final SourceTransformation boundedSourceTransformation =
+                Mockito.mock(SourceTransformation.class);
+        when(boundedSourceTransformation.getBoundedness())
+                .thenReturn(Boundedness.CONTINUOUS_UNBOUNDED);
+
+        return new StreamGraphGenerator(
+                Lists.newArrayList(boundedSourceTransformation),
+                executionConfig,
+                checkpointConfig,
+                configuration);
+    }
+}


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Change default value of `execution.runtime-mode` from `STREAMING` to `AUTOMATIC` to fix `shouldExecuteInBatchMode` is incorrect when doesn't set `execution.runtime-mode`.


## Brief change log

- Change default value of execution.runtime-mode from STREAMING to AUTOMATIC
- Add more validation in `shouldExecuteInBatchMode`.


## Verifying this change

Verify by `StreamGraphGeneratorTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
