### PR TITLE
[FLINK-36526][state/forst] Optimize the overhead of writing with direct buffer

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
@@ -154,7 +154,7 @@ public class MemoryUtils {
      * @param buffer {@link ByteBuffer} which wraps the native memory address to get
      * @return native memory address wrapped by the given {@link ByteBuffer}
      */
-    static long getByteBufferAddress(ByteBuffer buffer) {
+    public static long getByteBufferAddress(ByteBuffer buffer) {
         Preconditions.checkNotNull(buffer, "buffer is null");
         Preconditions.checkArgument(
                 buffer.isDirect(), "Can't get address of a non-direct ByteBuffer.");


### PR DESCRIPTION
## What is the purpose of the change

Currently, the ForSt gives a direct buffer to `ByteBufferWritableFSDataOutputStream`, where the data will be written one byte by byte. According our perf, the statistics of hadoop based fs will be updated once for each byte, which takes a lot of CPU. Below is a flamegraph, where the statistics part is marked as purple (taking 8.14% of the overall CPU).
![image](https://github.com/user-attachments/assets/c60cd376-f63c-4bb2-8c05-7a98bc6235d6)
This PR copies the data to a heap buffer before invoking `write` to optimize this.

## Brief change log

 - Writing logic in `ByteBufferWritableFSDataOutputStream`


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
