### PR TITLE
[FLINK-36405][runtime] Fix startup issues on kerberos clusters.

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/security/token/HiveServer2DelegationTokenProvider.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/security/token/HiveServer2DelegationTokenProvider.java
@@ -136,14 +136,9 @@ public class HiveServer2DelegationTokenProvider implements DelegationTokenProvid
                             try {
                                 LOG.info("Obtaining Kerberos security token for HiveServer2");
 
-                                String principal =
-                                        hiveConf.getTrimmed(
-                                                "hive.metastore.kerberos.principal", "");
+                                String user = UserGroupInformation.getCurrentUser().getUserName();
+                                String tokenStr = hive.getDelegationToken(user, user);
 
-                                String tokenStr =
-                                        hive.getDelegationToken(
-                                                UserGroupInformation.getCurrentUser().getUserName(),
-                                                principal);
                                 Token<HiveServer2DelegationTokenIdentifier> hive2Token =
                                         new Token<>();
                                 hive2Token.decodeFromUrlString(tokenStr);

--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.table.security.token.HiveServer2DelegationTokenIdentifier


### PR DESCRIPTION
Backport https://github.com/apache/flink/pull/25428 against the release-1.20.