### PR TITLE
[FLINK-36533][runtime] Fix detecting bind failure in case of Netty EPOLL transport

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerTest.java
@@ -30,8 +30,23 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for initializing Netty server from a port range. */
-class NettyServerFromPortRangeTest {
+/** Unit tests for {@link NettyServer}. */
+class NettyServerTest {
+
+    @Test
+    void testBindFailureDetection() {
+        Throwable ex = new java.net.BindException();
+        assertThat(NettyServer.isBindFailure(ex)).isTrue();
+
+        ex = new Exception(new java.net.BindException());
+        assertThat(NettyServer.isBindFailure(ex)).isTrue();
+
+        ex = new Exception();
+        assertThat(NettyServer.isBindFailure(ex)).isFalse();
+
+        ex = new RuntimeException();
+        assertThat(NettyServer.isBindFailure(ex)).isFalse();
+    }
 
     @Test
     void testStartMultipleNettyServerSameConfig() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

When Netty Epoll transport is enabled, Netty will throw a different bind exception if the given address is already in use. In case of a port range, or multiple ports are given, this will cause process termination after the first non-free port, even if there are more that could be tried.

## Brief change log

Introduce `NettyServer#isBindFailure` method to make bind exception detection more robust. The applied logic takes inspiration from https://github.com/apache/spark/pull/15830.

## Verifying this change

Added unit tests to `NettyServerTest`. I do not assert for `Errors.NativeIoException` because to instantiate such object, it requires proper JNI links, as its ctor always try to call out to native code.

Also verified with a Standalone job on a RedHat8 VM via setting `taskmanager.data.bind-port` to `8081, 55000`, as `8081` will be used by the JobManager anyways, application is able to start correctly with TM on `55000`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
