### PR TITLE
[FLINK-36543] Fix string serialization for OVER windows

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -2569,6 +2569,7 @@ public final class BuiltInFunctionDefinitions {
                     .kind(OTHER)
                     .inputTypeStrategy(SpecificInputTypeStrategies.OVER)
                     .outputTypeStrategy(TypeStrategies.argument(0))
+                    .callSyntax(SqlCallSyntax.OVER)
                     .build();
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/CallSyntaxUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/CallSyntaxUtils.java
@@ -19,10 +19,16 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.OverWindowRange;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.TableSymbol;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import java.util.Optional;
 
 /** Utility functions that can be used for writing {@link SqlCallSyntax}. */
 @Internal
@@ -43,6 +49,57 @@ class CallSyntaxUtils {
 
     static <T extends TableSymbol> T getSymbolLiteral(ResolvedExpression operands, Class<T> clazz) {
         return ((ValueLiteralExpression) operands).getValueAs(clazz).get();
+    }
+
+    static String overRangeToSerializableString(
+            ResolvedExpression preceding, ResolvedExpression following) {
+        return String.format(
+                "%s BETWEEN %s AND %s",
+                isRowsRange(preceding) ? "ROWS" : "RANGE",
+                toStringPrecedingOrFollowing(preceding, true),
+                toStringPrecedingOrFollowing(following, false));
+    }
+
+    private static String toStringPrecedingOrFollowing(
+            ResolvedExpression precedingOrFollowing, boolean isPreceding) {
+        final String suffix = isPreceding ? "PRECEDING" : "FOLLOWING";
+        return Optional.of(precedingOrFollowing)
+                .flatMap(
+                        expr -> {
+                            if (expr instanceof ValueLiteralExpression) {
+                                return ((ValueLiteralExpression) expr)
+                                        .getValueAs(OverWindowRange.class)
+                                        .map(
+                                                r -> {
+                                                    switch (r) {
+                                                        case CURRENT_ROW:
+                                                        case CURRENT_RANGE:
+                                                            return "CURRENT ROW";
+                                                        case UNBOUNDED_ROW:
+                                                        case UNBOUNDED_RANGE:
+                                                            return "UNBOUNDED " + suffix;
+                                                        default:
+                                                            throw new IllegalStateException(
+                                                                    "Unknown window range: " + r);
+                                                    }
+                                                });
+                            } else {
+                                return Optional.empty();
+                            }
+                        })
+                .orElseGet(() -> precedingOrFollowing.asSerializableString() + " " + suffix);
+    }
+
+    private static boolean isRowsRange(ResolvedExpression expression) {
+        LogicalType logicalType = expression.getOutputDataType().getLogicalType();
+        boolean isSymbol = logicalType.is(LogicalTypeRoot.SYMBOL);
+        if (isSymbol) {
+            OverWindowRange windowRange = getSymbolLiteral(expression, OverWindowRange.class);
+            return windowRange == OverWindowRange.CURRENT_ROW
+                    || windowRange == OverWindowRange.UNBOUNDED_ROW;
+        }
+
+        return logicalType.is(LogicalTypeFamily.NUMERIC);
     }
 
     private CallSyntaxUtils() {}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
@@ -316,4 +316,23 @@ public interface SqlCallSyntax {
                             CallSyntaxUtils.asSerializableOperand(operands.get(2)));
                 }
             };
+
+    SqlCallSyntax OVER =
+            ((sqlName, operands) -> {
+                String projection = operands.get(0).asSerializableString();
+                String order = operands.get(1).asSerializableString();
+                String rangeBounds =
+                        CallSyntaxUtils.overRangeToSerializableString(
+                                operands.get(2), operands.get(3));
+                if (operands.size() == 4) {
+                    return String.format("%s OVER(ORDER BY %s %s)", projection, order, rangeBounds);
+                } else {
+                    return String.format(
+                            "%s OVER(PARTITION BY %s ORDER BY %s %s)",
+                            projection,
+                            CallSyntaxUtils.asSerializableOperand(operands.get(4)),
+                            order,
+                            rangeBounds);
+                }
+            });
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlExecutionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlExecutionTest.java
@@ -71,7 +71,9 @@ public class QueryOperationSqlExecutionTest implements TableTestProgramRunner {
                 QueryOperationTestPrograms.SORT_LIMIT_DESC,
                 QueryOperationTestPrograms.GROUP_BY_UDF_WITH_MERGE,
                 QueryOperationTestPrograms.NON_WINDOW_INNER_JOIN,
-                QueryOperationTestPrograms.SQL_QUERY_OPERATION);
+                QueryOperationTestPrograms.SQL_QUERY_OPERATION,
+                QueryOperationTestPrograms.OVER_WINDOW_RANGE,
+                QueryOperationTestPrograms.OVER_WINDOW_ROWS);
     }
 
     @ParameterizedTest

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlSerializationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlSerializationTest.java
@@ -60,7 +60,9 @@ public class QueryOperationSqlSerializationTest implements TableTestProgramRunne
                 QueryOperationTestPrograms.WINDOW_AGGREGATE_QUERY_OPERATION,
                 QueryOperationTestPrograms.UNION_ALL_QUERY_OPERATION,
                 QueryOperationTestPrograms.LATERAL_JOIN_QUERY_OPERATION,
-                QueryOperationTestPrograms.SQL_QUERY_OPERATION);
+                QueryOperationTestPrograms.SQL_QUERY_OPERATION,
+                QueryOperationTestPrograms.OVER_WINDOW_RANGE,
+                QueryOperationTestPrograms.OVER_WINDOW_ROWS);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What is the purpose of the change

Fix string serialization of `OVER` window


## Verifying this change

added tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
