### PR TITLE
[BP-1.20][FLINK-36533][runtime] Fix detecting bind failure in case of Netty EPOLL transport

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -32,6 +32,7 @@ import org.apache.flink.shaded.netty4.io.netty.channel.epoll.EpollServerSocketCh
 import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import org.apache.flink.shaded.netty4.io.netty.channel.socket.nio.NioServerSocketChannel;
+import org.apache.flink.shaded.netty4.io.netty.channel.unix.Errors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,11 +159,12 @@ class NettyServer {
             try {
                 bindFuture = bootstrap.bind().syncUninterruptibly();
             } catch (Exception e) {
-                LOG.debug("Failed to bind Netty server", e);
                 // syncUninterruptibly() throws checked exceptions via Unsafe
                 // continue if the exception is due to the port being in use, fail early
                 // otherwise
-                if (!(e instanceof java.net.BindException)) {
+                if (isBindFailure(e)) {
+                    LOG.debug("Failed to bind Netty server", e);
+                } else {
                     throw e;
                 }
             }
@@ -238,6 +240,15 @@ class NettyServer {
 
     public static ThreadFactory getNamedThreadFactory(String name) {
         return THREAD_FACTORY_BUILDER.setNameFormat(name + " Thread %d").build();
+    }
+
+    @VisibleForTesting
+    static boolean isBindFailure(Throwable t) {
+        return t instanceof java.net.BindException
+                || (t instanceof Errors.NativeIoException
+                        && t.getMessage() != null
+                        && t.getMessage().matches("^bind\\(.*\\) failed:.*"))
+                || (t.getCause() != null && isBindFailure(t.getCause()));
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyServerTest.java
@@ -30,8 +30,23 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for initializing Netty server from a port range. */
-class NettyServerFromPortRangeTest {
+/** Unit tests for {@link NettyServer}. */
+class NettyServerTest {
+
+    @Test
+    void testBindFailureDetection() {
+        Throwable ex = new java.net.BindException();
+        assertThat(NettyServer.isBindFailure(ex)).isTrue();
+
+        ex = new Exception(new java.net.BindException());
+        assertThat(NettyServer.isBindFailure(ex)).isTrue();
+
+        ex = new Exception();
+        assertThat(NettyServer.isBindFailure(ex)).isFalse();
+
+        ex = new RuntimeException();
+        assertThat(NettyServer.isBindFailure(ex)).isFalse();
+    }
 
     @Test
     void testStartMultipleNettyServerSameConfig() throws Exception {


### PR DESCRIPTION
1.20 backport of https://github.com/apache/flink/pull/25518