### PR TITLE
[FLINK-36530][state] Fix S3 performance issue with uncompressed state restore

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/CompressibleFSDataInputStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/CompressibleFSDataInputStream.java
@@ -31,19 +31,21 @@ public class CompressibleFSDataInputStream extends FSDataInputStream {
 
     private final FSDataInputStream delegate;
     private final InputStream compressingDelegate;
+    private final boolean compressed;
 
     public CompressibleFSDataInputStream(
             FSDataInputStream delegate, StreamCompressionDecorator compressionDecorator)
             throws IOException {
         this.delegate = delegate;
         this.compressingDelegate = compressionDecorator.decorateWithCompression(delegate);
+        this.compressed = compressionDecorator != UncompressedStreamCompressionDecorator.INSTANCE;
     }
 
     @Override
     public void seek(long desired) throws IOException {
-        final int available = compressingDelegate.available();
-        if (available > 0) {
-            if (available != compressingDelegate.skip(available)) {
+        if (compressed) {
+            final int available = compressingDelegate.available();
+            if (available > 0 && available != compressingDelegate.skip(available)) {
                 throw new IOException("Unable to skip buffered data.");
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

This is backport of https://github.com/apache/flink/pull/25509.

Flink state restore from S3 is super slow because `skip` function is consuming ~15 seconds for ~6Mb of data. This operation is called for each and every list state element for `CompactCoordinator` state (all similar operator list states are effected). The list of this is several thousands during normal operation which ends up in multiple days of restore time.

In this PR the `skip` going to be called only in case of compression because otherwise a stream is seekable.

## Brief change log

Do not call `skip` operation in case of uncompressed state.

## Verifying this change

Manually on cluster + changed unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
