### PR TITLE
[FLINK-36455] Sinks retry synchronously

### DIFF
--- a/docs/layouts/shortcodes/generated/common_miscellaneous_section.html
+++ b/docs/layouts/shortcodes/generated/common_miscellaneous_section.html
@@ -26,5 +26,11 @@
             <td>String</td>
             <td>Directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
         </tr>
+        <tr>
+            <td><h5>sink.committer.retries</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>The number of retries a Flink application attempts for committable operations (such as transactions) on retriable errors, as specified by the sink connector, before Flink fails and potentially restarts.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorStateHandler.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorStateHandler.java
@@ -176,7 +176,6 @@ public class CompactorOperatorStateHandler
                                 summary.getNumberOfSubtasks(),
                                 summary.getCheckpointIdOrEOI(),
                                 summary.getNumberOfCommittables() + results.size(),
-                                summary.getNumberOfPendingCommittables() + results.size(),
                                 summary.getNumberOfFailedCommittables())));
         for (FileSinkCommittable committable : results) {
             output.collect(

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactorOperatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactorOperatorTest.java
@@ -98,7 +98,6 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
             // 1summary+1compacted+2cleanup
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(4);
-            results.element(0, as(committableSummary())).hasPendingCommittables(3);
             results.element(1, as(committableWithLineage()))
                     .hasCommittable(committable("0", "compacted-0", 10));
             results.element(2, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".0"));
@@ -140,7 +139,6 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
 
             ListAssert<CommittableMessage<FileSinkCommittable>> messages =
                     assertThat(harness.extractOutputValues()).hasSize(3);
-            messages.element(0, as(committableSummary())).hasPendingCommittables(2);
             messages.element(1, as(committableWithLineage()))
                     .hasCommittable(cleanupInprogressRequest);
             messages.element(2, as(committableWithLineage())).hasCommittable(cleanupPathRequest);
@@ -207,13 +205,13 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
             // 1summary+1compacted+2cleanup * 2
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(8);
-            results.element(0, as(committableSummary())).hasPendingCommittables(3);
+            results.element(0, as(committableSummary()));
             results.element(1, as(committableWithLineage()))
                     .hasCommittable(committable("0", "compacted-0", 10));
             results.element(2, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".0"));
             results.element(3, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".1"));
 
-            results.element(4, as(committableSummary())).hasPendingCommittables(3);
+            results.element(4, as(committableSummary()));
             results.element(5, as(committableWithLineage()))
                     .hasCommittable(committable("0", "compacted-2", 10));
             results.element(6, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".2"));
@@ -311,7 +309,7 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
             // + 1 summary + 1 cleanup + 1 summary
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(18);
-            results.element(0, as(committableSummary())).hasPendingCommittables(14);
+            results.element(0, as(committableSummary()));
 
             List<FileSinkCommittable> expectedResult =
                     Arrays.asList(
@@ -335,11 +333,11 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
                         .hasCommittable(expectedResult.get(i));
             }
 
-            results.element(15, as(committableSummary())).hasPendingCommittables(1);
+            results.element(15, as(committableSummary()));
             results.element(16, as(committableWithLineage()))
                     .hasCommittable(cleanupPath("0", ".6"));
 
-            results.element(17, as(committableSummary())).hasPendingCommittables(3);
+            results.element(17, as(committableSummary()));
         }
     }
 
@@ -378,7 +376,7 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
 
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(3);
-            results.element(0, as(committableSummary())).hasPendingCommittables(4);
+            results.element(0, as(committableSummary()));
             results.element(1, as(committableWithLineage()))
                     .hasCommittable(committable("0", "compacted-1", 1));
             results.element(2, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".1"));
@@ -437,7 +435,7 @@ class CompactorOperatorTest extends AbstractCompactTestBase {
 
             ListAssert<CommittableMessage<FileSinkCommittable>> results =
                     assertThat(harness.extractOutputValues()).hasSize(2);
-            results.element(0, as(committableSummary())).hasPendingCommittables(1);
+            results.element(0, as(committableSummary()));
             results.element(1, as(committableWithLineage())).hasCommittable(cleanupPath("0", ".2"));
         }
     }

--- a/flink-core/src/main/java/org/apache/flink/configuration/SinkOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SinkOptions.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/** Configuration options for sinks. */
+@PublicEvolving
+public class SinkOptions {
+    /**
+     * The number of retries on a committable (e.g., transaction) before Flink application fails and
+     * potentially restarts.
+     */
+    @Documentation.Section(Documentation.Sections.COMMON_MISCELLANEOUS)
+    public static final ConfigOption<Integer> COMMITTER_RETRIES =
+            key("sink.committer.retries")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "The number of retries a Flink application attempts for committable operations (such as transactions) on retriable errors, as specified by the sink connector, before Flink fails and potentially restarts.");
+
+    private SinkOptions() {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummary.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummary.java
@@ -39,11 +39,29 @@ public class CommittableSummary<CommT> implements CommittableMessage<CommT> {
     private final long checkpointId;
     /** The number of committables coming from the given subtask in the particular checkpoint. */
     private final int numberOfCommittables;
+
+    @Deprecated
     /** The number of committables that have not been successfully committed. */
     private final int numberOfPendingCommittables;
     /** The number of committables that are not retried and have been failed. */
     private final int numberOfFailedCommittables;
 
+    public CommittableSummary(
+            int subtaskId,
+            int numberOfSubtasks,
+            long checkpointId,
+            int numberOfCommittables,
+            int numberOfFailedCommittables) {
+        this(
+                subtaskId,
+                numberOfSubtasks,
+                checkpointId,
+                numberOfCommittables,
+                0,
+                numberOfFailedCommittables);
+    }
+
+    @Deprecated
     public CommittableSummary(
             int subtaskId,
             int numberOfSubtasks,
@@ -75,8 +93,9 @@ public class CommittableSummary<CommT> implements CommittableMessage<CommT> {
         return numberOfCommittables;
     }
 
+    @Deprecated
     public int getNumberOfPendingCommittables() {
-        return numberOfPendingCommittables;
+        return 0;
     }
 
     public int getNumberOfFailedCommittables() {
@@ -89,7 +108,6 @@ public class CommittableSummary<CommT> implements CommittableMessage<CommT> {
                 numberOfSubtasks,
                 checkpointId,
                 numberOfCommittables,
-                numberOfPendingCommittables,
                 numberOfFailedCommittables);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.configuration.SinkOptions;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.InternalSinkCommitterMetricGroup;
@@ -47,7 +48,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.streaming.api.connector.sink2.CommittableMessage.EOI;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -115,6 +115,7 @@ public class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamO
     private long lastCompletedCheckpointId = -1;
     private SimpleVersionedSerializer<CommT> committableSerializer;
     private SinkCommitterMetricGroup metricGroup;
+    private int maxRetries;
 
     @Nullable private SimpleVersionedSerializer<GlobalCommT> globalCommittableSerializer;
     private List<GlobalCommT> sinkV1State = new ArrayList<>();
@@ -138,6 +139,7 @@ public class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamO
         metricGroup = InternalSinkCommitterMetricGroup.wrap(metrics);
         committableCollector = CommittableCollector.of(metricGroup);
         committableSerializer = committableSerializerFactory.get();
+        maxRetries = config.getConfiguration().get(SinkOptions.COMMITTER_RETRIES);
     }
 
     @Override
@@ -195,23 +197,14 @@ public class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamO
 
     private void commit(long checkpointIdOrEOI) throws IOException, InterruptedException {
         lastCompletedCheckpointId = Math.max(lastCompletedCheckpointId, checkpointIdOrEOI);
-        // this is true for the last commit and we need to make sure that all committables are
-        // indeed committed as this function will never be invoked again
-        boolean waitForAllCommitted =
-                lastCompletedCheckpointId == EOI
-                        && committableCollector
-                                .getEndOfInputCommittable()
-                                .map(CheckpointCommittableManager::hasGloballyReceivedAll)
-                                .orElse(false);
-        do {
-            for (CheckpointCommittableManager<CommT> committable :
-                    committableCollector.getCheckpointCommittablesUpTo(lastCompletedCheckpointId)) {
-                if (committable.hasGloballyReceivedAll()) {
-                    committable.commit(committer);
-                }
+        for (CheckpointCommittableManager<CommT> checkpointManager :
+                committableCollector.getCheckpointCommittablesUpTo(lastCompletedCheckpointId)) {
+            if (!checkpointManager.hasGloballyReceivedAll()) {
+                return;
             }
-            committableCollector.compact();
-        } while (waitForAllCommitted && !committableCollector.isFinished());
+            checkpointManager.commit(committer, maxRetries);
+            committableCollector.remove(checkpointManager);
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -22,12 +22,14 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.CommitterInitContext;
+import org.apache.flink.configuration.SinkOptions;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.InternalSinkCommitterMetricGroup;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -66,7 +68,6 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
         implements OneInputStreamOperator<CommittableMessage<CommT>, CommittableMessage<CommT>>,
                 BoundedOneInput {
 
-    private static final long RETRY_DELAY = 1000;
     private final SimpleVersionedSerializer<CommT> committableSerializer;
     private final FunctionWithException<CommitterInitContext, Committer<CommT>, IOException>
             committerSupplier;
@@ -77,6 +78,7 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
     private Committer<CommT> committer;
     private CommittableCollector<CommT> committableCollector;
     private long lastCompletedCheckpointId = -1;
+    private int maxRetries;
 
     private boolean endInput = false;
 
@@ -114,6 +116,7 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
         super.setup(containingTask, config, output);
         metricGroup = InternalSinkCommitterMetricGroup.wrap(getMetricGroup());
         committableCollector = CommittableCollector.of(metricGroup);
+        maxRetries = config.getConfiguration().get(SinkOptions.COMMITTER_RETRIES);
     }
 
     @Override
@@ -164,41 +167,42 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
 
     private void commitAndEmitCheckpoints() throws IOException, InterruptedException {
         long completedCheckpointId = endInput ? EOI : lastCompletedCheckpointId;
-        do {
-            for (CheckpointCommittableManager<CommT> manager :
-                    committableCollector.getCheckpointCommittablesUpTo(completedCheckpointId)) {
-                commitAndEmit(manager);
-            }
-            // !committableCollector.isFinished() indicates that we should retry
-            // Retry should be done here if this is a final checkpoint (indicated by endInput)
-            // WARN: this is an endless retry, may make the job stuck while finishing
-        } while (!committableCollector.isFinished() && endInput);
-
-        if (!committableCollector.isFinished()) {
-            // if not endInput, we can schedule retrying later
-            retryWithDelay();
+        for (CheckpointCommittableManager<CommT> checkpointManager :
+                committableCollector.getCheckpointCommittablesUpTo(completedCheckpointId)) {
+            // ensure that all committables of the first checkpoint are fully committed before
+            // attempting the next committable
+            commitAndEmit(checkpointManager);
+            committableCollector.remove(checkpointManager);
         }
-        committableCollector.compact();
     }
 
     private void commitAndEmit(CheckpointCommittableManager<CommT> committableManager)
             throws IOException, InterruptedException {
-        Collection<CommittableWithLineage<CommT>> committed = committableManager.commit(committer);
-        if (emitDownstream && committableManager.isFinished()) {
-            int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
-            int numberOfSubtasks = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
-            output.collect(
-                    new StreamRecord<>(committableManager.getSummary(subtaskId, numberOfSubtasks)));
-            for (CommittableWithLineage<CommT> committable : committed) {
-                output.collect(new StreamRecord<>(committable.withSubtaskId(subtaskId)));
-            }
+        committableManager.commit(committer, maxRetries);
+        if (emitDownstream) {
+            emit(committableManager);
         }
     }
 
-    private void retryWithDelay() {
-        processingTimeService.registerTimer(
-                processingTimeService.getCurrentProcessingTime() + RETRY_DELAY,
-                ts -> commitAndEmitCheckpoints());
+    private void emit(CheckpointCommittableManager<CommT> committableManager) {
+        int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
+        int numberOfSubtasks = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
+        long checkpointId = committableManager.getCheckpointId();
+        Collection<CommT> committables = committableManager.getSuccessfulCommittables();
+        output.collect(
+                new StreamRecord<>(
+                        new CommittableSummary<>(
+                                subtaskId,
+                                numberOfSubtasks,
+                                checkpointId,
+                                committables.size(),
+                                0,
+                                0)));
+        for (CommT committable : committables) {
+            output.collect(
+                    new StreamRecord<>(
+                            new CommittableWithLineage<>(committable, checkpointId, subtaskId)));
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -196,8 +196,7 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
                                 numberOfSubtasks,
                                 checkpointId,
                                 committables.size(),
-                                0,
-                                0)));
+                                committableManager.getNumFailed())));
         for (CommT committable : committables) {
             output.collect(
                     new StreamRecord<>(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
@@ -66,5 +66,24 @@ public interface CheckpointCommittableManager<CommT> {
     void commit(Committer<CommT> committer, int maxRetries)
             throws IOException, InterruptedException;
 
+    /**
+     * Returns the number of committables that have been successfully committed; that is, the
+     * corresponding {@link org.apache.flink.api.connector.sink2.Committer.CommitRequest} was not
+     * used to signal an error of any kind (retryable or not).
+     *
+     * @return number of successful committables
+     */
     Collection<CommT> getSuccessfulCommittables();
+
+    /**
+     * Returns the number of committables that have failed with a known error. By the current
+     * semantics of {@link
+     * org.apache.flink.api.connector.sink2.Committer.CommitRequest#signalFailedWithKnownReason(Throwable)}
+     * discards the committable but proceeds processing. The returned number should be emitted
+     * downstream in a {@link org.apache.flink.streaming.api.connector.sink2.CommittableSummary},
+     * such that downstream can assess if all committables have been processed.
+     *
+     * @return number of failed committables
+     */
+    int getNumFailed();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
@@ -20,8 +20,6 @@ package org.apache.flink.streaming.runtime.operators.sink.committables;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.sink2.Committer;
-import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
-import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -50,12 +48,6 @@ public interface CheckpointCommittableManager<CommT> {
     /** Returns the number of upstream subtasks belonging to the checkpoint. */
     int getNumberOfSubtasks();
 
-    /**
-     * Returns a summary of the current commit progress for the emitting subtask identified by the
-     * parameters.
-     */
-    CommittableSummary<CommT> getSummary(int emittingSubtaskId, int emittingNumberOfSubtasks);
-
     boolean isFinished();
 
     /**
@@ -69,8 +61,10 @@ public interface CheckpointCommittableManager<CommT> {
      * checkpoint have been received.
      *
      * @param committer used to commit to the external system
-     * @return successfully committed committables with meta information
+     * @param maxRetries
      */
-    Collection<CommittableWithLineage<CommT>> commit(Committer<CommT> committer)
+    void commit(Committer<CommT> committer, int maxRetries)
             throws IOException, InterruptedException;
+
+    Collection<CommT> getSuccessfulCommittables();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImpl.java
@@ -166,6 +166,13 @@ class CheckpointCommittableManagerImpl<CommT> implements CheckpointCommittableMa
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public int getNumFailed() {
+        return subtasksCommittableManagers.values().stream()
+                .mapToInt(SubtaskCommittableManager::getNumFailed)
+                .sum();
+    }
+
     Stream<CommitRequestImpl<CommT>> getPendingRequests() {
         return subtasksCommittableManagers.values().stream()
                 .peek(this::assertReceivedAll)

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +133,7 @@ public class CommittableCollector<CommT> {
      */
     public Collection<? extends CheckpointCommittableManager<CommT>> getCheckpointCommittablesUpTo(
             long checkpointId) {
-        return checkpointCommittables.headMap(checkpointId, true).values();
+        return new ArrayList<>(checkpointCommittables.headMap(checkpointId, true).values());
     }
 
     /**
@@ -208,9 +209,9 @@ public class CommittableCollector<CommT> {
         return checkNotNull(committables, "Unknown checkpoint for %s", committable);
     }
 
-    /** Removes all metadata about checkpoints of which all committables are fully committed. */
-    public void compact() {
-        checkpointCommittables.values().removeIf(CheckpointCommittableManagerImpl::isFinished);
+    /** Removes the manager for a specific checkpoint and all it's metadata. */
+    public void remove(CheckpointCommittableManager<CommT> manager) {
+        checkpointCommittables.remove(manager.getCheckpointId());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
@@ -66,6 +66,13 @@ public class CommittableCollector<CommT> {
             SinkCommitterMetricGroup metricGroup) {
         this.checkpointCommittables = new TreeMap<>(checkNotNull(checkpointCommittables));
         this.metricGroup = metricGroup;
+        this.metricGroup.setCurrentPendingCommittablesGauge(this::getNumPending);
+    }
+
+    private int getNumPending() {
+        return checkpointCommittables.values().stream()
+                .mapToInt(m -> (int) m.getPendingRequests().count())
+                .sum();
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializer.java
@@ -207,7 +207,7 @@ public final class CommittableCollectorSerializer<CommT>
 
         @Override
         public int getVersion() {
-            return 1;
+            return 2;
         }
 
         @Override
@@ -219,7 +219,6 @@ public final class CommittableCollectorSerializer<CommT>
                     new ArrayList<>(subtask.getRequests()),
                     out);
             out.writeInt(subtask.getNumCommittables());
-            out.writeInt(subtask.getNumDrained());
             out.writeInt(subtask.getNumFailed());
             return out.getCopyOfBuffer();
         }
@@ -236,7 +235,7 @@ public final class CommittableCollectorSerializer<CommT>
             return new SubtaskCommittableManager<>(
                     requests,
                     in.readInt(),
-                    in.readInt(),
+                    version >= 2 ? 0 : in.readInt(),
                     in.readInt(),
                     subtaskId,
                     checkNotNull(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.streaming.runtime.operators.sink.committables.CommitRequestState.COMMITTED;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -138,6 +139,12 @@ class SubtaskCommittableManager<CommT> {
         return requests.stream().filter(c -> !c.isFinished());
     }
 
+    Stream<CommT> getSuccessfulCommittables() {
+        return getRequests().stream()
+                .filter(c -> c.getState() == COMMITTED)
+                .map(CommitRequestImpl::getCommittable);
+    }
+
     /**
      * Iterates through all currently registered {@link #requests} and returns all {@link
      * CommittableWithLineage} that could be successfully committed.
@@ -184,7 +191,7 @@ class SubtaskCommittableManager<CommT> {
         return checkpointId;
     }
 
-    Deque<CommitRequestImpl<CommT>> getRequests() {
+    Collection<CommitRequestImpl<CommT>> getRequests() {
         return requests;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableMessageSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableMessageSerializerTest.java
@@ -47,7 +47,7 @@ class CommittableMessageSerializerTest {
     @Test
     void testCommittableSummarySerDe() throws IOException {
         final CommittableSummary<Integer> committableSummary =
-                new CommittableSummary<>(1, 2, 3L, 4, 5, 6);
+                new CommittableSummary<>(1, 2, 3L, 4, 5);
         final CommittableMessage<Integer> message =
                 SERIALIZER.deserialize(
                         CommittableMessageSerializer.VERSION,
@@ -58,7 +58,5 @@ class CommittableMessageSerializerTest {
         assertThat(copy.getNumberOfSubtasks()).isEqualTo(2);
         assertThat(copy.getCheckpointIdOrEOI()).isEqualTo(3L);
         assertThat(copy.getNumberOfCommittables()).isEqualTo(4);
-        assertThat(copy.getNumberOfPendingCommittables()).isEqualTo(5);
-        assertThat(copy.getNumberOfFailedCommittables()).isEqualTo(6);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummaryAssert.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummaryAssert.java
@@ -40,10 +40,6 @@ public class CommittableSummaryAssert<CommT>
         return returns(committableNumber, CommittableSummary::getNumberOfCommittables);
     }
 
-    public CommittableSummaryAssert<CommT> hasPendingCommittables(int committableNumber) {
-        return returns(committableNumber, CommittableSummary::getNumberOfPendingCommittables);
-    }
-
     public CommittableSummaryAssert<CommT> hasFailedCommittables(int committableNumber) {
         return returns(committableNumber, CommittableSummary::getNumberOfFailedCommittables);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
@@ -48,7 +48,7 @@ class GlobalCommitterOperatorTest {
 
             long cid = 1L;
             testHarness.processElement(
-                    new StreamRecord<>(new CommittableSummary<>(1, 1, cid, 2, 0, 0)));
+                    new StreamRecord<>(new CommittableSummary<>(1, 1, cid, 2, 0)));
 
             testHarness.processElement(new StreamRecord<>(new CommittableWithLineage<>(1, cid, 1)));
 
@@ -63,7 +63,6 @@ class GlobalCommitterOperatorTest {
             if (commitOnInput) {
                 assertThat(committer.committed).containsExactly(1, 2);
             } else {
-                // 3PC behavior
                 assertThat(committer.committed).isEmpty();
                 testHarness.notifyOfCompletedCheckpoint(cid + 1);
                 assertThat(committer.committed).containsExactly(1, 2);
@@ -83,7 +82,7 @@ class GlobalCommitterOperatorTest {
 
             long cid = 1L;
             testHarness.processElement(
-                    new StreamRecord<>(new CommittableSummary<>(1, 1, cid, 2, 0, 0)));
+                    new StreamRecord<>(new CommittableSummary<>(1, 1, cid, 2, 0)));
 
             testHarness.processElement(new StreamRecord<>(new CommittableWithLineage<>(1, cid, 1)));
 
@@ -116,7 +115,7 @@ class GlobalCommitterOperatorTest {
             testHarness.open();
 
             final CommittableSummary<Integer> committableSummary =
-                    new CommittableSummary<>(1, 1, 0L, 1, 1, 0);
+                    new CommittableSummary<>(1, 1, 0L, 1, 1);
             testHarness.processElement(new StreamRecord<>(committableSummary));
             final CommittableWithLineage<Integer> first = new CommittableWithLineage<>(1, 0L, 1);
             testHarness.processElement(new StreamRecord<>(first));
@@ -147,10 +146,10 @@ class GlobalCommitterOperatorTest {
         testHarness.open();
 
         final CommittableSummary<Integer> committableSummary =
-                new CommittableSummary<>(1, 2, EOI, 1, 1, 0);
+                new CommittableSummary<>(1, 2, EOI, 1, 0);
         testHarness.processElement(new StreamRecord<>(committableSummary));
         final CommittableSummary<Integer> committableSummary2 =
-                new CommittableSummary<>(2, 2, EOI, 1, 1, 0);
+                new CommittableSummary<>(2, 2, EOI, 1, 0);
         testHarness.processElement(new StreamRecord<>(committableSummary2));
 
         final CommittableWithLineage<Integer> first = new CommittableWithLineage<>(1, EOI, 1);

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
@@ -63,6 +63,7 @@ class GlobalCommitterOperatorTest {
             if (commitOnInput) {
                 assertThat(committer.committed).containsExactly(1, 2);
             } else {
+                // 3PC behavior
                 assertThat(committer.committed).isEmpty();
                 testHarness.notifyOfCompletedCheckpoint(cid + 1);
                 assertThat(committer.committed).containsExactly(1, 2);

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterSerializerTest.java
@@ -70,7 +70,6 @@ class GlobalCommitterSerializerTest {
         final GlobalCommittableWrapper<Integer, String> copy =
                 serializer.deserialize(2, serializer.serialize(wrapper));
         assertThat(copy.getGlobalCommittables()).containsExactlyInAnyOrderElementsOf(v1State);
-        assertThat(collector).returns(false, CommittableCollector::isFinished);
         assertThat(collector.getCheckpointCommittablesUpTo(2))
                 .singleElement()
                 .returns(1L, CheckpointCommittableManager::getCheckpointId)

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImplTest.java
@@ -48,17 +48,15 @@ class CheckpointCommittableManagerImplTest {
                 new CheckpointCommittableManagerImpl<>(new HashMap<>(), 1, 1L, METRIC_GROUP);
         assertThat(checkpointCommittables.getSubtaskCommittableManagers()).isEmpty();
 
-        final CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1, 0, 0);
+        final CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1, 0);
         checkpointCommittables.addSummary(first);
         assertThat(checkpointCommittables.getSubtaskCommittableManagers())
                 .singleElement()
                 .returns(1, SubtaskCommittableManager::getSubtaskId)
-                .returns(1L, SubtaskCommittableManager::getCheckpointId)
-                .returns(1, SubtaskCommittableManager::getNumPending)
-                .returns(0, SubtaskCommittableManager::getNumFailed);
+                .returns(1L, SubtaskCommittableManager::getCheckpointId);
 
         // Add different subtask id
-        final CommittableSummary<Integer> third = new CommittableSummary<>(2, 1, 2L, 2, 1, 1);
+        final CommittableSummary<Integer> third = new CommittableSummary<>(2, 1, 2L, 2, 1);
         checkpointCommittables.addSummary(third);
         assertThat(checkpointCommittables.getSubtaskCommittableManagers()).hasSize(2);
     }
@@ -67,8 +65,8 @@ class CheckpointCommittableManagerImplTest {
     void testCommit() throws IOException, InterruptedException {
         final CheckpointCommittableManagerImpl<Integer> checkpointCommittables =
                 new CheckpointCommittableManagerImpl<>(new HashMap<>(), 1, 1L, METRIC_GROUP);
-        checkpointCommittables.addSummary(new CommittableSummary<>(1, 1, 1L, 1, 0, 0));
-        checkpointCommittables.addSummary(new CommittableSummary<>(2, 1, 1L, 2, 0, 0));
+        checkpointCommittables.addSummary(new CommittableSummary<>(1, 1, 1L, 1, 0));
+        checkpointCommittables.addSummary(new CommittableSummary<>(2, 1, 1L, 2, 0));
         checkpointCommittables.addCommittable(new CommittableWithLineage<>(3, 1L, 1));
         checkpointCommittables.addCommittable(new CommittableWithLineage<>(4, 1L, 2));
 
@@ -95,11 +93,11 @@ class CheckpointCommittableManagerImplTest {
     void testUpdateCommittableSummary() {
         final CheckpointCommittableManagerImpl<Integer> checkpointCommittables =
                 new CheckpointCommittableManagerImpl<>(new HashMap<>(), 1, 1L, METRIC_GROUP);
-        checkpointCommittables.addSummary(new CommittableSummary<>(1, 1, 1L, 1, 0, 0));
+        checkpointCommittables.addSummary(new CommittableSummary<>(1, 1, 1L, 1, 0));
         assertThatThrownBy(
                         () ->
                                 checkpointCommittables.addSummary(
-                                        new CommittableSummary<>(1, 1, 1L, 2, 0, 0)))
+                                        new CommittableSummary<>(1, 1, 1L, 2, 0)))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("FLINK-25920");
     }
@@ -114,7 +112,7 @@ class CheckpointCommittableManagerImplTest {
                 new CheckpointCommittableManagerImpl<>(
                         new HashMap<>(), numberOfSubtasks, checkpointId, METRIC_GROUP);
         original.addSummary(
-                new CommittableSummary<>(subtaskId, numberOfSubtasks, checkpointId, 1, 0, 0));
+                new CommittableSummary<>(subtaskId, numberOfSubtasks, checkpointId, 1, 0));
 
         CheckpointCommittableManagerImpl<Integer> copy = original.copy();
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
@@ -63,8 +63,6 @@ class CommittableCollectorSerializerTest {
         final CommittableCollector<Integer> committableCollector =
                 SERIALIZER.deserialize(1, serialized);
 
-        assertThat(committableCollector.isFinished()).isFalse();
-
         assertThat(committableCollector.getCheckpointCommittables())
                 .singleElement()
                 .extracting(
@@ -89,17 +87,14 @@ class CommittableCollectorSerializerTest {
         final CommittableCollector<Integer> committableCollector =
                 new CommittableCollector<>(METRIC_GROUP);
         committableCollector.addMessage(
-                new CommittableSummary<>(subtaskId, numberOfSubtasks, 1L, 1, 1, 0));
+                new CommittableSummary<>(subtaskId, numberOfSubtasks, 1L, 1, 0));
         committableCollector.addMessage(
-                new CommittableSummary<>(subtaskId, numberOfSubtasks, 2L, 1, 1, 0));
+                new CommittableSummary<>(subtaskId, numberOfSubtasks, 2L, 1, 0));
         committableCollector.addMessage(new CommittableWithLineage<>(1, 1L, subtaskId));
         committableCollector.addMessage(new CommittableWithLineage<>(2, 2L, subtaskId));
 
         final CommittableCollector<Integer> copy =
                 ccSerializer.deserialize(2, SERIALIZER.serialize(committableCollector));
-
-        // Expect the subtask Id equal to the origin of the collector
-        assertThat(copy.isFinished()).isFalse();
 
         // assert original CommittableCollector
         assertCommittableCollector(
@@ -139,9 +134,6 @@ class CommittableCollectorSerializerTest {
 
         final CommittableCollector<Integer> copy =
                 ccSerializer.deserialize(2, SERIALIZER.serialize(committableCollector));
-
-        // Expect the subtask Id equal to the origin of the collector
-        assertThat(copy.isFinished()).isFalse();
 
         // assert original CommittableCollector
         assertCommittableCollector(

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.api.connector.sink2.IntegerSerializer;
-import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
@@ -205,11 +204,10 @@ class CommittableCollectorSerializerTest {
                                     checkpointCommittableManager.getSubtaskCommittableManager(
                                             subtaskId);
 
-                            SinkV2Assertions.assertThat(
-                                            checkpointCommittableManager.getSummary(
-                                                    subtaskId, numberOfSubtasks))
-                                    .hasSubtaskId(subtaskId)
-                                    .hasNumberOfSubtasks(numberOfSubtasks);
+                            assertThat(checkpointCommittableManager)
+                                    .returns(
+                                            numberOfSubtasks,
+                                            CheckpointCommittableManagerImpl::getNumberOfSubtasks);
 
                             assertPendingRequests(
                                     subtaskCommittableManager, expectedPendingRequestCount);

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.operators.sink.committables;
 import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
-import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,7 +58,8 @@ class CommittableCollectorTest {
         Optional<CheckpointCommittableManager<Integer>> endOfInputCommittable =
                 committableCollector.getEndOfInputCommittable();
         assertThat(endOfInputCommittable).isPresent();
-        SinkV2Assertions.assertThat(endOfInputCommittable.get().getSummary(1, 1))
-                .hasCheckpointId(EOI);
+        assertThat(endOfInputCommittable)
+                .get()
+                .returns(EOI, CheckpointCommittableManager::getCheckpointId);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
@@ -37,11 +37,11 @@ class CommittableCollectorTest {
     void testGetCheckpointCommittablesUpTo() {
         final CommittableCollector<Integer> committableCollector =
                 new CommittableCollector<>(METRIC_GROUP);
-        CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1, 0, 0);
+        CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, 1L, 1, 0);
         committableCollector.addMessage(first);
-        CommittableSummary<Integer> second = new CommittableSummary<>(1, 1, 2L, 1, 0, 0);
+        CommittableSummary<Integer> second = new CommittableSummary<>(1, 1, 2L, 1, 0);
         committableCollector.addMessage(second);
-        committableCollector.addMessage(new CommittableSummary<>(1, 1, 3L, 1, 0, 0));
+        committableCollector.addMessage(new CommittableSummary<>(1, 1, 3L, 1, 0));
 
         assertThat(committableCollector.getCheckpointCommittablesUpTo(2)).hasSize(2);
 
@@ -52,7 +52,7 @@ class CommittableCollectorTest {
     void testGetEndOfInputCommittable() {
         final CommittableCollector<Integer> committableCollector =
                 new CommittableCollector<>(METRIC_GROUP);
-        CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, EOI, 1, 0, 0);
+        CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, EOI, 1, 0);
         committableCollector.addMessage(first);
 
         Optional<CheckpointCommittableManager<Integer>> endOfInputCommittable =

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManagerTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 
-import org.assertj.core.api.ListAssert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -30,8 +29,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.stream.IntStream;
 
-import static org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions.committableWithLineage;
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SubtaskCommittableManagerTest {
@@ -39,7 +36,7 @@ class SubtaskCommittableManagerTest {
             MetricsGroupTestUtils.mockCommitterMetricGroup();
 
     @Test
-    void testDrainCommittables() {
+    void testSuccessfulCommittables() {
         final SubtaskCommittableManager<Integer> subtaskCommittableManager =
                 new SubtaskCommittableManager<>(3, 1, 1L, METRIC_GROUP);
         final CommittableWithLineage<Integer> first = new CommittableWithLineage<>(1, 1L, 1);
@@ -54,7 +51,6 @@ class SubtaskCommittableManagerTest {
         subtaskCommittableManager.add(third);
         assertThat(subtaskCommittableManager.getPendingRequests()).hasSize(3);
         assertThat(subtaskCommittableManager.getNumCommittables()).isEqualTo(3);
-        assertThat(subtaskCommittableManager.getNumDrained()).isEqualTo(0);
         assertThat(subtaskCommittableManager.isFinished()).isFalse();
 
         // Trigger commit
@@ -63,36 +59,18 @@ class SubtaskCommittableManagerTest {
         IntStream.range(0, 2).forEach(i -> requests.next().setCommittedIfNoError());
         assertThat(subtaskCommittableManager.getPendingRequests()).hasSize(1);
         assertThat(subtaskCommittableManager.getNumCommittables()).isEqualTo(3);
-        assertThat(subtaskCommittableManager.getNumDrained()).isEqualTo(0);
 
-        // Drain committed committables
-        ListAssert<CommittableWithLineage<Integer>> committables =
-                assertThat(subtaskCommittableManager.drainCommitted()).hasSize(2);
-        committables
-                .element(0, as(committableWithLineage()))
-                .hasSubtaskId(1)
-                .hasCommittable(1)
-                .hasCheckpointId(1);
-        committables
-                .element(1, as(committableWithLineage()))
-                .hasSubtaskId(1)
-                .hasCommittable(2)
-                .hasCheckpointId(1);
-        assertThat(subtaskCommittableManager.getNumFailed()).isEqualTo(0);
-
-        // Drain again should not yield anything
-        assertThat(subtaskCommittableManager.drainCommitted()).hasSize(0);
+        // Check the successful committables
+        assertThat(subtaskCommittableManager.getSuccessfulCommittables())
+                .containsExactlyInAnyOrder(1, 2);
 
         // Fail commit
         requests.next().signalFailedWithKnownReason(new RuntimeException("Unused exception"));
-        assertThat(subtaskCommittableManager.getNumFailed()).isEqualTo(0);
         assertThat(subtaskCommittableManager.getPendingRequests()).hasSize(0);
         assertThat(subtaskCommittableManager.getNumCommittables()).isEqualTo(3);
-        assertThat(subtaskCommittableManager.isFinished()).isFalse();
-
-        // Drain to update fail count
-        assertThat(subtaskCommittableManager.drainCommitted()).hasSize(0);
-        assertThat(subtaskCommittableManager.getNumFailed()).isEqualTo(1);
+        // doesn't change the successful committables
+        assertThat(subtaskCommittableManager.getSuccessfulCommittables())
+                .containsExactlyInAnyOrder(1, 2);
         assertThat(subtaskCommittableManager.isFinished()).isTrue();
     }
 
@@ -102,7 +80,6 @@ class SubtaskCommittableManagerTest {
                 new SubtaskCommittableManager<>(
                         Collections.singletonList(new CommitRequestImpl<>(1, METRIC_GROUP)),
                         5,
-                        1,
                         2,
                         1,
                         2L,
@@ -114,13 +91,11 @@ class SubtaskCommittableManagerTest {
                                         new CommitRequestImpl<>(2, METRIC_GROUP),
                                         new CommitRequestImpl<>(3, METRIC_GROUP)),
                                 10,
-                                2,
                                 3,
                                 1,
                                 2L,
                                 METRIC_GROUP));
-        assertThat(merged.getNumCommittables()).isEqualTo(11);
-        assertThat(merged.getNumDrained()).isEqualTo(3);
+        assertThat(merged.getNumCommittables()).isEqualTo(3);
         assertThat(merged.isFinished()).isFalse();
         assertThat(merged.getNumFailed()).isEqualTo(5);
         assertThat(merged.getPendingRequests()).hasSize(3);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/TestSinkV2.java
@@ -463,17 +463,17 @@ public class TestSinkV2<InputT> implements Sink<InputT> {
     /** A {@link Committer} that always re-commits the committables data it received. */
     static class RetryOnceCommitter extends DefaultCommitter {
 
-        private final Set<CommitRequest<String>> seen = new LinkedHashSet<>();
+        private final Set<String> seen = new LinkedHashSet<>();
 
         @Override
         public void commit(Collection<CommitRequest<String>> committables) {
             committables.forEach(
                     c -> {
-                        if (seen.remove(c)) {
+                        if (seen.remove(c.getCommittable())) {
                             checkNotNull(committedData);
                             committedData.add(c);
                         } else {
-                            seen.add(c);
+                            seen.add(c.getCommittable());
                             c.retryLater();
                         }
                     });


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Sinks so far retried asynchronously to increase commit throughput in case of temporary issues. However, the contract of notifyCheckpointCompleted states that checkpoints must be side-effect free meaning all transactions have to be committed on return of the PRC call.

## Brief change log


* This commit retries a fixed number of times and then fails in notifyCheckpointCompleted.
* Simplifies parts of committable handling now that all committables of a subtask either succeed or fail


## Verifying this change

* Already covered by many tests
* Adjusted and changed tests in
api/connector/sink2
runtime/operators/sink/committables

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (**yes** / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
