### PR TITLE
[FLINK-36571][web] Fix issue to allow Busy and Backpressure numbers o…

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/dagre/components/node/node.component.ts
@@ -71,7 +71,9 @@ export class NodeComponent {
     if (this.isValid(value.busyPercentage)) {
       this.busyPercentage = value.busyPercentage;
     }
-    this.dataSkewPercentage = value.dataSkewPercentage;
+    if (this.isValid(value.dataSkewPercentage)) {
+        this.dataSkewPercentage = value.dataSkewPercentage;
+    }
     this.height = value.height || 0;
     this.id = value.id;
     if (description && description.length > 300) {
@@ -82,7 +84,7 @@ export class NodeComponent {
   }
 
   isValid = (value?: number): boolean => {
-    return value === undefined || value === 0 || isNaN(value);
+    return !!value || value === undefined || value === 0 || isNaN(value);
   };
 
   toRGBA = (d: string): number[] => {


### PR DESCRIPTION
…n Flink dashboard

## What is the purpose of the change
Fix bug so that non-zero numbers of Busy / Backpressure can be shown on Flink dashboard

## Brief change log
- Add check for `!!value` to convert value to boolean
- Add check before setting `dataSkewPercentage`

## Verifying this change
- This change is a trivial rework / code cleanup without any test coverage.
- Manually checked on a job running locally, that non-zero Busy % can be seen.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
