### PR TITLE
[FLINK-36537] Bump snappy-java from 1.1.10.4 to 1.1.10.7

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -20,7 +20,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.javassist:javassist:3.24.0-GA
 - org.lz4:lz4-java:1.8.0
 - org.objenesis:objenesis:2.1
-- org.xerial.snappy:snappy-java:1.1.10.4
+- org.xerial.snappy:snappy-java:1.1.10.7
 - tools.profiler:async-profiler:2.9
 - org.snakeyaml:snakeyaml-engine:2.6
 

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -31,7 +31,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
-- org.xerial.snappy:snappy-java:1.1.10.4
+- org.xerial.snappy:snappy-java:1.1.10.7
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -41,7 +41,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
 - org.wildfly.openssl:wildfly-openssl:1.0.7.Final
-- org.xerial.snappy:snappy-java:1.1.10.4
+- org.xerial.snappy:snappy-java:1.1.10.7
 - software.amazon.ion:ion-java:1.0.2
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -55,7 +55,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.kerby:kerby-util:1.0.1
 - org.weakref:jmxutils:1.19
 - org.wildfly.openssl:wildfly-openssl:1.0.7.Final
-- org.xerial.snappy:snappy-java:1.1.10.4
+- org.xerial.snappy:snappy-java:1.1.10.7
 - software.amazon.ion:ion-java:1.0.2
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -17,7 +17,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-compress:1.26.0
 - org.apache.commons:commons-lang3:3.12.0
 - org.apache.kafka:kafka-clients:7.5.3-ccs
-- org.xerial.snappy:snappy-java:1.1.10.4
+- org.xerial.snappy:snappy-java:1.1.10.7
 - org.yaml:snakeyaml:1.33
 
 This project bundles the following dependencies under the BSD license.

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@ under the License.
 		<!-- Can be set to any value to reproduce a specific build. -->
 		<test.randomization.seed/>
 		<test.unit.pattern>**/*Test.*</test.unit.pattern>
+		<snappy.java.version>1.1.10.7</snappy.java.version>
 	</properties>
 
 	<dependencies>
@@ -547,7 +548,7 @@ under the License.
 			<dependency>
 				<groupId>org.xerial.snappy</groupId>
 				<artifactId>snappy-java</artifactId>
-				<version>1.1.10.4</version>
+				<version>${snappy.java.version}</version>
 				<exclusions>
 					<exclusion>
 						<!-- Causes unnecessary dependency convergence errors; see MENFORCER-437 -->


### PR DESCRIPTION
## What is the purpose of the change

Bump snappy-java from 1.1.10.4 to 1.1.10.7


## Brief change log

The current version has vulnerability in the dependant package, bumping it to the latest version will remediate.

Vulnerabilities from dependencies:
[CVE-2024-23454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-23454)
[CVE-2022-26612](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-26612)

Package details:
https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java/1.1.10.7


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
