### PR TITLE
[FLINK-36575][runtime] ExecutionVertexInputInfo supports consuming subpartition groups

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ConsumedSubpartitionContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ConsumedSubpartitionContext.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.runtime.executiongraph.IndexRange;
+import org.apache.flink.runtime.executiongraph.IndexRangeUtil;
+import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/*
+ * Helper class used to track and manage the relationships between shuffle descriptors and their
+ * associated subpartitions.
+ */
+class ConsumedSubpartitionContext implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    /** The number of consumed shuffle descriptors. */
+    private final int numConsumedShuffleDescriptors;
+
+    /**
+     * A mapping between ranges of consumed shuffle descriptors and their corresponding subpartition
+     * ranges.
+     *
+     * <p>For ALL_TO_ALL, the consumed partition range to subpartition range might be like this:
+     * task1: [0, 10] -> [0, 0]; task2: [0,5] -> [1,1]; task3: [6,10] -> [1,1], [0,10] -> [2,2].
+     * Since ALL_TO_ALL shares the same set of shuffle descriptors, the index mapping from partition
+     * rang to shuffle descriptor range is: [0,10]->[0,10]. Finally, the shuffle descriptor range to
+     * subpartition range mappings are: task1: [0, 10] -> [0, 0]; task2: [0,5] -> [1,1]; task3:
+     * [6,10] -> [1,1], [0,10] -> [2,2].
+     *
+     * <p>For POINTWISE, the consumed partition range to subpartition range might be like this:
+     * task1: [0, 0] -> [0, 10]; task2: [1, 1] -> [0,5]; task3: [1,1] -> [6,10], [2,10]->[0,10]. The
+     * mappings from partition rang to shuffle descriptor range for each task are: task1: [0,0] ->
+     * [0,0]; task2: [1,1] -> [0,0]; task3: [1,1] -> [0,0], [2,10] -> [1,9]. Finally, the shuffle
+     * descriptor range to subpartition range mappings are: task1: [0,0] -> [0,10]; task2: [0,0] ->
+     * [0,5]; task3: [0,0] -> [6,10], [1,9] -> [0,10].
+     */
+    private final Map<IndexRange, IndexRange> consumedShuffleDescriptorToSubpartitionRangeMap;
+
+    private ConsumedSubpartitionContext(
+            int numConsumedShuffleDescriptors,
+            Map<IndexRange, IndexRange> consumedShuffleDescriptorToSubpartitionRangeMap) {
+        this.numConsumedShuffleDescriptors = numConsumedShuffleDescriptors;
+        this.consumedShuffleDescriptorToSubpartitionRangeMap =
+                checkNotNull(consumedShuffleDescriptorToSubpartitionRangeMap);
+    }
+
+    public int getNumConsumedShuffleDescriptors() {
+        return numConsumedShuffleDescriptors;
+    }
+
+    public Collection<IndexRange> getConsumedShuffleDescriptorRanges() {
+        return Collections.unmodifiableCollection(
+                consumedShuffleDescriptorToSubpartitionRangeMap.keySet());
+    }
+
+    public IndexRange getConsumedSubpartitionRange(int shuffleDescriptorIndex) {
+        //  For ALL_TO_ALL the consumedShuffleDescriptorToSubpartitionRange might like this:
+        //  [0,10] -> [2,2], [0,5] -> [3,3], we need to find all the consumed subpartition ranges
+        // and return the merged result.
+        List<IndexRange> consumedSubpartitionRanges = new ArrayList<>();
+        for (Map.Entry<IndexRange, IndexRange> entry :
+                consumedShuffleDescriptorToSubpartitionRangeMap.entrySet()) {
+            IndexRange shuffleDescriptorRange = entry.getKey();
+            if (shuffleDescriptorIndex >= shuffleDescriptorRange.getStartIndex()
+                    && shuffleDescriptorIndex <= shuffleDescriptorRange.getEndIndex()) {
+                consumedSubpartitionRanges.add(entry.getValue());
+            }
+        }
+        List<IndexRange> mergedConsumedSubpartitionRanges =
+                IndexRangeUtil.mergeIndexRanges(consumedSubpartitionRanges);
+        checkState(
+                mergedConsumedSubpartitionRanges.size() == 1,
+                "Illegal consumed subpartition range for shuffle descriptor index "
+                        + shuffleDescriptorIndex);
+        return mergedConsumedSubpartitionRanges.get(0);
+    }
+
+    /**
+     * Builds a {@link ConsumedSubpartitionContext} based on the provided inputs.
+     *
+     * <p>Note: The construction is based on subscribing to consecutive subpartitions of the same
+     * partition. If this assumption is violated, an exception will be thrown.
+     *
+     * @param consumedSubpartitionGroups a mapping of consumed partition index ranges to
+     *     subpartition ranges.
+     * @param consumedResultPartitions an iterator of {@link IntermediateResultPartitionID} for the
+     *     consumed result partitions.
+     * @param partitions all partition ids of consumed {@link IntermediateResult}.
+     * @return a {@link ConsumedSubpartitionContext} instance constructed from the input parameters.
+     */
+    public static ConsumedSubpartitionContext buildConsumedSubpartitionContext(
+            Map<IndexRange, IndexRange> consumedSubpartitionGroups,
+            Iterator<IntermediateResultPartitionID> consumedResultPartitions,
+            IntermediateResultPartitionID[] partitions) {
+        Map<IntermediateResultPartitionID, Integer> partitionIdToShuffleDescriptorIndexMap =
+                new HashMap<>();
+        while (consumedResultPartitions.hasNext()) {
+            IntermediateResultPartitionID partitionId = consumedResultPartitions.next();
+            partitionIdToShuffleDescriptorIndexMap.put(
+                    partitionId, partitionIdToShuffleDescriptorIndexMap.size());
+        }
+
+        Map<IndexRange, IndexRange> consumedShuffleDescriptorToSubpartitionRangeMap =
+                new LinkedHashMap<>();
+        for (Map.Entry<IndexRange, IndexRange> entry : consumedSubpartitionGroups.entrySet()) {
+            IndexRange partitionRange = entry.getKey();
+            IndexRange subpartitionRange = entry.getValue();
+            IndexRange shuffleDescriptorRange =
+                    new IndexRange(
+                            partitionIdToShuffleDescriptorIndexMap.get(
+                                    partitions[partitionRange.getStartIndex()]),
+                            partitionIdToShuffleDescriptorIndexMap.get(
+                                    partitions[partitionRange.getEndIndex()]));
+            checkState(
+                    partitionRange.size() == shuffleDescriptorRange.size()
+                            && !consumedShuffleDescriptorToSubpartitionRangeMap.containsKey(
+                                    shuffleDescriptorRange));
+            consumedShuffleDescriptorToSubpartitionRangeMap.put(
+                    shuffleDescriptorRange, subpartitionRange);
+        }
+        // For ALL_TO_ALL, there might be overlaps in shuffle descriptor to subpartition range map:
+        // [0,10] -> [2,2], [0,5] -> [3,3], so we need to count consumed shuffle descriptors after
+        // merging.
+        int numConsumedShuffleDescriptors = 0;
+        List<IndexRange> mergedConsumedShuffleDescriptor =
+                IndexRangeUtil.mergeIndexRanges(
+                        consumedShuffleDescriptorToSubpartitionRangeMap.keySet());
+        for (IndexRange range : mergedConsumedShuffleDescriptor) {
+            numConsumedShuffleDescriptors += range.size();
+        }
+        return new ConsumedSubpartitionContext(
+                numConsumedShuffleDescriptors, consumedShuffleDescriptorToSubpartitionRangeMap);
+    }
+
+    /**
+     * Builds a {@link ConsumedSubpartitionContext} using a given number of consumed shuffle
+     * descriptors and a single {@link IndexRange} representing the consumed subpartition range.
+     *
+     * <p>Note: This method is designed as a compatibility method. It assumes that the task will
+     * subscribe to all shuffle descriptors and to the same subpartitions for every descriptor.
+     *
+     * @param numConsumedShuffleDescriptors the total number of consumed shuffle descriptors; must
+     *     be greater than 0.
+     * @param consumedSubpartitionRange the range of consumed subpartitions.
+     * @return a {@link ConsumedSubpartitionContext} instance constructed from the input parameters.
+     */
+    public static ConsumedSubpartitionContext buildConsumedSubpartitionContext(
+            int numConsumedShuffleDescriptors, IndexRange consumedSubpartitionRange) {
+        checkState(numConsumedShuffleDescriptors > 0);
+        return new ConsumedSubpartitionContext(
+                numConsumedShuffleDescriptors,
+                Map.of(
+                        new IndexRange(0, numConsumedShuffleDescriptors - 1),
+                        consumedSubpartitionRange));
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "ConsumedSubpartitionContext [num consumed shuffle descriptors: %s, "
+                        + "consumed shuffle descriptors to subpartition range: %s]",
+                numConsumedShuffleDescriptors, consumedShuffleDescriptorToSubpartitionRangeMap);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/InputGateDeploymentDescriptor.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptorFactory.Shuff
 import org.apache.flink.runtime.executiongraph.IndexRange;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
-import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.util.GroupCache;
@@ -42,6 +41,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -71,11 +71,10 @@ public class InputGateDeploymentDescriptor implements Serializable {
     private final ResultPartitionType consumedPartitionType;
 
     /**
-     * Range of the index of the consumed subpartition of each consumed partition. This index
-     * depends on the {@link DistributionPattern} and the subtask indices of the producing and
-     * consuming task. The range is inclusive.
+     * Provides information about the number of consumed shuffle descriptors and the mapping between
+     * consumed shuffle descriptor ranges and their corresponding subpartition ranges.
      */
-    private final IndexRange consumedSubpartitionIndexRange;
+    private final ConsumedSubpartitionContext consumedSubpartitionContext;
 
     /** An input channel for each consumed subpartition. */
     private transient ShuffleDescriptor[] inputChannels;
@@ -110,9 +109,24 @@ public class InputGateDeploymentDescriptor implements Serializable {
             IndexRange consumedSubpartitionIndexRange,
             int numberOfInputChannels,
             List<MaybeOffloaded<ShuffleDescriptorGroup>> serializedInputChannels) {
+        this(
+                consumedResultId,
+                consumedPartitionType,
+                ConsumedSubpartitionContext.buildConsumedSubpartitionContext(
+                        numberOfInputChannels, consumedSubpartitionIndexRange),
+                numberOfInputChannels,
+                serializedInputChannels);
+    }
+
+    public InputGateDeploymentDescriptor(
+            IntermediateDataSetID consumedResultId,
+            ResultPartitionType consumedPartitionType,
+            ConsumedSubpartitionContext consumedSubpartitionContext,
+            int numberOfInputChannels,
+            List<MaybeOffloaded<ShuffleDescriptorGroup>> serializedInputChannels) {
         this.consumedResultId = checkNotNull(consumedResultId);
         this.consumedPartitionType = checkNotNull(consumedPartitionType);
-        this.consumedSubpartitionIndexRange = checkNotNull(consumedSubpartitionIndexRange);
+        this.consumedSubpartitionContext = checkNotNull(consumedSubpartitionContext);
         this.serializedInputChannels = checkNotNull(serializedInputChannels);
         this.numberOfInputChannels = numberOfInputChannels;
     }
@@ -130,19 +144,31 @@ public class InputGateDeploymentDescriptor implements Serializable {
         return consumedPartitionType;
     }
 
-    @Nonnegative
-    public int getConsumedSubpartitionIndex() {
-        checkState(
-                consumedSubpartitionIndexRange.getStartIndex()
-                        == consumedSubpartitionIndexRange.getEndIndex());
-        return consumedSubpartitionIndexRange.getStartIndex();
+    public int getNumConsumedShuffleDescriptors() {
+        return consumedSubpartitionContext.getNumConsumedShuffleDescriptors();
     }
 
-    /** Return the index range of the consumed subpartitions. */
-    public IndexRange getConsumedSubpartitionIndexRange() {
-        return consumedSubpartitionIndexRange;
+    public Collection<IndexRange> getConsumedShuffleDescriptorRanges() {
+        return consumedSubpartitionContext.getConsumedShuffleDescriptorRanges();
     }
 
+    public IndexRange getConsumedSubpartitionRange(int shuffleDescriptorIndex) {
+        return consumedSubpartitionContext.getConsumedSubpartitionRange(shuffleDescriptorIndex);
+    }
+
+    /**
+     * Retrieves all {@link ShuffleDescriptor}s associated of this input gate deployment descriptor.
+     *
+     * <p>Note that the returned descriptors may not be fully consumed. The {@link
+     * #getConsumedShuffleDescriptorRanges} method provides the indices of the shuffle descriptors
+     * that are really consumed.
+     *
+     * <p>We need to return all {@link ShuffleDescriptor}s to maintain the mapping between the
+     * descriptors and the indices recorded in the {@link ConsumedSubpartitionContext}.
+     *
+     * @return an array of {@link ShuffleDescriptor}s.
+     * @throws RuntimeException if deserialization of shuffle descriptors fails.
+     */
     public ShuffleDescriptor[] getShuffleDescriptors() {
         if (inputChannels == null) {
             // This is only for testing scenarios, in a production environment we always call
@@ -248,7 +274,7 @@ public class InputGateDeploymentDescriptor implements Serializable {
     public String toString() {
         return String.format(
                 "InputGateDeploymentDescriptor [result id: %s, "
-                        + "consumed subpartition index range: %s]",
-                consumedResultId.toString(), consumedSubpartitionIndexRange);
+                        + "consumed subpartition context: %s]",
+                consumedResultId.toString(), consumedSubpartitionContext.toString());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor.MaybeOffload
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-import org.apache.flink.runtime.executiongraph.IndexRange;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.executiongraph.InternalExecutionGraphAccessor;
@@ -54,6 +53,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -151,16 +151,19 @@ public class TaskDeploymentDescriptorFactory {
 
             IntermediateDataSetID resultId = consumedIntermediateResult.getId();
             ResultPartitionType partitionType = consumedIntermediateResult.getResultType();
-            IndexRange subpartitionRange =
-                    executionVertex
-                            .getExecutionVertexInputInfo(resultId)
-                            .getSubpartitionIndexRange();
 
             inputGates.add(
                     new InputGateDeploymentDescriptor(
                             resultId,
                             partitionType,
-                            subpartitionRange,
+                            ConsumedSubpartitionContext.buildConsumedSubpartitionContext(
+                                    executionVertex
+                                            .getExecutionVertexInputInfo(resultId)
+                                            .getConsumedSubpartitionGroups(),
+                                    consumedPartitionGroup.iterator(),
+                                    Arrays.stream(consumedIntermediateResult.getPartitions())
+                                            .map(IntermediateResultPartition::getPartitionId)
+                                            .toArray(IntermediateResultPartitionID[]::new)),
                             consumedPartitionGroup.size(),
                             getConsumedPartitionShuffleDescriptors(
                                     consumedIntermediateResult,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputInfo.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.executiongraph;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -32,27 +34,28 @@ public class ExecutionVertexInputInfo implements Serializable {
 
     private final int subtaskIndex;
 
-    private final IndexRange partitionIndexRange;
-
-    private final IndexRange subpartitionIndexRange;
+    // The key is the partition index range, and the value is the subpartition index range.
+    private final Map<IndexRange, IndexRange> consumedSubpartitionGroups;
 
     public ExecutionVertexInputInfo(
             final int subtaskIndex,
             final IndexRange partitionIndexRange,
             final IndexRange subpartitionIndexRange) {
+        this(
+                subtaskIndex,
+                Collections.singletonMap(
+                        checkNotNull(partitionIndexRange), checkNotNull(subpartitionIndexRange)));
+    }
+
+    public ExecutionVertexInputInfo(
+            final int subtaskIndex, final Map<IndexRange, IndexRange> consumedSubpartitionGroups) {
         this.subtaskIndex = subtaskIndex;
-        this.partitionIndexRange = checkNotNull(partitionIndexRange);
-        this.subpartitionIndexRange = checkNotNull(subpartitionIndexRange);
+        this.consumedSubpartitionGroups = checkNotNull(consumedSubpartitionGroups);
     }
 
-    /** Get the subpartition range this subtask should consume. */
-    public IndexRange getSubpartitionIndexRange() {
-        return subpartitionIndexRange;
-    }
-
-    /** Get the partition range this subtask should consume. */
-    public IndexRange getPartitionIndexRange() {
-        return partitionIndexRange;
+    /** Get the subpartition groups this subtask should consume. */
+    public Map<IndexRange, IndexRange> getConsumedSubpartitionGroups() {
+        return consumedSubpartitionGroups;
     }
 
     /** Get the index of this subtask. */
@@ -67,8 +70,7 @@ public class ExecutionVertexInputInfo implements Serializable {
         } else if (obj != null && obj.getClass() == getClass()) {
             ExecutionVertexInputInfo that = (ExecutionVertexInputInfo) obj;
             return that.subtaskIndex == this.subtaskIndex
-                    && that.partitionIndexRange.equals(this.partitionIndexRange)
-                    && that.subpartitionIndexRange.equals(this.subpartitionIndexRange);
+                    && that.consumedSubpartitionGroups.equals(this.consumedSubpartitionGroups);
         } else {
             return false;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IndexRangeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IndexRangeUtil.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Utils for {@link IndexRange}. */
+public class IndexRangeUtil {
+
+    /**
+     * Merges overlapping or consecutive {@link IndexRange} instances from the given collection.
+     *
+     * <p>The method sorts the provided ranges by their start index, then iteratively merges ranges
+     * that either overlap or are directly adjacent. The result is a list of non-overlapping and
+     * consolidated {@link IndexRange} instances.
+     *
+     * @param ranges the collection of {@link IndexRange} instances to merge.
+     * @return a list of merged {@link IndexRange} instances. If the input is null or empty, an
+     *     empty list is returned.
+     */
+    public static List<IndexRange> mergeIndexRanges(Collection<IndexRange> ranges) {
+        if (ranges == null || ranges.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<IndexRange> sortedRanges =
+                ranges.stream()
+                        .sorted(Comparator.comparingInt(IndexRange::getStartIndex))
+                        .collect(Collectors.toList());
+
+        List<IndexRange> merged = new ArrayList<>();
+        IndexRange current = sortedRanges.get(0);
+
+        for (int i = 1; i < ranges.size(); i++) {
+            IndexRange next = sortedRanges.get(i);
+            if (next.getStartIndex() <= current.getEndIndex() + 1) {
+                current =
+                        new IndexRange(
+                                current.getStartIndex(),
+                                Math.max(current.getEndIndex(), next.getEndIndex()));
+            } else {
+                merged.add(current);
+                current = next;
+            }
+        }
+        merged.add(current);
+
+        return merged;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtils.java
@@ -190,15 +190,19 @@ public class SsgNetworkMemoryCalculationUtils {
 
                 IntermediateResultPartition resultPartition =
                         ejv.getGraph().getResultPartitionOrThrow((partitionGroup.getFirst()));
-                IndexRange subpartitionIndexRange =
+                Map<IndexRange, IndexRange> consumedSubpartitionGroups =
                         vertex.getExecutionVertexInputInfo(
                                         resultPartition.getIntermediateResult().getId())
-                                .getSubpartitionIndexRange();
+                                .getConsumedSubpartitionGroups();
+
+                int inputChannelNums = 0;
+                for (Map.Entry<IndexRange, IndexRange> entry :
+                        consumedSubpartitionGroups.entrySet()) {
+                    inputChannelNums += entry.getKey().size() * entry.getValue().size();
+                }
 
                 maxInputChannelNums.merge(
-                        partitionGroup.getIntermediateDataSetID(),
-                        subpartitionIndexRange.size() * partitionGroup.size(),
-                        Integer::max);
+                        partitionGroup.getIntermediateDataSetID(), inputChannelNums, Integer::max);
                 inputPartitionTypes.putIfAbsent(
                         partitionGroup.getIntermediateDataSetID(),
                         partitionGroup.getResultPartitionType());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -760,13 +760,18 @@ public class AdaptiveBatchScheduler extends DefaultScheduler implements JobGraph
             for (IntermediateResult intermediateResult : intermediateResults) {
                 ExecutionVertexInputInfo inputInfo =
                         ev.getExecutionVertexInputInfo(intermediateResult.getId());
-                IndexRange partitionIndexRange = inputInfo.getPartitionIndexRange();
-                IndexRange subpartitionIndexRange = inputInfo.getSubpartitionIndexRange();
                 BlockingResultInfo blockingResultInfo =
                         checkNotNull(getBlockingResultInfo(intermediateResult.getId()));
-                inputBytes +=
-                        blockingResultInfo.getNumBytesProduced(
-                                partitionIndexRange, subpartitionIndexRange);
+                Map<IndexRange, IndexRange> consumedSubpartitionGroups =
+                        inputInfo.getConsumedSubpartitionGroups();
+                for (Map.Entry<IndexRange, IndexRange> entry :
+                        consumedSubpartitionGroups.entrySet()) {
+                    IndexRange partitionIndexRange = entry.getKey();
+                    IndexRange subpartitionIndexRange = entry.getValue();
+                    inputBytes +=
+                            blockingResultInfo.getNumBytesProduced(
+                                    partitionIndexRange, subpartitionIndexRange);
+                }
             }
             ev.setInputBytes(inputBytes);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ConsumedSubpartitionContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ConsumedSubpartitionContextTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.deployment;
+
+import org.apache.flink.runtime.executiongraph.IndexRange;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ConsumedSubpartitionContext}. */
+class ConsumedSubpartitionContextTest {
+    @Test
+    void testBuildConsumedSubpartitionContextWithGroups() {
+        Map<IndexRange, IndexRange> consumedSubpartitionGroups =
+                Map.of(
+                        new IndexRange(0, 1), new IndexRange(0, 2),
+                        new IndexRange(2, 3), new IndexRange(3, 5));
+
+        List<IntermediateResultPartitionID> consumedPartitionIds = new ArrayList<>();
+
+        IntermediateResultPartitionID[] partitions = new IntermediateResultPartitionID[4];
+        for (int i = 0; i < partitions.length; i++) {
+            partitions[i] = new IntermediateResultPartitionID(new IntermediateDataSetID(), i);
+            consumedPartitionIds.add(partitions[i]);
+        }
+
+        ConsumedSubpartitionContext context =
+                ConsumedSubpartitionContext.buildConsumedSubpartitionContext(
+                        consumedSubpartitionGroups, consumedPartitionIds.iterator(), partitions);
+
+        assertThat(context.getNumConsumedShuffleDescriptors()).isEqualTo(4);
+
+        Collection<IndexRange> shuffleDescriptorRanges =
+                context.getConsumedShuffleDescriptorRanges();
+        assertThat(shuffleDescriptorRanges).hasSize(2);
+
+        assertThat(context.getConsumedSubpartitionRange(0)).isEqualTo(new IndexRange(0, 2));
+        assertThat(context.getConsumedSubpartitionRange(1)).isEqualTo(new IndexRange(0, 2));
+        assertThat(context.getConsumedSubpartitionRange(2)).isEqualTo(new IndexRange(3, 5));
+        assertThat(context.getConsumedSubpartitionRange(3)).isEqualTo(new IndexRange(3, 5));
+    }
+
+    @Test
+    void testBuildConsumedSubpartitionContextWithUnorderedGroups() {
+        Map<IndexRange, IndexRange> consumedSubpartitionGroups =
+                Map.of(
+                        new IndexRange(3, 3), new IndexRange(1, 1),
+                        new IndexRange(0, 0), new IndexRange(0, 1));
+
+        List<IntermediateResultPartitionID> consumedPartitionIds = new ArrayList<>();
+
+        IntermediateResultPartitionID[] partitions = new IntermediateResultPartitionID[4];
+        for (int i = 0; i < partitions.length; i++) {
+            partitions[i] = new IntermediateResultPartitionID(new IntermediateDataSetID(), i);
+            consumedPartitionIds.add(partitions[i]);
+        }
+
+        ConsumedSubpartitionContext context =
+                ConsumedSubpartitionContext.buildConsumedSubpartitionContext(
+                        consumedSubpartitionGroups, consumedPartitionIds.iterator(), partitions);
+
+        assertThat(context.getNumConsumedShuffleDescriptors()).isEqualTo(2);
+
+        Collection<IndexRange> shuffleDescriptorRanges =
+                context.getConsumedShuffleDescriptorRanges();
+        assertThat(shuffleDescriptorRanges).hasSize(2);
+
+        assertThat(context.getConsumedSubpartitionRange(0)).isEqualTo(new IndexRange(0, 1));
+        assertThat(context.getConsumedSubpartitionRange(3)).isEqualTo(new IndexRange(1, 1));
+    }
+
+    @Test
+    void testBuildConsumedSubpartitionContextWithOverlapGroups() {
+        Map<IndexRange, IndexRange> consumedSubpartitionGroups =
+                Map.of(
+                        new IndexRange(0, 3), new IndexRange(1, 1),
+                        new IndexRange(0, 1), new IndexRange(2, 2));
+
+        List<IntermediateResultPartitionID> consumedPartitionIds = new ArrayList<>();
+
+        IntermediateResultPartitionID[] partitions = new IntermediateResultPartitionID[4];
+        for (int i = 0; i < partitions.length; i++) {
+            partitions[i] = new IntermediateResultPartitionID(new IntermediateDataSetID(), i);
+            consumedPartitionIds.add(partitions[i]);
+        }
+
+        ConsumedSubpartitionContext context =
+                ConsumedSubpartitionContext.buildConsumedSubpartitionContext(
+                        consumedSubpartitionGroups, consumedPartitionIds.iterator(), partitions);
+
+        assertThat(context.getNumConsumedShuffleDescriptors()).isEqualTo(4);
+
+        Collection<IndexRange> shuffleDescriptorRanges =
+                context.getConsumedShuffleDescriptorRanges();
+        assertThat(shuffleDescriptorRanges).hasSize(2);
+
+        assertThat(context.getConsumedSubpartitionRange(0)).isEqualTo(new IndexRange(1, 2));
+        assertThat(context.getConsumedSubpartitionRange(1)).isEqualTo(new IndexRange(1, 2));
+        assertThat(context.getConsumedSubpartitionRange(2)).isEqualTo(new IndexRange(1, 1));
+        assertThat(context.getConsumedSubpartitionRange(3)).isEqualTo(new IndexRange(1, 1));
+    }
+
+    @Test
+    void testBuildConsumedSubpartitionContextWithRange() {
+        int numConsumedShuffleDescriptors = 5;
+        IndexRange consumedSubpartitionRange = new IndexRange(0, 4);
+
+        ConsumedSubpartitionContext context =
+                ConsumedSubpartitionContext.buildConsumedSubpartitionContext(
+                        numConsumedShuffleDescriptors, consumedSubpartitionRange);
+
+        assertThat(context.getNumConsumedShuffleDescriptors())
+                .isEqualTo(numConsumedShuffleDescriptors);
+
+        Collection<IndexRange> shuffleDescriptorRanges =
+                context.getConsumedShuffleDescriptorRanges();
+        assertThat(shuffleDescriptorRanges).hasSize(1);
+        assertThat(shuffleDescriptorRanges).contains(new IndexRange(0, 4));
+
+        IndexRange subpartitionRange = context.getConsumedSubpartitionRange(2);
+        assertThat(subpartitionRange).isEqualTo(consumedSubpartitionRange);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IndexRangeUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/IndexRangeUtilTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.runtime.executiongraph.IndexRangeUtil.mergeIndexRanges;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link IndexRangeUtil}. */
+class IndexRangeUtilTest {
+    @Test
+    void testMergeIndexRanges() {
+        Collection<IndexRange> emptyList = List.of();
+        List<IndexRange> emptyResult = mergeIndexRanges(emptyList);
+        assertThat(emptyResult).isEmpty();
+
+        Collection<IndexRange> singleRangeList = List.of(new IndexRange(5, 10));
+        List<IndexRange> singleRangeResult = mergeIndexRanges(singleRangeList);
+        assertThat(singleRangeResult).containsExactly(new IndexRange(5, 10));
+
+        Collection<IndexRange> overlappingRangesList =
+                List.of(new IndexRange(5, 10), new IndexRange(8, 12));
+        List<IndexRange> overlappingRangesResult = mergeIndexRanges(overlappingRangesList);
+        assertThat(overlappingRangesResult).containsExactly(new IndexRange(5, 12));
+
+        Collection<IndexRange> nonOverlappingRangesList =
+                List.of(new IndexRange(1, 5), new IndexRange(10, 15));
+        List<IndexRange> nonOverlappingRangesResult = mergeIndexRanges(nonOverlappingRangesList);
+        assertThat(nonOverlappingRangesResult)
+                .containsExactly(new IndexRange(1, 5), new IndexRange(10, 15));
+
+        Collection<IndexRange> touchingRangesList =
+                List.of(new IndexRange(1, 5), new IndexRange(6, 10));
+        List<IndexRange> touchingRangesResult = mergeIndexRanges(touchingRangesList);
+        assertThat(touchingRangesResult).containsExactly(new IndexRange(1, 10));
+
+        Collection<IndexRange> mixedRangesList =
+                List.of(
+                        new IndexRange(1, 3),
+                        new IndexRange(2, 6),
+                        new IndexRange(8, 10),
+                        new IndexRange(15, 18),
+                        new IndexRange(19, 20));
+        List<IndexRange> mixedRangesResult = mergeIndexRanges(mixedRangesList);
+        assertThat(mixedRangesResult)
+                .containsExactly(
+                        new IndexRange(1, 6), new IndexRange(8, 10), new IndexRange(15, 20));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, the ExecutionVertexInputInfo describes the task's input through a combination of a PartitionRange and a SubpartitionRange. However, in the case of skewed join optimization, we need to split a group of data corresponding to the specific key, which may result in a downstream task subscribing to multiple combinations of PartitionRanges and SubpartitionRanges.

Therefore, we need to modify the ExecutionVertexInputInfo to describe the input data as multiple combinations of PartitionRanges and SubpartitionRanges to meet the requirements of the aforementioned scenario and improve Flink's flexibility in describing the task's inputs.


## Brief change log

  - Modify the description of the input in ExecutionVertexInputInfo.
  - Modify the connect function for edges.
  - Modify the InputGate creation logic of the network layer to adapt to this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
