### PR TITLE
[FLINK-36194][Runtime] Handle the Graceful close of ExecutionGraphInfoStore from ClusterEntrypoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/FileExecutionGraphInfoStore.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.ShutdownHookUtil;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.apache.flink.shaded.guava32.com.google.common.base.Ticker;
@@ -71,8 +70,6 @@ public class FileExecutionGraphInfoStore implements ExecutionGraphInfoStore {
     private final LoadingCache<JobID, ExecutionGraphInfo> executionGraphInfoCache;
 
     private final ScheduledFuture<?> cleanupFuture;
-
-    private final Thread shutdownHook;
 
     private int numFinishedJobs;
 
@@ -131,8 +128,6 @@ public class FileExecutionGraphInfoStore implements ExecutionGraphInfoStore {
                         expirationTime.toMillis(),
                         expirationTime.toMillis(),
                         TimeUnit.MILLISECONDS);
-
-        this.shutdownHook = ShutdownHookUtil.addShutdownHook(this, getClass().getSimpleName(), LOG);
 
         this.numFinishedJobs = 0;
         this.numFailedJobs = 0;
@@ -232,9 +227,6 @@ public class FileExecutionGraphInfoStore implements ExecutionGraphInfoStore {
 
         // clean up the storage directory
         FileUtils.deleteFileOrDirectory(storageDir);
-
-        // Remove shutdown hook to prevent resource leaks
-        ShutdownHookUtil.removeShutdownHook(shutdownHook, getClass().getSimpleName(), LOG);
     }
 
     // --------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MemoryExecutionGraphInfoStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/MemoryExecutionGraphInfoStore.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
-import org.apache.flink.util.ShutdownHookUtil;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.apache.flink.shaded.guava32.com.google.common.base.Ticker;
@@ -54,8 +53,6 @@ public class MemoryExecutionGraphInfoStore implements ExecutionGraphInfoStore {
     private final Cache<JobID, ExecutionGraphInfo> serializableExecutionGraphInfos;
 
     @Nullable private final ScheduledFuture<?> cleanupFuture;
-
-    private final Thread shutdownHook;
 
     public MemoryExecutionGraphInfoStore() {
         this(Duration.ofMillis(0), 0, null, null);
@@ -89,7 +86,6 @@ public class MemoryExecutionGraphInfoStore implements ExecutionGraphInfoStore {
         } else {
             this.cleanupFuture = null;
         }
-        this.shutdownHook = ShutdownHookUtil.addShutdownHook(this, getClass().getSimpleName(), LOG);
     }
 
     @Override
@@ -149,8 +145,5 @@ public class MemoryExecutionGraphInfoStore implements ExecutionGraphInfoStore {
         }
 
         serializableExecutionGraphInfos.invalidateAll();
-
-        // Remove shutdown hook to prevent resource leaks
-        ShutdownHookUtil.removeShutdownHook(shutdownHook, getClass().getSimpleName(), LOG);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -510,6 +510,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
             if (executionGraphInfoStore != null) {
                 try {
                     executionGraphInfoStore.close();
+                    executionGraphInfoStore = null;
                 } catch (Throwable t) {
                     exception = ExceptionUtils.firstOrSuppressed(t, exception);
                 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This fixes the race-condition of writing to a closed file in the cluster shutdown is triggered 


## Brief change log
- removing the shutdown hook from `ExecutionGraphInfoStore` and waiting for the `ClusterEntrypoint` ( which holds an instance of  `ExecutionGraphInfoStore` ) to close it


## Verifying this change
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
