### PR TITLE
[FLINK-36589][state/runtime] Decouple the initialization of sync and async keyed statebackend

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/StreamOperatorContextBuilder.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/StreamOperatorContextBuilder.java
@@ -135,6 +135,7 @@ class StreamOperatorContextBuilder {
                     registry,
                     ctx.getMetricGroup(),
                     1.0,
+                    false,
                     false);
         } catch (Exception e) {
             throw new IOException("Failed to restore state backend", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -28,18 +28,14 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.AsyncStateException;
 import org.apache.flink.runtime.asyncprocessing.RecordContext;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
-import org.apache.flink.runtime.state.CheckpointStreamFactory;
-import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.v2.StateDescriptor;
 import org.apache.flink.runtime.state.v2.adaptor.AsyncKeyedStateBackendAdaptor;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
-import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
@@ -59,8 +55,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-
-import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -89,7 +83,6 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
     public void initializeState(StreamTaskStateInitializer streamTaskStateManager)
             throws Exception {
         super.initializeState(streamTaskStateManager);
-        this.timeServiceManager = stateHandler.getAsyncInternalTimerServiceManager();
         getRuntimeContext().setKeyedStateStoreV2(stateHandler.getKeyedStateStoreV2().orElse(null));
         final StreamTask<?, ?> containingTask = checkNotNull(getContainingTask());
         environment = containingTask.getEnvironment();
@@ -239,25 +232,6 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
         }
     }
 
-    @Override
-    public OperatorSnapshotFutures snapshotState(
-            long checkpointId,
-            long timestamp,
-            CheckpointOptions checkpointOptions,
-            CheckpointStreamFactory factory)
-            throws Exception {
-        return stateHandler.snapshotState(
-                this,
-                Optional.ofNullable(timeServiceManager),
-                getOperatorName(),
-                checkpointId,
-                timestamp,
-                checkpointOptions,
-                factory,
-                isUsingCustomRawKeyedState(),
-                true);
-    }
-
     /**
      * Returns a {@link InternalTimerService} that can be used to query current processing time and
      * event time and to set timers. An operator can have several timer services, where each has its
@@ -293,13 +267,13 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
 
         InternalTimeServiceManager<K> keyedTimeServiceHandler =
                 (InternalTimeServiceManager<K>) timeServiceManager;
-        KeyedStateBackend<K> keyedStateBackend = getKeyedStateBackend();
-        checkState(keyedStateBackend != null, "Timers can only be used on keyed operators.");
+        TypeSerializer<K> keySerializer = stateHandler.getKeySerializer();
+        checkState(keySerializer != null, "Timers can only be used on keyed operators.");
         // A {@link RecordContext} will be set as the current processing context to preserve record
         // order when the given {@link Triggerable} is invoked.
         return keyedTimeServiceHandler.getAsyncInternalTimerService(
                 name,
-                keyedStateBackend.getKeySerializer(),
+                keySerializer,
                 namespaceSerializer,
                 triggerable,
                 (AsyncExecutionController<K>) asyncExecutionController);

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -286,12 +286,15 @@ public abstract class AbstractStreamOperator<OUT>
                                 runtimeContext.getJobConfiguration(),
                                 runtimeContext.getTaskManagerRuntimeInfo().getConfiguration(),
                                 runtimeContext.getUserCodeClassLoader()),
-                        isUsingCustomRawKeyedState());
-
+                        isUsingCustomRawKeyedState(),
+                        isAsyncStateProcessingEnabled());
         stateHandler =
                 new StreamOperatorStateHandler(
                         context, getExecutionConfig(), streamTaskCloseableRegistry);
-        timeServiceManager = context.internalTimerServiceManager();
+        timeServiceManager =
+                isAsyncStateProcessingEnabled()
+                        ? context.asyncInternalTimerServiceManager()
+                        : context.internalTimerServiceManager();
         stateHandler.initializeOperatorState(this);
         runtimeContext.setKeyedStateStore(stateHandler.getKeyedStateStore().orElse(null));
     }
@@ -317,6 +320,14 @@ public abstract class AbstractStreamOperator<OUT>
      */
     @Internal
     protected boolean isUsingCustomRawKeyedState() {
+        return false;
+    }
+
+    /**
+     * Indicates whether this operator is enabling the async state. Can be overridden by subclasses.
+     */
+    @Internal
+    public boolean isAsyncStateProcessingEnabled() {
         return false;
     }
 
@@ -402,7 +413,7 @@ public abstract class AbstractStreamOperator<OUT>
                 checkpointOptions,
                 factory,
                 isUsingCustomRawKeyedState(),
-                false);
+                isAsyncStateProcessingEnabled());
     }
 
     /**
@@ -650,10 +661,10 @@ public abstract class AbstractStreamOperator<OUT>
         @SuppressWarnings("unchecked")
         InternalTimeServiceManager<K> keyedTimeServiceHandler =
                 (InternalTimeServiceManager<K>) timeServiceManager;
-        KeyedStateBackend<K> keyedStateBackend = getKeyedStateBackend();
-        checkState(keyedStateBackend != null, "Timers can only be used on keyed operators.");
+        TypeSerializer<K> keySerializer = stateHandler.getKeySerializer();
+        checkState(keySerializer != null, "Timers can only be used on keyed operators.");
         return keyedTimeServiceHandler.getInternalTimerService(
-                name, keyedStateBackend.getKeySerializer(), namespaceSerializer, triggerable);
+                name, keySerializer, namespaceSerializer, triggerable);
     }
 
     public void processWatermark(Watermark mark) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
@@ -49,6 +50,9 @@ public interface StreamOperatorStateContext {
     /** Returns the operator state backend for the stream operator. */
     OperatorStateBackend operatorStateBackend();
 
+    /** Returns the key serializer for keyed state backends. */
+    TypeSerializer<?> keySerializer();
+
     /**
      * Returns the keyed state backend for the stream operator. This method returns null for
      * non-keyed operators.
@@ -59,7 +63,7 @@ public interface StreamOperatorStateContext {
      * Returns the async keyed state backend for the stream operator. This method returns null for
      * operators which don't support async keyed state backend.
      */
-    AsyncKeyedStateBackend asyncKeyedStateBackend();
+    AsyncKeyedStateBackend<?> asyncKeyedStateBackend();
 
     /**
      * Returns the internal timer service manager for the stream operator. This method returns null

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -83,6 +83,8 @@ public class StreamOperatorStateHandler {
 
     protected static final Logger LOG = LoggerFactory.getLogger(StreamOperatorStateHandler.class);
 
+    @Nullable private final TypeSerializer<?> keySerializer;
+
     @Nullable private final AsyncKeyedStateBackend<?> asyncKeyedStateBackend;
 
     @Nullable private final KeyedStateStoreV2 keyedStateStoreV2;
@@ -100,8 +102,9 @@ public class StreamOperatorStateHandler {
             ExecutionConfig executionConfig,
             CloseableRegistry closeableRegistry) {
         this.context = context;
-        operatorStateBackend = context.operatorStateBackend();
-        keyedStateBackend = context.keyedStateBackend();
+        this.keySerializer = context.keySerializer();
+        this.operatorStateBackend = context.operatorStateBackend();
+        this.keyedStateBackend = context.keyedStateBackend();
         this.closeableRegistry = closeableRegistry;
 
         if (keyedStateBackend != null) {
@@ -234,22 +237,28 @@ public class StreamOperatorStateHandler {
             throws CheckpointException {
         try {
             if (timeServiceManager.isPresent()) {
-                checkState(
-                        keyedStateBackend != null,
-                        "keyedStateBackend should be available with timeServiceManager");
-                final InternalTimeServiceManager<?> manager = timeServiceManager.get();
+                boolean requiresLegacyRawKeyedStateSnapshots;
+                final InternalTimeServiceManager<?> manager;
+                if (useAsyncState) {
+                    checkState(
+                            asyncKeyedStateBackend != null,
+                            "keyedStateBackend should be available with timeServiceManager");
+                    manager = timeServiceManager.get();
+                    requiresLegacyRawKeyedStateSnapshots =
+                            asyncKeyedStateBackend.requiresLegacySynchronousTimerSnapshots(
+                                    checkpointOptions.getCheckpointType());
+                } else {
+                    checkState(
+                            keyedStateBackend != null,
+                            "keyedStateBackend should be available with timeServiceManager");
+                    manager = timeServiceManager.get();
 
-                boolean requiresLegacyRawKeyedStateSnapshots =
-                        keyedStateBackend instanceof AbstractKeyedStateBackend
-                                && ((AbstractKeyedStateBackend<?>) keyedStateBackend)
-                                        .requiresLegacySynchronousTimerSnapshots(
-                                                checkpointOptions.getCheckpointType());
-                requiresLegacyRawKeyedStateSnapshots |=
-                        keyedStateBackend instanceof AsyncKeyedStateBackend
-                                && ((AsyncKeyedStateBackend<?>) keyedStateBackend)
-                                        .requiresLegacySynchronousTimerSnapshots(
-                                                checkpointOptions.getCheckpointType());
-
+                    requiresLegacyRawKeyedStateSnapshots =
+                            keyedStateBackend instanceof AbstractKeyedStateBackend
+                                    && ((AbstractKeyedStateBackend<?>) keyedStateBackend)
+                                            .requiresLegacySynchronousTimerSnapshots(
+                                                    checkpointOptions.getCheckpointType());
+                }
                 if (requiresLegacyRawKeyedStateSnapshots) {
                     checkState(
                             !isUsingCustomRawKeyedState,
@@ -366,13 +375,19 @@ public class StreamOperatorStateHandler {
     }
 
     @SuppressWarnings("unchecked")
+    public <K> TypeSerializer<K> getKeySerializer() {
+        return (TypeSerializer<K>) keySerializer;
+    }
+
+    @SuppressWarnings("unchecked")
     public <K> KeyedStateBackend<K> getKeyedStateBackend() {
         return (KeyedStateBackend<K>) keyedStateBackend;
     }
 
     @Nullable
-    public AsyncKeyedStateBackend getAsyncKeyedStateBackend() {
-        return asyncKeyedStateBackend;
+    @SuppressWarnings("unchecked")
+    public <K> AsyncKeyedStateBackend<K> getAsyncKeyedStateBackend() {
+        return (AsyncKeyedStateBackend<K>) asyncKeyedStateBackend;
     }
 
     public OperatorStateBackend getOperatorStateBackend() {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializer.java
@@ -63,6 +63,7 @@ public interface StreamTaskStateInitializer {
             @Nonnull CloseableRegistry streamTaskCloseableRegistry,
             @Nonnull MetricGroup metricGroup,
             double managedMemoryFraction,
-            boolean isUsingCustomRawKeyedState)
+            boolean isUsingCustomRawKeyedState,
+            boolean isAsyncState)
             throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -122,9 +122,11 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
     }
 
     public void setKeyedStateStoreV2(@Nullable KeyedStateStoreV2 keyedStateStoreV2) {
-        this.keyedStateStoreV2 = keyedStateStoreV2;
-        // Only if the keyedStateStoreV2 is set, this context is switch to support state v2
-        this.supportKeyedStateApiSet = SupportKeyedStateApiSet.STATE_V2;
+        if (keyedStateStoreV2 != null) {
+            // Only if the keyedStateStoreV2 is set, this context is switch to support state v2
+            this.keyedStateStoreV2 = keyedStateStoreV2;
+            this.supportKeyedStateApiSet = SupportKeyedStateApiSet.STATE_V2;
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -230,6 +230,7 @@ class StateInitializationContextImplTest {
                         closableRegistry,
                         new UnregisteredMetricsGroup(),
                         1.0,
+                        false,
                         false);
 
         OptionalLong restoredCheckpointId = stateContext.getRestoredCheckpointId();

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandlerTest.java
@@ -110,6 +110,7 @@ class StreamOperatorStateHandlerTest {
                             closeableRegistry,
                             new InterceptingOperatorMetricGroup(),
                             1.0,
+                            false,
                             false);
             StreamOperatorStateHandler stateHandler =
                     new StreamOperatorStateHandler(

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -111,6 +111,7 @@ class StreamTaskStateInitializerImplTest {
                         closeableRegistry,
                         new UnregisteredMetricsGroup(),
                         1.0,
+                        false,
                         false);
 
         OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();
@@ -224,6 +225,7 @@ class StreamTaskStateInitializerImplTest {
                         closeableRegistry,
                         new UnregisteredMetricsGroup(),
                         1.0,
+                        false,
                         false);
 
         OperatorStateBackend operatorStateBackend = stateContext.operatorStateBackend();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -2315,7 +2315,8 @@ public class StreamTaskTest {
                     closeableRegistry,
                     metricGroup,
                     fraction,
-                    isUsingCustomRawKeyedState) -> {
+                    isUsingCustomRawKeyedState,
+                    isAsyncState) -> {
                 final StreamOperatorStateContext controller =
                         streamTaskStateManager.streamOperatorStateContext(
                                 operatorID,
@@ -2326,7 +2327,8 @@ public class StreamTaskTest {
                                 closeableRegistry,
                                 metricGroup,
                                 fraction,
-                                isUsingCustomRawKeyedState);
+                                isUsingCustomRawKeyedState,
+                                isAsyncState);
 
                 return new StreamOperatorStateContext() {
                     @Override
@@ -2345,12 +2347,17 @@ public class StreamTaskTest {
                     }
 
                     @Override
+                    public TypeSerializer<?> keySerializer() {
+                        return controller.keySerializer();
+                    }
+
+                    @Override
                     public CheckpointableKeyedStateBackend<?> keyedStateBackend() {
                         return controller.keyedStateBackend();
                     }
 
                     @Override
-                    public AsyncKeyedStateBackend asyncKeyedStateBackend() {
+                    public AsyncKeyedStateBackend<?> asyncKeyedStateBackend() {
                         return controller.asyncKeyedStateBackend();
                     }
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, the operator will create both `AsyncKeyedStateBackend` and `KeyedStateBackend` and pick one for use. This PR only creates one depending on whether the operator performs async state processing or not.

## Brief change log

 - Introduce internal method `isAsyncStateProcessingEnabled` in `AbstractStreamOperator`.
 - Determine `isAsyncStateProcessingEnabled` in state initialization (including timerservice).
 - Remove redundant override methods.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
