### PR TITLE
[FLINK-36594][hive]HiveCatalog should set HiveConf.hiveSiteLocation back

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -253,10 +253,14 @@ public class HiveCatalog extends AbstractCatalog {
             hadoopConf = new Configuration();
         }
         // ignore all the static conf file URLs that HiveConf may have set
+        URL originalHiveSiteURL = HiveConf.getHiveSiteLocation();
         HiveConf.setHiveSiteLocation(null);
         HiveConf.setLoadMetastoreConfig(false);
         HiveConf.setLoadHiveServer2Config(false);
         HiveConf hiveConf = new HiveConf(hadoopConf, HiveConf.class);
+        // set it back if there was a hive-site.xml to keep HiveConf behaviour as expected
+        HiveConf.setHiveSiteLocation(originalHiveSiteURL);
+
 
         LOG.info("Setting hive conf dir as {}", hiveConfDir);
 


### PR DESCRIPTION
## What is the purpose of the change

Using HiveCatalog will cause another hive program lost the hive-site.xml from HiveConf

This change will set HiveConf.hiveSiteLocation back.


## Brief change log
Visit JIRA ticket to for details.


## Verifying this change

*(Please pick either of the following options)*


This change is already covered by existing tests, such as *(please describe tests)*.

org.apache.flink.table.catalog.hive.HiveCatalogTest#testCreateHiveConf

This change added tests and can be verified as follows:

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
