### PR TITLE
[FLINK-36585][connector / common] SplitFetcherManager.close() should not chain runnables to the element queue future in a tight loop.

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +61,7 @@ import static org.apache.flink.configuration.PipelineOptions.ALLOW_UNALIGNED_SOU
 @PublicEvolving
 public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
     private static final Logger LOG = LoggerFactory.getLogger(SplitFetcherManager.class);
+    static final String THREAD_NAME_PREFIX = "Source Data Fetcher for ";
 
     private final Consumer<Throwable> errorHandler;
 
@@ -153,7 +155,7 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
         final String taskThreadName = Thread.currentThread().getName();
         this.executors =
                 Executors.newCachedThreadPool(
-                        r -> new Thread(r, "Source Data Fetcher for " + taskThreadName));
+                        r -> new Thread(r, THREAD_NAME_PREFIX + taskThreadName));
         this.closed = false;
     }
 
@@ -269,19 +271,32 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
         // fetcher threads blocking on putting batches into the element queue.
         executors.submit(
                 () -> {
-                    while (fetchersToShutDown.get() > 0
-                            && System.currentTimeMillis() - startTime < timeoutMs) {
-                        elementsQueue
-                                .getAvailabilityFuture()
-                                .thenRun(() -> elementsQueue.poll().recycle());
+                    long timeElapsed = System.currentTimeMillis() - startTime;
+                    while (fetchersToShutDown.get() > 0 && timeElapsed < timeoutMs) {
+                        try {
+                            elementsQueue
+                                    .getAvailabilityFuture()
+                                    .thenRun(() -> elementsQueue.poll().recycle())
+                                    .get(timeoutMs - timeElapsed, TimeUnit.MILLISECONDS);
+                        } catch (ExecutionException ee) {
+                            // Ignore the exception and continue.
+                        } catch (Exception e) {
+                            LOG.warn(
+                                    "Received exception when waiting for the fetchers to "
+                                            + "shutdown.",
+                                    e);
+                            break;
+                        }
+                        timeElapsed = System.currentTimeMillis() - startTime;
                     }
                 });
         executors.shutdown();
-        if (!executors.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {
+        long timeElapsed = System.currentTimeMillis() - startTime;
+        if (!executors.awaitTermination(timeoutMs - timeElapsed, TimeUnit.NANOSECONDS)) {
             LOG.warn(
                     "Failed to close the split fetchers in {} ms. There are still {} split fetchers running",
                     timeoutMs,
-                    fetchersToShutDown);
+                    fetchersToShutDown.get());
         }
     }
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
@@ -37,8 +37,10 @@ import org.junit.jupiter.api.Timeout;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
@@ -98,6 +100,50 @@ class SplitFetcherManagerTest {
                 "The idle fetcher should have been removed.");
         // Now close the fetcher manager. The fetcher manager closing should not block.
         fetcherManager.close(Long.MAX_VALUE);
+    }
+
+    /**
+     * This test is somewhat testing the implementation instead of contract. This is because the
+     * test is trying to make sure the element queue draining thread is not tight looping.
+     */
+    @Test
+    public void testCloseBlockingWaitingForFetcherShutdown() throws Exception {
+        final String splitId = "testSplit";
+        // create a reader which blocks on close().
+        final AwaitingReader<Integer, TestingSourceSplit> reader = new AwaitingReader<>();
+        final SplitFetcherManager<Integer, TestingSourceSplit> fetcherManager =
+                createFetcher(splitId, reader, new Configuration());
+        // Now close the fetcher manager. The fetcher should still be running when the fetcher
+        // manager returns.
+        Thread closingThread =
+                new Thread(
+                        () -> {
+                            try {
+                                fetcherManager.close(Long.MAX_VALUE);
+                            } catch (Exception e) {
+                                fail("failed.");
+                                throw new RuntimeException(e);
+                            }
+                        },
+                        "closingThread");
+        closingThread.start();
+
+        waitUntil(
+                () -> findThread(SplitFetcherManager.THREAD_NAME_PREFIX).size() == 2,
+                "The element queue draining thread should have started.");
+        for (Thread t : findThread(SplitFetcherManager.THREAD_NAME_PREFIX)) {
+            assertThat(t.getState().equals(Thread.State.WAITING))
+                    .as("All the executor threads should be in waiting status.");
+        }
+
+        assertThat(fetcherManager.getQueue().getAvailabilityFuture().getNumberOfDependents())
+                .as("The future should have just one dependent stage")
+                .isEqualTo(1);
+        assertThat(fetcherManager.fetchers.size()).isEqualTo(1);
+        reader.triggerThrowException();
+        reader.triggerClose();
+        waitUntil(fetcherManager.fetchers::isEmpty, "The fetcher should be closed now.");
+        closingThread.join();
     }
 
     @Test
@@ -197,6 +243,16 @@ class SplitFetcherManagerTest {
         while (queue.poll() != null) {}
     }
 
+    private static List<Thread> findThread(String keyword) {
+        List<Thread> threads = new ArrayList<>();
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if (t.getName().contains(keyword)) {
+                threads.add(t);
+            }
+        }
+        return threads;
+    }
+
     // ------------------------------------------------------------------------
     //  test mocks
     // ------------------------------------------------------------------------
@@ -209,13 +265,19 @@ class SplitFetcherManagerTest {
 
         private final OneShotLatch inBlocking = new OneShotLatch();
         private final OneShotLatch throwError = new OneShotLatch();
-
+        private final OneShotLatch closeBlocker = new OneShotLatch();
         private volatile boolean isClosed = false;
 
         @SafeVarargs
         AwaitingReader(IOException testError, RecordsWithSplitIds<E>... fetches) {
             this.testError = testError;
             this.fetches = new ArrayDeque<>(Arrays.asList(fetches));
+            this.closeBlocker.trigger();
+        }
+
+        AwaitingReader() {
+            this.testError = new IOException("DummyException");
+            this.fetches = new ArrayDeque<>(Collections.emptyList());
         }
 
         @Override
@@ -242,6 +304,7 @@ class SplitFetcherManagerTest {
 
         @Override
         public void close() throws Exception {
+            closeBlocker.await();
             isClosed = true;
         }
 
@@ -251,6 +314,10 @@ class SplitFetcherManagerTest {
 
         public void triggerThrowException() {
             throwError.trigger();
+        }
+
+        public void triggerClose() {
+            closeBlocker.trigger();
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
This patch fixes an issue introduced in #25130. In `SplitFetcherManager.close()`, the element queue draining thread was chaining the runnables to the element queue availability future in a tight loop. This causes problem (e.g. OOM, high CPU util) when the fetcher threads do not shutdown quickly.

This patch changes the tight async loop to a blocking loop.

## Brief change log
This patch changes the tight async loop to a blocking loop.

## Verifying this change
This change added a unit test. However, that unit test is kind of testing against the implementation instead of the behavior. But given we are fixing an interal impl issue, this might be necessary.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
