### PR TITLE
[FLINK-33571][table] Backport json-path upgrades to deal with CVE

### DIFF
--- a/flink-table/flink-table-calcite-bridge/pom.xml
+++ b/flink-table/flink-table-calcite-bridge/pom.xml
@@ -152,7 +152,19 @@ under the License.
 					<groupId>org.locationtech.proj4j</groupId>
 					<artifactId>proj4j</artifactId>
 				</exclusion>
+				<!-- Exclude json-path as we are manually overriding it to a newer version -->
+				<exclusion>
+					<groupId>com.jayway.jsonpath</groupId>
+					<artifactId>json-path</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+
+		<!-- Override the json-path version used by Calcite 1.32 to deal with CVE-2023-1370 -->
+		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+			<version>${jsonpath.version}</version>
 		</dependency>
 
 		<dependency>

--- a/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.jayway.jsonpath:json-path:2.7.0
+- com.jayway.jsonpath:json-path:2.9.0
 - org.codehaus.janino:janino:3.1.10
 - org.codehaus.janino:commons-compiler:3.1.10

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -83,7 +83,7 @@ under the License.
 		at the same time minimum 3.1.x Janino version passing Flink tests without WAs is 3.1.10,
 		more details are in FLINK-27995 -->
 		<janino.version>3.1.10</janino.version>
-		<jsonpath.version>2.7.0</jsonpath.version>
+		<jsonpath.version>2.9.0</jsonpath.version>
 		<guava.version>32.1.3-jre</guava.version>
 		<quartz.version>2.3.2</quartz.version>
 	</properties>


### PR DESCRIPTION
## What is the purpose of the change

Currently, the `flink-table` modules uses `json-path` 2.7.0. This is vulnerable to CVE-2023-1370 and CVE-2023-51074. This also effects the `json-path` version used by Calcite 1.32 in the `flink-table-calcite-bridge` module.

Newer versions of Calcite update to newer versions of `json-path`. However, updating Calcite to the latest version ([FLINK-36602](https://issues.apache.org/jira/browse/FLINK-36602)) is not straightforward and involves changes to the SQL parsing logic. Following [discussion](https://lists.apache.org/thread/7ogwvj5z3o176dw95145dzvlolrkyps4) on the dev mailing list, an incremental Calcite upgrade process is preferred. Therefore, this PR simply patches the transitive dependency. 

## Brief change log

- Upgrade the `com.jayway.jsonpath:json-path` version used in `flink-table` from `2.7.0` to `2.9.0`.
- Overrides the specific transitive `json-path` (version 2.7.0) dependency in the `flink-table-calcite-bridge` pom file to version 2.9.0.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no