### PR TITLE
[FLINK-36556][FLINK-36555] Improve buffer debloating

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_section.html
@@ -111,6 +111,12 @@
             <td>Size of memory buffers used by the network stack and the memory manager.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.memory.starting-segment-size</h5></td>
+            <td style="word-wrap: break-word;">1 kb</td>
+            <td>MemorySize</td>
+            <td>Starting size of memory buffers used by the network stack and the memory manager, when using automatic buffer size adjustment.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.bind-policy</h5></td>
             <td style="word-wrap: break-word;">"ip"</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/task_manager_memory_configuration.html
+++ b/docs/layouts/shortcodes/generated/task_manager_memory_configuration.html
@@ -111,6 +111,12 @@
             <td>Size of memory buffers used by the network stack and the memory manager.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.memory.starting-segment-size</h5></td>
+            <td style="word-wrap: break-word;">1 kb</td>
+            <td>MemorySize</td>
+            <td>Starting size of memory buffers used by the network stack and the memory manager, when using automatic buffer size adjustment.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.task.heap.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -215,6 +215,16 @@ public class TaskManagerOptions {
                             "Minimum possible size of memory buffers used by the network stack and the memory manager. "
                                     + "ex. can be used for automatic buffer size adjustment.");
 
+    /** Starting size of memory buffers used by the network stack and the memory manager. */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
+    public static final ConfigOption<MemorySize> STARTING_MEMORY_SEGMENT_SIZE =
+            key("taskmanager.memory.starting-segment-size")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("1024"))
+                    .withDescription(
+                            "Starting size of memory buffers used by the network stack and the memory manager, "
+                                    + "when using automatic buffer size adjustment.");
+
     /**
      * The config parameter for automatically defining the TaskManager's binding address, if {@link
      * #HOST} configuration option is not set.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -226,6 +226,7 @@ public class NettyShuffleServiceFactory
                         config.networkBuffersPerChannel(),
                         config.floatingNetworkBuffersPerGate(),
                         config.networkBufferSize(),
+                        config.startingBufferSize(),
                         config.isBatchShuffleCompressionEnabled(),
                         config.getCompressionCodec(),
                         config.getMaxBuffersPerChannel(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
@@ -42,8 +42,11 @@ public class PipelinedApproximateSubpartition extends PipelinedSubpartition {
     private boolean isPartialBufferCleanupRequired = false;
 
     PipelinedApproximateSubpartition(
-            int index, int receiverExclusiveBuffersPerChannel, ResultPartition parent) {
-        super(index, receiverExclusiveBuffersPerChannel, parent);
+            int index,
+            int receiverExclusiveBuffersPerChannel,
+            int startingBufferSize,
+            ResultPartition parent) {
+        super(index, receiverExclusiveBuffersPerChannel, startingBufferSize, parent);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -107,7 +107,7 @@ public class PipelinedSubpartition extends ResultSubpartition implements Channel
     /** Writes in-flight data. */
     private ChannelStateWriter channelStateWriter;
 
-    private int bufferSize = Integer.MAX_VALUE;
+    private int bufferSize;
 
     /** The channelState Future of unaligned checkpoint. */
     @GuardedBy("buffers")
@@ -132,13 +132,17 @@ public class PipelinedSubpartition extends ResultSubpartition implements Channel
     // ------------------------------------------------------------------------
 
     PipelinedSubpartition(
-            int index, int receiverExclusiveBuffersPerChannel, ResultPartition parent) {
+            int index,
+            int receiverExclusiveBuffersPerChannel,
+            int startingBufferSize,
+            ResultPartition parent) {
         super(index, parent);
 
         checkArgument(
                 receiverExclusiveBuffersPerChannel >= 0,
                 "Buffers per channel must be non-negative.");
         this.receiverExclusiveBuffersPerChannel = receiverExclusiveBuffersPerChannel;
+        this.bufferSize = startingBufferSize;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -72,6 +72,8 @@ public class ResultPartitionFactory {
 
     private final int networkBufferSize;
 
+    private final int startingBufferSize;
+
     private final boolean batchShuffleCompressionEnabled;
 
     private final CompressionCodec compressionCodec;
@@ -98,6 +100,7 @@ public class ResultPartitionFactory {
             int configuredNetworkBuffersPerChannel,
             int floatingNetworkBuffersPerGate,
             int networkBufferSize,
+            int startingBufferSize,
             boolean batchShuffleCompressionEnabled,
             CompressionCodec compressionCodec,
             int maxBuffersPerChannel,
@@ -116,6 +119,7 @@ public class ResultPartitionFactory {
         this.batchShuffleReadIOExecutor = batchShuffleReadIOExecutor;
         this.blockingSubpartitionType = blockingSubpartitionType;
         this.networkBufferSize = networkBufferSize;
+        this.startingBufferSize = startingBufferSize;
         this.batchShuffleCompressionEnabled = batchShuffleCompressionEnabled;
         this.compressionCodec = compressionCodec;
         this.maxBuffersPerChannel = maxBuffersPerChannel;
@@ -189,11 +193,17 @@ public class ResultPartitionFactory {
                 if (type == ResultPartitionType.PIPELINED_APPROXIMATE) {
                     subpartitions[i] =
                             new PipelinedApproximateSubpartition(
-                                    i, configuredNetworkBuffersPerChannel, pipelinedPartition);
+                                    i,
+                                    configuredNetworkBuffersPerChannel,
+                                    startingBufferSize,
+                                    pipelinedPartition);
                 } else {
                     subpartitions[i] =
                             new PipelinedSubpartition(
-                                    i, configuredNetworkBuffersPerChannel, pipelinedPartition);
+                                    i,
+                                    configuredNetworkBuffersPerChannel,
+                                    startingBufferSize,
+                                    pipelinedPartition);
                 }
             }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -224,6 +224,7 @@ public class SingleInputGateFactory {
                             owningTaskName,
                             gateIndex,
                             debloatConfiguration.getTargetTotalTime().toMillis(),
+                            debloatConfiguration.getStartingBufferSize(),
                             debloatConfiguration.getMaxBufferSize(),
                             debloatConfiguration.getMinBufferSize(),
                             debloatConfiguration.getBufferDebloatThresholdPercentages(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -60,6 +60,8 @@ public class NettyShuffleEnvironmentConfiguration {
 
     private final int networkBufferSize;
 
+    private final int startingBufferSize;
+
     private final int partitionRequestInitialBackoff;
 
     private final int partitionRequestMaxBackoff;
@@ -114,6 +116,7 @@ public class NettyShuffleEnvironmentConfiguration {
     public NettyShuffleEnvironmentConfiguration(
             int numNetworkBuffers,
             int networkBufferSize,
+            int startingBufferSize,
             int partitionRequestInitialBackoff,
             int partitionRequestMaxBackoff,
             int partitionRequestListenerTimeout,
@@ -138,6 +141,7 @@ public class NettyShuffleEnvironmentConfiguration {
 
         this.numNetworkBuffers = numNetworkBuffers;
         this.networkBufferSize = networkBufferSize;
+        this.startingBufferSize = startingBufferSize;
         this.partitionRequestInitialBackoff = partitionRequestInitialBackoff;
         this.partitionRequestMaxBackoff = partitionRequestMaxBackoff;
         this.partitionRequestListenerTimeout = partitionRequestListenerTimeout;
@@ -169,6 +173,10 @@ public class NettyShuffleEnvironmentConfiguration {
 
     public int networkBufferSize() {
         return networkBufferSize;
+    }
+
+    public int startingBufferSize() {
+        return startingBufferSize;
     }
 
     public int partitionRequestInitialBackoff() {
@@ -282,6 +290,15 @@ public class NettyShuffleEnvironmentConfiguration {
 
         final int pageSize = ConfigurationParserUtils.getPageSize(configuration);
 
+        int startingBufferSize = Integer.MAX_VALUE;
+        if (configuration.get(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED)) {
+            startingBufferSize =
+                    (int)
+                            configuration
+                                    .get(TaskManagerOptions.STARTING_MEMORY_SEGMENT_SIZE)
+                                    .getBytes();
+        }
+
         final NettyConfig nettyConfig =
                 createNettyConfig(
                         configuration,
@@ -360,6 +377,7 @@ public class NettyShuffleEnvironmentConfiguration {
         return new NettyShuffleEnvironmentConfiguration(
                 numberOfNetworkBuffers,
                 pageSize,
+                startingBufferSize,
                 initialRequestBackoff,
                 maxRequestBackoff,
                 listenerTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferDebloatConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferDebloatConfiguration.java
@@ -47,6 +47,16 @@ public final class BufferDebloatConfiguration {
             int minBufferSize,
             int bufferDebloatThresholdPercentages,
             int numberOfSamples) {
+        // Right now the buffer size can not be grater than integer max value according to
+        // MemorySegment and buffer implementation.
+        checkArgument(maxBufferSize > 0);
+        checkArgument(minBufferSize > 0);
+        checkArgument(numberOfSamples > 0);
+        checkArgument(maxBufferSize >= minBufferSize);
+        checkArgument(targetTotalTime.toMillis() > 0.0);
+        checkArgument(maxBufferSize >= startingBufferSize);
+        checkArgument(minBufferSize <= startingBufferSize);
+
         this.targetTotalTime = checkNotNull(targetTotalTime);
         this.startingBufferSize = startingBufferSize;
         this.maxBufferSize = maxBufferSize;
@@ -97,15 +107,6 @@ public final class BufferDebloatConfiguration {
         int bufferDebloatThresholdPercentages = config.get(BUFFER_DEBLOAT_THRESHOLD_PERCENTAGES);
         final int numberOfSamples = config.get(BUFFER_DEBLOAT_SAMPLES);
 
-        // Right now the buffer size can not be grater than integer max value according to
-        // MemorySegment and buffer implementation.
-        checkArgument(maxBufferSize > 0);
-        checkArgument(minBufferSize > 0);
-        checkArgument(numberOfSamples > 0);
-        checkArgument(maxBufferSize >= minBufferSize);
-        checkArgument(targetTotalTime.toMillis() > 0.0);
-        checkArgument(maxBufferSize >= startingBufferSize);
-        checkArgument(minBufferSize <= startingBufferSize);
         return new BufferDebloatConfiguration(
                 config.get(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED),
                 targetTotalTime,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferDebloatConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferDebloatConfiguration.java
@@ -32,6 +32,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** Configuration for {@link BufferDebloater}. */
 public final class BufferDebloatConfiguration {
     private final Duration targetTotalTime;
+    private final int startingBufferSize;
     private final int maxBufferSize;
     private final int minBufferSize;
     private final int bufferDebloatThresholdPercentages;
@@ -41,11 +42,13 @@ public final class BufferDebloatConfiguration {
     private BufferDebloatConfiguration(
             boolean enabled,
             Duration targetTotalTime,
+            int startingBufferSize,
             int maxBufferSize,
             int minBufferSize,
             int bufferDebloatThresholdPercentages,
             int numberOfSamples) {
         this.targetTotalTime = checkNotNull(targetTotalTime);
+        this.startingBufferSize = startingBufferSize;
         this.maxBufferSize = maxBufferSize;
         this.minBufferSize = minBufferSize;
         this.bufferDebloatThresholdPercentages = bufferDebloatThresholdPercentages;
@@ -59,6 +62,10 @@ public final class BufferDebloatConfiguration {
 
     public Duration getTargetTotalTime() {
         return targetTotalTime;
+    }
+
+    public int getStartingBufferSize() {
+        return startingBufferSize;
     }
 
     public int getMaxBufferSize() {
@@ -83,6 +90,9 @@ public final class BufferDebloatConfiguration {
                 Math.toIntExact(config.get(TaskManagerOptions.MEMORY_SEGMENT_SIZE).getBytes());
         int minBufferSize =
                 Math.toIntExact(config.get(TaskManagerOptions.MIN_MEMORY_SEGMENT_SIZE).getBytes());
+        int startingBufferSize =
+                Math.toIntExact(
+                        config.get(TaskManagerOptions.STARTING_MEMORY_SEGMENT_SIZE).getBytes());
 
         int bufferDebloatThresholdPercentages = config.get(BUFFER_DEBLOAT_THRESHOLD_PERCENTAGES);
         final int numberOfSamples = config.get(BUFFER_DEBLOAT_SAMPLES);
@@ -94,9 +104,12 @@ public final class BufferDebloatConfiguration {
         checkArgument(numberOfSamples > 0);
         checkArgument(maxBufferSize >= minBufferSize);
         checkArgument(targetTotalTime.toMillis() > 0.0);
+        checkArgument(maxBufferSize >= startingBufferSize);
+        checkArgument(minBufferSize <= startingBufferSize);
         return new BufferDebloatConfiguration(
                 config.get(TaskManagerOptions.BUFFER_DEBLOAT_ENABLED),
                 targetTotalTime,
+                startingBufferSize,
                 maxBufferSize,
                 minBufferSize,
                 bufferDebloatThresholdPercentages,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferDebloater.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferDebloater.java
@@ -53,6 +53,26 @@ public class BufferDebloater {
             int minBufferSize,
             int bufferDebloatThresholdPercentages,
             long numberOfSamples) {
+        this(
+                owningTaskName,
+                gateIndex,
+                targetTotalTime,
+                maxBufferSize,
+                maxBufferSize,
+                minBufferSize,
+                bufferDebloatThresholdPercentages,
+                numberOfSamples);
+    }
+
+    public BufferDebloater(
+            String owningTaskName,
+            int gateIndex,
+            long targetTotalTime,
+            int startingBufferSize,
+            int maxBufferSize,
+            int minBufferSize,
+            int bufferDebloatThresholdPercentages,
+            long numberOfSamples) {
         this.owningTaskName = owningTaskName;
         this.gateIndex = gateIndex;
         this.targetTotalTime = targetTotalTime;
@@ -60,8 +80,10 @@ public class BufferDebloater {
         this.minBufferSize = minBufferSize;
         this.bufferDebloatThresholdFactor = bufferDebloatThresholdPercentages / 100.0;
 
-        this.lastBufferSize = maxBufferSize;
-        bufferSizeEMA = new BufferSizeEMA(maxBufferSize, minBufferSize, numberOfSamples);
+        this.lastBufferSize = startingBufferSize;
+        bufferSizeEMA =
+                new BufferSizeEMA(
+                        startingBufferSize, maxBufferSize, minBufferSize, numberOfSamples);
 
         LOG.debug(
                 "{}: Buffer debloater init settings: gateIndex={}, targetTotalTime={}, maxBufferSize={}, minBufferSize={}, bufferDebloatThresholdPercentages={}, numberOfSamples={}",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferSizeEMA.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferSizeEMA.java
@@ -27,7 +27,7 @@ public class BufferSizeEMA {
     /** EMA algorithm specific constant which responsible for speed of reaction. */
     private final double alpha;
 
-    private int lastBufferSize;
+    private double lastBufferSize;
 
     public BufferSizeEMA(int maxBufferSize, int minBufferSize, long numberOfSamples) {
         this(maxBufferSize, maxBufferSize, minBufferSize, numberOfSamples);
@@ -64,10 +64,11 @@ public class BufferSizeEMA {
         // Example of change speed:
         // growing = 32768, 29647, 26823, 24268, 21956, 19864
         // shrinking = 19864, 21755, 23826, 26095, 28580, 31301, 32768
-        long desirableBufferSize =
-                Math.min(totalBufferSizeInBytes / totalBuffers, 2L * lastBufferSize);
+        double desirableBufferSize =
+                Math.min(((double) totalBufferSizeInBytes) / totalBuffers, 2L * lastBufferSize);
 
         lastBufferSize += alpha * (desirableBufferSize - lastBufferSize);
-        return lastBufferSize = Math.max(minBufferSize, Math.min(lastBufferSize, maxBufferSize));
+        lastBufferSize = Math.max(minBufferSize, Math.min(lastBufferSize, maxBufferSize));
+        return (int) Math.round(lastBufferSize);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferSizeEMA.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/throughput/BufferSizeEMA.java
@@ -30,10 +30,15 @@ public class BufferSizeEMA {
     private int lastBufferSize;
 
     public BufferSizeEMA(int maxBufferSize, int minBufferSize, long numberOfSamples) {
+        this(maxBufferSize, maxBufferSize, minBufferSize, numberOfSamples);
+    }
+
+    public BufferSizeEMA(
+            int startingBufferSize, int maxBufferSize, int minBufferSize, long numberOfSamples) {
         this.maxBufferSize = maxBufferSize;
         this.minBufferSize = minBufferSize;
         alpha = 2.0 / (numberOfSamples + 1);
-        this.lastBufferSize = maxBufferSize;
+        this.lastBufferSize = startingBufferSize;
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -51,6 +51,8 @@ public class NettyShuffleEnvironmentBuilder {
 
     private int bufferSize = DEFAULT_NETWORK_BUFFER_SIZE;
 
+    private int startingBufferSize = Integer.MAX_VALUE;
+
     private int numNetworkBuffers = DEFAULT_NUM_NETWORK_BUFFERS;
 
     private int partitionRequestInitialBackoff;
@@ -113,6 +115,11 @@ public class NettyShuffleEnvironmentBuilder {
 
     public NettyShuffleEnvironmentBuilder setBufferSize(int bufferSize) {
         this.bufferSize = bufferSize;
+        return this;
+    }
+
+    public NettyShuffleEnvironmentBuilder startingBufferSize(int startingBufferSize) {
+        this.startingBufferSize = startingBufferSize;
         return this;
     }
 
@@ -257,6 +264,7 @@ public class NettyShuffleEnvironmentBuilder {
                 new NettyShuffleEnvironmentConfiguration(
                         numNetworkBuffers,
                         bufferSize,
+                        startingBufferSize,
                         partitionRequestInitialBackoff,
                         partitionRequestMaxBackoff,
                         partitionRequestTimeout,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -184,7 +184,10 @@ class NettyShuffleEnvironmentTest {
                                             getDebloatingMetric(
                                                     metrics, i, MetricNames.DEBLOATED_BUFFER_SIZE))
                                     .getValue())
-                    .isEqualTo(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().getBytes());
+                    .isEqualTo(
+                            TaskManagerOptions.STARTING_MEMORY_SEGMENT_SIZE
+                                    .defaultValue()
+                                    .getBytes());
             assertThat(
                             ((Gauge<Long>)
                                             getDebloatingMetric(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionWithReadViewTest.java
@@ -38,7 +38,8 @@ class PipelinedApproximateSubpartitionWithReadViewTest
     @Override
     void before() throws IOException {
         setup(ResultPartitionType.PIPELINED_APPROXIMATE);
-        subpartition = new PipelinedApproximateSubpartition(0, 2, resultPartition);
+        subpartition =
+                new PipelinedApproximateSubpartition(0, 2, Integer.MAX_VALUE, resultPartition);
         availablityListener = new AwaitableBufferAvailablityListener();
         readView = subpartition.createReadView(availablityListener);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -59,6 +59,7 @@ import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -308,6 +309,13 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
     }
 
     @TestTemplate
+    public void testStartingBufferSize() throws Exception {
+        int startingBufferSize = 1234;
+        final PipelinedSubpartition subpartition = createPipelinedSubpartition(startingBufferSize);
+        assertEquals(startingBufferSize, subpartition.add(createFilledFinishedBufferConsumer(4)));
+    }
+
+    @TestTemplate
     void testNewBufferSize() throws Exception {
         // given: Buffer size equal to integer max value by default.
         final PipelinedSubpartition subpartition = createSubpartition();
@@ -513,21 +521,27 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
         assertThat(view.isReleased()).isTrue();
     }
 
+    public static PipelinedSubpartition createPipelinedSubpartition(int startingBufferSize) {
+        final ResultPartition parent = PartitionTestUtils.createPartition();
+
+        return new PipelinedSubpartition(0, 2, startingBufferSize, parent);
+    }
+
     public static PipelinedSubpartition createPipelinedSubpartition() {
         final ResultPartition parent = PartitionTestUtils.createPartition();
 
-        return new PipelinedSubpartition(0, 2, parent);
+        return new PipelinedSubpartition(0, 2, Integer.MAX_VALUE, parent);
     }
 
     public static PipelinedSubpartition createPipelinedSubpartition(ResultPartition parent) {
-        return new PipelinedSubpartition(0, 2, parent);
+        return new PipelinedSubpartition(0, 2, Integer.MAX_VALUE, parent);
     }
 
     private static class FailurePipelinedSubpartition extends PipelinedSubpartition {
 
         FailurePipelinedSubpartition(
                 int index, int receiverExclusiveBuffersPerChannel, ResultPartition parent) {
-            super(index, receiverExclusiveBuffersPerChannel, parent);
+            super(index, receiverExclusiveBuffersPerChannel, Integer.MAX_VALUE, parent);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -81,7 +81,7 @@ class PipelinedSubpartitionWithReadViewTest {
     @BeforeEach
     void before() throws IOException {
         setup(ResultPartitionType.PIPELINED);
-        subpartition = new PipelinedSubpartition(0, 2, resultPartition);
+        subpartition = new PipelinedSubpartition(0, 2, Integer.MAX_VALUE, resultPartition);
         availablityListener = new AwaitableBufferAvailablityListener();
         readView = subpartition.createReadView(availablityListener);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -235,6 +235,7 @@ public class ResultPartitionBuilder {
                         networkBuffersPerChannel,
                         floatingNetworkBuffersPerGate,
                         networkBufferSize,
+                        Integer.MAX_VALUE,
                         blockingShuffleCompressionEnabled,
                         compressionCodec,
                         maxBuffersPerChannel,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -176,6 +176,7 @@ class ResultPartitionFactoryTest {
                         1,
                         1,
                         SEGMENT_SIZE,
+                        Integer.MAX_VALUE,
                         false,
                         CompressionCodec.LZ4,
                         Integer.MAX_VALUE,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/BufferDebloaterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/BufferDebloaterTest.java
@@ -46,7 +46,7 @@ class BufferDebloaterTest {
                 .withBufferSize(50, 1100)
                 .withNumberOfBuffersInUse(16)
                 .withThroughput(3333)
-                .expectBufferSize(249);
+                .expectBufferSize(250);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/BufferSizeEMATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/throughput/BufferSizeEMATest.java
@@ -32,21 +32,40 @@ class BufferSizeEMATest {
 
         // The result value seeks to the bottom limit but it will take a while until it reaches it.
         assertThat(calculator.calculateBufferSize(111, 13)).isEqualTo(104);
-        assertThat(calculator.calculateBufferSize(107, 7)).isEqualTo(59);
-        assertThat(calculator.calculateBufferSize(107, 7)).isEqualTo(37);
+        assertThat(calculator.calculateBufferSize(107, 7)).isEqualTo(60);
+        assertThat(calculator.calculateBufferSize(107, 7)).isEqualTo(38);
         assertThat(calculator.calculateBufferSize(107, 7)).isEqualTo(26);
-        assertThat(calculator.calculateBufferSize(107, 7)).isEqualTo(20);
-        assertThat(calculator.calculateBufferSize(107, 7)).isEqualTo(17);
-        assertThat(calculator.calculateBufferSize(107, 13)).isEqualTo(12);
+        assertThat(calculator.calculateBufferSize(107, 7)).isEqualTo(21);
+        assertThat(calculator.calculateBufferSize(107, 7)).isEqualTo(18);
+        assertThat(calculator.calculateBufferSize(107, 13)).isEqualTo(13);
+        assertThat(calculator.calculateBufferSize(107, 13)).isEqualTo(11);
         assertThat(calculator.calculateBufferSize(107, 13)).isEqualTo(10);
 
         // Upgrade
         assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(15);
-        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(22);
-        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(33);
-        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(49);
-        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(73);
-        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(109);
+        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(23);
+        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(34);
+        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(51);
+        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(76);
+        assertThat(calculator.calculateBufferSize(333, 1)).isEqualTo(114);
+    }
+
+    /**
+     * Check that even with very small alpha, buffer size doesn't get stuck and can not eventually
+     * grow.
+     */
+    @Test
+    public void testSmallBufferSizeChanges() {
+        int numberOfSamples = 10000;
+        int startingBufferSize = 16;
+        BufferSizeEMA calculator =
+                new BufferSizeEMA(startingBufferSize, 32 * 1024, 16, numberOfSamples);
+
+        for (int i = 0; i < numberOfSamples; i++) {
+            calculator.calculateBufferSize(20000, 10);
+        }
+
+        assertThat(calculator.calculateBufferSize(10000, 10)).isGreaterThan(startingBufferSize);
     }
 
     @Test
@@ -70,7 +89,7 @@ class BufferSizeEMATest {
         assertThat(calculator.calculateBufferSize(0, 1)).isEqualTo(100);
         assertThat(calculator.calculateBufferSize(0, 1)).isEqualTo(50);
         assertThat(calculator.calculateBufferSize(0, 1)).isEqualTo(25);
-        assertThat(calculator.calculateBufferSize(0, 1)).isEqualTo(12);
+        assertThat(calculator.calculateBufferSize(0, 1)).isEqualTo(13);
         assertThat(calculator.calculateBufferSize(0, 1)).isEqualTo(10);
         assertThat(calculator.calculateBufferSize(0, 1)).isEqualTo(10);
     }


### PR DESCRIPTION
## What is the purpose of the change

This PR intends to improve the behaviour of buffer debloating.

## Brief change log

[FLINK-36555] Guarantee buffer grows even with very small alpha
[FLINK-36556] Add starting buffer size config option

## Verifying this change

This PR adds new unit tests or is cover by existing ones 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
