### PR TITLE
[FLINK-36606][tests] TimestampITCase generates test artifacts outside of tmp folder

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/TimestampITCase.java
@@ -60,7 +60,9 @@ import org.apache.flink.util.function.SerializableFunction;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -77,6 +79,8 @@ import static org.junit.Assert.fail;
 /** Tests for timestamps, watermarks, and event-time sources. */
 @SuppressWarnings("serial")
 public class TimestampITCase extends TestLogger {
+
+    @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
     private static final int NUM_TASK_MANAGERS = 2;
     private static final int NUM_TASK_SLOTS = 3;
@@ -227,14 +231,16 @@ public class TimestampITCase extends TestLogger {
                             JobID id = running.get(0);
 
                             waitUntilAllTasksAreRunning(CLUSTER.getRestClusterClient(), id);
+
                             // send stop until the job is stopped
+                            final String savepointDirName = tmpFolder.newFolder().getAbsolutePath();
                             do {
                                 try {
                                     clusterClient
                                             .stopWithSavepoint(
                                                     id,
                                                     false,
-                                                    "test",
+                                                    savepointDirName,
                                                     SavepointFormatType.CANONICAL)
                                             .get();
                                 } catch (Exception e) {


### PR DESCRIPTION
## What is the purpose of the change

The problem of  `TimestampITCase` is that it generates `test` folder outside of temp folder and it appears in git diff
steps to reproduce
```
cd flink-tests && ../mvnw -Dtest=TimestampITCase test && git status
```

## Brief change log

TimestampITCase


## Verifying this change
The change is change of tests itself
also could be verified with 
```
cd flink-tests && ../mvnw -Dtest=TimestampITCase test && git status
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
