### PR TITLE
[FLINK-36607][table-planner] Introduce AdaptiveBroadcastJoinProcessor to inject adaptive broadcast join.

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>table.optimizer.adaptive-broadcast-join.strategy</h5><br> <span class="label label-primary">Batch</span></td>
+            <td style="word-wrap: break-word;">none</td>
+            <td><p>Enum</p></td>
+            <td>Flink will perform broadcast hash join optimization when the runtime statistics on one side of a join operator is less than the threshold `table.optimizer.join.broadcast-threshold`. The value of this configuration option decides when Flink should perform this optimization. AUTO means Flink will automatically choose the timing for optimization, RUNTIME_ONLY means broadcast hash join optimization is only performed at runtime, and NONE means the optimization is only carried out at compile time.<br /><br />Possible values:<ul><li>"auto": Flink will automatically choose the timing for optimization</li><li>"runtime_only": Broadcast hash join optimization is only performed at runtime.</li><li>"none": Broadcast hash join optimization is only carried out at compile time.</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.optimizer.agg-phase-strategy</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">AUTO</td>
             <td><p>Enum</p></td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -21,11 +21,14 @@ package org.apache.flink.table.api.config;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
+import org.apache.flink.configuration.description.InlineElement;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /**
  * This class holds configuration constants used by Flink's table planner module.
@@ -157,6 +160,22 @@ public class OptimizerConfigOptions {
                     .withDescription(
                             "A flag to enable or disable the runtime filter. "
                                     + "When it is true, the optimizer will try to inject a runtime filter for eligible join.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+    public static final ConfigOption<AdaptiveBroadcastJoinStrategy>
+            TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY =
+                    key("table.optimizer.adaptive-broadcast-join.strategy")
+                            .enumType(AdaptiveBroadcastJoinStrategy.class)
+                            .defaultValue(AdaptiveBroadcastJoinStrategy.NONE)
+                            .withDescription(
+                                    "Flink will perform broadcast hash join optimization when the runtime "
+                                            + "statistics on one side of a join operator is less than the "
+                                            + "threshold `table.optimizer.join.broadcast-threshold`. The "
+                                            + "value of this configuration option decides when Flink should "
+                                            + "perform this optimization. AUTO means Flink will automatically "
+                                            + "choose the timing for optimization, RUNTIME_ONLY means broadcast "
+                                            + "hash join optimization is only performed at runtime, and NONE "
+                                            + "means the optimization is only carried out at compile time.");
 
     /**
      * The data volume of build side needs to be under this value. If the data volume of build side
@@ -303,5 +322,34 @@ public class OptimizerConfigOptions {
          * Do nothing if exists non-deterministic updates, the risk of wrong result still exists.
          */
         IGNORE
+    }
+
+    /** Strategies used for {@link #TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY}. */
+    @PublicEvolving
+    public enum AdaptiveBroadcastJoinStrategy implements DescribedEnum {
+        AUTO("auto", text("Flink will automatically choose the timing for optimization")),
+        RUNTIME_ONLY(
+                "runtime_only",
+                text("Broadcast hash join optimization is only performed at runtime.")),
+        NONE("none", text("Broadcast hash join optimization is only carried out at compile time."));
+
+        private final String value;
+
+        private final InlineElement description;
+
+        AdaptiveBroadcastJoinStrategy(String value, InlineElement description) {
+            this.value = value;
+            this.description = description;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        @Override
+        public InlineElement getDescription() {
+            return description;
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/AdaptiveJoinExecNode.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/AdaptiveJoinExecNode.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec;
+
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecAdaptiveJoin;
+
+/** A {@link ExecNode} which support to convert to adaptive join node. */
+public interface AdaptiveJoinExecNode {
+
+    /** Check whether the join node can be transformed to {@link BatchExecAdaptiveJoin}. */
+    boolean canBeTransformedToAdaptiveJoin();
+
+    /** Transform this node to {@link BatchExecAdaptiveJoin}. */
+    BatchExecAdaptiveJoin toAdaptiveJoinNode();
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecAdaptiveJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecAdaptiveJoin.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.batch;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.adaptive.AdaptiveJoinOperatorGenerator;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
+import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec;
+import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
+import org.apache.flink.table.planner.plan.utils.JoinUtil;
+import org.apache.flink.table.planner.plan.utils.OperatorType;
+import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
+import org.apache.flink.table.runtime.operators.join.adaptive.AdaptiveJoin;
+import org.apache.flink.table.runtime.operators.join.adaptive.AdaptiveJoinOperatorFactory;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.util.List;
+
+/** {@link BatchExecNode} for adaptive join. */
+public class BatchExecAdaptiveJoin extends ExecNodeBase<RowData>
+        implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
+
+    private final JoinSpec joinSpec;
+    private final boolean leftIsBuild;
+    private final int estimatedLeftAvgRowSize;
+    private final int estimatedRightAvgRowSize;
+    private final long estimatedLeftRowCount;
+    private final long estimatedRightRowCount;
+    private final boolean tryDistinctBuildRow;
+    private final String description;
+    private final OperatorType originalJoin;
+
+    public BatchExecAdaptiveJoin(
+            ReadableConfig tableConfig,
+            JoinSpec joinSpec,
+            int estimatedLeftAvgRowSize,
+            int estimatedRightAvgRowSize,
+            long estimatedLeftRowCount,
+            long estimatedRightRowCount,
+            boolean leftIsBuild,
+            boolean tryDistinctBuildRow,
+            List<InputProperty> inputProperties,
+            RowType outputType,
+            String description,
+            OperatorType originalJoin) {
+        super(
+                ExecNodeContext.newNodeId(),
+                ExecNodeContext.newContext(BatchExecAdaptiveJoin.class),
+                ExecNodeContext.newPersistedConfig(BatchExecAdaptiveJoin.class, tableConfig),
+                inputProperties,
+                outputType,
+                description);
+        this.joinSpec = joinSpec;
+        this.estimatedLeftAvgRowSize = estimatedLeftAvgRowSize;
+        this.estimatedRightAvgRowSize = estimatedRightAvgRowSize;
+        this.estimatedLeftRowCount = estimatedLeftRowCount;
+        this.estimatedRightRowCount = estimatedRightRowCount;
+        this.leftIsBuild = leftIsBuild;
+        this.tryDistinctBuildRow = tryDistinctBuildRow;
+        this.description = description;
+        this.originalJoin = originalJoin;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Transformation<RowData> translateToPlanInternal(
+            PlannerBase planner, ExecNodeConfig config) {
+        ExecEdge leftInputEdge = getInputEdges().get(0);
+        ExecEdge rightInputEdge = getInputEdges().get(1);
+
+        Transformation<RowData> leftInputTransform =
+                (Transformation<RowData>) leftInputEdge.translateToPlan(planner);
+        Transformation<RowData> rightInputTransform =
+                (Transformation<RowData>) rightInputEdge.translateToPlan(planner);
+        // get input types
+        RowType leftType = (RowType) leftInputEdge.getOutputType();
+        RowType rightType = (RowType) rightInputEdge.getOutputType();
+        long managedMemory = JoinUtil.getManagedMemory(joinSpec.getJoinType(), config);
+        GeneratedJoinCondition condFunc =
+                JoinUtil.generateConditionFunction(
+                        config,
+                        planner.getFlinkContext().getClassLoader(),
+                        joinSpec.getNonEquiCondition().orElse(null),
+                        leftType,
+                        rightType);
+
+        AdaptiveJoinOperatorGenerator adaptiveJoin =
+                new AdaptiveJoinOperatorGenerator(
+                        joinSpec.getLeftKeys(),
+                        joinSpec.getRightKeys(),
+                        joinSpec.getJoinType(),
+                        joinSpec.getFilterNulls(),
+                        leftType,
+                        rightType,
+                        condFunc,
+                        estimatedLeftAvgRowSize,
+                        estimatedRightAvgRowSize,
+                        estimatedLeftRowCount,
+                        estimatedRightRowCount,
+                        tryDistinctBuildRow,
+                        managedMemory,
+                        leftIsBuild,
+                        originalJoin);
+
+        return ExecNodeUtil.createTwoInputTransformation(
+                leftInputTransform,
+                rightInputTransform,
+                createTransformationName(config),
+                createTransformationDescription(config),
+                getAdaptiveJoinOperatorFactory(adaptiveJoin),
+                InternalTypeInfo.of(getOutputType()),
+                // Given that the probe side might be decided at runtime, we choose the larger
+                // parallelism here.
+                Math.max(leftInputTransform.getParallelism(), rightInputTransform.getParallelism()),
+                managedMemory,
+                false);
+    }
+
+    private StreamOperatorFactory<RowData> getAdaptiveJoinOperatorFactory(
+            AdaptiveJoin adaptiveJoin) {
+        try {
+            byte[] adaptiveJoinSerialized = InstantiationUtil.serializeObject(adaptiveJoin);
+            return new AdaptiveJoinOperatorFactory<>(adaptiveJoinSerialized);
+        } catch (IOException e) {
+            throw new TableException("The adaptive join operator failed to serialize.", e);
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return "AdaptiveJoin("
+                + "originalJoin=["
+                + originalJoin
+                + "], "
+                + description.substring(description.indexOf('(') + 1);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
@@ -20,25 +20,25 @@ package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.AdaptiveJoinExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.planner.plan.utils.JoinUtil;
+import org.apache.flink.table.planner.plan.utils.OperatorType;
 import org.apache.flink.table.planner.plan.utils.SorMergeJoinOperatorUtil;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
-import org.apache.flink.table.runtime.operators.join.SortMergeJoinFunction;
-import org.apache.flink.table.runtime.operators.join.SortMergeJoinOperator;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.calcite.rex.RexNode;
@@ -46,21 +46,27 @@ import org.apache.calcite.rex.RexNode;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.stream.IntStream;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** {@link BatchExecNode} for Sort Merge Join. */
 public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
-        implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
+        implements BatchExecNode<RowData>,
+                SingleTransformationTranslator<RowData>,
+                AdaptiveJoinExecNode {
 
     private final FlinkJoinType joinType;
     private final int[] leftKeys;
     private final int[] rightKeys;
     private final boolean[] filterNulls;
     private final @Nullable RexNode nonEquiCondition;
+    private final int estimatedLeftAvgRowSize;
+    private final int estimatedRightAvgRowSize;
+    private final long estimatedLeftRowCount;
+    private final long estimatedRightRowCount;
     private final boolean leftIsSmaller;
+    private final boolean withJobStrategyHint;
 
     public BatchExecSortMergeJoin(
             ReadableConfig tableConfig,
@@ -69,10 +75,15 @@ public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
             int[] rightKeys,
             boolean[] filterNulls,
             @Nullable RexNode nonEquiCondition,
+            int estimatedLeftAvgRowSize,
+            int estimatedRightAvgRowSize,
+            long estimatedLeftRowCount,
+            long estimatedRightRowCount,
             boolean leftIsSmaller,
             InputProperty leftInputProperty,
             InputProperty rightInputProperty,
             RowType outputType,
+            boolean withJobStrategyHint,
             String description) {
         super(
                 ExecNodeContext.newNodeId(),
@@ -89,7 +100,12 @@ public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
         checkArgument(leftKeys.length == filterNulls.length);
 
         this.nonEquiCondition = nonEquiCondition;
+        this.estimatedLeftAvgRowSize = estimatedLeftAvgRowSize;
+        this.estimatedRightAvgRowSize = estimatedRightAvgRowSize;
+        this.estimatedLeftRowCount = estimatedLeftRowCount;
+        this.estimatedRightRowCount = estimatedRightRowCount;
         this.leftIsSmaller = leftIsSmaller;
+        this.withJobStrategyHint = withJobStrategyHint;
     }
 
     @Override
@@ -103,18 +119,6 @@ public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
         RowType leftType = (RowType) leftInputEdge.getOutputType();
         RowType rightType = (RowType) rightInputEdge.getOutputType();
 
-        LogicalType[] keyFieldTypes =
-                IntStream.of(leftKeys).mapToObj(leftType::getTypeAt).toArray(LogicalType[]::new);
-        RowType keyType = RowType.of(keyFieldTypes);
-
-        GeneratedJoinCondition condFunc =
-                JoinUtil.generateConditionFunction(
-                        config,
-                        planner.getFlinkContext().getClassLoader(),
-                        nonEquiCondition,
-                        leftType,
-                        rightType);
-
         long externalBufferMemory =
                 config.get(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_EXTERNAL_BUFFER_MEMORY)
                         .getBytes();
@@ -127,20 +131,27 @@ public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
 
         long managedMemory = externalBufferMemory * externalBufferNum + sortMemory * 2;
 
-        SortMergeJoinFunction sortMergeJoinFunction =
-                SorMergeJoinOperatorUtil.getSortMergeJoinFunction(
-                        planner.getFlinkContext().getClassLoader(),
+        GeneratedJoinCondition condFunc =
+                JoinUtil.generateConditionFunction(
                         config,
-                        joinType,
+                        planner.getFlinkContext().getClassLoader(),
+                        nonEquiCondition,
+                        leftType,
+                        rightType);
+
+        StreamOperatorFactory<RowData> sortMergeJoinOperatorFactory =
+                SorMergeJoinOperatorUtil.generateOperatorFactory(
+                        condFunc,
                         leftType,
                         rightType,
                         leftKeys,
                         rightKeys,
-                        keyType,
+                        joinType,
+                        config,
                         leftIsSmaller,
                         filterNulls,
-                        condFunc,
-                        1.0 * externalBufferMemory / managedMemory);
+                        managedMemory,
+                        planner.getFlinkContext().getClassLoader());
 
         Transformation<RowData> leftInputTransform =
                 (Transformation<RowData>) leftInputEdge.translateToPlan(planner);
@@ -151,10 +162,32 @@ public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
                 rightInputTransform,
                 createTransformationName(config),
                 createTransformationDescription(config),
-                SimpleOperatorFactory.of(new SortMergeJoinOperator(sortMergeJoinFunction)),
+                sortMergeJoinOperatorFactory,
                 InternalTypeInfo.of(getOutputType()),
                 rightInputTransform.getParallelism(),
                 managedMemory,
                 false);
+    }
+
+    @Override
+    public boolean canBeTransformedToAdaptiveJoin() {
+        return !withJobStrategyHint && joinType != FlinkJoinType.FULL;
+    }
+
+    @Override
+    public BatchExecAdaptiveJoin toAdaptiveJoinNode() {
+        return new BatchExecAdaptiveJoin(
+                getPersistedConfig(),
+                new JoinSpec(joinType, leftKeys, rightKeys, filterNulls, nonEquiCondition),
+                estimatedLeftAvgRowSize,
+                estimatedRightAvgRowSize,
+                estimatedLeftRowCount,
+                estimatedRightRowCount,
+                leftIsSmaller,
+                false,
+                getInputProperties(),
+                (RowType) getOutputType(),
+                getDescription(),
+                OperatorType.SortMergeJoin);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/AdaptiveJoinProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/AdaptiveJoinProcessor.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.processor;
+
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.planner.plan.nodes.exec.AdaptiveJoinExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
+import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.InputProperty.DistributionType;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecAdaptiveJoin;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecExchange;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
+import org.apache.flink.table.planner.plan.utils.OperatorType;
+import org.apache.flink.table.planner.utils.TableConfigUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.planner.plan.nodes.exec.InputProperty.DistributionType.KEEP_INPUT_AS_IS;
+
+/**
+ * A {@link ExecNodeGraphProcessor} which replace the qualified join nodes into adaptive join nodes.
+ */
+public class AdaptiveJoinProcessor implements ExecNodeGraphProcessor {
+
+    @Override
+    public ExecNodeGraph process(ExecNodeGraph execGraph, ProcessorContext context) {
+        if (execGraph.getRootNodes().get(0) instanceof StreamExecNode) {
+            throw new TableException("AdaptiveJoin does not support streaming jobs.");
+        }
+        if (!isAdaptiveJoinEnabled(context)) {
+            return execGraph;
+        }
+
+        AbstractExecNodeExactlyOnceVisitor visitor =
+                new AbstractExecNodeExactlyOnceVisitor() {
+                    @Override
+                    protected void visitNode(ExecNode<?> node) {
+                        visitInputs(node);
+                        // AdaptiveJoin conversion should be avoided when there is a
+                        // KEEP_INPUT_AS_IS constraint downstream. And we don't need to check all
+                        // downstream nodes of the join, because the KEEP_INPUT_AS_IS constraint
+                        // will be bound to BatchExecExchange, which will be the direct downstream
+                        // node of the join.
+                        if (shouldKeepInputAsIs(node.getInputProperties())) {
+                            return;
+                        }
+                        for (int i = 0; i < node.getInputEdges().size(); ++i) {
+                            ExecEdge edge = node.getInputEdges().get(i);
+                            ExecNode<?> newNode = tryReplaceWithAdaptiveJoinNode(edge.getSource());
+                            node.replaceInputEdge(
+                                    i,
+                                    ExecEdge.builder()
+                                            .source(newNode)
+                                            .target(node)
+                                            .shuffle(edge.getShuffle())
+                                            .exchangeMode(edge.getExchangeMode())
+                                            .build());
+                        }
+                    }
+                };
+
+        List<ExecNode<?>> newRootNodes =
+                execGraph.getRootNodes().stream()
+                        .map(
+                                node -> {
+                                    node = tryReplaceWithAdaptiveJoinNode(node);
+                                    node.accept(visitor);
+                                    return node;
+                                })
+                        .collect(Collectors.toList());
+
+        return new ExecNodeGraph(execGraph.getFlinkVersion(), newRootNodes);
+    }
+
+    private ExecNode<?> tryReplaceWithAdaptiveJoinNode(ExecNode<?> node) {
+        // For AdaptiveJoin to be converted, its upstream input must ensure:
+        // 1. Data distribution is by Hash.
+        // 2. No upstream nodes require KEEP_INPUT_AS_IS (achieved by inserting BatchExecExchange).
+        if (!(areAllInputsHashShuffle(node))
+                || shouldKeepUpstreamExchangeInputAsIs(node.getInputEdges())) {
+            return node;
+        }
+        ExecNode<?> newNode = node;
+        if (node instanceof AdaptiveJoinExecNode
+                && ((AdaptiveJoinExecNode) node).canBeTransformedToAdaptiveJoin()) {
+            BatchExecAdaptiveJoin adaptiveJoin = ((AdaptiveJoinExecNode) node).toAdaptiveJoinNode();
+            replaceInputEdge(adaptiveJoin, node);
+            newNode = adaptiveJoin;
+        }
+
+        return newNode;
+    }
+
+    private boolean shouldKeepInputAsIs(List<InputProperty> inputProperties) {
+        return inputProperties.stream()
+                .anyMatch(
+                        inputProperty ->
+                                inputProperty.getRequiredDistribution().getType()
+                                        == KEEP_INPUT_AS_IS);
+    }
+
+    // If KEEP_INPUT_AS_IS constraint exists on an operator, it will always show on its upstream
+    // BatchExecExchange.
+    private boolean shouldKeepUpstreamExchangeInputAsIs(List<ExecEdge> inputEdges) {
+        return inputEdges.stream()
+                .filter(execEdge -> execEdge.getSource() instanceof BatchExecExchange)
+                .map(execEdge -> (BatchExecExchange) execEdge.getSource())
+                .anyMatch(exchange -> shouldKeepInputAsIs(exchange.getInputProperties()));
+    }
+
+    private boolean isAdaptiveJoinEnabled(ProcessorContext context) {
+        TableConfig tableConfig = context.getPlanner().getTableConfig();
+        boolean isAdaptiveJoinEnabled =
+                tableConfig.get(
+                                        OptimizerConfigOptions
+                                                .TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY)
+                                != OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.NONE
+                        && !TableConfigUtils.isOperatorDisabled(
+                                tableConfig, OperatorType.BroadcastHashJoin);
+        JobManagerOptions.SchedulerType schedulerType =
+                context.getPlanner()
+                        .getExecEnv()
+                        .getConfig()
+                        .getSchedulerType()
+                        .orElse(JobManagerOptions.SchedulerType.AdaptiveBatch);
+        boolean isAdaptiveBatchSchedulerEnabled =
+                schedulerType == JobManagerOptions.SchedulerType.AdaptiveBatch;
+
+        return isAdaptiveJoinEnabled && isAdaptiveBatchSchedulerEnabled;
+    }
+
+    private boolean areAllInputsHashShuffle(ExecNode<?> node) {
+        for (InputProperty inputProperty : node.getInputProperties()) {
+            if (inputProperty.getRequiredDistribution().getType() != DistributionType.HASH) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void replaceInputEdge(ExecNode<?> newNode, ExecNode<?> originalNode) {
+        List<ExecEdge> inputEdges = new ArrayList<>();
+        for (int i = 0; i < originalNode.getInputEdges().size(); ++i) {
+            ExecEdge edge = originalNode.getInputEdges().get(i);
+            inputEdges.add(
+                    ExecEdge.builder()
+                            .source(edge.getSource())
+                            .target(newNode)
+                            .shuffle(edge.getShuffle())
+                            .exchangeMode(edge.getExchangeMode())
+                            .build());
+        }
+        newNode.setInputEdges(inputEdges);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -25,11 +25,11 @@ import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.delegation.{Executor, InternalPlan}
 import org.apache.flink.table.module.ModuleManager
-import org.apache.flink.table.operations.{ModifyOperation, Operation}
+import org.apache.flink.table.operations.Operation
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistributionTraitDef
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecNode
-import org.apache.flink.table.planner.plan.nodes.exec.processor.{DeadlockBreakupProcessor, DynamicFilteringDependencyProcessor, ExecNodeGraphProcessor, ForwardHashExchangeProcessor, MultipleInputNodeCreationProcessor}
+import org.apache.flink.table.planner.plan.nodes.exec.processor.{AdaptiveJoinProcessor, DeadlockBreakupProcessor, DynamicFilteringDependencyProcessor, ExecNodeGraphProcessor, ForwardHashExchangeProcessor, MultipleInputNodeCreationProcessor}
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodePlanDumper
 import org.apache.flink.table.planner.plan.optimize.{BatchCommonSubGraphBasedOptimizer, Optimizer}
 import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
@@ -81,6 +81,7 @@ class BatchPlanner(
       processors.add(new MultipleInputNodeCreationProcessor(false))
     }
     processors.add(new ForwardHashExchangeProcessor)
+    processors.add(new AdaptiveJoinProcessor)
     processors
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSortMergeJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSortMergeJoin.scala
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.{RelCollationTraitDef, RelNode, RelWriter}
 import org.apache.calcite.rel.core._
 import org.apache.calcite.rel.metadata.RelMetadataQuery
 import org.apache.calcite.rex.RexNode
+import org.apache.calcite.util.Util
 
 import scala.collection.JavaConversions._
 
@@ -45,7 +46,8 @@ class BatchPhysicalSortMergeJoin(
     // true if LHS is sorted by left join keys, else false
     val leftSorted: Boolean,
     // true if RHS is sorted by right join key, else false
-    val rightSorted: Boolean)
+    val rightSorted: Boolean,
+    withJobStrategyHint: Boolean)
   extends BatchPhysicalJoinBase(cluster, traitSet, leftRel, rightRel, condition, joinType) {
 
   protected def isMergeJoinSupportedType(joinRelType: FlinkJoinType): Boolean = {
@@ -70,7 +72,8 @@ class BatchPhysicalSortMergeJoin(
       conditionExpr,
       joinType,
       leftSorted,
-      rightSorted)
+      rightSorted,
+      withJobStrategyHint)
   }
 
   override def explainTerms(pw: RelWriter): RelWriter =
@@ -175,6 +178,8 @@ class BatchPhysicalSortMergeJoin(
       FlinkTypeFactory.toLogicalRowType(left.getRowType),
       FlinkTypeFactory.toLogicalRowType(right.getRowType))
 
+    val (leftRowSize, leftRowCount, rightRowSize, rightRowCount) =
+      JoinUtil.getEstimatedRowStats(this)
     new BatchExecSortMergeJoin(
       unwrapTableConfig(this),
       JoinTypeUtil.getFlinkJoinType(joinType),
@@ -182,6 +187,10 @@ class BatchPhysicalSortMergeJoin(
       joinSpec.getRightKeys,
       joinSpec.getFilterNulls,
       condition,
+      leftRowSize,
+      rightRowSize,
+      leftRowCount,
+      rightRowCount,
       estimateOutputSize(getLeft) < estimateOutputSize(getRight),
       InputProperty
         .builder()
@@ -194,6 +203,7 @@ class BatchPhysicalSortMergeJoin(
         .damBehavior(InputProperty.DamBehavior.END_INPUT)
         .build(),
       FlinkTypeFactory.toLogicalRowType(getRowType),
+      withJobStrategyHint,
       getRelDetailedDescription)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashJoinRule.scala
@@ -23,6 +23,7 @@ import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalHashJoin
+import org.apache.flink.table.planner.plan.utils.JoinUtil
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
@@ -110,6 +111,7 @@ class BatchPhysicalHashJoinRule
       val newLeft = RelOptRule.convert(left, leftRequiredTrait)
       val newRight = RelOptRule.convert(right, rightRequiredTrait)
       val providedTraitSet = join.getTraitSet.replace(FlinkConventions.BATCH_PHYSICAL)
+      val withJobStrategyHint = JoinUtil.containsJoinStrategyHint(join.getHints)
 
       val newJoin = new BatchPhysicalHashJoin(
         join.getCluster,
@@ -120,7 +122,8 @@ class BatchPhysicalHashJoinRule
         join.getJoinType,
         isLeftToBroadcastOrBuild,
         isBroadcast,
-        tryDistinctBuildRow)
+        tryDistinctBuildRow,
+        withJobStrategyHint)
 
       call.transformTo(newJoin)
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalJoinRuleBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalJoinRuleBase.scala
@@ -192,6 +192,13 @@ trait BatchPhysicalJoinRuleBase {
           (false, false)
       }
     } else {
+      if (
+        tableConfig.get(OptimizerConfigOptions.TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY)
+          == OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.RUNTIME_ONLY
+      ) {
+        return (false, false)
+      }
+
       val leftSize = JoinUtil.binaryRowRelNodeSize(join.getLeft)
       val rightSize = JoinUtil.binaryRowRelNodeSize(join.getRight)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalSortMergeJoinRule.scala
@@ -22,6 +22,7 @@ import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalJoin
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalSortMergeJoin
+import org.apache.flink.table.planner.plan.utils.JoinUtil
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
@@ -72,6 +73,7 @@ class BatchPhysicalSortMergeJoinRule
     val providedTraitSet = call.getPlanner
       .emptyTraitSet()
       .replace(FlinkConventions.BATCH_PHYSICAL)
+    val withJobStrategyHint = JoinUtil.containsJoinStrategyHint(join.getHints)
     // do not try to remove redundant sort for shorter optimization time
     val newJoin = new BatchPhysicalSortMergeJoin(
       join.getCluster,
@@ -81,7 +83,8 @@ class BatchPhysicalSortMergeJoinRule
       join.getCondition,
       join.getJoinType,
       false,
-      false)
+      false,
+      withJobStrategyHint)
     call.transformTo(newJoin)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
@@ -19,28 +19,36 @@ package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.configuration.ReadableConfig
 import org.apache.flink.table.api.TableException
+import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.JDouble
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, ExprCodeGenerator, FunctionCodeGenerator}
+import org.apache.flink.table.planner.hint.JoinStrategy
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig
 import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalJoin, FlinkLogicalSnapshot}
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchPhysicalJoinBase
 import org.apache.flink.table.planner.plan.utils.IntervalJoinUtil.satisfyIntervalJoin
 import org.apache.flink.table.planner.plan.utils.TemporalJoinUtil.satisfyTemporalJoin
 import org.apache.flink.table.planner.plan.utils.WindowJoinUtil.satisfyWindowJoin
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType
 import org.apache.flink.table.runtime.operators.join.stream.utils.JoinInputSideSpec
 import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.{LogicalType, RowType}
 
+import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rel.`type`.{RelDataType, RelDataTypeField}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.{Join, JoinInfo, JoinRelType}
+import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexUtil}
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 import org.apache.calcite.util.ImmutableIntList
+import org.apache.calcite.util.Util
 
 import java.util
 import java.util.Collections
@@ -274,5 +282,43 @@ object JoinUtil {
     } else {
       rowCount * FlinkRelMdUtil.binaryRowAverageSize(relNode)
     }
+  }
+
+  /**
+   * Get managed memory for hash join. Because hash join may fallback to sort merge join, it takes
+   * larger managed memory to support a HashJoin being converted into a SortMergeJoin.
+   */
+  def getManagedMemory(joinType: FlinkJoinType, config: ExecNodeConfig): Long = {
+    val hashJoinManagedMemory =
+      config.get(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_HASH_JOIN_MEMORY).getBytes
+    // The memory used by SortMergeJoinIterator that buffer the matched rows, each side needs
+    // this memory if it is full outer join
+    val externalBufferMemory =
+      config.get(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_EXTERNAL_BUFFER_MEMORY).getBytes
+    // The memory used by BinaryExternalSorter for sort, the left and right side both need it
+    val sortMemory = config.get(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_SORT_MEMORY).getBytes
+    var externalBufferNum = 1
+    if (joinType eq FlinkJoinType.FULL) {
+      externalBufferNum = 2
+    }
+    val sortMergeJoinManagedMemory = externalBufferMemory * externalBufferNum + sortMemory * 2
+    // Due to hash join maybe fallback to sort merge join, so here managed memory choose the
+    // large one
+    Math.max(hashJoinManagedMemory, sortMergeJoinManagedMemory)
+  }
+
+  /** Get estimated row stats for hash join. */
+  def getEstimatedRowStats(joinBase: BatchPhysicalJoinBase): (Int, Long, Int, Long) = {
+    val mq = joinBase.getCluster.getMetadataQuery
+    val leftRowSize = Util.first(mq.getAverageRowSize(joinBase.getLeft), 24).toInt
+    val leftRowCount = Util.first(mq.getRowCount(joinBase.getLeft), 200000).toLong
+    val rightRowSize = Util.first(mq.getAverageRowSize(joinBase.getRight), 24).toInt
+    val rightRowCount = Util.first(mq.getRowCount(joinBase.getRight), 200000).toLong
+
+    (leftRowSize, leftRowCount, rightRowSize, rightRowCount)
+  }
+
+  def containsJoinStrategyHint(relHints: ImmutableList[RelHint]): Boolean = {
+    relHints.exists(relHint => JoinStrategy.isJoinStrategy(relHint.hintName))
   }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/adaptive/AdaptiveJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/adaptive/AdaptiveJoinTest.xml
@@ -1,0 +1,231 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+	<TestCase name="testShuffleJoinWithForwardForConsecutiveHash">
+		<Resource name="sql">
+			<![CDATA[
+WITH
+  r AS (SELECT * FROM T1, T2, T3 WHERE a1 = a2 and a1 = a3)
+SELECT sum(b1) FROM r group by a1
+]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(EXPR$0=[$1])
++- LogicalAggregate(group=[{0}], EXPR$0=[SUM($1)])
+   +- LogicalProject(a1=[$0], b1=[$1])
+      +- LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6], d2=[$7], a3=[$8], b3=[$9], c3=[$10], d3=[$11])
+         +- LogicalFilter(condition=[AND(=($0, $4), =($0, $8))])
+            +- LogicalJoin(condition=[true], joinType=[inner])
+               :- LogicalJoin(condition=[true], joinType=[inner])
+               :  :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+               :  +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
+               +- LogicalTableScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+Calc(select=[EXPR$0])
++- HashAggregate(isMerge=[false], groupBy=[a1], select=[a1, SUM(b1) AS EXPR$0])
+   +- Exchange(distribution=[keep_input_as_is[hash[a1]]])
+      +- Calc(select=[a1, b1])
+         +- Exchange(distribution=[keep_input_as_is[hash[a1]]])
+            +- HashJoin(joinType=[InnerJoin], where=[(a1 = a3)], select=[a1, b1, a3], build=[left])
+               :- Exchange(distribution=[keep_input_as_is[hash[a1]]])
+               :  +- Calc(select=[a1, b1])
+               :     +- Exchange(distribution=[keep_input_as_is[hash[a1]]])
+               :        +- HashJoin(joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, a2], build=[right])
+               :           :- Exchange(distribution=[hash[a1]])
+               :           :  +- Calc(select=[a1, b1])
+               :           :     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
+               :           +- Exchange(distribution=[hash[a2]])
+               :              +- Calc(select=[a2])
+               :                 +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]], fields=[a2, b2, c2, d2])
+               +- Exchange(distribution=[hash[a3]])
+                  +- Calc(select=[a3])
+                     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T3, source: [TestTableSource(a3, b3, c3, d3)]]], fields=[a3, b3, c3, d3])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testWithShuffleMergeJoin">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM T1, T2 WHERE a1 = a2]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6], d2=[$7])
++- LogicalFilter(condition=[=($0, $4)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+AdaptiveJoin(originalJoin=[SortMergeJoin], joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, c1, d1, a2, b2, c2, d2])
+:- Exchange(distribution=[hash[a1]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
++- Exchange(distribution=[hash[a2]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]], fields=[a2, b2, c2, d2])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testWithBroadcastJoinRuntimeOnly">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM T1, T2 WHERE a1 = a2]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6], d2=[$7])
++- LogicalFilter(condition=[=($0, $4)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+AdaptiveJoin(originalJoin=[ShuffleHashJoin], joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, c1, d1, a2, b2, c2, d2], build=[left])
+:- Exchange(distribution=[hash[a1]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
++- Exchange(distribution=[hash[a2]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]], fields=[a2, b2, c2, d2])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testWithShuffleHashJoin">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM T1, T2 WHERE a1 = a2]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6], d2=[$7])
++- LogicalFilter(condition=[=($0, $4)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+AdaptiveJoin(originalJoin=[ShuffleHashJoin], joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, c1, d1, a2, b2, c2, d2], build=[left])
+:- Exchange(distribution=[hash[a1]])
+:  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
++- Exchange(distribution=[hash[a2]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]], fields=[a2, b2, c2, d2])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testWithStaticBroadcastJoin">
+		<Resource name="sql">
+			<![CDATA[SELECT * FROM T1, T2 WHERE a1 = a2]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], a2=[$4], b2=[$5], c2=[$6], d2=[$7])
++- LogicalFilter(condition=[=($0, $4)])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+HashJoin(joinType=[InnerJoin], where=[(a1 = a2)], select=[a1, b1, c1, d1, a2, b2, c2, d2], isBroadcast=[true], build=[right])
+:- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
++- Exchange(distribution=[broadcast])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]], fields=[a2, b2, c2, d2])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testJoinWithUnionInput">
+		<Resource name="sql">
+			<![CDATA[
+SELECT * FROM
+  (SELECT a FROM (SELECT a1 as a FROM T1) UNION ALL (SELECT a2 as a FROM T2)) Y
+  LEFT JOIN T ON T.a = Y.a
+]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0], a0=[$1], b=[$2], c=[$3], d=[$4])
++- LogicalJoin(condition=[=($1, $0)], joinType=[left])
+   :- LogicalUnion(all=[true])
+   :  :- LogicalProject(a=[$0])
+   :  :  +- LogicalProject(a=[$0])
+   :  :     +- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+   :  +- LogicalProject(a=[$0])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+AdaptiveJoin(originalJoin=[ShuffleHashJoin], joinType=[LeftOuterJoin], where=[(a0 = a)], select=[a, a0, b, c, d], build=[left])
+:- Exchange(distribution=[hash[a]])
+:  +- Union(all=[true], union=[a])
+:     :- Calc(select=[a1 AS a])
+:     :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
+:     +- Calc(select=[a2 AS a])
+:        +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]], fields=[a2, b2, c2, d2])
++- Exchange(distribution=[hash[a]])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+		</Resource>
+	</TestCase>
+	<TestCase name="testJoinWithMultipleInput">
+		<Resource name="sql">
+			<![CDATA[
+SELECT * FROM
+  (SELECT a FROM T1 JOIN T ON a = a1) t1
+  INNER JOIN
+  (SELECT d2 FROM T JOIN T2 ON d2 = a) t2
+ON t1.a = t2.d2
+]]>
+		</Resource>
+		<Resource name="ast">
+			<![CDATA[
+LogicalProject(a=[$0], d2=[$1])
++- LogicalJoin(condition=[=($0, $1)], joinType=[inner])
+   :- LogicalProject(a=[$4])
+   :  +- LogicalJoin(condition=[=($4, $0)], joinType=[inner])
+   :     :- LogicalTableScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+   +- LogicalProject(d2=[$7])
+      +- LogicalJoin(condition=[=($7, $0)], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]])
+]]>
+		</Resource>
+		<Resource name="optimized exec plan">
+			<![CDATA[
+MultipleInput(readOrder=[0,1,1,2], members=[\nHashJoin(joinType=[InnerJoin], where=[(a = d2)], select=[a, d2], build=[left])\n:- Calc(select=[a])\n:  +- HashJoin(joinType=[InnerJoin], where=[(a = a1)], select=[a1, a], build=[left])\n:     :- [#1] Exchange(distribution=[hash[a1]])\n:     +- [#2] Exchange(distribution=[hash[a]])\n+- Calc(select=[d2])\n   +- HashJoin(joinType=[InnerJoin], where=[(d2 = a)], select=[a, d2], build=[left])\n      :- [#2] Exchange(distribution=[hash[a]])\n      +- [#4] Exchange(distribution=[hash[d2]])\n])
+:- Exchange(distribution=[hash[a1]])
+:  +- Calc(select=[a1])
+:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T1, source: [TestTableSource(a1, b1, c1, d1)]]], fields=[a1, b1, c1, d1])
+:- Exchange(distribution=[hash[a]])(reuse_id=[1])
+:  +- Calc(select=[a])
+:     +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+:- Reused(reference_id=[1])
++- Exchange(distribution=[hash[d2]])
+   +- Calc(select=[d2])
+      +- LegacyTableSourceScan(table=[[default_catalog, default_database, T2, source: [TestTableSource(a2, b2, c2, d2)]]], fields=[a2, b2, c2, d2])
+]]>
+		</Resource>
+	</TestCase>
+</Root>

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-inner-join-with-duplicate-key/plan/join-inner-join-with-duplicate-key.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-inner-join-with-duplicate-key/plan/join-inner-join-with-duplicate-key.json
@@ -165,6 +165,7 @@
     "isBroadcast" : false,
     "leftIsBuild" : false,
     "tryDistinctBuildRow" : false,
+    "withJobStrategyHint": false,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-inner-join-with-non-equi-join/plan/join-inner-join-with-non-equi-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-inner-join-with-non-equi-join/plan/join-inner-join-with-non-equi-join.json
@@ -134,6 +134,7 @@
     "isBroadcast" : false,
     "leftIsBuild" : true,
     "tryDistinctBuildRow" : false,
+    "withJobStrategyHint": false,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-left-join/plan/join-left-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-left-join/plan/join-left-join.json
@@ -129,6 +129,7 @@
     "isBroadcast" : false,
     "leftIsBuild" : true,
     "tryDistinctBuildRow" : false,
+    "withJobStrategyHint": false,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-non-window-inner-join-with-null-cond/plan/join-non-window-inner-join-with-null-cond.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-non-window-inner-join-with-null-cond/plan/join-non-window-inner-join-with-null-cond.json
@@ -220,6 +220,7 @@
     "isBroadcast" : false,
     "leftIsBuild" : true,
     "tryDistinctBuildRow" : false,
+    "withJobStrategyHint": false,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-non-window-inner-join/plan/join-non-window-inner-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-non-window-inner-join/plan/join-non-window-inner-join.json
@@ -220,6 +220,7 @@
     "isBroadcast" : false,
     "leftIsBuild" : true,
     "tryDistinctBuildRow" : false,
+    "withJobStrategyHint": false,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-outer-join/plan/join-outer-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-outer-join/plan/join-outer-join.json
@@ -129,6 +129,7 @@
     "isBroadcast" : false,
     "leftIsBuild" : true,
     "tryDistinctBuildRow" : false,
+    "withJobStrategyHint": false,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-right-join/plan/join-right-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-right-join/plan/join-right-join.json
@@ -129,6 +129,7 @@
     "isBroadcast" : false,
     "leftIsBuild" : true,
     "tryDistinctBuildRow" : false,
+    "withJobStrategyHint": false,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-semi-join/plan/join-semi-join.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-semi-join/plan/join-semi-join.json
@@ -129,6 +129,7 @@
     "isBroadcast" : false,
     "leftIsBuild" : false,
     "tryDistinctBuildRow" : false,
+    "withJobStrategyHint": false,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",

--- a/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-with-filter/plan/join-with-filter.json
+++ b/flink-table/flink-table-planner/src/test/resources/restore-tests/batch-exec-join_1/join-with-filter/plan/join-with-filter.json
@@ -185,6 +185,7 @@
     "isBroadcast" : false,
     "leftIsBuild" : false,
     "tryDistinctBuildRow" : false,
+    "withJobStrategyHint": false,
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "HASH",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/adaptive/AdaptiveJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/adaptive/AdaptiveJoinTest.scala
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.batch.sql.adaptive
+
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
+import org.apache.flink.table.planner.utils.TableTestBase
+
+import org.junit.jupiter.api.{BeforeEach, Test}
+
+/** Tests for AdaptiveJoinProcessor. */
+class AdaptiveJoinTest extends TableTestBase {
+
+  private val util = batchTestUtil()
+
+  @BeforeEach
+  def before(): Unit = {
+    util.addTableSource[(Long, Long, String, Long)]("T", 'a, 'b, 'c, 'd)
+    util.addTableSource[(Long, Long, String, Long)]("T1", 'a1, 'b1, 'c1, 'd1)
+    util.addTableSource[(Long, Long, String, Long)]("T2", 'a2, 'b2, 'c2, 'd2)
+    util.addTableSource[(Long, Long, String, Long)]("T3", 'a3, 'b3, 'c3, 'd3)
+    util.tableConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY,
+      OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.AUTO)
+  }
+
+  @Test
+  def testWithShuffleHashJoin(): Unit = {
+    util.tableEnv.getConfig
+      .set(ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "NestedLoopJoin,SortMergeJoin")
+    val sql = "SELECT * FROM T1, T2 WHERE a1 = a2"
+    util.verifyExecPlan(sql)
+  }
+
+  @Test
+  def testWithShuffleMergeJoin(): Unit = {
+    util.tableEnv.getConfig
+      .set(ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "NestedLoopJoin,ShuffleHashJoin")
+    val sql = "SELECT * FROM T1, T2 WHERE a1 = a2"
+    util.verifyExecPlan(sql)
+  }
+
+  // For join nodes that have already been converted as broadcast join during the compilation phase,
+  // no further transformation will be performed.
+  @Test
+  def testWithStaticBroadcastJoin(): Unit = {
+    util.tableEnv.getConfig.set(
+      ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS,
+      "SortMergeJoin,ShuffleHashJoin,NestedLoopJoin")
+    util.tableEnv.getConfig
+      .set(OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD, Long.box(Long.MaxValue))
+    val sql = "SELECT * FROM T1, T2 WHERE a1 = a2"
+    util.verifyExecPlan(sql)
+  }
+
+  @Test
+  def testWithBroadcastJoinRuntimeOnly(): Unit = {
+    util.tableEnv.getConfig
+      .set(ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "NestedLoopJoin")
+    util.tableEnv.getConfig
+      .set(OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD, Long.box(Long.MaxValue))
+    util.tableEnv.getConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY,
+      OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.RUNTIME_ONLY)
+    val sql = "SELECT * FROM T1, T2 WHERE a1 = a2"
+    util.verifyExecPlan(sql)
+  }
+
+  @Test
+  def testJoinWithUnionInput(): Unit = {
+    val sql =
+      """
+        |SELECT * FROM
+        |  (SELECT a FROM (SELECT a1 as a FROM T1) UNION ALL (SELECT a2 as a FROM T2)) Y
+        |  LEFT JOIN T ON T.a = Y.a
+        |""".stripMargin
+    util.verifyExecPlan(sql)
+  }
+
+  // AdaptiveJoin does not support case of ForwardForConsecutiveHash, it may lead to data incorrectness.
+  @Test
+  def testShuffleJoinWithForwardForConsecutiveHash(): Unit = {
+    util.tableEnv.getConfig
+      .set(OptimizerConfigOptions.TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED, Boolean.box(false))
+    val sql =
+      """
+        |WITH
+        |  r AS (SELECT * FROM T1, T2, T3 WHERE a1 = a2 and a1 = a3)
+        |SELECT sum(b1) FROM r group by a1
+        |""".stripMargin
+    util.verifyExecPlan(sql)
+  }
+
+  // AdaptiveJoin does not support case of MultipleInput, because the optimizer is unable to see the
+  // join node within the MultipleInput, but this might be supported in the future.
+  @Test
+  def testJoinWithMultipleInput(): Unit = {
+    val sql =
+      """
+        |SELECT * FROM
+        |  (SELECT a FROM T1 JOIN T ON a = a1) t1
+        |  INNER JOIN
+        |  (SELECT d2 FROM T JOIN T2 ON d2 = a) t2
+        |ON t1.a = t2.d2
+        |""".stripMargin
+    util.verifyExecPlan(sql)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

To implement the Adaptive Broadcast Join capability proposed by FLIP-470, while enabling Adaptive Broadcast Join, the compatible join operators will be replaced with Adaptive Broadcast Join operators in the table-planner phase, and the corresponding OperatorFactory is introduced.


## Brief change log

  - *Introduce configuration options for adaptive broadcast join.*
  - *Introduce Exec node for adaptive broadcast join.*
  - *Introduce AdaptiveBroadcastJoinOperatorFactory.*
  - *Introduce AdaptiveBroadcastJoinProcessor to inject adaptive broadcast join.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add IT and UT cases to verify the correctness of injecting the Adaptive Broadcast Join operator and generating dynamic join operators.*
  - *The proposed changes will be tested for correctness and stability in a real cluster.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (docs and JavaDocs )
