### PR TITLE
[FLINK-36501][table] Remove all deprecated methods in `CatalogFactory`

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/CatalogFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/CatalogFactory.java
@@ -25,7 +25,6 @@ import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.legacy.factories.TableFactory;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -38,20 +37,7 @@ import java.util.Set;
  * instead.
  */
 @PublicEvolving
-public interface CatalogFactory extends TableFactory, Factory {
-
-    /**
-     * Creates and configures a {@link Catalog} using the given properties.
-     *
-     * @param properties normalized properties describing an external catalog.
-     * @return the configured catalog.
-     * @deprecated Use {@link this#createCatalog(Context)} instead and implement {@link Factory}
-     *     instead of {@link TableFactory}.
-     */
-    @Deprecated
-    default Catalog createCatalog(String name, Map<String, String> properties) {
-        throw new CatalogException("Catalog factories must implement createCatalog()");
-    }
+public interface CatalogFactory extends Factory {
 
     /**
      * Creates and configures a {@link Catalog} using the given context.
@@ -88,48 +74,14 @@ public interface CatalogFactory extends TableFactory, Factory {
     }
 
     default String factoryIdentifier() {
-        if (requiredContext() == null || supportedProperties() == null) {
-            throw new CatalogException("Catalog factories must implement factoryIdentifier()");
-        }
-
-        return null;
+        throw new CatalogException("Catalog factories must implement factoryIdentifier()");
     }
 
     default Set<ConfigOption<?>> requiredOptions() {
-        if (requiredContext() == null || supportedProperties() == null) {
-            throw new CatalogException("Catalog factories must implement requiredOptions()");
-        }
-
-        return null;
+        throw new CatalogException("Catalog factories must implement requiredOptions()");
     }
 
     default Set<ConfigOption<?>> optionalOptions() {
-        if (requiredContext() == null || supportedProperties() == null) {
-            throw new CatalogException("Catalog factories must implement optionalOptions()");
-        }
-
-        return null;
-    }
-
-    // --------------------------------------------------------------------------------------------
-    // Default implementations for legacy {@link TableFactory} stack.
-    // --------------------------------------------------------------------------------------------
-
-    /**
-     * @deprecated Implement the {@link Factory} based stack instead.
-     */
-    @Deprecated
-    default Map<String, String> requiredContext() {
-        // Default implementation for catalogs implementing the new {@link Factory} stack instead.
-        return null;
-    }
-
-    /**
-     * @deprecated Implement the {@link Factory} based stack instead.
-     */
-    @Deprecated
-    default List<String> supportedProperties() {
-        // Default implementation for catalogs implementing the new {@link Factory} stack instead.
-        return null;
+        throw new CatalogException("Catalog factories must implement optionalOptions()");
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/CatalogFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/CatalogFactory.java
@@ -19,14 +19,11 @@
 package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.catalog.Catalog;
-import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.legacy.factories.TableFactory;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A factory to create configured catalog instances based on string-based properties. See also
@@ -45,9 +42,7 @@ public interface CatalogFactory extends Factory {
      * <p>An implementation should perform validation and the discovery of further (nested)
      * factories in this method.
      */
-    default Catalog createCatalog(Context context) {
-        throw new CatalogException("Catalog factories must implement createCatalog(Context)");
-    }
+    Catalog createCatalog(Context context);
 
     /** Context provided when a catalog is created. */
     @PublicEvolving
@@ -71,17 +66,5 @@ public interface CatalogFactory extends Factory {
          * <p>The class loader is in particular useful for discovering further (nested) factories.
          */
         ClassLoader getClassLoader();
-    }
-
-    default String factoryIdentifier() {
-        throw new CatalogException("Catalog factories must implement factoryIdentifier()");
-    }
-
-    default Set<ConfigOption<?>> requiredOptions() {
-        throw new CatalogException("Catalog factories must implement requiredOptions()");
-    }
-
-    default Set<ConfigOption<?>> optionalOptions() {
-        throw new CatalogException("Catalog factories must implement optionalOptions()");
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -372,8 +372,6 @@ public final class FactoryUtil {
             Map<String, String> options,
             ReadableConfig configuration,
             ClassLoader classLoader) {
-        // No matching legacy factory found, try using the new stack
-
         final DefaultCatalogContext discoveryContext =
                 new DefaultCatalogContext(catalogName, options, configuration, classLoader);
         try {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -372,48 +372,41 @@ public final class FactoryUtil {
             Map<String, String> options,
             ReadableConfig configuration,
             ClassLoader classLoader) {
-        // Use the legacy mechanism first for compatibility
+        // No matching legacy factory found, try using the new stack
+
+        final DefaultCatalogContext discoveryContext =
+                new DefaultCatalogContext(catalogName, options, configuration, classLoader);
         try {
-            final CatalogFactory legacyFactory =
-                    TableFactoryService.find(CatalogFactory.class, options, classLoader);
-            return legacyFactory.createCatalog(catalogName, options);
-        } catch (NoMatchingTableFactoryException e) {
-            // No matching legacy factory found, try using the new stack
+            final CatalogFactory factory = getCatalogFactory(discoveryContext);
 
-            final DefaultCatalogContext discoveryContext =
-                    new DefaultCatalogContext(catalogName, options, configuration, classLoader);
-            try {
-                final CatalogFactory factory = getCatalogFactory(discoveryContext);
-
-                // The type option is only used for discovery, we don't actually want to forward it
-                // to the catalog factory itself.
-                final Map<String, String> factoryOptions =
-                        options.entrySet().stream()
-                                .filter(
-                                        entry ->
-                                                !CommonCatalogOptions.CATALOG_TYPE
-                                                        .key()
-                                                        .equals(entry.getKey()))
-                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-                final DefaultCatalogContext context =
-                        new DefaultCatalogContext(
-                                catalogName, factoryOptions, configuration, classLoader);
-                return factory.createCatalog(context);
-            } catch (Throwable t) {
-                throw new ValidationException(
-                        String.format(
-                                "Unable to create catalog '%s'.%n%nCatalog options are:%n%s",
-                                catalogName,
-                                options.entrySet().stream()
-                                        .map(
-                                                optionEntry ->
-                                                        stringifyOption(
-                                                                optionEntry.getKey(),
-                                                                optionEntry.getValue()))
-                                        .sorted()
-                                        .collect(Collectors.joining("\n"))),
-                        t);
-            }
+            // The type option is only used for discovery, we don't actually want to forward it
+            // to the catalog factory itself.
+            final Map<String, String> factoryOptions =
+                    options.entrySet().stream()
+                            .filter(
+                                    entry ->
+                                            !CommonCatalogOptions.CATALOG_TYPE
+                                                    .key()
+                                                    .equals(entry.getKey()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            final DefaultCatalogContext context =
+                    new DefaultCatalogContext(
+                            catalogName, factoryOptions, configuration, classLoader);
+            return factory.createCatalog(context);
+        } catch (Throwable t) {
+            throw new ValidationException(
+                    String.format(
+                            "Unable to create catalog '%s'.%n%nCatalog options are:%n%s",
+                            catalogName,
+                            options.entrySet().stream()
+                                    .map(
+                                            optionEntry ->
+                                                    stringifyOption(
+                                                            optionEntry.getKey(),
+                                                            optionEntry.getValue()))
+                                    .sorted()
+                                    .collect(Collectors.joining("\n"))),
+                    t);
         }
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogITCase.java
@@ -99,53 +99,6 @@ class CatalogITCase {
     }
 
     @Test
-    void testCreateLegacyCatalogFromUserClassLoader() throws Exception {
-        final String className = "UserCatalogFactory";
-        URLClassLoader classLoader =
-                ClassLoaderUtils.withRoot(TempDirUtils.newFolder(temporaryFolder))
-                        .addResource(
-                                "META-INF/services/org.apache.flink.table.legacy.factories.TableFactory",
-                                "UserCatalogFactory")
-                        .addClass(
-                                className,
-                                "import org.apache.flink.table.catalog.GenericInMemoryCatalog;\n"
-                                        + "import org.apache.flink.table.factories.CatalogFactory;\n"
-                                        + "import java.util.Collections;\n"
-                                        + "import org.apache.flink.table.catalog.Catalog;\n"
-                                        + "import java.util.HashMap;\n"
-                                        + "import java.util.List;\n"
-                                        + "import java.util.Map;\n"
-                                        + "\tpublic class UserCatalogFactory implements CatalogFactory {\n"
-                                        + "\t\t@Override\n"
-                                        + "\t\tpublic Catalog createCatalog(\n"
-                                        + "\t\t\t\tString name,\n"
-                                        + "\t\t\t\tMap<String, String> properties) {\n"
-                                        + "\t\t\treturn new GenericInMemoryCatalog(name);\n"
-                                        + "\t\t}\n"
-                                        + "\n"
-                                        + "\t\t@Override\n"
-                                        + "\t\tpublic Map<String, String> requiredContext() {\n"
-                                        + "\t\t\tHashMap<String, String> hashMap = new HashMap<>();\n"
-                                        + "\t\t\thashMap.put(\"type\", \"userCatalog\");\n"
-                                        + "\t\t\treturn hashMap;\n"
-                                        + "\t\t}\n"
-                                        + "\n"
-                                        + "\t\t@Override\n"
-                                        + "\t\tpublic List<String> supportedProperties() {\n"
-                                        + "\t\t\treturn Collections.emptyList();\n"
-                                        + "\t\t}\n"
-                                        + "\t}")
-                        .build();
-
-        try (TemporaryClassLoaderContext context = TemporaryClassLoaderContext.of(classLoader)) {
-            TableEnvironment tableEnvironment = getTableEnvironment();
-            tableEnvironment.executeSql("CREATE CATALOG cat WITH ('type'='userCatalog')");
-
-            assertThat(tableEnvironment.getCatalog("cat")).isPresent();
-        }
-    }
-
-    @Test
     void testCreateCatalogFromUserClassLoader() throws Exception {
         final String className = "UserCatalogFactory";
         URLClassLoader classLoader =


### PR DESCRIPTION
## What is the purpose of the change

*Remove all deprecated methods in `CatalogFactory`* 


## Brief change log

*Remove all deprecated methods in `CatalogFactory`* 


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
