### PR TITLE
[FLINK-36613][tests] Ensure RescaleCheckpointManuallyITCase.testCheckpointRescalingInKeyedState runs with large enough value for STARTING_MEMORY_SEGMENT_SIZE

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescaleCheckpointManuallyITCase.java
@@ -27,8 +27,10 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExternalizedCheckpointRetention;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.configuration.StateBackendOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
@@ -87,6 +89,9 @@ public class RescaleCheckpointManuallyITCase extends TestLogger {
         Configuration config = new Configuration();
         config.set(StateBackendOptions.STATE_BACKEND, "rocksdb");
         config.set(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true);
+        config.set(
+                TaskManagerOptions.STARTING_MEMORY_SEGMENT_SIZE,
+                MemorySize.parse(String.valueOf(Short.MAX_VALUE)));
 
         cluster =
                 new MiniClusterWithClientResource(


### PR DESCRIPTION


## What is the purpose of the change

There is a floating issue while execution of `RescaleCheckpointManuallyITCase.testCheckpointRescalingInKeyedState`
also could be reproduced locally like
```
cd flink-tests

for i in $(seq 1 100); do ../mvnw -Dtest=RescaleCheckpointManuallyITCase test || break ; done
```

It seems it starts appearing after introduction of default value for `STARTING_MEMORY_SEGMENT_SIZE` (FLINK-36556)
The idea is to use the value for this config option which was used before that change

## Brief change log
RescaleCheckpointManuallyITCase


## Verifying this change
Existing tests
\+
```
cd flink-tests

for i in $(seq 1 100); do ../mvnw -Dtest=RescaleCheckpointManuallyITCase test || break ; done
```

 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
