### PR TITLE
[FLINK-36615] Support LEAD/LAG functions in Table API

### DIFF
--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -867,6 +867,28 @@ def json_array_agg(on_null: JsonOnNull, item_expr) -> Expression:
     return _binary_op("jsonArrayAgg", on_null._to_j_json_on_null(), item_expr)
 
 
+def lag(expr, offset=1, default=None) -> Expression:
+    """
+    A window function that provides access to a row at a specified physical offset which comes
+    before the current row.
+    """
+    if default is None:
+        return _binary_op("lag", expr, offset)
+    else:
+        return _ternary_op("lag", expr, offset, default)
+
+
+def lead(expr, offset=1, default=None) -> Expression:
+    """
+    A window function that provides access to a row at a specified physical offset which comes
+    after the current row.
+    """
+    if default is None:
+        return _binary_op("lead", expr, offset)
+    else:
+        return _ternary_op("lead", expr, offset, default)
+
+
 def call(f: Union[str, UserDefinedFunctionWrapper], *args) -> Expression:
     """
     The first parameter `f` could be a str or a Python user-defined function.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -948,13 +948,12 @@ public final class Expressions {
     }
 
     /**
-     * A window function that provides access to a row at a specified physical offset which comes
-     * after the current row.
+     * A window function that provides access to a row that comes directly after the current row.
      *
      * <p>Example:
      *
      * <pre>{@code
-     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     * table.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
      *    .select(
      *       $("organisation"),
      *       $("revenue"),
@@ -973,7 +972,7 @@ public final class Expressions {
      * <p>Example:
      *
      * <pre>{@code
-     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     * table.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
      *    .select(
      *       $("organisation"),
      *       $("revenue"),
@@ -989,10 +988,14 @@ public final class Expressions {
      * A window function that provides access to a row at a specified physical offset which comes
      * after the current row.
      *
+     * <p>The value to return when offset is beyond the scope of the partition. If a default value
+     * is not specified, NULL is returned. {@code default} must be type-compatible with {@code
+     * value}.
+     *
      * <p>Example:
      *
      * <pre>{@code
-     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     * table.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
      *    .select(
      *       $("organisation"),
      *       $("revenue"),
@@ -1005,13 +1008,12 @@ public final class Expressions {
     }
 
     /**
-     * A window function that provides access to a row at a specified physical offset which comes
-     * before the current row.
+     * A window function that provides access to a row that comes directly before the current row.
      *
      * <p>Example:
      *
      * <pre>{@code
-     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     * table.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
      *    .select(
      *       $("organisation"),
      *       $("revenue"),
@@ -1030,7 +1032,7 @@ public final class Expressions {
      * <p>Example:
      *
      * <pre>{@code
-     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     * table.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
      *    .select(
      *       $("organisation"),
      *       $("revenue"),
@@ -1045,6 +1047,10 @@ public final class Expressions {
     /**
      * A window function that provides access to a row at a specified physical offset which comes
      * before the current row.
+     *
+     * <p>The value to return when offset is beyond the scope of the partition. If a default value
+     * is not specified, NULL is returned. {@code default} must be type-compatible with {@code
+     * value}.
      *
      * <p>Example:
      *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -948,6 +948,120 @@ public final class Expressions {
     }
 
     /**
+     * A window function that provides access to a row at a specified physical offset which comes
+     * after the current row.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     *    .select(
+     *       $("organisation"),
+     *       $("revenue"),
+     *       lag($("revenue")).over($("w").as("next_revenue")
+     *    )
+     * }</pre>
+     */
+    public static ApiExpression lead(Object value) {
+        return apiCall(BuiltInFunctionDefinitions.LEAD, value);
+    }
+
+    /**
+     * A window function that provides access to a row at a specified physical offset which comes
+     * after the current row.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     *    .select(
+     *       $("organisation"),
+     *       $("revenue"),
+     *       lag($("revenue"), 1).over($("w").as("next_revenue")
+     *    )
+     * }</pre>
+     */
+    public static ApiExpression lead(Object value, Object offset) {
+        return apiCall(BuiltInFunctionDefinitions.LEAD, value, offset);
+    }
+
+    /**
+     * A window function that provides access to a row at a specified physical offset which comes
+     * after the current row.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     *    .select(
+     *       $("organisation"),
+     *       $("revenue"),
+     *       lag($("revenue"), 1, lit(0)).over($("w").as("next_revenue")
+     *    )
+     * }</pre>
+     */
+    public static ApiExpression lead(Object value, Object offset, Object defaultValue) {
+        return apiCall(BuiltInFunctionDefinitions.LEAD, value, offset, defaultValue);
+    }
+
+    /**
+     * A window function that provides access to a row at a specified physical offset which comes
+     * before the current row.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     *    .select(
+     *       $("organisation"),
+     *       $("revenue"),
+     *       lag($("revenue")).over($("w").as("prev_revenue")
+     *    )
+     * }</pre>
+     */
+    public static ApiExpression lag(Object value) {
+        return apiCall(BuiltInFunctionDefinitions.LAG, value);
+    }
+
+    /**
+     * A window function that provides access to a row at a specified physical offset which comes
+     * before the current row.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     *    .select(
+     *       $("organisation"),
+     *       $("revenue"),
+     *       lag($("revenue"), 1).over($("w").as("prev_revenue")
+     *    )
+     * }</pre>
+     */
+    public static ApiExpression lag(Object value, Object offset) {
+        return apiCall(BuiltInFunctionDefinitions.LAG, value, offset);
+    }
+
+    /**
+     * A window function that provides access to a row at a specified physical offset which comes
+     * before the current row.
+     *
+     * <p>Example:
+     *
+     * <pre>{@code
+     * org.window(Over.orderBy($("ts")).partitionBy("organisation").as("w"))
+     *    .select(
+     *       $("organisation"),
+     *       $("revenue"),
+     *       lag($("revenue"), 1, lit(0)).over($("w").as("prev_revenue")
+     *    )
+     * }</pre>
+     */
+    public static ApiExpression lag(Object value, Object offset, Object defaultValue) {
+        return apiCall(BuiltInFunctionDefinitions.LAG, value, offset, defaultValue);
+    }
+
+    /**
      * A call to a function that will be looked up in a catalog. There are two kinds of functions:
      *
      * <ul>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindow.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindow.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.api;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.expressions.Expression;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -36,15 +38,15 @@ public final class OverWindow {
     private final Expression alias;
     private final List<Expression> partitioning;
     private final Expression order;
-    private final Expression preceding;
-    private final Optional<Expression> following;
+    private final @Nullable Expression preceding;
+    private final @Nullable Expression following;
 
     OverWindow(
             Expression alias,
             List<Expression> partitionBy,
             Expression orderBy,
-            Expression preceding,
-            Optional<Expression> following) {
+            @Nullable Expression preceding,
+            @Nullable Expression following) {
         this.alias = alias;
         this.partitioning = partitionBy;
         this.order = orderBy;
@@ -64,11 +66,11 @@ public final class OverWindow {
         return order;
     }
 
-    public Expression getPreceding() {
-        return preceding;
+    public Optional<Expression> getPreceding() {
+        return Optional.ofNullable(preceding);
     }
 
     public Optional<Expression> getFollowing() {
-        return following;
+        return Optional.ofNullable(following);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrdered.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrdered.java
@@ -22,10 +22,8 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.expressions.Expression;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
-import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
 
 /** Partially defined over window with (optional) partitioning and order. */
 @PublicEvolving
@@ -66,11 +64,6 @@ public final class OverWindowPartitionedOrdered {
      * @return the fully defined over window
      */
     public OverWindow as(Expression alias) {
-        return new OverWindow(
-                alias,
-                partitionBy,
-                orderBy,
-                valueLiteral(OverWindowRange.UNBOUNDED_RANGE),
-                Optional.empty());
+        return new OverWindow(alias, partitionBy, orderBy, null, null);
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrderedPreceding.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrderedPreceding.java
@@ -21,8 +21,9 @@ package org.apache.flink.table.api;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.expressions.Expression;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
-import java.util.Optional;
 
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
 
@@ -32,8 +33,8 @@ public final class OverWindowPartitionedOrderedPreceding {
 
     private final List<Expression> partitionBy;
     private final Expression orderBy;
-    private final Expression preceding;
-    private Optional<Expression> optionalFollowing = Optional.empty();
+    private final @Nullable Expression preceding;
+    private @Nullable Expression optionalFollowing = null;
 
     OverWindowPartitionedOrderedPreceding(
             List<Expression> partitionBy, Expression orderBy, Expression preceding) {
@@ -69,7 +70,7 @@ public final class OverWindowPartitionedOrderedPreceding {
      * @return an over window with defined following
      */
     public OverWindowPartitionedOrderedPreceding following(Expression following) {
-        optionalFollowing = Optional.of(following);
+        optionalFollowing = following;
         return this;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
@@ -367,7 +367,7 @@ public class ExpressionResolver {
                 overWindow.getAlias(),
                 prepareExpressions(overWindow.getPartitioning()),
                 resolveFieldsInSingleExpression(overWindow.getOrder()),
-                resolveFieldsInSingleExpression(overWindow.getPreceding()),
+                overWindow.getPreceding().map(this::resolveFieldsInSingleExpression).orElse(null),
                 overWindow.getFollowing().map(this::resolveFieldsInSingleExpression).orElse(null));
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/LocalOverWindow.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/LocalOverWindow.java
@@ -36,7 +36,7 @@ public final class LocalOverWindow {
 
     private Expression orderBy;
 
-    private Expression preceding;
+    private @Nullable Expression preceding;
 
     private @Nullable Expression following;
 
@@ -44,7 +44,7 @@ public final class LocalOverWindow {
             Expression alias,
             List<Expression> partitionBy,
             Expression orderBy,
-            Expression preceding,
+            @Nullable Expression preceding,
             @Nullable Expression following) {
         this.alias = alias;
         this.partitionBy = partitionBy;
@@ -65,8 +65,8 @@ public final class LocalOverWindow {
         return orderBy;
     }
 
-    public Expression getPreceding() {
-        return preceding;
+    public Optional<Expression> getPreceding() {
+        return Optional.ofNullable(preceding);
     }
 
     public Optional<Expression> getFollowing() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -788,6 +788,7 @@ public final class BuiltInFunctionDefinitions {
                     .kind(AGGREGATE)
                     .inputTypeStrategy(SpecificInputTypeStrategies.LEAD_LAG)
                     .outputTypeStrategy(SpecificTypeStrategies.LEAD_LAG)
+                    .runtimeProvided()
                     .build();
 
     public static final BuiltInFunctionDefinition LAG =
@@ -796,6 +797,7 @@ public final class BuiltInFunctionDefinitions {
                     .kind(AGGREGATE)
                     .inputTypeStrategy(SpecificInputTypeStrategies.LEAD_LAG)
                     .outputTypeStrategy(SpecificTypeStrategies.LEAD_LAG)
+                    .runtimeProvided()
                     .build();
 
     public static final BuiltInFunctionDefinition LISTAGG =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -788,7 +788,6 @@ public final class BuiltInFunctionDefinitions {
                     .kind(AGGREGATE)
                     .inputTypeStrategy(SpecificInputTypeStrategies.LEAD_LAG)
                     .outputTypeStrategy(SpecificTypeStrategies.LEAD_LAG)
-                    .runtimeProvided()
                     .build();
 
     public static final BuiltInFunctionDefinition LAG =
@@ -797,7 +796,6 @@ public final class BuiltInFunctionDefinitions {
                     .kind(AGGREGATE)
                     .inputTypeStrategy(SpecificInputTypeStrategies.LEAD_LAG)
                     .outputTypeStrategy(SpecificTypeStrategies.LEAD_LAG)
-                    .runtimeProvided()
                     .build();
 
     public static final BuiltInFunctionDefinition LISTAGG =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -788,6 +788,7 @@ public final class BuiltInFunctionDefinitions {
                     .kind(AGGREGATE)
                     .inputTypeStrategy(SpecificInputTypeStrategies.LEAD_LAG)
                     .outputTypeStrategy(SpecificTypeStrategies.LEAD_LAG)
+                    .runtimeDeferred()
                     .build();
 
     public static final BuiltInFunctionDefinition LAG =
@@ -796,6 +797,7 @@ public final class BuiltInFunctionDefinitions {
                     .kind(AGGREGATE)
                     .inputTypeStrategy(SpecificInputTypeStrategies.LEAD_LAG)
                     .outputTypeStrategy(SpecificTypeStrategies.LEAD_LAG)
+                    .runtimeDeferred()
                     .build();
 
     public static final BuiltInFunctionDefinition LISTAGG =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -782,6 +782,22 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(TypeStrategies.aggArg0(t -> t, true))
                     .build();
 
+    public static final BuiltInFunctionDefinition LEAD =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("lead")
+                    .kind(AGGREGATE)
+                    .inputTypeStrategy(SpecificInputTypeStrategies.LEAD_LAG)
+                    .outputTypeStrategy(SpecificTypeStrategies.LEAD_LAG)
+                    .build();
+
+    public static final BuiltInFunctionDefinition LAG =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("lag")
+                    .kind(AGGREGATE)
+                    .inputTypeStrategy(SpecificInputTypeStrategies.LEAD_LAG)
+                    .outputTypeStrategy(SpecificTypeStrategies.LEAD_LAG)
+                    .build();
+
     public static final BuiltInFunctionDefinition LISTAGG =
             BuiltInFunctionDefinition.newBuilder()
                     .name("listAgg")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/CallSyntaxUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/CallSyntaxUtils.java
@@ -53,8 +53,12 @@ class CallSyntaxUtils {
 
     static String overRangeToSerializableString(
             ResolvedExpression preceding, ResolvedExpression following) {
+        if (((ValueLiteralExpression) preceding).isNull()
+                || ((ValueLiteralExpression) following).isNull()) {
+            return "";
+        }
         return String.format(
-                "%s BETWEEN %s AND %s",
+                " %s BETWEEN %s AND %s",
                 isRowsRange(preceding) ? "ROWS" : "RANGE",
                 toStringPrecedingOrFollowing(preceding, true),
                 toStringPrecedingOrFollowing(following, false));

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
@@ -325,10 +325,10 @@ public interface SqlCallSyntax {
                         CallSyntaxUtils.overRangeToSerializableString(
                                 operands.get(2), operands.get(3));
                 if (operands.size() == 4) {
-                    return String.format("%s OVER(ORDER BY %s %s)", projection, order, rangeBounds);
+                    return String.format("%s OVER(ORDER BY %s%s)", projection, order, rangeBounds);
                 } else {
                     return String.format(
-                            "%s OVER(PARTITION BY %s ORDER BY %s %s)",
+                            "%s OVER(PARTITION BY %s ORDER BY %s%s)",
                             projection,
                             CallSyntaxUtils.asSerializableOperand(operands.get(4)),
                             order,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/LeadLagInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/LeadLagInputTypeStrategy.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.ArgumentCount;
+import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.ConstantArgumentCount;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.Signature.Argument;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Type strategy for {@link BuiltInFunctionDefinitions#LAG} & { @link
+ * BuiltInFunctionDefinitions#LEAD}.
+ *
+ * <p>The second argument needs to be NUMERIC if provided. Third argument must have a common type
+ * with the first.
+ */
+@Internal
+public final class LeadLagInputTypeStrategy implements InputTypeStrategy {
+
+    private static final ArgumentTypeStrategy NUMERIC_ARGUMENT =
+            InputTypeStrategies.logical(LogicalTypeFamily.NUMERIC);
+
+    @Override
+    public ArgumentCount getArgumentCount() {
+        return ConstantArgumentCount.between(1, 3);
+    }
+
+    @Override
+    public Optional<List<DataType>> inferInputTypes(
+            CallContext callContext, boolean throwOnFailure) {
+        List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+
+        if (argumentDataTypes.size() == 1) {
+            return Optional.of(argumentDataTypes);
+        }
+
+        Optional<DataType> offsetArg =
+                NUMERIC_ARGUMENT.inferArgumentType(callContext, 1, throwOnFailure);
+
+        if (!offsetArg.isPresent()) {
+            return Optional.empty();
+        }
+
+        final DataType arg0 = argumentDataTypes.get(0);
+        if (argumentDataTypes.size() == 2) {
+            return Optional.of(Arrays.asList(arg0, offsetArg.get()));
+        } else {
+            LogicalType defaultType = argumentDataTypes.get(2).getLogicalType();
+            Optional<LogicalType> commonType =
+                    LogicalTypeMerging.findCommonType(
+                            Arrays.asList(arg0.getLogicalType(), defaultType));
+
+            if (!commonType.isPresent()) {
+                return callContext.fail(
+                        throwOnFailure,
+                        "The default value must have a common "
+                                + "type with the given expression. ARG0: %s, default: %s",
+                        arg0,
+                        defaultType);
+            }
+
+            DataType commonDataType = commonType.map(TypeConversions::fromLogicalToDataType).get();
+            return Optional.of(Arrays.asList(commonDataType, offsetArg.get(), commonDataType));
+        }
+    }
+
+    @Override
+    public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
+        return Arrays.asList(
+                Signature.of(Argument.ofGroup("ANY")),
+                Signature.of(Argument.ofGroup("ANY"), Argument.ofGroup("NUMERIC")),
+                Signature.of(
+                        Argument.ofGroup("COMMON"),
+                        Argument.ofGroup("NUMERIC"),
+                        Argument.ofGroup("COMMON")));
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/LeadLagInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/LeadLagInputTypeStrategy.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Type strategy for {@link BuiltInFunctionDefinitions#LAG} & { @link
+ * Type strategy for {@link BuiltInFunctionDefinitions#LAG} and { @link
  * BuiltInFunctionDefinitions#LEAD}.
  *
  * <p>The second argument needs to be NUMERIC if provided. Third argument must have a common type

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OverTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OverTypeStrategy.java
@@ -33,7 +33,7 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -202,18 +202,6 @@ public class OverTypeStrategy implements InputTypeStrategy {
 
     @Override
     public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
-        return Arrays.asList(
-                Signature.of(
-                        Argument.ofGroup("ANY"),
-                        Argument.ofGroup("TIME ATTRIBUTE"),
-                        Argument.ofGroup("INTERVAL LITERAL | CURRENT_RANGE | UNBOUNDED_RANGE"),
-                        Argument.ofGroup("INTERVAL LITERAL | CURRENT_RANGE | UNBOUNDED_RANGE"),
-                        Argument.ofGroupVarying("ANY")),
-                Signature.of(
-                        Argument.ofGroup("ANY"),
-                        Argument.ofGroup("TIME ATTRIBUTE"),
-                        Argument.ofGroup("BIGINT | CURRENT_ROW | UNBOUNDED_ROW"),
-                        Argument.ofGroup("BIGINT | CURRENT_ROW | UNBOUNDED_ROW"),
-                        Argument.ofGroupVarying("ANY")));
+        return Collections.singletonList(Signature.of(Argument.ofGroupVarying("INTERNAL")));
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OverTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OverTypeStrategy.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.inference.ConstantArgumentCount;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.inference.Signature;
+import org.apache.flink.table.types.inference.Signature.Argument;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
@@ -70,6 +71,27 @@ public class OverTypeStrategy implements InputTypeStrategy {
         final DataType preceding = argumentDataTypes.get(2);
         final DataType following = argumentDataTypes.get(3);
 
+        if (preceding.getLogicalType().is(LogicalTypeRoot.NULL)
+                || following.getLogicalType().is(LogicalTypeRoot.NULL)) {
+            if (!preceding.getLogicalType().is(LogicalTypeRoot.NULL)
+                    || !following.getLogicalType().is(LogicalTypeRoot.NULL)) {
+                return callContext.fail(
+                        throwOnFailure, "Both preceding and following must be provided" + ".");
+            }
+
+            return Optional.of(argumentDataTypes);
+        }
+
+        return validatePrecedingFollowingPresent(
+                callContext, throwOnFailure, preceding, following, argumentDataTypes);
+    }
+
+    private Optional<List<DataType>> validatePrecedingFollowingPresent(
+            CallContext callContext,
+            boolean throwOnFailure,
+            DataType preceding,
+            DataType following,
+            List<DataType> argumentDataTypes) {
         final LogicalTypeRoot precedingTypeRoot = preceding.getLogicalType().getTypeRoot();
         final Optional<String> precedingErr =
                 validateFollowingPreceding(
@@ -182,18 +204,16 @@ public class OverTypeStrategy implements InputTypeStrategy {
     public List<Signature> getExpectedSignatures(FunctionDefinition definition) {
         return Arrays.asList(
                 Signature.of(
-                        Signature.Argument.ofGroup("ANY"),
-                        Signature.Argument.ofGroup("TIME ATTRIBUTE"),
-                        Signature.Argument.ofGroup(
-                                "INTERVAL LITERAL | CURRENT_RANGE | UNBOUNDED_RANGE"),
-                        Signature.Argument.ofGroup(
-                                "INTERVAL LITERAL | CURRENT_RANGE | UNBOUNDED_RANGE"),
-                        Signature.Argument.ofGroupVarying("ANY")),
+                        Argument.ofGroup("ANY"),
+                        Argument.ofGroup("TIME ATTRIBUTE"),
+                        Argument.ofGroup("INTERVAL LITERAL | CURRENT_RANGE | UNBOUNDED_RANGE"),
+                        Argument.ofGroup("INTERVAL LITERAL | CURRENT_RANGE | UNBOUNDED_RANGE"),
+                        Argument.ofGroupVarying("ANY")),
                 Signature.of(
-                        Signature.Argument.ofGroup("ANY"),
-                        Signature.Argument.ofGroup("TIME ATTRIBUTE"),
-                        Signature.Argument.ofGroup("BIGINT | CURRENT_ROW | UNBOUNDED_ROW"),
-                        Signature.Argument.ofGroup("BIGINT | CURRENT_ROW | UNBOUNDED_ROW"),
-                        Signature.Argument.ofGroupVarying("ANY")));
+                        Argument.ofGroup("ANY"),
+                        Argument.ofGroup("TIME ATTRIBUTE"),
+                        Argument.ofGroup("BIGINT | CURRENT_ROW | UNBOUNDED_ROW"),
+                        Argument.ofGroup("BIGINT | CURRENT_ROW | UNBOUNDED_ROW"),
+                        Argument.ofGroupVarying("ANY")));
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -167,6 +167,12 @@ public final class SpecificInputTypeStrategies {
     /** Type strategy specific for {@link BuiltInFunctionDefinitions#IN}. */
     public static final InputTypeStrategy IN = new SubQueryInputTypeStrategy();
 
+    /**
+     * Type strategy for {@link BuiltInFunctionDefinitions#LAG} & { @link
+     * BuiltInFunctionDefinitions#LEAD}.
+     */
+    public static final InputTypeStrategy LEAD_LAG = new LeadLagInputTypeStrategy();
+
     private SpecificInputTypeStrategies() {
         // no instantiation
     }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificInputTypeStrategies.java
@@ -168,7 +168,7 @@ public final class SpecificInputTypeStrategies {
     public static final InputTypeStrategy IN = new SubQueryInputTypeStrategy();
 
     /**
-     * Type strategy for {@link BuiltInFunctionDefinitions#LAG} & { @link
+     * Type strategy for {@link BuiltInFunctionDefinitions#LAG} and { @link
      * BuiltInFunctionDefinitions#LEAD}.
      */
     public static final InputTypeStrategy LEAD_LAG = new LeadLagInputTypeStrategy();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -22,11 +22,13 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -168,6 +170,23 @@ public final class SpecificTypeStrategies {
                                             .getElementDataType(),
                                     ((CollectionDataType) callContext.getArgumentDataTypes().get(1))
                                             .getElementDataType()));
+
+    /**
+     * Strategy for {@link org.apache.flink.table.functions.BuiltInFunctionDefinitions#LAG} and
+     * {@link org.apache.flink.table.functions.BuiltInFunctionDefinitions#LEAD}. Returns a nullable
+     * type of arg0, unless the default value is not null. In that case the result will be not null.
+     */
+    public static final TypeStrategy LEAD_LAG =
+            callContext -> {
+                final List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+                final DataType arg0 = argumentDataTypes.get(0);
+                if (argumentDataTypes.size() == 3
+                        && !argumentDataTypes.get(2).getLogicalType().isNullable()) {
+                    return Optional.of(arg0.notNull());
+                } else {
+                    return Optional.of(arg0.nullable());
+                }
+            };
 
     private SpecificTypeStrategies() {
         // no instantiation

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types.inference;
 
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.inference.strategies.SpecificTypeStrategies;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.utils.LogicalTypeMerging;
 
@@ -178,6 +179,23 @@ class TypeStrategiesTest extends TypeStrategiesTestBase {
                         .expectDataType(DataTypes.DOUBLE()),
                 TypeStrategiesTestBase.TestSpec.forStrategy(PERCENTILE)
                         .inputTypes(DataTypes.INT(), DataTypes.ARRAY(DataTypes.DECIMAL(5, 2)))
-                        .expectDataType(DataTypes.ARRAY(DataTypes.DOUBLE())));
+                        .expectDataType(DataTypes.ARRAY(DataTypes.DOUBLE())),
+
+                // LeadLagStrategy
+                TypeStrategiesTestBase.TestSpec.forStrategy(
+                                "Expression not null", SpecificTypeStrategies.LEAD_LAG)
+                        .inputTypes(DataTypes.INT().notNull(), DataTypes.BIGINT())
+                        .expectDataType(DataTypes.INT()),
+                TypeStrategiesTestBase.TestSpec.forStrategy(
+                                "Default value not null", SpecificTypeStrategies.LEAD_LAG)
+                        .inputTypes(
+                                DataTypes.STRING(),
+                                DataTypes.BIGINT(),
+                                DataTypes.STRING().notNull())
+                        .expectDataType(DataTypes.STRING().notNull()),
+                TypeStrategiesTestBase.TestSpec.forStrategy(
+                                "Default value nullable", SpecificTypeStrategies.LEAD_LAG)
+                        .inputTypes(DataTypes.STRING(), DataTypes.BIGINT(), DataTypes.STRING())
+                        .expectDataType(DataTypes.STRING()));
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/LeadLagInputTypeStrategyTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/strategies/LeadLagInputTypeStrategyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.inference.InputTypeStrategiesTestBase;
+
+import java.util.stream.Stream;
+
+/** Tests for {@link LeadLagInputTypeStrategy}. */
+class LeadLagInputTypeStrategyTest extends InputTypeStrategiesTestBase {
+
+    @Override
+    protected Stream<TestSpec> testData() {
+        return Stream.of(
+                TestSpec.forStrategy(SpecificInputTypeStrategies.LEAD_LAG)
+                        .calledWithArgumentTypes(
+                                DataTypes.BIGINT(), DataTypes.SMALLINT(), DataTypes.INT())
+                        .calledWithLiteralAt(1)
+                        .expectSignature(
+                                "f(<ANY>)\n"
+                                        + "f(<ANY>, <NUMERIC>)\n"
+                                        + "f(<COMMON>, <NUMERIC>, <COMMON>)")
+                        .expectArgumentTypes(
+                                DataTypes.BIGINT(), DataTypes.SMALLINT(), DataTypes.BIGINT()),
+                TestSpec.forStrategy(SpecificInputTypeStrategies.LEAD_LAG)
+                        .calledWithArgumentTypes(
+                                DataTypes.BIGINT(), DataTypes.SMALLINT(), DataTypes.STRING())
+                        .expectErrorMessage(
+                                "The default value must have a"
+                                        + " common type with the given expression. ARG0: BIGINT, "
+                                        + "default: STRING"),
+                TestSpec.forStrategy(SpecificInputTypeStrategies.LEAD_LAG)
+                        .calledWithArgumentTypes(DataTypes.BIGINT(), DataTypes.STRING())
+                        .expectErrorMessage(
+                                "Unsupported argument type. "
+                                        + "Expected type of family 'NUMERIC' but actual type was 'STRING'."));
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/SqlAggFunctionVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/SqlAggFunctionVisitor.java
@@ -70,6 +70,9 @@ public class SqlAggFunctionVisitor extends ExpressionDefaultVisitor<SqlAggFuncti
                 BuiltInFunctionDefinitions.FIRST_VALUE, FlinkSqlOperatorTable.FIRST_VALUE);
         AGG_DEF_SQL_OPERATOR_MAPPING.put(
                 BuiltInFunctionDefinitions.LAST_VALUE, FlinkSqlOperatorTable.LAST_VALUE);
+        AGG_DEF_SQL_OPERATOR_MAPPING.put(BuiltInFunctionDefinitions.LAG, FlinkSqlOperatorTable.LAG);
+        AGG_DEF_SQL_OPERATOR_MAPPING.put(
+                BuiltInFunctionDefinitions.LEAD, FlinkSqlOperatorTable.LEAD);
         AGG_DEF_SQL_OPERATOR_MAPPING.put(
                 BuiltInFunctionDefinitions.LISTAGG, FlinkSqlOperatorTable.LISTAGG);
         AGG_DEF_SQL_OPERATOR_MAPPING.put(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlExecutionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlExecutionTest.java
@@ -75,6 +75,7 @@ public class QueryOperationSqlExecutionTest implements TableTestProgramRunner {
                 QueryOperationTestPrograms.OVER_WINDOW_RANGE,
                 QueryOperationTestPrograms.OVER_WINDOW_ROWS,
                 QueryOperationTestPrograms.OVER_WINDOW_ROWS_UNBOUNDED_NO_PARTITION,
+                QueryOperationTestPrograms.OVER_WINDOW_LAG,
                 QueryOperationTestPrograms.ACCESSING_NESTED_COLUMN);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlSerializationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationSqlSerializationTest.java
@@ -64,6 +64,7 @@ public class QueryOperationSqlSerializationTest implements TableTestProgramRunne
                 QueryOperationTestPrograms.OVER_WINDOW_RANGE,
                 QueryOperationTestPrograms.OVER_WINDOW_ROWS,
                 QueryOperationTestPrograms.OVER_WINDOW_ROWS_UNBOUNDED_NO_PARTITION,
+                QueryOperationTestPrograms.OVER_WINDOW_LAG,
                 QueryOperationTestPrograms.ACCESSING_NESTED_COLUMN);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/api/QueryOperationTestPrograms.java
@@ -940,9 +940,9 @@ public class QueryOperationTestPrograms {
                                             .select($("ts"), lag($("b"), 1).over($("bLag"))),
                             "sink_t")
                     .runSql(
-                            "SELECT `ts`, (LAG(`b`, 1) OVER(ORDER BY `r_time`)) AS `_c1` FROM (\n"
-                                    + "    SELECT `ts`, `b`, `r_time` FROM `default_catalog`.`default_database`.`t`\n"
-                                    + ")")
+                            "SELECT `$$T_PROJECT`.`ts`, (LAG(`$$T_PROJECT`.`b`, 1) OVER(ORDER BY `$$T_PROJECT`.`r_time`)) AS `_c1` FROM (\n"
+                                    + "    SELECT `$$T_SOURCE`.`ts`, `$$T_SOURCE`.`b`, `$$T_SOURCE`.`r_time` FROM `default_catalog`.`default_database`.`t` $$T_SOURCE\n"
+                                    + ") $$T_PROJECT")
                     .build();
 
     static final TableTestProgram ACCESSING_NESTED_COLUMN =


### PR DESCRIPTION
## What is the purpose of the change

Support `LEAD/LAG` functions natively in Table API.


## Verifying this change

Added tests for input, output strategies and e2e test for serializing and executing table API programs as SQL.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
