### PR TITLE
[FLINK-36617] migrate kyro package

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -112,7 +112,7 @@ under the License.
 
 		<!-- for the fallback generic serializer -->
 		<dependency>
-			<groupId>com.esotericsoftware.kryo</groupId>
+			<groupId>com.esotericsoftware</groupId>
 			<artifactId>kryo</artifactId>
 			<!-- managed version -->
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,7 @@ under the License.
 		<!-- Can be set to any value to reproduce a specific build. -->
 		<test.randomization.seed/>
 		<test.unit.pattern>**/*Test.*</test.unit.pattern>
+		<kryo.version>4.0.3</kryo.version>
 	</properties>
 
 	<dependencies>
@@ -756,9 +757,9 @@ under the License.
 
 			<!-- kryo used in different versions by Flink an chill -->
 			<dependency>
-				<groupId>com.esotericsoftware.kryo</groupId>
+				<groupId>com.esotericsoftware</groupId>
 				<artifactId>kryo</artifactId>
-				<version>2.24.0</version>
+				<version>${kryo.version}</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
## What is the purpose of the change

Migrate kryo package

## Brief change log

Kryo has been moved to the com.esotericsoftware package. Updating to this version will enhance capabilities, ensure the dependency is up to date, and address vulnerabilities in the current dependencies, specifically [CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)

Package details: https://mvnrepository.com/artifact/com.esotericsoftware/kryo/4.0.3

Updating to version 4.0.3, as higher versions are causing local build failures.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
