### PR TITLE
[FLINK-36622] Remove the dependency of StateBenchmark on RocksDBKeyedStateBackend APIs.

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/state/benchmark/StateBackendBenchmarkUtils.java
@@ -280,10 +280,22 @@ public class StateBackendBenchmarkUtils {
                 function);
     }
 
-    public static <K, S extends State, T> void compactState(
-            RocksDBKeyedStateBackend<K> backend, StateDescriptor<S, T> stateDescriptor)
+    /**
+     * Compact state if the backend is RocksDBKeyedStateBackend.
+     *
+     * @param backend The backend for which the state is bind to.
+     * @param stateDescriptor The descriptor for the state.
+     * @return true if the backend is RocksDBKeyedStateBackend, false otherwise
+     * @throws RocksDBException thrown if an error occurs within RocksDB
+     */
+    public static <K, S extends State, T> boolean compactState(
+            KeyedStateBackend<K> backend, StateDescriptor<S, T> stateDescriptor)
             throws RocksDBException {
-        backend.compactState(stateDescriptor);
+        if (!(backend instanceof RocksDBKeyedStateBackend)) {
+            return false;
+        }
+        ((RocksDBKeyedStateBackend<K>) backend).compactState(stateDescriptor);
+        return true;
     }
 
     public static void cleanUp(KeyedStateBackend<?> backend) throws IOException {


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, flink-benchmarks relies on non-public APIs in Flink. For example, in StateBackendBenchmarkUtils.java, the function compactState takes RocksDBKeyedStateBackend as its first argument.

This requires explicit type conversion in flink-benchmark(from KeyedStateBackend to RocksDBKeyedStateBackend). Moreover, this means that once the signature of RocksDBKeyedStateBackend changes, we need to modify flink-benchmark correspondingly.

Therefore, we should avoid exposing non-public APIs in StateBackendBenchmarkUtils.


## Brief change log

Change the 1st argument of `StateBackendBenchmarkUtils#compactState` from RocksDBKeyedStateBackend to KeyedStateBackend.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
