### PR TITLE
[FLINK-36011][runtime] Improved logging in StateTransitionManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
@@ -157,7 +157,7 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
         Preconditions.checkState(
                 !(phase instanceof Transitioning),
                 "The state transition operation has already been triggered.");
-        LOG.debug("Transitioning from {} to {}.", phase, newPhase);
+        LOG.info("Transitioning from {} to {}.", phase, newPhase);
         phase = newPhase;
     }
 
@@ -228,6 +228,11 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
         void onChange() {}
 
         void onTrigger() {}
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName();
+        }
     }
 
     /**
@@ -345,6 +350,7 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
 
         private void transitionToSubSequentStateForDesiredResources() {
             if (hasDesiredResources()) {
+                LOG.info("Desired resources are met, transitioning to the subsequent state.");
                 context().triggerTransitionToSubsequentState();
             } else {
                 LOG.debug(
@@ -373,6 +379,7 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
         @Override
         void onTrigger() {
             if (hasSufficientResources()) {
+                LOG.info("Sufficient resources are met, progressing to subsequent state.");
                 context().triggerTransitionToSubsequentState();
             } else {
                 LOG.debug("Sufficient resources are not met, progressing to idling.");


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the log-level regression introduced in https://github.com/apache/flink/pull/25280#discussion_r1818949028


## Brief change log

  - The log level reverted back to the INFO in the StateTransitionManager
  - Added a few more log lines  in the StateTransitionManager


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
