### PR TITLE
[FLINK-30284][flink-metrics] Adding datacenter url property to datadog

### DIFF
--- a/docs/content/docs/deployment/metric_reporters.md
+++ b/docs/content/docs/deployment/metric_reporters.md
@@ -257,7 +257,8 @@ Parameters:
 - `apikey` - the Datadog API key
 - `proxyHost` - (optional) The proxy host to use when sending to Datadog.
 - `proxyPort` - (optional) The proxy port to use when sending to Datadog, defaults to 8080.
-- `dataCenter` - (optional) The data center (`EU`/`US`) to connect to, defaults to `US`.
+- `dataCenter` - (deprecated/optional) The data center (`EU`/`US`) to connect to, defaults to `US`. *DEPRECATED* will be removed in a future flink version, please use `dataCenterUrl`.
+- `dataCenterUrl`- (optional) The datacenter url to connect to, defaults to `https://app.datadoghq.com`.
 - `maxMetricsPerRequest` - (optional) The maximum number of metrics to include in each request, defaults to 2000.
 - `useLogicalIdentifier` -> (optional) Whether the reporter uses a logical metric identifier, defaults to `false`.
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -41,9 +41,9 @@ public class DatadogHttpClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(DatadogHttpClient.class);
 
     private static final String SERIES_URL_FORMAT =
-            "https://app.datadoghq.%s/api/v1/series?api_key=%s";
+            "%s/api/v1/series?api_key=%s";
     private static final String VALIDATE_URL_FORMAT =
-            "https://app.datadoghq.%s/api/v1/validate?api_key=%s";
+            "%s/api/v1/validate?api_key=%s";
     private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
     private static final int TIMEOUT = 3;
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -60,7 +60,7 @@ public class DatadogHttpClient {
             String dgApiKey,
             String dgProxyHost,
             int dgProxyPort,
-            DataCenter dataCenter,
+            String dataCenterUrl,
             boolean validateApiKey) {
         if (dgApiKey == null || dgApiKey.isEmpty()) {
             throw new IllegalArgumentException("Invalid API key:" + dgApiKey);
@@ -79,8 +79,8 @@ public class DatadogHttpClient {
                         .proxy(proxy)
                         .build();
 
-        seriesUrl = String.format(SERIES_URL_FORMAT, dataCenter.getDomain(), apiKey);
-        validateUrl = String.format(VALIDATE_URL_FORMAT, dataCenter.getDomain(), apiKey);
+        seriesUrl = String.format(SERIES_URL_FORMAT, dataCenterUrl, apiKey);
+        validateUrl = String.format(VALIDATE_URL_FORMAT, dataCenterUrl, apiKey);
 
         if (validateApiKey) {
             validateApiKey();

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -67,20 +67,20 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
             String proxyHost,
             int proxyPort,
             int maxMetricsPerRequestValue,
-            DataCenter dataCenter,
+            String dataCenterUrl,
             String tags,
             boolean useLogicalIdentifier) {
         this.maxMetricsPerRequestValue = maxMetricsPerRequestValue;
         this.useLogicalIdentifier = useLogicalIdentifier;
-        this.client = new DatadogHttpClient(apiKey, proxyHost, proxyPort, dataCenter, true);
+        this.client = new DatadogHttpClient(apiKey, proxyHost, proxyPort, dataCenterUrl, true);
         this.configTags = getTagsFromConfig(tags);
 
         LOGGER.info(
-                "Configured DatadogHttpReporter with {tags={}, proxyHost={}, proxyPort={}, dataCenter={}, maxMetricsPerRequest={}",
+                "Configured DatadogHttpReporter with {tags={}, proxyHost={}, proxyPort={}, dataCenterUrl={}, maxMetricsPerRequest={}",
                 tags,
                 proxyHost,
                 proxyPort,
-                dataCenter,
+                dataCenterUrl,
                 maxMetricsPerRequestValue);
     }
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporterFactory.java
@@ -30,11 +30,13 @@ import java.util.Properties;
 public class DatadogHttpReporterFactory implements MetricReporterFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(DatadogHttpReporterFactory.class);
+    private static final String DEFAULT_DATACENTER_DOMAIN = "https://app.datadoghq.%s";
 
     private static final String API_KEY = "apikey";
     private static final String PROXY_HOST = "proxyHost";
     private static final String PROXY_PORT = "proxyPort";
     private static final String DATA_CENTER = "dataCenter";
+    private static final String DATA_CENTER_URL = "dataCenterUrl";
     private static final String TAGS = "tags";
     private static final String MAX_METRICS_PER_REQUEST = "maxMetricsPerRequest";
     private static final String USE_LOGICAL_IDENTIFIER = "useLogicalIdentifier";
@@ -44,10 +46,18 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
         final String apiKey = config.getProperty(API_KEY, null);
         final String proxyHost = config.getProperty(PROXY_HOST, null);
         final int proxyPort = Integer.valueOf(config.getProperty(PROXY_PORT, "8080"));
+
+        if (config.containsKey(DATA_CENTER)) {
+            LOG.warn(
+                    "The 'dataCenter' option is deprecated; please use 'dataCenterUrl' instead.");
+        }
         final String rawDataCenter = config.getProperty(DATA_CENTER, "US");
+        final String dataCenterUrl = config.getProperty(
+                DATA_CENTER_URL,
+                String.format(DEFAULT_DATACENTER_DOMAIN,  DataCenter.valueOf(rawDataCenter).getDomain()));
+
         final int maxMetricsPerRequestValue =
                 Integer.valueOf(config.getProperty(MAX_METRICS_PER_REQUEST, "2000"));
-        final DataCenter dataCenter = DataCenter.valueOf(rawDataCenter);
         if (config.containsKey(TAGS)) {
             LOG.warn(
                     "The 'tags' option is deprecated; please use 'scope.variables.additional' instead.");
@@ -61,7 +71,7 @@ public class DatadogHttpReporterFactory implements MetricReporterFactory {
                 proxyHost,
                 proxyPort,
                 maxMetricsPerRequestValue,
-                dataCenter,
+                dataCenterUrl,
                 tags,
                 useLogicalIdentifier);
     }

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -46,6 +46,7 @@ class DatadogHttpClientTest {
             tags.stream().collect(Collectors.joining("\",\"", "[\"", "\"]"));
     private static final String HOST = "localhost";
     private static final String METRIC = "testMetric";
+    private static final String DATACENTER_URL = "https://app.datadoghq.com";
 
     private static final ObjectMapper MAPPER;
 
@@ -58,27 +59,27 @@ class DatadogHttpClientTest {
 
     @Test
     void testClientWithEmptyKey() {
-        assertThatThrownBy(() -> new DatadogHttpClient("", null, 123, DataCenter.US, false))
+        assertThatThrownBy(() -> new DatadogHttpClient("", null, 123, DATACENTER_URL, false))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testClientWithNullKey() {
-        assertThatThrownBy(() -> new DatadogHttpClient(null, null, 123, DataCenter.US, false))
+        assertThatThrownBy(() -> new DatadogHttpClient(null, null, 123, DATACENTER_URL, false))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void testGetProxyWithNullProxyHost() {
         DatadogHttpClient client =
-                new DatadogHttpClient("anApiKey", null, 123, DataCenter.US, false);
+                new DatadogHttpClient("anApiKey", null, 123, DATACENTER_URL, false);
         assert (client.getProxy() == Proxy.NO_PROXY);
     }
 
     @Test
     void testGetProxy() {
         DatadogHttpClient client =
-                new DatadogHttpClient("anApiKey", "localhost", 123, DataCenter.US, false);
+                new DatadogHttpClient("anApiKey", "localhost", 123, DATACENTER_URL, false);
 
         assertThat(client.getProxy().address()).isInstanceOf(InetSocketAddress.class);
 


### PR DESCRIPTION
## What is the purpose of the change

This change deprecates the `dataCenter` configuration for DataDog reporter and replaces it with `dataCenterUrl` that allows users to configure whole address of the data center to use.

## Brief change log

  - Deprecates dataCenter key from DataDog reporter configuration (logs a warning to the users).
  - Add new configuration option dataCenterUrl that accepts full address of Data Dog site, it defaults to US data center.


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).


This change is already covered by existing tests, such as `DatadogHttpClientTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know): no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know): no
  - The S3 file system connector: (yes / no / don't know): no

## Documentation

  - Does this pull request introduce a new feature? (yes / no): yes
  - If yes, how is the feature documented? docs
