### PR TITLE
[FLINK-36499][table]Remove deprecated method `SupportsProjectionPushD…

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
@@ -57,14 +57,6 @@ public interface SupportsProjectionPushDown {
     /** Returns whether this source supports nested projection. */
     boolean supportsNestedProjection();
 
-    /** @deprecated Please implement {@link #applyProjection(int[][], DataType)} */
-    @Deprecated
-    default void applyProjection(int[][] projectedFields) {
-        throw new UnsupportedOperationException(
-                "No implementation provided for SupportsProjectionPushDown. "
-                        + "Please implement SupportsProjectionPushDown#applyProjection(int[][], DataType)");
-    }
-
     /**
      * Provides the field index paths that should be used for a projection. The indices are 0-based
      * and support fields within (possibly nested) structures if this is enabled via {@link
@@ -87,6 +79,8 @@ public interface SupportsProjectionPushDown {
      * @param producedDataType the final output type of the source, with the projection applied
      */
     default void applyProjection(int[][] projectedFields, DataType producedDataType) {
-        applyProjection(projectedFields);
+        throw new UnsupportedOperationException(
+                "No implementation provided for SupportsProjectionPushDown. "
+                        + "Please implement SupportsProjectionPushDown#applyProjection(int[][], DataType)");
     }
 }


### PR DESCRIPTION
# [FLINK-36499][table]Remove deprecated method \`SupportsProjectionPushDown#applyProjection`



## What is the purpose of the change

Remove all deprecated method `SupportsProjectionPushDown#applyProjection`

## Brief change log

Remove all deprecated method `SupportsProjectionPushDown#applyProjection`

## Verifying this change

This change is a simple code cleanup without any specific usage.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (no)

