### PR TITLE
[FLINK-36496][table]Remove deprecated method `CatalogFunction#isGeneric`

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -1827,18 +1827,8 @@ public class HiveCatalog extends AbstractCatalog {
 
     @Internal
     public static boolean isHiveTable(Table table) {
-        boolean isHiveTable;
-        if (table.getParameters().containsKey(CatalogPropertiesUtil.IS_GENERIC)) {
-            isHiveTable =
-                    !Boolean.parseBoolean(
-                            table.getParameters().remove(CatalogPropertiesUtil.IS_GENERIC));
-        } else {
-            isHiveTable =
-                    !table.getParameters().containsKey(FLINK_PROPERTY_PREFIX + CONNECTOR.key())
-                            && !table.getParameters()
-                                    .containsKey(FLINK_PROPERTY_PREFIX + CONNECTOR_TYPE);
-        }
-        return isHiveTable;
+        return !table.getParameters().containsKey(FLINK_PROPERTY_PREFIX + CONNECTOR.key())
+                && !table.getParameters().containsKey(FLINK_PROPERTY_PREFIX + CONNECTOR_TYPE);
     }
 
     @Internal
@@ -1994,10 +1984,6 @@ public class HiveCatalog extends AbstractCatalog {
                 break;
             default:
                 throw new CatalogException("Unsupported alter database op:" + opStr);
-        }
-        // is_generic is deprecated, remove it
-        if (hiveDB.getParameters() != null) {
-            hiveDB.getParameters().remove(CatalogPropertiesUtil.IS_GENERIC);
         }
         return hiveDB;
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveTableUtil.java
@@ -81,7 +81,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.catalog.CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX;
-import static org.apache.flink.table.catalog.CatalogPropertiesUtil.IS_GENERIC;
 import static org.apache.flink.table.catalog.hive.util.Constants.ALTER_TABLE_OP;
 import static org.apache.flink.table.catalog.hive.util.Constants.COLLECTION_DELIM;
 import static org.apache.flink.table.catalog.hive.util.Constants.SERDE_INFO_PROP_PREFIX;
@@ -91,7 +90,6 @@ import static org.apache.flink.table.catalog.hive.util.Constants.STORED_AS_INPUT
 import static org.apache.flink.table.catalog.hive.util.Constants.STORED_AS_OUTPUT_FORMAT;
 import static org.apache.flink.table.catalog.hive.util.Constants.TABLE_IS_EXTERNAL;
 import static org.apache.flink.table.catalog.hive.util.Constants.TABLE_LOCATION_URI;
-import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -541,15 +539,6 @@ public class HiveTableUtil {
             }
 
             properties = maskFlinkProperties(properties);
-            // we may need to explicitly set is_generic flag in the following cases:
-            // 1. user doesn't specify 'connector' or 'connector.type' when creating a table, w/o
-            // 'is_generic', such a table will be considered as a hive table upon retrieval
-            // 2. when creating views which don't have connector properties
-            if (isView
-                    || (!properties.containsKey(FLINK_PROPERTY_PREFIX + CONNECTOR.key())
-                            && !properties.containsKey(FLINK_PROPERTY_PREFIX + CONNECTOR_TYPE))) {
-                properties.put(IS_GENERIC, "true");
-            }
             hiveTable.setParameters(properties);
         }
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogGenericMetadataTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogPartition;
-import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.FunctionLanguage;
@@ -48,7 +47,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -109,7 +107,6 @@ class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
                             tablePath.getDatabaseName(), tablePath.getObjectName());
             hiveTable.setDbName(tablePath.getDatabaseName());
             hiveTable.setTableName(tablePath.getObjectName());
-            setLegacyGeneric(hiveTable.getParameters());
             hiveTable.getParameters().put("flink.generic.table.schema.0.name", "ti");
             hiveTable.getParameters().put("flink.generic.table.schema.0.data-type", "TINYINT");
             hiveTable.getParameters().put("flink.generic.table.schema.1.name", "si");
@@ -164,7 +161,6 @@ class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
                             tablePath.getDatabaseName(), tablePath.getObjectName());
             hiveTable.setDbName(tablePath.getDatabaseName());
             hiveTable.setTableName(tablePath.getObjectName());
-            setLegacyGeneric(hiveTable.getParameters());
             hiveTable.setTableName(tablePath.getObjectName());
             hiveTable.getParameters().put("flink.generic.table.schema.0.name", "c");
             hiveTable.getParameters().put("flink.generic.table.schema.0.data-type", "CHAR(265)");
@@ -220,7 +216,6 @@ class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
                             tablePath.getDatabaseName(), tablePath.getObjectName());
             hiveTable.setDbName(tablePath.getDatabaseName());
             hiveTable.setTableName(tablePath.getObjectName());
-            setLegacyGeneric(hiveTable.getParameters());
             hiveTable.setTableName(tablePath.getObjectName());
             hiveTable.getParameters().put("flink.generic.table.schema.0.name", "dt");
             hiveTable.getParameters().put("flink.generic.table.schema.0.data-type", "DATE");
@@ -272,7 +267,6 @@ class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
                             tablePath.getDatabaseName(), tablePath.getObjectName());
             hiveTable.setDbName(tablePath.getDatabaseName());
             hiveTable.setTableName(tablePath.getObjectName());
-            setLegacyGeneric(hiveTable.getParameters());
             hiveTable.setTableName(tablePath.getObjectName());
             hiveTable.getParameters().put("flink.generic.table.schema.0.name", "a");
             hiveTable.getParameters().put("flink.generic.table.schema.0.data-type", "ARRAY<INT>");
@@ -517,11 +511,6 @@ class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
     // ------ test utils ------
 
     @Override
-    protected boolean isGeneric() {
-        return true;
-    }
-
-    @Override
     public CatalogPartition createPartition() {
         throw new UnsupportedOperationException();
     }
@@ -540,9 +529,5 @@ class HiveCatalogGenericMetadataTest extends HiveCatalogMetadataTestBase {
     protected CatalogFunction createAnotherFunction() {
         return new CatalogFunctionImpl(
                 TestSimpleUDF.class.getCanonicalName(), FunctionLanguage.SCALA);
-    }
-
-    private static void setLegacyGeneric(Map<String, String> properties) {
-        properties.put(CatalogPropertiesUtil.IS_GENERIC, "true");
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
-import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTestUtil;
 import org.apache.flink.table.catalog.CatalogView;
@@ -135,8 +134,6 @@ class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
                             name, HiveTypeUtil.toHiveTypeInfo(type, true).getTypeName(), null));
         }
         hiveView.getSd().setCols(fields);
-        // test mark as non-generic with is_generic
-        hiveView.getParameters().put(CatalogPropertiesUtil.IS_GENERIC, "false");
         // add some other properties
         hiveView.getParameters().put("k1", "v1");
 
@@ -152,7 +149,6 @@ class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
         // test mark as non-generic with connector
         hiveView.setDbName(path3.getDatabaseName());
         hiveView.setTableName(path3.getObjectName());
-        hiveView.getParameters().remove(CatalogPropertiesUtil.IS_GENERIC);
         hiveView.getParameters().put(CONNECTOR.key(), IDENTIFIER);
 
         ((HiveCatalog) catalog).client.createTable(hiveView);
@@ -650,11 +646,6 @@ class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
     private void createPartition(Map<String, String> partitionSpec) throws Exception {
         catalog.createPartition(
                 path1, new CatalogPartitionSpec(partitionSpec), createPartition(), true);
-    }
-
-    @Override
-    protected boolean isGeneric() {
-        return false;
     }
 
     @Override

--- a/flink-python/docs/reference/pyflink.table/catalog.rst
+++ b/flink-python/docs/reference/pyflink.table/catalog.rst
@@ -142,7 +142,6 @@ Represents a partition object in catalog.
     CatalogFunction.copy
     CatalogFunction.get_description
     CatalogFunction.get_detailed_description
-    CatalogFunction.is_generic
     CatalogFunction.get_function_language
 
 

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -1089,16 +1089,6 @@ class CatalogFunction(object):
         else:
             return None
 
-    def is_generic(self) -> bool:
-        """
-        Whether or not is the function a flink UDF.
-
-        :return: Whether is the function a flink UDF.
-
-        .. versionadded:: 1.10.0
-        """
-        return self._j_catalog_function.isGeneric()
-
     def get_function_language(self):
         """
         Get the language used for the function definition.

--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -74,7 +74,6 @@ class CatalogTestBase(PyFlinkTestCase):
 
     def check_catalog_function_equals(self, f1, f2):
         self.assertEqual(f1.get_class_name(), f2.get_class_name())
-        self.assertEqual(f1.is_generic(), f2.is_generic())
         self.assertEqual(f1.get_function_language(), f2.get_function_language())
 
     def check_catalog_partition_equals(self, p1, p2):

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.resource.ResourceUri;
 import org.apache.flink.util.StringUtils;
 
@@ -75,23 +74,6 @@ public class CatalogFunctionImpl implements CatalogFunction {
     @Override
     public Optional<String> getDetailedDescription() {
         return Optional.of("This is a user-defined function");
-    }
-
-    @Override
-    public boolean isGeneric() {
-        if (functionLanguage == FunctionLanguage.PYTHON) {
-            return true;
-        }
-        try {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            Class c = Class.forName(className, true, cl);
-            if (UserDefinedFunction.class.isAssignableFrom(c)) {
-                return true;
-            }
-        } catch (ClassNotFoundException e) {
-            throw new RuntimeException(String.format("Can't resolve udf class %s", className), e);
-        }
-        return false;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -876,12 +876,6 @@ public final class FunctionCatalog {
         }
 
         @Override
-        public boolean isGeneric() {
-            throw new UnsupportedOperationException(
-                    "This CatalogFunction is a InlineCatalogFunction. This method should not be called.");
-        }
-
-        @Override
         public FunctionLanguage getFunctionLanguage() {
             return FunctionLanguage.JAVA;
         }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogTestBase.java
@@ -168,7 +168,7 @@ public abstract class CatalogTestBase extends CatalogTest {
         return new HashMap<String, String>() {
             {
                 put(IS_STREAMING, "false");
-                putAll(getGenericFlag(isGeneric()));
+                put(FactoryUtil.CONNECTOR.key(), "hive");
             }
         };
     }
@@ -177,20 +177,8 @@ public abstract class CatalogTestBase extends CatalogTest {
         return new HashMap<String, String>() {
             {
                 put(IS_STREAMING, "true");
-                putAll(getGenericFlag(isGeneric()));
+                put(FactoryUtil.CONNECTOR.key(), "hive");
             }
         };
     }
-
-    private Map<String, String> getGenericFlag(boolean isGeneric) {
-        return new HashMap<String, String>() {
-            {
-                String connector = isGeneric ? "COLLECTION" : "hive";
-                put(FactoryUtil.CONNECTOR.key(), connector);
-            }
-        };
-    }
-
-    /** Whether the test meta-object is generic or not. */
-    protected abstract boolean isGeneric();
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -211,11 +211,6 @@ class GenericInMemoryCatalogTest extends CatalogTestBase {
 
     // ------ utilities ------
 
-    @Override
-    protected boolean isGeneric() {
-        return true;
-    }
-
     private CatalogColumnStatistics createColumnStats() {
         CatalogColumnStatisticsDataBoolean booleanColStats =
                 new CatalogColumnStatisticsDataBoolean(55L, 45L, 5L);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
@@ -57,16 +57,6 @@ public interface CatalogFunction {
     Optional<String> getDetailedDescription();
 
     /**
-     * Distinguish if the function is a generic function.
-     *
-     * @return whether the function is a generic function
-     * @deprecated There is no replacement for this function, as now functions have type inference
-     *     strategies
-     */
-    @Deprecated
-    boolean isGeneric();
-
-    /**
      * Get the language used for the definition of function.
      *
      * @return the language type of the function definition

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogPropertiesUtil.java
@@ -56,14 +56,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public final class CatalogPropertiesUtil {
 
     /**
-     * Flag to distinguish if a meta-object is a generic Flink object or not.
-     *
-     * <p>It is used to distinguish between Flink's generic connector discovery logic or specialized
-     * catalog connectors.
-     */
-    public static final String IS_GENERIC = "is_generic";
-
-    /**
      * Globally reserved prefix for catalog properties. User-defined properties should not use this
      * prefix. E.g. it is used to distinguish properties created by Hive and Flink, as Hive
      * metastore has its own properties created upon table creation and migration between different
@@ -90,8 +82,6 @@ public final class CatalogPropertiesUtil {
 
             properties.putAll(resolvedTable.getOptions());
 
-            properties.remove(IS_GENERIC); // reserved option
-
             return properties;
         } catch (Exception e) {
             throw new CatalogException("Error in serializing catalog table.", e);
@@ -111,8 +101,6 @@ public final class CatalogPropertiesUtil {
             }
 
             properties.putAll(resolvedView.getOptions());
-
-            properties.remove(IS_GENERIC); // reserved option
 
             return properties;
         } catch (Exception e) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -1739,7 +1739,6 @@ public abstract class CatalogTest {
 
     protected void checkEquals(CatalogFunction f1, CatalogFunction f2) {
         assertThat(f2.getClassName()).isEqualTo(f1.getClassName());
-        assertThat(f2.isGeneric()).isEqualTo(f1.isGeneric());
         assertThat(f2.getFunctionLanguage()).isEqualTo(f1.getFunctionLanguage());
     }
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/UserDefinedFunctionHelperTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/UserDefinedFunctionHelperTest.java
@@ -251,11 +251,6 @@ class UserDefinedFunctionHelperTest {
         }
 
         @Override
-        public boolean isGeneric() {
-            return false;
-        }
-
-        @Override
         public FunctionLanguage getFunctionLanguage() {
             return FunctionLanguage.JAVA;
         }


### PR DESCRIPTION


## What is the purpose of the change

Remove all deprecated methods `CatalogFunction#isGeneric`

## Brief change log

Remove deprecated methods `CatalogFunction#isGeneric`

## Verifying this change

This change is a simple code cleanup without any specific usage.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
- The S3 file system connector: (no)

## Documentation

- Does this pull request introduce a new feature? (no)