### PR TITLE
[FLINK-36642][table] Fix SQL names of built-in functions

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ExpressionSerializationTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ExpressionSerializationTest.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.lit;
 import static org.apache.flink.table.api.Expressions.timestampDiff;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -129,6 +130,8 @@ public class ExpressionSerializationTest {
                 TestSpec.forExpr(Expressions.negative($("f0")))
                         .withField("f0", DataTypes.BIGINT())
                         .expectStr("- `f0`"),
+                TestSpec.forExpr(Expressions.randInteger(Expressions.lit(10)))
+                        .expectStr("RAND_INTEGER(10)"),
                 TestSpec.forExpr($("f0").in(1, 2, 3, 4, 5))
                         .withField("f0", DataTypes.INT())
                         .expectStr("`f0` IN (1, 2, 3, 4, 5)"),
@@ -194,6 +197,27 @@ public class ExpressionSerializationTest {
                 TestSpec.forExpr($("f0").substring(2, 5))
                         .withField("f0", DataTypes.STRING())
                         .expectStr("SUBSTRING(`f0` FROM 2 FOR 5)"),
+                TestSpec.forExpr($("f0").charLength())
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("CHAR_LENGTH(`f0`)"),
+                TestSpec.forExpr($("f0").fromBase64())
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("FROM_BASE64(`f0`)"),
+                TestSpec.forExpr($("f0").toBase64())
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("TO_BASE64(`f0`)"),
+                TestSpec.forExpr($("f0").parseUrl(lit("HOST")))
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("PARSE_URL(`f0`, 'HOST')"),
+                TestSpec.forExpr($("f0").regexpReplace(lit("[0-9]"), lit("$")))
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("REGEXP_REPLACE(`f0`, '[0-9]', '$')"),
+                TestSpec.forExpr($("f0").splitIndex(lit(":"), lit(2)))
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("SPLIT_INDEX(`f0`, ':', 2)"),
+                TestSpec.forExpr($("f0").strToMap())
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("STR_TO_MAP(`f0`)"),
                 TestSpec.forExpr($("f0").get("g0").plus($("f0").get("g1").get("h1")))
                         .withField(
                                 "f0",
@@ -289,6 +313,18 @@ public class ExpressionSerializationTest {
                                         .plus($("f0").max()))
                         .withField("f0", DataTypes.BIGINT())
                         .expectStr("((COUNT(DISTINCT `f0`)) + (AVG(DISTINCT `f0`))) + (MAX(`f0`))"),
+                TestSpec.forExpr($("f0").stddevPop())
+                        .withField("f0", DataTypes.BIGINT())
+                        .expectStr("STDDEV_POP(`f0`)"),
+                TestSpec.forExpr($("f0").stddevSamp())
+                        .withField("f0", DataTypes.BIGINT())
+                        .expectStr("STDDEV_SAMP(`f0`)"),
+                TestSpec.forExpr($("f0").varPop())
+                        .withField("f0", DataTypes.BIGINT())
+                        .expectStr("VAR_POP(`f0`)"),
+                TestSpec.forExpr($("f0").varSamp())
+                        .withField("f0", DataTypes.BIGINT())
+                        .expectStr("VAR_SAMP(`f0`)"),
 
                 // Time functions
                 TestSpec.forExpr($("f0").extract(TimeIntervalUnit.HOUR))
@@ -312,7 +348,35 @@ public class ExpressionSerializationTest {
                 TestSpec.forExpr(timestampDiff(TimePointUnit.DAY, $("f0"), $("f1")))
                         .withField("f0", DataTypes.TIMESTAMP())
                         .withField("f1", DataTypes.TIMESTAMP())
-                        .expectStr("TIMESTAMPDIFF(DAY, `f0`, `f1`)"));
+                        .expectStr("TIMESTAMPDIFF(DAY, `f0`, `f1`)"),
+                TestSpec.forExpr(Expressions.currentDate()).expectStr("CURRENT_DATE()"),
+                TestSpec.forExpr(Expressions.currentTime()).expectStr("CURRENT_TIME()"),
+                TestSpec.forExpr(Expressions.currentTimestamp()).expectStr("CURRENT_TIMESTAMP()"),
+                TestSpec.forExpr(Expressions.dateFormat($("f0"), lit("yyyy-MM-dd")))
+                        .withField("f0", DataTypes.TIMESTAMP(3))
+                        .expectStr("DATE_FORMAT(`f0`, 'yyyy-MM-dd')"),
+                TestSpec.forExpr(Expressions.toTimestamp($("f0")))
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("TO_TIMESTAMP(`f0`)"),
+                TestSpec.forExpr(Expressions.toTimestampLtz($("f0"), lit(3)))
+                        .withField("f0", DataTypes.BIGINT())
+                        .expectStr("TO_TIMESTAMP_LTZ(`f0`, 3)"),
+                TestSpec.forExpr($("f0").toDate())
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("CAST(`f0` AS DATE)"),
+                TestSpec.forExpr($("f0").toTime())
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("CAST(`f0` AS TIME(0))"),
+                TestSpec.forExpr($("f0").toTimestamp())
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("CAST(`f0` AS TIMESTAMP(3))"),
+                TestSpec.forExpr(Expressions.convertTz($("f0"), lit("PST"), lit("GMT")))
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("CONVERT_TZ(`f0`, 'PST', 'GMT')"),
+                TestSpec.forExpr(Expressions.fromUnixtime($("f0")))
+                        .withField("f0", DataTypes.BIGINT())
+                        .expectStr("FROM_UNIXTIME(`f0`)"),
+                TestSpec.forExpr(Expressions.unixTimestamp()).expectStr("UNIX_TIMESTAMP()"));
     }
 
     @ParameterizedTest

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -2174,7 +2174,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition CURRENT_ROW_TIMESTAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("currentRowTimestamp")
-                    .name("CURRENT_ROW_TIMESTAMP")
+                    .sqlName("CURRENT_ROW_TIMESTAMP")
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIMESTAMP_LTZ(3).notNull()))
                     .notDeterministic()

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -811,6 +811,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition STDDEV_POP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("stddevPop")
+                    .sqlName("STDDEV_POP")
                     .kind(AGGREGATE)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
                     .outputTypeStrategy(
@@ -820,6 +821,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition STDDEV_SAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("stddevSamp")
+                    .sqlName("STDDEV_SAMP")
                     .kind(AGGREGATE)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
                     .outputTypeStrategy(
@@ -829,6 +831,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition VAR_POP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("varPop")
+                    .sqlName("VAR_POP")
                     .kind(AGGREGATE)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
                     .outputTypeStrategy(
@@ -838,6 +841,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition VAR_SAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("varSamp")
+                    .sqlName("VAR_SAMP")
                     .kind(AGGREGATE)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.NUMERIC)))
                     .outputTypeStrategy(
@@ -896,6 +900,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition CHAR_LENGTH =
             BuiltInFunctionDefinition.newBuilder()
                     .name("charLength")
+                    .sqlName("CHAR_LENGTH")
                     .kind(SCALAR)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
                     .outputTypeStrategy(nullableIfArgs(explicit(INT())))
@@ -1288,6 +1293,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition FROM_BASE64 =
             BuiltInFunctionDefinition.newBuilder()
                     .name("fromBase64")
+                    .sqlName("FROM_BASE64")
                     .kind(SCALAR)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
@@ -1296,6 +1302,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition TO_BASE64 =
             BuiltInFunctionDefinition.newBuilder()
                     .name("toBase64")
+                    .sqlName("TO_BASE64")
                     .kind(SCALAR)
                     .inputTypeStrategy(sequence(logical(LogicalTypeFamily.CHARACTER_STRING)))
                     .outputTypeStrategy(nullableIfArgs(explicit(DataTypes.STRING())))
@@ -1391,6 +1398,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition PARSE_URL =
             BuiltInFunctionDefinition.newBuilder()
                     .name("parseUrl")
+                    .sqlName("PARSE_URL")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             or(
@@ -1496,6 +1504,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition REGEXP_REPLACE =
             BuiltInFunctionDefinition.newBuilder()
                     .name("regexpReplace")
+                    .sqlName("REGEXP_REPLACE")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             sequence(
@@ -1516,6 +1525,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition SPLIT_INDEX =
             BuiltInFunctionDefinition.newBuilder()
                     .name("splitIndex")
+                    .sqlName("SPLIT_INDEX")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             sequence(
@@ -1528,6 +1538,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition STR_TO_MAP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("strToMap")
+                    .sqlName("STR_TO_MAP")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             or(
@@ -2030,6 +2041,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition RAND_INTEGER =
             BuiltInFunctionDefinition.newBuilder()
                     .name("randInteger")
+                    .sqlName("RAND_INTEGER")
                     .kind(SCALAR)
                     .notDeterministic()
                     .inputTypeStrategy(
@@ -2124,6 +2136,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition CURRENT_DATE =
             BuiltInFunctionDefinition.newBuilder()
                     .name("currentDate")
+                    .sqlName("CURRENT_DATE")
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(DATE().notNull()))
                     .build();
@@ -2131,6 +2144,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition CURRENT_TIME =
             BuiltInFunctionDefinition.newBuilder()
                     .name("currentTime")
+                    .sqlName("CURRENT_TIME")
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIME().notNull()))
                     .build();
@@ -2145,6 +2159,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition CURRENT_TIMESTAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("currentTimestamp")
+                    .sqlName("CURRENT_TIMESTAMP")
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIMESTAMP_LTZ(3).notNull()))
                     .build();
@@ -2159,6 +2174,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition CURRENT_ROW_TIMESTAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("currentRowTimestamp")
+                    .name("CURRENT_ROW_TIMESTAMP")
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIMESTAMP_LTZ(3).notNull()))
                     .notDeterministic()
@@ -2190,6 +2206,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition DATE_FORMAT =
             BuiltInFunctionDefinition.newBuilder()
                     .name("dateFormat")
+                    .sqlName("DATE_FORMAT")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             or(
@@ -2237,6 +2254,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition CONVERT_TZ =
             BuiltInFunctionDefinition.newBuilder()
                     .name("convertTz")
+                    .sqlName("CONVERT_TZ")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             sequence(
@@ -2249,6 +2267,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition FROM_UNIXTIME =
             BuiltInFunctionDefinition.newBuilder()
                     .name("fromUnixtime")
+                    .sqlName("FROM_UNIXTIME")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             or(
@@ -2262,6 +2281,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition UNIX_TIMESTAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("unixTimestamp")
+                    .sqlName("UNIX_TIMESTAMP")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             or(
@@ -2276,6 +2296,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition TO_DATE =
             BuiltInFunctionDefinition.newBuilder()
                     .name("toDate")
+                    .sqlName("TO_DATE")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             or(
@@ -2289,6 +2310,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition TO_TIMESTAMP_LTZ =
             BuiltInFunctionDefinition.newBuilder()
                     .name("toTimestampLtz")
+                    .sqlName("TO_TIMESTAMP_LTZ")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             sequence(
@@ -2300,6 +2322,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition TO_TIMESTAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("toTimestamp")
+                    .sqlName("TO_TIMESTAMP")
                     .kind(SCALAR)
                     .inputTypeStrategy(
                             or(


### PR DESCRIPTION
## What is the purpose of the change

Fix the SQL names of several built-in functions. 
The names are used to serialize Table API expressions to SQL. Using wrong function names results in SQL statements that cannot be executed.

## Brief change log

* add `sqlName()` to several `BuiltInFunctionDefinition` in `BuiltInFunctionDefinitions`
* add test cases to `ExpressionSerializationTest`

## Verifying this change

This change added tests and can be verified as follows:

* run `ExpressionSerializationTest` unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes (`BuiltInFunctionDefinitions` is `@PublicEvolving`)
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
