### PR TITLE
[FLINK-36830][table] Override json-path version in Calcite to deal with CVE

### DIFF
--- a/flink-table/flink-table-calcite-bridge/pom.xml
+++ b/flink-table/flink-table-calcite-bridge/pom.xml
@@ -152,7 +152,27 @@ under the License.
 					<groupId>org.locationtech.proj4j</groupId>
 					<artifactId>proj4j</artifactId>
 				</exclusion>
+				<!--
+				Exclude json-path as we are manually overriding it to a newer version (FLINK-36830).
+				This can be removed once calcite is upgraded to 1.38 or greater, more details
+				in JIRA issue FLINK-36602.
+				-->
+				<exclusion>
+					<groupId>com.jayway.jsonpath</groupId>
+					<artifactId>json-path</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+
+		<!--
+		Override the json-path version used by Calcite to deal with CVE-2023-1370 (FLINK-36830).
+		This can be removed once calcite is upgraded to 1.38 or greater, more details
+		in JIRA issue FLINK-36602.
+		 -->
+		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+			<version>2.9.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## What is the purpose of the change

There is a high severity CVE ([CVE-2023-1370](https://nvd.nist.gov/vuln/detail/CVE-2023-1370)) in the json-path version used by the Calcite library (currently version 1.34) used in the `flink-table-calcite-bridge` module.

Newer versions of Calcite update to newer versions of `json-path`. However, updating Calcite to the latest 1.38 version ([FLINK-36602](https://issues.apache.org/jira/browse/FLINK-36602)) is not straightforward and involves changes to the SQL parsing logic. Following [discussion](https://lists.apache.org/thread/7ogwvj5z3o176dw95145dzvlolrkyps4) on the dev mailing list, an incremental Calcite upgrade process is preferred. Therefore, this PR simply patches the transitive dependency.

Note: The `flink-table-runtime` directly depends on `json-path` and is also effected by this CVE. However, `json-path` was recently moved to `flink-shaded`. So we will need to update it there ([PR](https://github.com/apache/flink-shaded/pull/140)) first before fixing the direct dependency in flink master.

## Brief change log

This PR overrides the specific transitive `json-path` (version 2.7.0) dependency in the `flink-table-calcite-bridge` pom file to version 2.9.0.

## Verifying this change

This change is already covered by existing tests in the `flink-table` module.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no