### PR TITLE
[FLINK-36510][rpc] bump pekko to 1.1.2, remove netty 3 (backport to release-1.19)

### DIFF
--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -37,7 +37,7 @@ under the License.
 	</description>
 
 	<properties>
-		<pekko.version>1.0.1</pekko.version>
+		<pekko.version>1.1.2</pekko.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<scala.version>2.12.16</scala.version>
 	</properties>
@@ -94,8 +94,8 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
-			<artifactId>netty</artifactId>
-			<version>3.10.6.Final</version>
+			<artifactId>netty-all</artifactId>
+			<scope>test</scope>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
@@ -172,9 +172,15 @@ under the License.
 									<include>*</include>
 								</includes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>org.apache.flink.shaded.netty4.io.netty</shadedPattern>
+								</relocation>
+							</relocations>
 							<filters>
 								<filter>
-									<artifact>io.netty:netty</artifact>
+									<artifact>io.netty:*</artifact>
 									<excludes>
 										<!-- Only some of these licenses actually apply to the JAR and have been manually
 											 placed in this module's resources directory. -->

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/ActorSystemBootstrapTools.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/ActorSystemBootstrapTools.java
@@ -122,7 +122,9 @@ public class ActorSystemBootstrapTools {
             } catch (Exception e) {
                 // we can continue to try if this contains a netty channel exception
                 Throwable cause = e.getCause();
-                if (!(cause instanceof org.jboss.netty.channel.ChannelException
+                if (!(cause
+                                instanceof
+                                org.apache.flink.shaded.netty4.io.netty.channel.ChannelException
                         || cause instanceof java.net.BindException)) {
                     throw e;
                 } // else fall through the loop and try the next port

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
@@ -27,14 +27,15 @@ import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.function.FunctionUtils;
 
+import org.apache.flink.shaded.netty4.io.netty.util.internal.logging.InternalLoggerFactory;
+import org.apache.flink.shaded.netty4.io.netty.util.internal.logging.Slf4JLoggerFactory;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.Address;
 import org.apache.pekko.actor.AddressFromURIString;
-import org.jboss.netty.logging.InternalLoggerFactory;
-import org.jboss.netty.logging.Slf4JLoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -6,17 +6,17 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.hierynomus:asn-one:0.5.0
+- com.hierynomus:asn-one:0.6.0
 - com.typesafe:config:1.4.2
 - com.typesafe:ssl-config-core_2.12:0.6.1
-- io.netty:netty:3.10.6.Final
-- org.agrona:agrona:1.15.1
-- org.apache.pekko:pekko-actor_2.12:1.0.1
-- org.apache.pekko:pekko-remote_2.12:1.0.1
-- org.apache.pekko:pekko-pki_2.12:1.0.1
-- org.apache.pekko:pekko-protobuf-v3_2.12:1.0.1
-- org.apache.pekko:pekko-slf4j_2.12:1.0.1
-- org.apache.pekko:pekko-stream_2.12:1.0.1
+- io.netty:netty-all:4.1.91.Final
+- org.agrona:agrona:1.22.0
+- org.apache.pekko:pekko-actor_2.12:1.1.2
+- org.apache.pekko:pekko-remote_2.12:1.1.2
+- org.apache.pekko:pekko-pki_2.12:1.1.2
+- org.apache.pekko:pekko-protobuf-v3_2.12:1.1.2
+- org.apache.pekko:pekko-slf4j_2.12:1.1.2
+- org.apache.pekko:pekko-stream_2.12:1.1.2
 - org.scala-lang:scala-library:2.12.16
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Updates Pekko dependency to 1.1.2 which in turn upgrades Netty 3 to 4 (addressing [FLINK-29065](https://issues.apache.org/jira/browse/FLINK-29065) and removing several CVEs from Flink). Pekko 1.1 also upgrades other dependencies such as slf4j and Jackson. For more details see the [Pekko 1.1 release notes](https://pekko.apache.org/docs/pekko/current/release-notes/releases-1.1.html). CC @uce and @ferenc-csaky :smile:

## Brief change log

  - Update Pekko version from 1.0.1 to 1.1.2
  - Replace Pekko Netty 3 dependency with flink-shaded Netty 4 (and test-scoped direct Netty 4 dependency) - _Note [Flink 1.19 uses flink-shaded 17.0](https://github.com/apache/flink/blob/release-1.19/pom.xml#L124), which [bundles Netty 4.1.91.Final](https://github.com/apache/flink-shaded/blob/release-17.0/pom.xml#L65)_
  - Update Netty imports in `ActorSystemBootstrapTools` and `PekkoUtils`
  - Update NOTICE file

## Verifying this change

This change is covered by existing tests in flink-rpc.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable