### PR TITLE
[FLINK-36593][runtime] Upgrade io.airlift:aircompressor to 0.27 [1.20]

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -232,7 +232,7 @@ under the License.
 		<dependency>
 			<groupId>io.airlift</groupId>
 			<artifactId>aircompressor</artifactId>
-			<version>0.21</version>
+			<version>0.27</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 

--- a/flink-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-runtime/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.airlift:aircompressor:0.21
+- io.airlift:aircompressor:0.27


### PR DESCRIPTION
## What is the purpose of the change

Addresses [CVE-2024-36114](https://nvd.nist.gov/vuln/detail/CVE-2024-36114) which concerns a vulnerability in the aircompressor library.

This is a backport of #25567.

## Brief change log

Upgrade the `io.airlift:aircompressor` version used by flink-runtime from `0.21` to `0.27`.

## Verifying this change

This change is already covered by existing tests in the `flink-runtime` module.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no