### PR TITLE
[hotfix] [docs] Correct inaccurate description of JobMaster's role in Flink JobManager

### DIFF
--- a/docs/content.zh/docs/concepts/glossary.md
+++ b/docs/content.zh/docs/concepts/glossary.md
@@ -77,7 +77,7 @@ Flink JobManager 是 [Flink Cluster](#flink-cluster) 的主节点。它包含三
 
 #### Flink JobMaster
 
-JobMaster 是在 [Flink JobManager](#flink-jobmanager) 运行中的组件之一。JobManager 负责监督单个作业 [Task](#task) 的执行。以前，整个 [Flink JobManager](#flink-jobmanager) 都叫做 JobManager。
+JobMaster 是在 [Flink JobManager](#flink-jobmanager) 运行中的组件之一。JobMaster 负责监督单个作业 [Task](#task) 的执行。以前，整个 [Flink JobManager](#flink-jobmanager) 都叫做 JobManager。
 
 #### JobResultStore
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request corrects an inaccurate translation in the documentation regarding the role of JobMaster in Flink's architecture. The current documentation implies that JobManager supervises the execution of individual tasks, whereas it is actually the JobMaster, as a component within the JobManager, that is responsible for overseeing the execution of tasks for a single job.

## Brief change log

  - Updated the documentation to clarify that the JobMaster supervises the tasks for a single job, rather than implying that the JobManager itself manages each task.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no