### PR TITLE
[FLINK-36623] Improve logging in DefaultStateTransitionManager

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -1134,6 +1134,11 @@ public class AdaptiveScheduler
     }
 
     @Override
+    public JobID getJobId() {
+        return jobInfo.getJobId();
+    }
+
+    @Override
     public ArchivedExecutionGraph getArchivedExecutionGraph(
             JobStatus jobStatus, @Nullable Throwable cause) {
         return ArchivedExecutionGraph.createSparseArchivedExecutionGraphWithJobVertices(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
@@ -386,7 +386,15 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
                 Temporal firstChangeEventTimestamp,
                 Duration maxTriggerDelay) {
             super(clock, context);
-            this.scheduleRelativelyTo(this::onTrigger, firstChangeEventTimestamp, maxTriggerDelay);
+            this.scheduleRelativelyTo(
+                    () -> {
+                        LOG.info(
+                                "Scheduled onTrigger event fired in Stabilized phase, job {}.",
+                                getJobId());
+                        onTrigger();
+                    },
+                    firstChangeEventTimestamp,
+                    maxTriggerDelay);
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.scheduler.adaptive;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -109,13 +110,13 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
 
     @Override
     public void onChange() {
-        LOG.debug("OnChange event received in phase {}.", getPhase());
+        LOG.debug("OnChange event received in phase {} for job {}.", getPhase(), getJobId());
         phase.onChange();
     }
 
     @Override
     public void onTrigger() {
-        LOG.debug("OnTrigger event received in phase {}.", getPhase());
+        LOG.debug("OnTrigger event received in phase {} for job {}.", getPhase(), getJobId());
         phase.onTrigger();
     }
 
@@ -157,7 +158,7 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
         Preconditions.checkState(
                 !(phase instanceof Transitioning),
                 "The state transition operation has already been triggered.");
-        LOG.info("Transitioning from {} to {}.", phase, newPhase);
+        LOG.info("Transitioning from {} to {}, job {}.", phase, newPhase, getJobId());
         phase = newPhase;
     }
 
@@ -172,10 +173,15 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
             callback.run();
         } else {
             LOG.debug(
-                    "Ignoring scheduled action because expected phase {} is not the actual phase {}.",
+                    "Ignoring scheduled action because expected phase {} is not the actual phase {}, job {}.",
                     expectedPhase,
-                    getPhase());
+                    getPhase(),
+                    getJobId());
         }
+    }
+
+    private JobID getJobId() {
+        return transitionContext.getJobId();
     }
 
     /**
@@ -232,6 +238,10 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
         @Override
         public String toString() {
             return getClass().getSimpleName();
+        }
+
+        JobID getJobId() {
+            return context.getJobId();
         }
     }
 
@@ -350,11 +360,14 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
 
         private void transitionToSubSequentStateForDesiredResources() {
             if (hasDesiredResources()) {
-                LOG.info("Desired resources are met, transitioning to the subsequent state.");
+                LOG.info(
+                        "Desired resources are met, transitioning to the subsequent state, job {}.",
+                        getJobId());
                 context().triggerTransitionToSubsequentState();
             } else {
                 LOG.debug(
-                        "Desired resources are not met, skipping the transition to the subsequent state.");
+                        "Desired resources are not met, skipping the transition to the subsequent state, job {}.",
+                        getJobId());
             }
         }
     }
@@ -379,10 +392,14 @@ public class DefaultStateTransitionManager implements StateTransitionManager {
         @Override
         void onTrigger() {
             if (hasSufficientResources()) {
-                LOG.info("Sufficient resources are met, progressing to subsequent state.");
+                LOG.info(
+                        "Sufficient resources are met, progressing to subsequent state, job {}.",
+                        getJobId());
                 context().triggerTransitionToSubsequentState();
             } else {
-                LOG.debug("Sufficient resources are not met, progressing to idling.");
+                LOG.debug(
+                        "Sufficient resources are not met, progressing to idling, job {}.",
+                        getJobId());
                 context().progressToIdling();
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Finished.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/Finished.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptive;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 
@@ -57,12 +58,15 @@ class Finished implements State {
     }
 
     @Override
+    public JobID getJobId() {
+        return archivedExecutionGraph.getJobID();
+    }
+
+    @Override
     public void handleGlobalFailure(
             Throwable cause, CompletableFuture<Map<String, String>> failureLabels) {
         logger.debug(
-                "Ignore global failure because we already finished the job {}.",
-                archivedExecutionGraph.getJobID(),
-                cause);
+                "Ignore global failure because we already finished the job {}.", getJobId(), cause);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/State.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptive;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.util.function.FunctionWithException;
@@ -50,6 +51,15 @@ interface State extends LabeledGlobalFailureHandler {
      * @param cause cause for the suspension
      */
     void suspend(Throwable cause);
+
+    /**
+     * Gets the {@link JobID} of the job. The implementation should avoid to use the {@link
+     * State#getJob()} method as it may create the {@link ArchivedExecutionGraph} which is
+     * expensive.
+     *
+     * @return the {@link JobID} of the job
+     */
+    JobID getJobId();
 
     /**
      * Gets the current {@link JobStatus}. The returned job status will remain unchanged at least

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateTransitionManager.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.scheduler.adaptive;
 
+import org.apache.flink.api.common.JobID;
+
 import java.time.Duration;
 import java.util.concurrent.ScheduledFuture;
 
@@ -68,5 +70,12 @@ public interface StateTransitionManager {
          * @return a ScheduledFuture representing pending completion of the operation.
          */
         ScheduledFuture<?> scheduleOperation(Runnable callback, Duration delay);
+
+        /**
+         * Gets the {@link JobID} of the job.
+         *
+         * @return the {@link JobID} of the job
+         */
+        JobID getJobId();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithExecutionGraph.java
@@ -141,7 +141,8 @@ abstract class StateWithExecutionGraph implements State {
         return executionGraph;
     }
 
-    JobID getJobId() {
+    @Override
+    public JobID getJobId() {
         return executionGraph.getJobID();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithoutExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/StateWithoutExecutionGraph.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptive;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 
@@ -54,6 +55,11 @@ abstract class StateWithoutExecutionGraph implements State {
     }
 
     @Override
+    public JobID getJobId() {
+        return context.getJobId();
+    }
+
+    @Override
     public ArchivedExecutionGraph getJob() {
         return context.getArchivedExecutionGraph(getJobStatus(), null);
     }
@@ -71,6 +77,13 @@ abstract class StateWithoutExecutionGraph implements State {
 
     /** Context of the {@link StateWithoutExecutionGraph} state. */
     interface Context extends StateTransitions.ToFinished {
+
+        /**
+         * Gets the {@link JobID} of the job.
+         *
+         * @return the {@link JobID} of the job
+         */
+        JobID getJobId();
 
         /**
          * Creates the {@link ArchivedExecutionGraph} for the given job status and cause. Cause can

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/DefaultStateTransitionManagerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptive;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.testutils.ScheduledTask;
 import org.apache.flink.runtime.scheduler.adaptive.DefaultStateTransitionManager.Idling;
 import org.apache.flink.util.Preconditions;
@@ -464,6 +465,7 @@ class DefaultStateTransitionManagerTest {
         // Instant.MIN makes debugging easier because timestamps become human-readable
         private final Instant initializationTime = Instant.MIN;
         private Duration elapsedTime = Duration.ZERO;
+        private final JobID jobId = new JobID();
 
         // ///////////////////////////////////////////////
         // Context creation
@@ -535,6 +537,11 @@ class DefaultStateTransitionManagerTest {
                     new ScheduledTask<>(Executors.callable(callback), delay.toMillis());
             scheduledTasks.get(triggerTime).add(scheduledTask);
             return scheduledTask;
+        }
+
+        @Override
+        public JobID getJobId() {
+            return jobId;
         }
 
         // ///////////////////////////////////////////////

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -1039,6 +1039,11 @@ class ExecutingTest {
         public void suspend(Throwable cause) {}
 
         @Override
+        public JobID getJobId() {
+            return null;
+        }
+
+        @Override
         public JobStatus getJobStatus() {
             return null;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockStateWithoutExecutionGraphContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockStateWithoutExecutionGraphContext.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptive;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
@@ -38,6 +39,7 @@ class MockStateWithoutExecutionGraphContext
             new StateValidator<>("Finished");
 
     private boolean hasStateTransition = false;
+    private final JobID jobId = new JobID();
 
     public void setExpectFinished(Consumer<ArchivedExecutionGraph> asserter) {
         finishedStateValidator.expectInput(asserter);
@@ -47,6 +49,11 @@ class MockStateWithoutExecutionGraphContext
     public void goToFinished(ArchivedExecutionGraph archivedExecutionGraph) {
         finishedStateValidator.validateInput(archivedExecutionGraph);
         registerStateTransition();
+    }
+
+    @Override
+    public JobID getJobId() {
+        return jobId;
     }
 
     @Override


### PR DESCRIPTION
## Brief change log
- Exposed the JobID in `Adaptive Scheduler` states
- Added JobID to logs in `DefaultStateTransitionManager`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
