### PR TITLE
[FLINK-36602][table] Backport: override json-path version for calcite 1.32

### DIFF
--- a/flink-table/flink-table-calcite-bridge/pom.xml
+++ b/flink-table/flink-table-calcite-bridge/pom.xml
@@ -152,7 +152,19 @@ under the License.
 					<groupId>org.locationtech.proj4j</groupId>
 					<artifactId>proj4j</artifactId>
 				</exclusion>
+				<!-- Exclude json-path as we are manually overriding it to a newer version -->
+				<exclusion>
+					<groupId>com.jayway.jsonpath</groupId>
+					<artifactId>json-path</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+
+		<!-- Override the json-path version used by Calcite 1.32 to deal with CVE-2023-1370 -->
+		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+			<version>2.9.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## What is the purpose of the change

This is a backport of #25602.

There is a high severity CVE ([CVE-2023-1370](https://nvd.nist.gov/vuln/detail/CVE-2023-1370)) in the json-path version used by Calcite 1.32 used in the `flink-table-calcite-bridge` module.

Newer versions of Calcite update to newer versions of `json-path`. However, updating Calcite to the latest version ([FLINK-36602](https://issues.apache.org/jira/browse/FLINK-36602)) is not straightforward and involves changes to the SQL parsing logic. Following [discussion](https://lists.apache.org/thread/7ogwvj5z3o176dw95145dzvlolrkyps4) on the dev mailing list, an incremental Calcite upgrade process is preferred. Therefore, this PR simply patches the transitive dependency.

## Brief change log

This PR overrides the specific transitive `json-path` (version 2.7.0) dependency in the `flink-table-calcite-bridge` pom file to version 2.9.0.

## Verifying this change

This change is already covered by existing tests in the `flink-table` module.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no