### PR TITLE
[FLINK-36675][table-planner] Always serialize dynamic options to exec json plan

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSinkSpec.java
@@ -35,6 +35,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -44,12 +45,10 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DynamicTableSinkSpec extends DynamicTableSpecBase {
 
-    public static final String FIELD_NAME_CATALOG_TABLE = "table";
     public static final String FIELD_NAME_SINK_ABILITIES = "abilities";
 
     public static final String FIELD_NAME_TARGET_COLUMNS = "targetColumns";
 
-    private final ContextResolvedTable contextResolvedTable;
     private final @Nullable List<SinkAbilitySpec> sinkAbilities;
 
     private final @Nullable int[][] targetColumns;
@@ -59,16 +58,12 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
     @JsonCreator
     public DynamicTableSinkSpec(
             @JsonProperty(FIELD_NAME_CATALOG_TABLE) ContextResolvedTable contextResolvedTable,
+            @Nullable @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS) Map<String, String> dynamicOptions,
             @Nullable @JsonProperty(FIELD_NAME_SINK_ABILITIES) List<SinkAbilitySpec> sinkAbilities,
             @Nullable @JsonProperty(FIELD_NAME_TARGET_COLUMNS) int[][] targetColumns) {
-        this.contextResolvedTable = contextResolvedTable;
+        super(contextResolvedTable, dynamicOptions);
         this.sinkAbilities = sinkAbilities;
         this.targetColumns = targetColumns;
-    }
-
-    @JsonGetter(FIELD_NAME_CATALOG_TABLE)
-    public ContextResolvedTable getContextResolvedTable() {
-        return contextResolvedTable;
     }
 
     @JsonGetter(FIELD_NAME_SINK_ABILITIES)
@@ -120,6 +115,7 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
         }
         DynamicTableSinkSpec that = (DynamicTableSinkSpec) o;
         return Objects.equals(contextResolvedTable, that.contextResolvedTable)
+                && Objects.equals(dynamicOptions, that.dynamicOptions)
                 && Objects.equals(sinkAbilities, that.sinkAbilities)
                 && Objects.equals(tableSink, that.tableSink)
                 && Objects.equals(targetColumns, that.targetColumns);
@@ -127,7 +123,8 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
 
     @Override
     public int hashCode() {
-        return Objects.hash(contextResolvedTable, sinkAbilities, targetColumns, tableSink);
+        return Objects.hash(
+                contextResolvedTable, dynamicOptions, sinkAbilities, targetColumns, tableSink);
     }
 
     @Override
@@ -135,6 +132,8 @@ public class DynamicTableSinkSpec extends DynamicTableSpecBase {
         return "DynamicTableSinkSpec{"
                 + "contextResolvedTable="
                 + contextResolvedTable
+                + ", dynamicOptions="
+                + dynamicOptions
                 + ", sinkAbilities="
                 + sinkAbilities
                 + ", targetColumns="

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/DynamicTableSourceSpec.java
@@ -42,6 +42,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -51,10 +52,8 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DynamicTableSourceSpec extends DynamicTableSpecBase {
 
-    public static final String FIELD_NAME_CATALOG_TABLE = "table";
     public static final String FIELD_NAME_SOURCE_ABILITIES = "abilities";
 
-    private final ContextResolvedTable contextResolvedTable;
     private final @Nullable List<SourceAbilitySpec> sourceAbilities;
 
     private DynamicTableSource tableSource;
@@ -62,9 +61,10 @@ public class DynamicTableSourceSpec extends DynamicTableSpecBase {
     @JsonCreator
     public DynamicTableSourceSpec(
             @JsonProperty(FIELD_NAME_CATALOG_TABLE) ContextResolvedTable contextResolvedTable,
+            @Nullable @JsonProperty(FIELD_NAME_DYNAMIC_OPTIONS) Map<String, String> dynamicOptions,
             @Nullable @JsonProperty(FIELD_NAME_SOURCE_ABILITIES)
                     List<SourceAbilitySpec> sourceAbilities) {
-        this.contextResolvedTable = contextResolvedTable;
+        super(contextResolvedTable, dynamicOptions);
         this.sourceAbilities = sourceAbilities;
     }
 
@@ -143,11 +143,6 @@ public class DynamicTableSourceSpec extends DynamicTableSpecBase {
         }
     }
 
-    @JsonGetter(FIELD_NAME_CATALOG_TABLE)
-    public ContextResolvedTable getContextResolvedTable() {
-        return contextResolvedTable;
-    }
-
     @JsonGetter(FIELD_NAME_SOURCE_ABILITIES)
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Nullable
@@ -169,13 +164,14 @@ public class DynamicTableSourceSpec extends DynamicTableSpecBase {
         }
         DynamicTableSourceSpec that = (DynamicTableSourceSpec) o;
         return Objects.equals(contextResolvedTable, that.contextResolvedTable)
+                && Objects.equals(dynamicOptions, that.dynamicOptions)
                 && Objects.equals(sourceAbilities, that.sourceAbilities)
                 && Objects.equals(tableSource, that.tableSource);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(contextResolvedTable, sourceAbilities, tableSource);
+        return Objects.hash(contextResolvedTable, dynamicOptions, sourceAbilities, tableSource);
     }
 
     @Override
@@ -183,6 +179,8 @@ public class DynamicTableSourceSpec extends DynamicTableSpecBase {
         return "DynamicTableSourceSpec{"
                 + "contextResolvedTable="
                 + contextResolvedTable
+                + ", dynamicOptions="
+                + dynamicOptions
                 + ", sourceAbilities="
                 + sourceAbilities
                 + ", tableSource="

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/spec/TemporalTableSourceSpec.java
@@ -37,6 +37,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.Map;
 
 /**
  * TemporalTableSpec describes how the right tale of lookupJoin ser/des.
@@ -57,7 +58,8 @@ public class TemporalTableSourceSpec {
 
     @JsonIgnore private RelOptTable temporalTable;
 
-    public TemporalTableSourceSpec(RelOptTable temporalTable) {
+    public TemporalTableSourceSpec(
+            RelOptTable temporalTable, @Nullable Map<String, String> extraOptions) {
         this.temporalTable = temporalTable;
         if (temporalTable instanceof TableSourceTable) {
             TableSourceTable tableSourceTable = (TableSourceTable) temporalTable;
@@ -65,6 +67,7 @@ public class TemporalTableSourceSpec {
             this.tableSourceSpec =
                     new DynamicTableSourceSpec(
                             tableSourceTable.contextResolvedTable(),
+                            extraOptions,
                             Arrays.asList(tableSourceTable.abilitySpecs()));
         }
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalDynamicFilteringTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalDynamicFilteringTableSourceScan.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.hint.FlinkHints
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecTableSourceScan
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSourceSpec
@@ -85,6 +86,7 @@ class BatchPhysicalDynamicFilteringTableSourceScan(
   override def translateToExecNode(): ExecNode[_] = {
     val tableSourceSpec = new DynamicTableSourceSpec(
       tableSourceTable.contextResolvedTable,
+      FlinkHints.getHintedOptions(getHints),
       util.Arrays.asList(tableSourceTable.abilitySpecs: _*))
     tableSourceSpec.setTableSource(tableSourceTable.tableSource)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalLookupJoin.scala
@@ -42,7 +42,8 @@ class BatchPhysicalLookupJoin(
     temporalTable: RelOptTable,
     tableCalcProgram: Option[RexProgram],
     joinInfo: JoinInfo,
-    joinType: JoinRelType)
+    joinType: JoinRelType,
+    dynamicOptionsOnTemporalTable: util.Map[String, String])
   extends CommonPhysicalLookupJoin(
     cluster,
     traitSet,
@@ -61,7 +62,8 @@ class BatchPhysicalLookupJoin(
       temporalTable,
       tableCalcProgram,
       joinInfo,
-      joinType)
+      joinType,
+      dynamicOptionsOnTemporalTable)
   }
 
   override def translateToExecNode(): ExecNode[_] = {
@@ -78,7 +80,7 @@ class BatchPhysicalLookupJoin(
       JoinTypeUtil.getFlinkJoinType(joinType),
       finalPreFilterCondition.orNull,
       finalRemainingCondition.orNull,
-      new TemporalTableSourceSpec(temporalTable),
+      new TemporalTableSourceSpec(temporalTable, dynamicOptionsOnTemporalTable),
       allLookupKeys.map(item => (Int.box(item._1), item._2)).asJava,
       projectionOnTemporalTable,
       filterOnTemporalTable,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSink.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 import org.apache.flink.table.catalog.ContextResolvedTable
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.hint.FlinkHints
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec
 import org.apache.flink.table.planner.plan.nodes.calcite.Sink
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
@@ -62,6 +63,7 @@ class BatchPhysicalSink(
     val tableSinkSpec =
       new DynamicTableSinkSpec(
         contextResolvedTable,
+        FlinkHints.getHintedOptions(hints),
         util.Arrays.asList(abilitySpecs: _*),
         targetColumns)
     tableSinkSpec.setTableSink(tableSink)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalTableSourceScan.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.hint.FlinkHints
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecTableSourceScan
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSourceSpec
@@ -72,6 +73,7 @@ class BatchPhysicalTableSourceScan(
   override def translateToExecNode(): ExecNode[_] = {
     val tableSourceSpec = new DynamicTableSourceSpec(
       tableSourceTable.contextResolvedTable,
+      FlinkHints.getHintedOptions(getHints),
       util.Arrays.asList(tableSourceTable.abilitySpecs: _*))
     tableSourceSpec.setTableSource(tableSourceTable.tableSource)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLookupJoin.scala
@@ -47,7 +47,8 @@ class StreamPhysicalLookupJoin(
     joinInfo: JoinInfo,
     joinType: JoinRelType,
     lookupHint: Option[RelHint],
-    upsertMaterialize: Boolean)
+    upsertMaterialize: Boolean,
+    dynamicOptionsOnTemporalTable: util.Map[String, String])
   extends CommonPhysicalLookupJoin(
     cluster,
     traitSet,
@@ -72,7 +73,8 @@ class StreamPhysicalLookupJoin(
       joinInfo,
       joinType,
       lookupHint,
-      upsertMaterialize
+      upsertMaterialize,
+      dynamicOptionsOnTemporalTable
     )
   }
 
@@ -86,7 +88,8 @@ class StreamPhysicalLookupJoin(
       joinInfo,
       joinType,
       lookupHint,
-      upsertMaterialize
+      upsertMaterialize,
+      dynamicOptionsOnTemporalTable
     )
   }
 
@@ -104,7 +107,7 @@ class StreamPhysicalLookupJoin(
       JoinTypeUtil.getFlinkJoinType(joinType),
       finalPreFilterCondition.orNull,
       finalRemainingCondition.orNull,
-      new TemporalTableSourceSpec(temporalTable),
+      new TemporalTableSourceSpec(temporalTable, dynamicOptionsOnTemporalTable),
       allLookupKeys.map(item => (Int.box(item._1), item._2)).asJava,
       projectionOnTemporalTable,
       filterOnTemporalTable,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.physical.stream
 import org.apache.flink.table.catalog.ContextResolvedTable
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.hint.FlinkHints
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.calcite.Sink
@@ -85,6 +86,7 @@ class StreamPhysicalSink(
     val tableSinkSpec =
       new DynamicTableSinkSpec(
         contextResolvedTable,
+        FlinkHints.getHintedOptions(hints),
         util.Arrays.asList(abilitySpecs: _*),
         targetColumns)
     tableSinkSpec.setTableSink(tableSink)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalTableSourceScan.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
+import org.apache.flink.table.planner.hint.FlinkHints
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSourceSpec
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan
@@ -74,6 +75,7 @@ class StreamPhysicalTableSourceScan(
   override def translateToExecNode(): ExecNode[_] = {
     val tableSourceSpec = new DynamicTableSourceSpec(
       tableSourceTable.contextResolvedTable,
+      FlinkHints.getHintedOptions(getHints),
       util.Arrays.asList(tableSourceTable.abilitySpecs: _*))
     tableSourceSpec.setTableSource(tableSource)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalLookupJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalLookupJoinRule.scala
@@ -27,6 +27,8 @@ import org.apache.flink.table.planner.plan.rules.physical.common.{BaseSnapshotOn
 import org.apache.calcite.plan.{RelOptRule, RelOptTable}
 import org.apache.calcite.rex.RexProgram
 
+import java.util
+
 /**
  * Rules that convert [[FlinkLogicalJoin]] on a [[FlinkLogicalSnapshot]] into
  * [[BatchPhysicalLookupJoin]].
@@ -47,8 +49,9 @@ object BatchPhysicalLookupJoinRule {
         join: FlinkLogicalJoin,
         input: FlinkLogicalRel,
         temporalTable: RelOptTable,
-        calcProgram: Option[RexProgram]): CommonPhysicalLookupJoin = {
-      doTransform(join, input, temporalTable, calcProgram)
+        calcProgram: Option[RexProgram],
+        dynamicOptionsOnTemporalTable: util.Map[String, String]): CommonPhysicalLookupJoin = {
+      doTransform(join, input, temporalTable, calcProgram, dynamicOptionsOnTemporalTable)
     }
   }
 
@@ -59,8 +62,9 @@ object BatchPhysicalLookupJoinRule {
         join: FlinkLogicalJoin,
         input: FlinkLogicalRel,
         temporalTable: RelOptTable,
-        calcProgram: Option[RexProgram]): CommonPhysicalLookupJoin = {
-      doTransform(join, input, temporalTable, calcProgram)
+        calcProgram: Option[RexProgram],
+        dynamicOptionsOnTemporalTable: util.Map[String, String]): CommonPhysicalLookupJoin = {
+      doTransform(join, input, temporalTable, calcProgram, dynamicOptionsOnTemporalTable)
     }
 
   }
@@ -69,7 +73,8 @@ object BatchPhysicalLookupJoinRule {
       join: FlinkLogicalJoin,
       input: FlinkLogicalRel,
       temporalTable: RelOptTable,
-      calcProgram: Option[RexProgram]): BatchPhysicalLookupJoin = {
+      calcProgram: Option[RexProgram],
+      dynamicOptionsOnTemporalTable: util.Map[String, String]): BatchPhysicalLookupJoin = {
     val joinInfo = join.analyzeCondition
     val cluster = join.getCluster
 
@@ -83,6 +88,7 @@ object BatchPhysicalLookupJoinRule {
       temporalTable,
       calcProgram,
       joinInfo,
-      join.getJoinType)
+      join.getJoinType,
+      dynamicOptionsOnTemporalTable)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalLookupJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalLookupJoinRule.scala
@@ -29,6 +29,8 @@ import org.apache.calcite.plan.{RelOptRule, RelOptTable}
 import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rex.RexProgram
 
+import java.util
+
 /**
  * Rules that convert [[FlinkLogicalJoin]] on a [[FlinkLogicalSnapshot]] into
  * [[StreamPhysicalLookupJoin]]
@@ -49,8 +51,9 @@ object StreamPhysicalLookupJoinRule {
         join: FlinkLogicalJoin,
         input: FlinkLogicalRel,
         temporalTable: RelOptTable,
-        calcProgram: Option[RexProgram]): CommonPhysicalLookupJoin = {
-      doTransform(join, input, temporalTable, calcProgram)
+        calcProgram: Option[RexProgram],
+        dynamicOptionsOnTemporalTable: util.Map[String, String]): CommonPhysicalLookupJoin = {
+      doTransform(join, input, temporalTable, calcProgram, dynamicOptionsOnTemporalTable)
     }
   }
 
@@ -61,8 +64,9 @@ object StreamPhysicalLookupJoinRule {
         join: FlinkLogicalJoin,
         input: FlinkLogicalRel,
         temporalTable: RelOptTable,
-        calcProgram: Option[RexProgram]): CommonPhysicalLookupJoin = {
-      doTransform(join, input, temporalTable, calcProgram)
+        calcProgram: Option[RexProgram],
+        dynamicOptionsOnTemporalTable: util.Map[String, String]): CommonPhysicalLookupJoin = {
+      doTransform(join, input, temporalTable, calcProgram, dynamicOptionsOnTemporalTable)
     }
   }
 
@@ -70,7 +74,8 @@ object StreamPhysicalLookupJoinRule {
       join: FlinkLogicalJoin,
       input: FlinkLogicalRel,
       temporalTable: RelOptTable,
-      calcProgram: Option[RexProgram]): StreamPhysicalLookupJoin = {
+      calcProgram: Option[RexProgram],
+      dynamicOptionsOnTemporalTable: util.Map[String, String]): StreamPhysicalLookupJoin = {
 
     val joinInfo = join.analyzeCondition
 
@@ -101,6 +106,7 @@ object StreamPhysicalLookupJoinRule {
       joinInfo,
       join.getJoinType,
       lookupHint,
-      false)
+      false,
+      dynamicOptionsOnTemporalTable)
   }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/utils/InputPriorityConflictResolverTest.java
@@ -205,7 +205,7 @@ class InputPriorityConflictResolverTest {
         BatchExecTableSourceScan scan =
                 new BatchExecTableSourceScan(
                         new Configuration(),
-                        new DynamicTableSourceSpec(null, null),
+                        new DynamicTableSourceSpec(null, null, null),
                         InputProperty.DEFAULT,
                         RowType.of(new IntType(), new IntType(), new IntType()),
                         "DynamicFilteringTableSourceScan");

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSinkSpecSerdeTest.java
@@ -103,6 +103,7 @@ class DynamicTableSinkSpecSerdeTest {
                                         "MyTable"),
                                 new ResolvedCatalogTable(catalogTable1, resolvedSchema1)),
                         null,
+                        null,
                         null);
 
         Map<String, String> options2 = new HashMap<>();
@@ -133,6 +134,7 @@ class DynamicTableSinkSpecSerdeTest {
                                         CatalogManagerMocks.DEFAULT_DATABASE,
                                         "MyTable"),
                                 new ResolvedCatalogTable(catalogTable2, resolvedSchema2)),
+                        Collections.singletonMap("path", "/tmp/hint"),
                         Arrays.asList(
                                 new OverwriteSpec(true),
                                 new PartitioningSpec(
@@ -170,6 +172,7 @@ class DynamicTableSinkSpecSerdeTest {
                                         CatalogManagerMocks.DEFAULT_DATABASE,
                                         "MyTable"),
                                 new ResolvedCatalogTable(catalogTable3, resolvedSchema3)),
+                        Collections.emptyMap(),
                         Collections.singletonList(
                                 new WritingMetadataSpec(
                                         Collections.singletonList("m"),
@@ -200,6 +203,7 @@ class DynamicTableSinkSpecSerdeTest {
                                 spec.getContextResolvedTable().getIdentifier(),
                                 catalogManager.getCatalog(catalogManager.getCurrentCatalog()).get(),
                                 spec.getContextResolvedTable().getResolvedTable()),
+                        spec.getDynamicOptions(),
                         spec.getSinkAbilities(),
                         null);
 
@@ -262,6 +266,7 @@ class DynamicTableSinkSpecSerdeTest {
                                 identifier,
                                 catalogManager.getCatalog(catalogManager.getCurrentCatalog()).get(),
                                 planResolvedCatalogTable),
+                        null,
                         Collections.emptyList(),
                         null);
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/DynamicTableSourceSpecSerdeTest.java
@@ -121,6 +121,7 @@ public class DynamicTableSourceSpecSerdeTest {
                                         TableConfigOptions.TABLE_DATABASE_NAME.defaultValue(),
                                         "MyTable"),
                                 new ResolvedCatalogTable(catalogTable1, resolvedSchema1)),
+                        null,
                         null);
 
         Map<String, String> options2 = new HashMap<>();
@@ -163,6 +164,7 @@ public class DynamicTableSourceSpecSerdeTest {
                                         TableConfigOptions.TABLE_DATABASE_NAME.defaultValue(),
                                         "MyTable"),
                                 new ResolvedCatalogTable(catalogTable2, resolvedSchema2)),
+                        Collections.singletonMap("source.sleep-time", "1s"),
                         Arrays.asList(
                                 new ProjectPushDownSpec(
                                         new int[][] {{0}, {1}, {4}, {6}},
@@ -268,6 +270,7 @@ public class DynamicTableSourceSpecSerdeTest {
                                 spec.getContextResolvedTable().getIdentifier(),
                                 catalogManager.getCatalog(catalogManager.getCurrentCatalog()).get(),
                                 spec.getContextResolvedTable().getResolvedTable()),
+                        spec.getDynamicOptions(),
                         spec.getSourceAbilities());
 
         String actualJson = toJson(serdeCtx, spec);
@@ -275,6 +278,7 @@ public class DynamicTableSourceSpecSerdeTest {
                 toObject(serdeCtx, actualJson, DynamicTableSourceSpec.class);
 
         assertThat(actual.getContextResolvedTable()).isEqualTo(spec.getContextResolvedTable());
+        assertThat(actual.getDynamicOptions()).isEqualTo(spec.getDynamicOptions());
         assertThat(actual.getSourceAbilities()).isEqualTo(spec.getSourceAbilities());
 
         assertThat(
@@ -333,6 +337,7 @@ public class DynamicTableSourceSpecSerdeTest {
                                 identifier,
                                 catalogManager.getCatalog(catalogManager.getCurrentCatalog()).get(),
                                 planResolvedCatalogTable),
+                        null,
                         Collections.emptyList());
 
         String actualJson = toJson(serdeCtx, planSpec);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/serde/TemporalTableSourceSpecSerdeTest.java
@@ -104,7 +104,7 @@ public class TemporalTableSourceSpecSerdeTest {
                         FACTORY,
                         new SourceAbilitySpec[] {new LimitPushDownSpec(100)});
         TemporalTableSourceSpec temporalTableSourceSpec1 =
-                new TemporalTableSourceSpec(tableSourceTable1);
+                new TemporalTableSourceSpec(tableSourceTable1, null);
         return Stream.of(temporalTableSourceSpec1);
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LoadJsonPlanTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/LoadJsonPlanTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.jsonplan;
+
+import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSinkSpec;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSourceSpec;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecLookupJoin;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink;
+import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitor;
+import org.apache.flink.table.planner.plan.nodes.exec.visitor.ExecNodeVisitorImpl;
+import org.apache.flink.table.planner.utils.JsonPlanTestBase;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+
+import org.apache.flink.shaded.guava32.com.google.common.collect.Sets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for loading plan to exec node graph. */
+@ExtendWith(ParameterizedTestExtension.class)
+class LoadJsonPlanTest extends JsonPlanTestBase {
+
+    private final TableConfigOptions.CatalogPlanCompilation compileCatalogObjectsLevel;
+
+    @Parameters(name = "compileCatalogObjectsLevel = {0}")
+    private static Collection<TableConfigOptions.CatalogPlanCompilation> data() {
+        return Arrays.asList(TableConfigOptions.CatalogPlanCompilation.values());
+    }
+
+    LoadJsonPlanTest(TableConfigOptions.CatalogPlanCompilation compileCatalogObjectsLevel) {
+        this.compileCatalogObjectsLevel = compileCatalogObjectsLevel;
+    }
+
+    @BeforeEach
+    protected void setup() throws Exception {
+        super.setup();
+
+        tableEnv.getConfig()
+                .set(TableConfigOptions.PLAN_COMPILE_CATALOG_OBJECTS, compileCatalogObjectsLevel);
+
+        tableEnv.executeSql(
+                "CREATE TABLE src (\n"
+                        + "  a int,\n"
+                        + "  b varchar,\n"
+                        + "  c int,\n"
+                        + "  proctime as PROCTIME()"
+                        + ") with (\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'bounded' = 'false'\n"
+                        + ")");
+        tableEnv.executeSql(
+                "CREATE TABLE dim (\n"
+                        + "  a int,\n"
+                        + "  b varchar,\n"
+                        + "  c int\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values'\n"
+                        + ")");
+
+        tableEnv.executeSql(
+                "CREATE TABLE snk (\n"
+                        + "  a int,\n"
+                        + "  b varchar,\n"
+                        + "  c int\n"
+                        + ") with (\n"
+                        + "  'connector' = 'values'\n"
+                        + ")");
+    }
+
+    @TestTemplate
+    void testLoadPlanWithHintsOnLookupSource() {
+        String sql =
+                "insert into snk select src.a, src.b, src.c from src "
+                        + "join dim /*+ OPTIONS('async'='true') */ for system_time as of "
+                        + "src.proctime on src.a = dim.a";
+        ExecNodeGraph execNodeGraph = compileSqlAndLoadPlan(sql);
+        StreamExecLookupJoin lookupJoin =
+                getSingleSpecificExecNodes(execNodeGraph, StreamExecLookupJoin.class);
+
+        DynamicTableSourceSpec spec = lookupJoin.getTemporalTableSourceSpec().getTableSourceSpec();
+        assertThat(spec).isNotNull();
+        Map<String, String> expectedExtraOptions = Collections.singletonMap("async", "true");
+
+        // verify the dynamic options in spec
+        assertThat(spec.getDynamicOptions()).isNotNull().isEqualTo(expectedExtraOptions);
+
+        // verify the table options in dim table
+        Map<String, String> tableOptions = spec.getContextResolvedTable().getTable().getOptions();
+        assertThat(tableOptions).containsAllEntriesOf(expectedExtraOptions);
+    }
+
+    @TestTemplate
+    void testLoadPlanWithHintsOnScanSource() {
+        String sql =
+                "insert into snk select src.a, src.b, src.c from src /*+ OPTIONS('source.sleep-time'='10s') */ ";
+
+        ExecNodeGraph execNodeGraph = compileSqlAndLoadPlan(sql);
+        StreamExecTableSourceScan source =
+                getSingleSpecificExecNodes(execNodeGraph, StreamExecTableSourceScan.class);
+
+        DynamicTableSourceSpec spec = source.getTableSourceSpec();
+        Map<String, String> expectedExtraOptions =
+                Collections.singletonMap("source.sleep-time", "10s");
+
+        // verify the dynamic options in spec
+        assertThat(spec.getDynamicOptions()).isNotNull().isEqualTo(expectedExtraOptions);
+
+        // verify the table options in table
+        Map<String, String> tableOptions = spec.getContextResolvedTable().getTable().getOptions();
+        assertThat(tableOptions).containsAllEntriesOf(expectedExtraOptions);
+    }
+
+    @TestTemplate
+    void testLoadPlanWithHintsOnSink() {
+        String sql =
+                "insert into snk /*+ OPTIONS('sink-insert-only'='false') */ select src.a, src.b, src.c from src";
+
+        ExecNodeGraph execNodeGraph = compileSqlAndLoadPlan(sql);
+        StreamExecSink sink = getSingleSpecificExecNodes(execNodeGraph, StreamExecSink.class);
+
+        DynamicTableSinkSpec spec = sink.getTableSinkSpec();
+        Map<String, String> expectedExtraOptions =
+                Collections.singletonMap("sink-insert-only", "false");
+
+        // verify the dynamic options in spec
+        assertThat(spec.getDynamicOptions()).isNotNull().isEqualTo(expectedExtraOptions);
+
+        // verify the table options in table
+        Map<String, String> tableOptions = spec.getContextResolvedTable().getTable().getOptions();
+        assertThat(tableOptions).containsAllEntriesOf(expectedExtraOptions);
+    }
+
+    private <T extends ExecNode<?>> T getSingleSpecificExecNodes(
+            ExecNodeGraph execNodeGraph, Class<T> expectExecNodeClazz) {
+        Set<T> collectResults = getSpecificExecNodes(execNodeGraph, expectExecNodeClazz);
+        if (collectResults.size() > 1) {
+            throw new IllegalArgumentException(
+                    "There are more than one "
+                            + expectExecNodeClazz.getSimpleName()
+                            + " in the execNodeGraph");
+        }
+        if (collectResults.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "There is no " + expectExecNodeClazz.getSimpleName() + " in the execNodeGraph");
+        }
+        return collectResults.iterator().next();
+    }
+
+    private <T extends ExecNode<?>> Set<T> getSpecificExecNodes(
+            ExecNodeGraph execNodeGraph, Class<T> clazz) {
+        final Set<T> collectResults = Sets.newIdentityHashSet();
+
+        final ExecNodeVisitor collector =
+                new ExecNodeVisitorImpl() {
+                    @Override
+                    public void visit(ExecNode<?> node) {
+                        if (clazz.isInstance(node)) {
+                            collectResults.add((T) node);
+                        }
+                        super.visit(node);
+                    }
+                };
+
+        execNodeGraph.getRootNodes().forEach(collector::visit);
+        return collectResults;
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/JsonPlanTestBase.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.internal.CompiledPlanUtils;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.types.Row;
@@ -96,6 +97,14 @@ public abstract class JsonPlanTestBase {
                         PlanReference.fromJsonString(
                                 jsonPlanTransformer.apply(compiledPlan.asJsonString())));
         return newCompiledPlan.execute();
+    }
+
+    protected ExecNodeGraph compileSqlAndLoadPlan(String sql) {
+        CompiledPlan compiledPlan = tableEnv.compilePlanSql(sql);
+        checkTransformationUids(compiledPlan);
+        CompiledPlan newCompiledPlan =
+                tableEnv.loadPlan(PlanReference.fromJsonString(compiledPlan.asJsonString()));
+        return CompiledPlanUtils.unwrap(newCompiledPlan).getExecNodeGraph();
     }
 
     protected void checkTransformationUids(CompiledPlan compiledPlan) {

--- a/flink-table/flink-table-planner/src/test/resources/jsonplan/testGetJsonPlanWithHints.out
+++ b/flink-table/flink-table-planner/src/test/resources/jsonplan/testGetJsonPlanWithHints.out
@@ -27,6 +27,10 @@
             "scan.parallelism" : "2"
           }
         }
+      },
+      "dynamicOptions" : {
+        "bounded" : "true",
+        "scan.parallelism" : "2"
       }
     },
     "outputType" : "ROW<`a` BIGINT, `b` INT, `c` VARCHAR(2147483647)>",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -2680,7 +2680,8 @@ class FlinkRelMdHandlerTestBase {
       batchScan.getTable,
       None,
       JoinInfo.of(ImmutableIntList.of(0), ImmutableIntList.of(0)),
-      JoinRelType.INNER
+      JoinRelType.INNER,
+      Collections.emptyMap()
     )
     val streamSourceOp = new TableSourceQueryOperation[RowData](temporalTableSource, false)
     val streamScan = relBuilder.queryOperation(streamSourceOp).build().asInstanceOf[TableScan]
@@ -2693,7 +2694,8 @@ class FlinkRelMdHandlerTestBase {
       JoinInfo.of(ImmutableIntList.of(0), ImmutableIntList.of(0)),
       JoinRelType.INNER,
       Option.empty[RelHint],
-      false
+      false,
+      Collections.emptyMap()
     )
     (batchLookupJoin, streamLookupJoin)
   }


### PR DESCRIPTION
## What is the purpose of the change

Before this fix, dynamic option hints will not take effect when restoring exec plan from json plan without setting 'table.plan.compile.catalog-objects' to 'all'.

This fix is trying to always serialize dynamic options to exec json plan, and merge them to table options when restoring from json plan.


## Brief change log

  - *Add a field for dynamic options in DynamicTableSpecBase to let it can be serialized to json plan*
  - *Add UT and IT cases*


## Verifying this change

Some tests are added to verify this fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
