### PR TITLE
[FLINK-36663][Window]Fix the first processWatermark has extra data after restore by restore timeService's watermark.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerService.java
@@ -38,6 +38,9 @@ public interface InternalTimerService<N> {
     /** Returns the current event-time watermark. */
     long currentWatermark();
 
+    /** Initialize watermark after restore. */
+    void initializeWatermark(long watermark);
+
     /**
      * Registers a timer to be fired when processing time passes the given time. The namespace you
      * pass here will be provided when the timer fires.

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
@@ -225,6 +225,11 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N> {
     }
 
     @Override
+    public void initializeWatermark(long watermark) {
+        this.currentWatermark = watermark;
+    }
+
+    @Override
     public void registerProcessingTimeTimer(N namespace, long time) {
         InternalTimer<K, N> oldHead = processingTimeTimersQueue.peek();
         if (processingTimeTimersQueue.add(

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeService.java
@@ -85,6 +85,11 @@ public class BatchExecutionInternalTimeService<K, N> implements InternalTimerSer
     }
 
     @Override
+    public void initializeWatermark(long watermark) {
+        this.currentWatermark = watermark;
+    }
+
+    @Override
     public void registerProcessingTimeTimer(N namespace, long time) {
         // the currentWatermark == Long.MAX_VALUE indicates the timer was registered from the
         // callback

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/TestInternalTimerService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/TestInternalTimerService.java
@@ -68,6 +68,11 @@ public class TestInternalTimerService<K, N> implements InternalTimerService<N> {
     }
 
     @Override
+    public void initializeWatermark(long watermark) {
+        this.currentWatermark = watermark;
+    }
+
+    @Override
     public void registerProcessingTimeTimer(N namespace, long time) {
         @SuppressWarnings("unchecked")
         Timer<K, N> timer = new Timer<>(time, (K) keyContext.getCurrentKey(), namespace);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractWindowAggProcessor.java
@@ -118,6 +118,9 @@ public abstract class AbstractWindowAggProcessor<W> implements WindowProcessor<W
     public void initializeWatermark(long watermark) {
         if (isEventTime) {
             currentProgress = watermark;
+            // Restore the watermark of timerService to prevent expired data from being treated as
+            // not expired when flushWindowBuffer is executed.
+            windowTimerService.initializeWatermark(watermark);
         }
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowTimerService.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowTimerService.java
@@ -43,6 +43,9 @@ public interface WindowTimerService<W> {
     /** Returns the current event-time watermark. */
     long currentWatermark();
 
+    /** Initialize watermark after restore. */
+    void initializeWatermark(long watermark);
+
     /**
      * Registers a window timer to be fired when processing time passes the window. The window you
      * pass here will be provided when the timer fires.

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowTimerServiceBase.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/common/WindowTimerServiceBase.java
@@ -48,4 +48,9 @@ public abstract class WindowTimerServiceBase<W> implements WindowTimerService<W>
     public long currentWatermark() {
         return internalTimerService.currentWatermark();
     }
+
+    @Override
+    public void initializeWatermark(long watermark) {
+        internalTimerService.initializeWatermark(watermark);
+    }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
@@ -165,6 +165,127 @@ class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
     }
 
     @TestTemplate
+    public void testEventTimeHoppingWindowWithExpiredSliceAndRestore() throws Exception {
+        final SliceAssigner assigner =
+                SliceAssigners.hopping(
+                        2, shiftTimeZone, Duration.ofSeconds(3), Duration.ofSeconds(1));
+        final SlicingSumAndCountAggsFunction aggsFunction =
+                new SlicingSumAndCountAggsFunction(assigner);
+        WindowAggOperator<RowData, ?> operator =
+                WindowAggOperatorBuilder.builder()
+                        .inputSerializer(INPUT_ROW_SER)
+                        .shiftTimeZone(shiftTimeZone)
+                        .keySerializer(KEY_SER)
+                        .assigner(assigner)
+                        .aggregate(createGeneratedAggsHandle(aggsFunction), ACC_SER)
+                        .countStarIndex(1)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // 1. process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        testHarness.processElement(insertRecord("key1", 1, fromEpochMillis(1020L)));
+        testHarness.processElement(insertRecord("key1", 1, fromEpochMillis(1001L)));
+        testHarness.processElement(insertRecord("key1", 1, fromEpochMillis(1999L)));
+
+        testHarness.processWatermark(new Watermark(2001));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, localMills(-1000L), localMills(2000L)));
+        expectedOutput.add(new Watermark(2001));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // 2. do a snapshot, close and restore again
+        testHarness.prepareSnapshotPreBarrier(0L);
+        OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+        testHarness.close();
+
+        assertThat(aggsFunction.closeCalled.get()).as("Close was not called.").isGreaterThan(0);
+
+        expectedOutput.clear();
+        testHarness = createTestHarness(operator);
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.initializeState(snapshot);
+        testHarness.open();
+
+        // 3. process elements
+        // Expired slice but belong to other window.
+        testHarness.processElement(insertRecord("key2", 1, fromEpochMillis(1500L)));
+
+        testHarness.processElement(insertRecord("key2", 1, fromEpochMillis(2998L)));
+        testHarness.processElement(insertRecord("key2", 1, fromEpochMillis(2999L)));
+        testHarness.processElement(insertRecord("key2", 1, fromEpochMillis(2000L)));
+
+        testHarness.processWatermark(new Watermark(2999));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, localMills(0L), localMills(3000L)));
+        expectedOutput.add(insertRecord("key2", 4L, 4L, localMills(0L), localMills(3000L)));
+        expectedOutput.add(new Watermark(2999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.close();
+    }
+
+    @TestTemplate
+    public void testEventTimeHoppingWindowWithExpiredSliceAndNoRestore() throws Exception {
+        final SliceAssigner assigner =
+                SliceAssigners.hopping(
+                        2, shiftTimeZone, Duration.ofSeconds(3), Duration.ofSeconds(1));
+        final SlicingSumAndCountAggsFunction aggsFunction =
+                new SlicingSumAndCountAggsFunction(assigner);
+        WindowAggOperator<RowData, ?> operator =
+                WindowAggOperatorBuilder.builder()
+                        .inputSerializer(INPUT_ROW_SER)
+                        .shiftTimeZone(shiftTimeZone)
+                        .keySerializer(KEY_SER)
+                        .assigner(assigner)
+                        .aggregate(createGeneratedAggsHandle(aggsFunction), ACC_SER)
+                        .countStarIndex(1)
+                        .build();
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // 1. process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        testHarness.processElement(insertRecord("key1", 1, fromEpochMillis(1020L)));
+        testHarness.processElement(insertRecord("key1", 1, fromEpochMillis(1001L)));
+        testHarness.processElement(insertRecord("key1", 1, fromEpochMillis(1999L)));
+
+        testHarness.processWatermark(new Watermark(2001));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, localMills(-1000L), localMills(2000L)));
+        expectedOutput.add(new Watermark(2001));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        // 2. process elements
+        // Expired slice but belong to other window.
+        testHarness.processElement(insertRecord("key2", 1, fromEpochMillis(1500L)));
+
+        testHarness.processElement(insertRecord("key2", 1, fromEpochMillis(2998L)));
+        testHarness.processElement(insertRecord("key2", 1, fromEpochMillis(2999L)));
+        testHarness.processElement(insertRecord("key2", 1, fromEpochMillis(2000L)));
+
+        testHarness.processWatermark(new Watermark(2999));
+        expectedOutput.add(insertRecord("key1", 3L, 3L, localMills(0L), localMills(3000L)));
+        expectedOutput.add(insertRecord("key2", 4L, 4L, localMills(0L), localMills(3000L)));
+        expectedOutput.add(new Watermark(2999));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.close();
+    }
+
+    @TestTemplate
     void testProcessingTimeHoppingWindows() throws Exception {
         final SliceAssigner assigner =
                 SliceAssigners.hopping(-1, shiftTimeZone, Duration.ofHours(3), Duration.ofHours(1));


### PR DESCRIPTION
# What is the purpose of the change

Restore the currentWatermark of WindowTimerService. If not restored, the slidingWindow will output extra data.

## Brief change log

Restore the currentWatermark of WindowTimerService.


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates whether the hopping window restores the output data consistently.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 