### PR TITLE
[FLINK-36664][Window]Window with offset need deal offset when cal nextTriggerWatermark.

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingTestBase.scala
@@ -33,6 +33,7 @@ class StreamingTestBase extends StreamAbstractTestBase {
   var env: StreamExecutionEnvironment = _
   var tEnv: StreamTableEnvironment = _
   var enableObjectReuse = true
+  var enableFailedBefore = true
 
   @TempDir
   var tempFolder: Path = _

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -81,7 +81,9 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
   @AfterEach
   override def after(): Unit = {
     super.after()
-    assertThat(FailingCollectionSource.failedBefore).isTrue
+    if (this.enableFailedBefore) {
+      assertThat(FailingCollectionSource.failedBefore).isTrue
+    }
   }
 
   /** Creates a BinaryRowData DataStream from the given non-empty [[Seq]]. */

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestData.scala
@@ -1270,6 +1270,87 @@ object TestData {
       "b")
   )
 
+  val windowDataForOffsetWithLtzInShanghai: Seq[Row] = List(
+    row(
+      toEpochMills("2020-10-10T00:07:59", shanghaiZone),
+      1,
+      1d,
+      1f,
+      new JBigDecimal("1.11"),
+      "Hi",
+      "a"),
+    row(
+      toEpochMills("2020-10-10T00:07:59", shanghaiZone),
+      2,
+      2d,
+      2f,
+      new JBigDecimal("2.22"),
+      "Comment#1",
+      "a"),
+    row(
+      toEpochMills("2020-10-10T11:11:59", shanghaiZone),
+      1,
+      1d,
+      1f,
+      new JBigDecimal("1.11"),
+      "Hi",
+      "a"),
+    row(
+      toEpochMills("2020-10-10T11:11:59", shanghaiZone),
+      2,
+      2d,
+      2f,
+      new JBigDecimal("2.22"),
+      "Comment#1",
+      "a"),
+    row(toEpochMills("2020-10-11T00:00:07", shanghaiZone), 3, 3d, 3f, null, "Hello", "b"),
+    row(
+      toEpochMills("2020-10-11T00:00:06", shanghaiZone),
+      6,
+      6d,
+      6f,
+      new JBigDecimal("6.66"),
+      "Hi",
+      "b"
+    ), // out of order
+    row(
+      toEpochMills("2020-10-11T00:00:16", shanghaiZone),
+      4,
+      4d,
+      4f,
+      new JBigDecimal("4.44"),
+      "Hi",
+      "b"),
+    row(
+      toEpochMills("2020-10-11T00:00:32", shanghaiZone),
+      7,
+      7d,
+      7f,
+      new JBigDecimal("7.77"),
+      null,
+      null),
+    row(
+      toEpochMills("2020-10-11T00:00:34", shanghaiZone),
+      1,
+      3d,
+      3f,
+      new JBigDecimal("3.33"),
+      "Comment#3",
+      "b")
+  )
+
+  val windowDataForOffsetWithTimestamp: Seq[Row] = List(
+    row("2020-10-10 00:07:59", 1, 1d, 1f, new JBigDecimal("1.11"), "Hi", "a"),
+    row("2020-10-10 00:07:59", 2, 2d, 2f, new JBigDecimal("2.22"), "Comment#1", "a"),
+    row("2020-10-10 11:11:59", 1, 1d, 1f, new JBigDecimal("1.11"), "Hi", "a"),
+    row("2020-10-10 11:11:59", 2, 2d, 2f, new JBigDecimal("2.22"), "Comment#1", "a"),
+    row("2020-10-11 00:00:07", 3, 3d, 3f, null, "Hello", "b"),
+    row("2020-10-11 00:00:06", 6, 6d, 6f, new JBigDecimal("6.66"), "Hi", "b"),
+    row("2020-10-11 00:00:16", 4, 4d, 4f, new JBigDecimal("4.44"), "Hi", "b"),
+    row("2020-10-11 00:00:32", 7, 7d, 7f, new JBigDecimal("7.77"), null, null),
+    row("2020-10-11 00:00:34", 1, 3d, 3f, new JBigDecimal("3.33"), "Comment#3", "b")
+  )
+
   val timestampData: Seq[Row] = List(
     row("1970-01-01 00:00:00.001", 1, 1d, 1f, new JBigDecimal("1"), "Hi", "a"),
     row("1970-01-01 00:00:00.002", 2, 2d, 2f, new JBigDecimal("2"), "Hallo", "a"),

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/asyncwindow/processors/AbstractAsyncStateSliceWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/asyncwindow/processors/AbstractAsyncStateSliceWindowAggProcessor.java
@@ -169,7 +169,11 @@ public abstract class AbstractAsyncStateSliceWindowAggProcessor
                 advanceFuture = windowBuffer.advanceProgress(currentKey, currentProgress);
                 nextTriggerProgress =
                         getNextTriggerWatermark(
-                                currentProgress, windowInterval, shiftTimeZone, useDayLightSaving);
+                                currentProgress,
+                                windowInterval,
+                                sliceAssigner.getWindowOffset(),
+                                shiftTimeZone,
+                                useDayLightSaving);
             }
         }
         return advanceFuture;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/LocalSlicingWindowAggOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/LocalSlicingWindowAggOperator.java
@@ -123,7 +123,11 @@ public class LocalSlicingWindowAggOperator extends AbstractStreamOperator<RowDat
                 windowBuffer.advanceProgress(currentWatermark);
                 nextTriggerWatermark =
                         getNextTriggerWatermark(
-                                currentWatermark, windowInterval, shiftTimezone, useDayLightSaving);
+                                currentWatermark,
+                                windowInterval,
+                                sliceAssigner.getWindowOffset(),
+                                shiftTimezone,
+                                useDayLightSaving);
             }
         }
         super.processWatermark(mark);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractSliceSyncStateWindowAggProcessor.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/aggregate/window/processors/AbstractSliceSyncStateWindowAggProcessor.java
@@ -147,7 +147,11 @@ public abstract class AbstractSliceSyncStateWindowAggProcessor
                 windowBuffer.advanceProgress(currentProgress);
                 nextTriggerProgress =
                         getNextTriggerWatermark(
-                                currentProgress, windowInterval, shiftTimeZone, useDayLightSaving);
+                                currentProgress,
+                                windowInterval,
+                                sliceAssigner.getWindowOffset(),
+                                shiftTimeZone,
+                                useDayLightSaving);
             }
         }
     }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/SliceAssigner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/SliceAssigner.java
@@ -65,4 +65,7 @@ public interface SliceAssigner extends WindowAssigner {
      * slice assigned.
      */
     long getSliceEndInterval();
+
+    /** Returns the offset of window. */
+    long getWindowOffset();
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/SliceAssigners.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/tvf/slicing/SliceAssigners.java
@@ -194,6 +194,11 @@ public final class SliceAssigners {
         }
 
         @Override
+        public long getWindowOffset() {
+            return offset;
+        }
+
+        @Override
         public String getDescription() {
             return String.format("TumblingWindow(size=%dms, offset=%dms)", size, offset);
         }
@@ -267,6 +272,11 @@ public final class SliceAssigners {
         @Override
         public long getSliceEndInterval() {
             return sliceSize;
+        }
+
+        @Override
+        public long getWindowOffset() {
+            return offset;
         }
 
         @Override
@@ -395,6 +405,11 @@ public final class SliceAssigners {
         }
 
         @Override
+        public long getWindowOffset() {
+            return offset;
+        }
+
+        @Override
         public void mergeSlices(long sliceEnd, MergeCallback<Long, Iterable<Long>> callback)
                 throws Exception {
             prepareReusableMergedList(sliceEnd);
@@ -498,6 +513,11 @@ public final class SliceAssigners {
         @Override
         public long getSliceEndInterval() {
             return innerAssigner.getSliceEndInterval();
+        }
+
+        @Override
+        public long getWindowOffset() {
+            return innerAssigner.getWindowOffset();
         }
 
         @Override
@@ -625,6 +645,11 @@ public final class SliceAssigners {
         @Override
         public long getSliceEndInterval() {
             return innerAssigner.getSliceEndInterval();
+        }
+
+        @Override
+        public long getWindowOffset() {
+            return innerAssigner.getWindowOffset();
         }
 
         @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/TimeWindowUtil.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/util/TimeWindowUtil.java
@@ -184,7 +184,11 @@ public class TimeWindowUtil {
 
     /** Method to get the next watermark to trigger window. */
     public static long getNextTriggerWatermark(
-            long currentWatermark, long interval, ZoneId shiftTimezone, boolean useDayLightSaving) {
+            long currentWatermark,
+            long interval,
+            long windowOffset,
+            ZoneId shiftTimezone,
+            boolean useDayLightSaving) {
         if (currentWatermark == Long.MAX_VALUE) {
             return currentWatermark;
         }
@@ -194,10 +198,12 @@ public class TimeWindowUtil {
         if (useDayLightSaving) {
             long utcWindowStart =
                     getWindowStartWithOffset(
-                            toUtcTimestampMills(currentWatermark, shiftTimezone), 0L, interval);
+                            toUtcTimestampMills(currentWatermark, shiftTimezone),
+                            windowOffset,
+                            interval);
             triggerWatermark = toEpochMillsForTimer(utcWindowStart + interval - 1, shiftTimezone);
         } else {
-            long start = getWindowStartWithOffset(currentWatermark, 0L, interval);
+            long start = getWindowStartWithOffset(currentWatermark, windowOffset, interval);
             triggerWatermark = start + interval - 1;
         }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/aggregate/window/SlicingWindowAggOperatorTest.java
@@ -721,6 +721,45 @@ class SlicingWindowAggOperatorTest extends WindowAggOperatorTestBase {
     }
 
     @TestTemplate
+    public void testEventTimeTumblingWindowsWithOffset() throws Exception {
+        final SliceAssigner assigner =
+                SliceAssigners.tumbling(2, shiftTimeZone, Duration.ofSeconds(3))
+                        .withOffset(Duration.ofSeconds(1));
+        final SlicingSumAndCountAggsFunction aggsFunction =
+                new SlicingSumAndCountAggsFunction(assigner);
+        OneInputStreamOperator<RowData, RowData> operator =
+                buildWindowOperator(assigner, aggsFunction, null);
+
+        OneInputStreamOperatorTestHarness<RowData, RowData> testHarness =
+                createTestHarness(operator);
+
+        testHarness.setup(OUT_SERIALIZER);
+        testHarness.open();
+
+        // process elements
+        ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+        testHarness.processElement(insertRecord("key1", 1, fromEpochMillis(2999L)));
+        testHarness.processWatermark(new Watermark(3000));
+        expectedOutput.add(new Watermark(3000));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(4000));
+        expectedOutput.add(insertRecord("key1", 1L, 1L, localMills(1000L), localMills(4000L)));
+        expectedOutput.add(new Watermark(4000));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.processWatermark(new Watermark(20000));
+        expectedOutput.add(new Watermark(20000));
+        ASSERTER.assertOutputEqualsSorted(
+                "Output was not correct.", expectedOutput, testHarness.getOutput());
+
+        testHarness.close();
+    }
+
+    @TestTemplate
     void testProcessingTimeTumblingWindows() throws Exception {
 
         final SliceAssigner assigner =


### PR DESCRIPTION
## What is the purpose of the change

Fixed the problem of data loss in window with offset.

## Brief change log

Passing in window offset when cal nextTriggerWatermark.


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test that validates that widow data with offset is not lost.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 