### PR TITLE
[FLINK-36679][runtime] Add a metric to track checkpoint _metadata size

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1318,6 +1318,11 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>lastCheckpointMetadataSize</td>
+      <td>上次检查点 _metadata 文件的大小（字节）.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>lastCheckpointExternalPath</td>
       <td>The path where the last external checkpoint was stored.</td>
       <td>Gauge</td>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1308,6 +1308,11 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>lastCheckpointMetadataSize</td>
+      <td>The metadata file size of the last checkpoint (in bytes).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
       <td>lastCheckpointExternalPath</td>
       <td>The path where the last external checkpoint was stored.</td>
       <td>Gauge</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCheckpointStats.java
@@ -93,10 +93,8 @@ public abstract class AbstractCheckpointStats implements Serializable {
      */
     public abstract long getCheckpointedSize();
 
-    /** @return The metadata file size, 0 if unknown. */
-    public long getMetadataSize() {
-        return 0;
-    }
+    /** @return The metadata file size. */
+    public abstract long getMetadataSize();
 
     /** @return the total number of processed bytes during the checkpoint. */
     public abstract long getProcessedData();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/AbstractCheckpointStats.java
@@ -93,6 +93,11 @@ public abstract class AbstractCheckpointStats implements Serializable {
      */
     public abstract long getCheckpointedSize();
 
+    /** @return The metadata file size, 0 if unknown. */
+    public long getMetadataSize() {
+        return 0;
+    }
+
     /** @return the total number of processed bytes during the checkpoint. */
     public abstract long getProcessedData();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStats.java
@@ -44,6 +44,9 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
     /** Total checkpoint state size over all subtasks. */
     private final long stateSize;
 
+    /** The persisted metadata file size. */
+    private final long metadataSize;
+
     private final long processedData;
 
     private final long persistedData;
@@ -67,6 +70,7 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
             Map<JobVertexID, TaskStateStats> taskStats,
             int numAcknowledgedSubtasks,
             long stateSize,
+            long metadataSize,
             long processedData,
             long persistedData,
             boolean unalignedCheckpoint,
@@ -81,6 +85,7 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
                 numAcknowledgedSubtasks,
                 stateSize,
                 stateSize,
+                metadataSize,
                 processedData,
                 persistedData,
                 unalignedCheckpoint,
@@ -100,6 +105,7 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
      * @param checkpointedSize Total persisted data size over all subtasks during the sync and async
      *     phases of this checkpoint.
      * @param stateSize Total checkpoint state size over all subtasks.
+     * @param metadataSize The metadata file size
      * @param processedData Processed data during the checkpoint.
      * @param persistedData Persisted data during the checkpoint.
      * @param unalignedCheckpoint Whether the checkpoint is unaligned.
@@ -115,6 +121,7 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
             int numAcknowledgedSubtasks,
             long checkpointedSize,
             long stateSize,
+            long metadataSize,
             long processedData,
             long persistedData,
             boolean unalignedCheckpoint,
@@ -128,6 +135,7 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
         this.checkpointedSize = checkpointedSize;
         checkArgument(stateSize >= 0, "Negative state size");
         this.stateSize = stateSize;
+        this.metadataSize = metadataSize;
         this.processedData = processedData;
         this.persistedData = persistedData;
         this.unalignedCheckpoint = unalignedCheckpoint;
@@ -153,6 +161,11 @@ public class CompletedCheckpointStats extends AbstractCheckpointStats {
     @Override
     public long getCheckpointedSize() {
         return checkpointedSize;
+    }
+
+    @Override
+    public long getMetadataSize() {
+        return metadataSize;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTracker.java
@@ -256,6 +256,7 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
                             .setAttribute("checkpointId", checkpointStats.getCheckpointId())
                             .setAttribute("fullSize", checkpointStats.getStateSize())
                             .setAttribute("checkpointedSize", checkpointStats.getCheckpointedSize())
+                            .setAttribute("metadataSize", checkpointStats.getMetadataSize())
                             .setAttribute("checkpointStatus", checkpointStats.getStatus().name())
                             .setAttribute(
                                     "isUnaligned",
@@ -423,6 +424,10 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
     static final String LATEST_COMPLETED_CHECKPOINT_FULL_SIZE_METRIC = "lastCheckpointFullSize";
 
     @VisibleForTesting
+    static final String LATEST_COMPLETED_CHECKPOINT_METADATA_SIZE_METRIC =
+            "lastCheckpointMetadataSize";
+
+    @VisibleForTesting
     static final String LATEST_COMPLETED_CHECKPOINT_DURATION_METRIC = "lastCheckpointDuration";
 
     @VisibleForTesting
@@ -463,6 +468,9 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
         metricGroup.gauge(
                 LATEST_COMPLETED_CHECKPOINT_FULL_SIZE_METRIC,
                 new LatestCompletedCheckpointFullSizeGauge());
+        metricGroup.gauge(
+                LATEST_COMPLETED_CHECKPOINT_METADATA_SIZE_METRIC,
+                new LatestCompletedCheckpointMetadataSizeGauge());
         metricGroup.gauge(
                 LATEST_COMPLETED_CHECKPOINT_DURATION_METRIC,
                 new LatestCompletedCheckpointDurationGauge());
@@ -537,6 +545,18 @@ public class DefaultCheckpointStatsTracker implements CheckpointStatsTracker {
             CompletedCheckpointStats completed = latestCompletedCheckpoint;
             if (completed != null) {
                 return completed.getStateSize();
+            } else {
+                return -1L;
+            }
+        }
+    }
+
+    private class LatestCompletedCheckpointMetadataSizeGauge implements Gauge<Long> {
+        @Override
+        public Long getValue() {
+            CompletedCheckpointStats completed = latestCompletedCheckpoint;
+            if (completed != null) {
+                return completed.getMetadataSize();
             } else {
                 return -1L;
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -369,7 +369,8 @@ public class PendingCheckpoint implements Checkpoint {
             CompletedCheckpointStorageLocation finalizedLocation) {
         return pendingCheckpointStats != null
                 ? pendingCheckpointStats.toCompletedCheckpointStats(
-                        finalizedLocation.getExternalPointer())
+                        finalizedLocation.getExternalPointer(),
+                        finalizedLocation.getMetadataHandle().getStateSize())
                 : null;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
@@ -156,6 +156,11 @@ public class PendingCheckpointStats extends AbstractCheckpointStats {
     }
 
     @Override
+    public long getMetadataSize() {
+        return 0;
+    }
+
+    @Override
     public long getCheckpointedSize() {
         return currentCheckpointedSize;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStats.java
@@ -221,7 +221,7 @@ public class PendingCheckpointStats extends AbstractCheckpointStats {
         }
     }
 
-    CompletedCheckpointStats toCompletedCheckpointStats(String externalPointer) {
+    CompletedCheckpointStats toCompletedCheckpointStats(String externalPointer, long metadataSize) {
         return new CompletedCheckpointStats(
                 checkpointId,
                 triggerTimestamp,
@@ -231,6 +231,7 @@ public class PendingCheckpointStats extends AbstractCheckpointStats {
                 currentNumAcknowledgedSubtasks,
                 currentCheckpointedSize,
                 currentStateSize,
+                metadataSize,
                 currentProcessedData,
                 currentPersistedData,
                 unalignedCheckpoint,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummaryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStatsSummaryTest.java
@@ -40,6 +40,7 @@ public class CompletedCheckpointStatsSummaryTest {
         long triggerTimestamp = 123123L;
         long ackTimestamp = 123123 + 1212312399L;
         long stateSize = Integer.MAX_VALUE + 17787L;
+        long metadataSize = Integer.MAX_VALUE + 1984L;
         long processedData = Integer.MAX_VALUE + 123123L;
         long persistedData = Integer.MAX_VALUE + 42L;
         boolean unalignedCheckpoint = true;
@@ -59,6 +60,7 @@ public class CompletedCheckpointStatsSummaryTest {
                             triggerTimestamp,
                             ackTimestamp + i,
                             stateSize + i,
+                            metadataSize + i,
                             processedData + i,
                             persistedData + i,
                             unalignedCheckpoint);
@@ -94,6 +96,7 @@ public class CompletedCheckpointStatsSummaryTest {
             long triggerTimestamp,
             long ackTimestamp,
             long stateSize,
+            long metadataSize,
             long processedData,
             long persistedData,
             boolean unalignedCheckpoint) {
@@ -114,6 +117,7 @@ public class CompletedCheckpointStatsSummaryTest {
                 taskStats,
                 1,
                 stateSize,
+                metadataSize,
                 processedData,
                 persistedData,
                 unalignedCheckpoint,
@@ -125,6 +129,7 @@ public class CompletedCheckpointStatsSummaryTest {
     @Test
     void testQuantiles() {
         int stateSize = 100;
+        int metadataSize = 110;
         int processedData = 200;
         int persistedData = 300;
         boolean unalignedCheckpoint = true;
@@ -141,6 +146,7 @@ public class CompletedCheckpointStatsSummaryTest {
                         singletonMap(new JobVertexID(), new TaskStateStats(new JobVertexID(), 1)),
                         1,
                         stateSize,
+                        metadataSize,
                         processedData,
                         persistedData,
                         unalignedCheckpoint,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
@@ -370,6 +370,7 @@ public class CompletedCheckpointTest {
                         1,
                         1,
                         1,
+                        1,
                         true,
                         mock(SubtaskStateStats.class),
                         null);
@@ -409,6 +410,7 @@ public class CompletedCheckpointTest {
                         taskStats,
                         1337,
                         123129837912L,
+                        2222379996L,
                         42L,
                         44L,
                         true,
@@ -426,6 +428,7 @@ public class CompletedCheckpointTest {
                 .isEqualTo(completed.getNumberOfAcknowledgedSubtasks());
         assertThat(copy.getEndToEndDuration()).isEqualTo(completed.getEndToEndDuration());
         assertThat(copy.getStateSize()).isEqualTo(completed.getStateSize());
+        assertThat(copy.getMetadataSize()).isEqualTo(completed.getMetadataSize());
         assertThat(copy.getProcessedData()).isEqualTo(completed.getProcessedData());
         assertThat(copy.getPersistedData()).isEqualTo(completed.getPersistedData());
         assertThat(copy.isUnalignedCheckpoint()).isEqualTo(completed.isUnalignedCheckpoint());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/DefaultCheckpointStatsTrackerTest.java
@@ -402,7 +402,7 @@ class DefaultCheckpointStatsTrackerTest {
         pending.reportSubtaskStats(jobVertexID, createSubtaskStats(0, true));
 
         // Complete checkpoint => new snapshot
-        tracker.reportCompletedCheckpoint(pending.toCompletedCheckpointStats(null));
+        tracker.reportCompletedCheckpoint(pending.toCompletedCheckpointStats(null, 1984));
 
         assertThat(reportedSpans.size()).isEqualTo(1);
         reportedSpan = Iterables.getOnlyElement(reportedSpans);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
@@ -146,7 +146,7 @@ public class PendingCheckpointStatsTest {
         // Report completed
         String externalPath = "asdjkasdjkasd";
 
-        callback.reportCompletedCheckpoint(pending.toCompletedCheckpointStats(externalPath));
+        callback.reportCompletedCheckpoint(pending.toCompletedCheckpointStats(externalPath, 1984));
 
         ArgumentCaptor<CompletedCheckpointStats> args =
                 ArgumentCaptor.forClass(CompletedCheckpointStats.class);


### PR DESCRIPTION
## What is the purpose of the change

Add a metric to track checkpoint _metadata size

## Brief change log

Add a metric `lastCheckpointMetadataSize` to track checkpoint _metadata size

## Verifying this change

Updated existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
