### PR TITLE
[FLINK-36598][state/ForSt] Provide FileSystem instance in initialization

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -71,7 +71,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.GuardedBy;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -522,7 +521,7 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
     }
 
     @VisibleForTesting
-    File getLocalBasePath() {
+    Path getLocalBasePath() {
         return optionsContainer.getLocalBasePath();
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackendBuilder.java
@@ -20,6 +20,7 @@ package org.apache.flink.state.forst;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.metrics.MetricGroup;
@@ -62,7 +63,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -301,10 +301,10 @@ public class ForStKeyedStateBackendBuilder<K>
         // working dir. We will implement this in ForStDB later, but before that, we achieved this
         // by setting the dbPath to "/" when the dfs directory existed.
         // TODO: use localForStPath as dbPath after ForSt Support mixing local-dir and remote-dir
-        File instanceForStPath =
+        Path instanceForStPath =
                 optionsContainer.getRemoteForStPath() == null
                         ? optionsContainer.getLocalForStPath()
-                        : new File("/");
+                        : new Path("/");
 
         if (CollectionUtil.isEmptyOrAllElementsNull(restoreStateHandles)) {
             return new ForStNoneRestoreOperation(
@@ -377,12 +377,7 @@ public class ForStKeyedStateBackendBuilder<K>
 
         ForStSnapshotStrategyBase<K, ?> snapshotStrategy;
 
-        ForStFlinkFileSystem forStFs =
-                optionsContainer.getRemoteForStPath() != null
-                        ? (ForStFlinkFileSystem)
-                                ForStFlinkFileSystem.get(
-                                        optionsContainer.getRemoteForStPath().toUri())
-                        : null;
+        ForStFlinkFileSystem forStFs = optionsContainer.getFileSystem();
         ForStStateDataTransfer stateTransfer =
                 new ForStStateDataTransfer(ForStStateDataTransfer.DEFAULT_THREAD_NUM, forStFs);
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateBackend.java
@@ -329,8 +329,10 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
                         "op_%s_attempt_%s",
                         fileCompatibleIdentifier, env.getTaskInfo().getAttemptNumber());
 
-        File localBasePath =
-                new File(new File(getNextStoragePath(), jobId.toHexString()), opChildPath);
+        Path localBasePath =
+                new Path(
+                        new File(new File(getNextStoragePath(), jobId.toHexString()), opChildPath)
+                                .getAbsolutePath());
         Path remoteBasePath =
                 remoteForStDirectory != null
                         ? new Path(new Path(remoteForStDirectory, jobId.toHexString()), opChildPath)
@@ -391,15 +393,17 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
 
         lazyInitializeForJob(env, fileCompatibleIdentifier);
 
-        File instanceBasePath =
-                new File(
-                        getNextStoragePath(),
-                        "job_"
-                                + jobId
-                                + "_op_"
-                                + fileCompatibleIdentifier
-                                + "_uuid_"
-                                + UUID.randomUUID());
+        Path instanceBasePath =
+                new Path(
+                        new File(
+                                        getNextStoragePath(),
+                                        "job_"
+                                                + jobId
+                                                + "_op_"
+                                                + fileCompatibleIdentifier
+                                                + "_uuid_"
+                                                + UUID.randomUUID())
+                                .getAbsolutePath());
 
         LocalRecoveryConfig localRecoveryConfig =
                 env.getTaskStateManager().createLocalRecoveryConfig();
@@ -671,14 +675,14 @@ public class ForStStateBackend extends AbstractManagedMemoryStateBackend
     }
 
     @VisibleForTesting
-    ForStResourceContainer createOptionsAndResourceContainer(@Nullable File localBasePath) {
+    ForStResourceContainer createOptionsAndResourceContainer(@Nullable Path localBasePath) {
         return createOptionsAndResourceContainer(null, localBasePath, null, false);
     }
 
     @VisibleForTesting
     private ForStResourceContainer createOptionsAndResourceContainer(
             @Nullable OpaqueMemoryResource<ForStSharedResources> sharedResources,
-            @Nullable File localBasePath,
+            @Nullable Path localBasePath,
             @Nullable Path remoteBasePath,
             boolean enableStatistics) {
 

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStHandle.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStHandle.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.state.forst.restore;
 
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
@@ -36,7 +37,6 @@ import org.forstdb.RocksDB;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,13 +62,13 @@ class ForStHandle implements AutoCloseable {
 
     protected ForStHandle(
             Map<String, ForStKvStateInfo> kvStateInformation,
-            File instanceRocksDBPath,
+            Path instanceRocksDBPath,
             DBOptions dbOptions,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             ForStNativeMetricOptions nativeMetricOptions,
             MetricGroup metricGroup) {
         this.kvStateInformation = kvStateInformation;
-        this.dbPath = instanceRocksDBPath.getAbsolutePath();
+        this.dbPath = instanceRocksDBPath.getPath();
         this.dbOptions = dbOptions;
         this.columnFamilyOptionsFactory = columnFamilyOptionsFactory;
         this.nativeMetricOptions = nativeMetricOptions;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStHeapTimersFullRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStHeapTimersFullRestoreOperation.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.forst.restore;
 
 import org.apache.flink.core.fs.ICloseableRegistry;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.CompositeKeySerializationUtils;
@@ -53,7 +54,6 @@ import org.forstdb.RocksDBException;
 import javax.annotation.Nonnull;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -85,7 +85,7 @@ public class ForStHeapTimersFullRestoreOperation<K> implements ForStRestoreOpera
             LinkedHashMap<String, HeapPriorityQueueSnapshotRestoreWrapper<?>> registeredPQStates,
             HeapPriorityQueueSetFactory priorityQueueFactory,
             StateSerializerProvider<K> keySerializerProvider,
-            File instanceRocksDBPath,
+            Path instanceRocksDBPath,
             DBOptions dbOptions,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             ForStNativeMetricOptions nativeMetricOptions,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStIncrementalRestoreOperation.java
@@ -42,7 +42,6 @@ import org.apache.flink.state.forst.ForStOperationUtils;
 import org.apache.flink.state.forst.ForStResourceContainer;
 import org.apache.flink.state.forst.ForStStateDataTransfer;
 import org.apache.flink.state.forst.StateHandleTransferSpec;
-import org.apache.flink.state.forst.fs.ForStFlinkFileSystem;
 import org.apache.flink.util.StateMigrationException;
 import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.function.RunnableWithException;
@@ -55,7 +54,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -105,7 +103,7 @@ public class ForStIncrementalRestoreOperation<K> implements ForStRestoreOperatio
             StateSerializerProvider<K> keySerializerProvider,
             ForStResourceContainer optionsContainer,
             Path forstBasePath,
-            File instanceRocksDBPath,
+            Path instanceRocksDBPath,
             DBOptions dbOptions,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             ForStNativeMetricOptions nativeMetricOptions,
@@ -221,10 +219,10 @@ public class ForStIncrementalRestoreOperation<K> implements ForStRestoreOperatio
         // TODO: Now not support rescale, so now ignore otherSpecs. Before implement transfer
         // otherSpecs, we may need reconsider the implementation of ForStFlinkFileSystem.
 
-        FileSystem forStFs =
-                optionsContainer.getRemoteForStPath() != null
-                        ? ForStFlinkFileSystem.get(optionsContainer.getRemoteForStPath().toUri())
-                        : FileSystem.getLocalFileSystem();
+        FileSystem forStFs = optionsContainer.getFileSystem();
+        if (forStFs == null) {
+            forStFs = FileSystem.getLocalFileSystem();
+        }
 
         try (ForStStateDataTransfer transfer =
                 new ForStStateDataTransfer(ForStStateDataTransfer.DEFAULT_THREAD_NUM, forStFs)) {

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStNoneRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/restore/ForStNoneRestoreOperation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.state.forst.restore;
 
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.state.forst.ForStKeyedStateBackend.ForStKvStateInfo;
 import org.apache.flink.state.forst.ForStNativeMetricOptions;
@@ -25,7 +26,6 @@ import org.apache.flink.state.forst.ForStNativeMetricOptions;
 import org.forstdb.ColumnFamilyOptions;
 import org.forstdb.DBOptions;
 
-import java.io.File;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -35,7 +35,7 @@ public class ForStNoneRestoreOperation implements ForStRestoreOperation {
 
     public ForStNoneRestoreOperation(
             Map<String, ForStKvStateInfo> kvStateInformation,
-            File instanceRocksDBPath,
+            Path instanceRocksDBPath,
             DBOptions dbOptions,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             ForStNativeMetricOptions nativeMetricOptions,

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/sync/ForStSyncKeyedStateBackend.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.typeutils.base.MapSerializerSnapshot;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.ICloseableRegistry;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataInputDeserializer;
 import org.apache.flink.core.memory.DataOutputSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -180,7 +181,7 @@ public class ForStSyncKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> 
     private final ForStResourceContainer optionsContainer;
 
     /** Path where this configured instance stores its data directory. */
-    private final File instanceBasePath;
+    private final Path instanceBasePath;
 
     /**
      * Protects access to RocksDB in other threads, like the checkpointing thread from parallel call
@@ -261,7 +262,7 @@ public class ForStSyncKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> 
 
     public ForStSyncKeyedStateBackend(
             ClassLoader userCodeClassLoader,
-            File instanceBasePath,
+            Path instanceBasePath,
             ForStResourceContainer optionsContainer,
             Function<String, ColumnFamilyOptions> columnFamilyOptionsFactory,
             TaskKvStateRegistry kvStateRegistry,
@@ -530,7 +531,7 @@ public class ForStSyncKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> 
                 instanceBasePath);
 
         try {
-            FileUtils.deleteDirectory(instanceBasePath);
+            FileUtils.deleteDirectory(new File(instanceBasePath.getPath()));
         } catch (IOException ex) {
             LOG.warn("Could not delete RocksDB working directory: {}", instanceBasePath, ex);
         }
@@ -905,7 +906,7 @@ public class ForStSyncKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> 
     }
 
     /** Only visible for testing, DO NOT USE. */
-    File getInstanceBasePath() {
+    Path getInstanceBasePath() {
         return instanceBasePath;
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStExtension.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStExtension.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
@@ -168,7 +169,7 @@ public class ForStExtension implements BeforeEachCallback, AfterEachCallback {
                         new Configuration(),
                         optionsFactory,
                         null,
-                        localWorkingDir,
+                        new Path(localWorkingDir.getAbsolutePath()),
                         null,
                         enableStatistics);
         resourceContainer.prepareDirectories();
@@ -186,16 +187,16 @@ public class ForStExtension implements BeforeEachCallback, AfterEachCallback {
         // working dir. We will implement this in ForStDB later, but before that, we achieved this
         // by setting the dbPath to "/" when the dfs directory existed.
         // TODO: use localForStPath as dbPath after ForSt Support mixing local-dir and remote-dir
-        File instanceForStPath =
+        Path instanceForStPath =
                 resourceContainer.getRemoteForStPath() == null
                         ? resourceContainer.getLocalForStPath()
-                        : new File("/");
+                        : new Path("/");
 
         this.columnFamilyHandles = new ArrayList<>(1);
         this.db =
                 RocksDB.open(
                         dbOptions,
-                        instanceForStPath.getAbsolutePath(),
+                        instanceForStPath.getPath(),
                         Collections.singletonList(
                                 new ColumnFamilyDescriptor(
                                         "default".getBytes(), columnFamilyOptions)),

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
@@ -306,33 +306,33 @@ public class ForStResourceContainerTest {
 
     @Test
     public void testDirectoryResources() throws Exception {
-        File localBasePath = TMP_FOLDER.newFolder();
+        Path localBasePath = new Path(TMP_FOLDER.newFolder().getPath());
         Path remoteBasePath = new Path(TMP_FOLDER.newFolder().getPath());
         try (final ForStResourceContainer optionsContainer =
                 new ForStResourceContainer(
                         new Configuration(), null, null, localBasePath, remoteBasePath, false)) {
             optionsContainer.prepareDirectories();
-            assertTrue(localBasePath.exists());
+            assertTrue(new File(localBasePath.getPath()).exists());
             assertTrue(new File(remoteBasePath.getPath()).exists());
             assertTrue(optionsContainer.getDbOptions().getEnv() instanceof FlinkEnv);
 
             optionsContainer.clearDirectories();
-            assertFalse(localBasePath.exists());
+            assertFalse(new File(localBasePath.getPath()).exists());
             assertFalse(new File(remoteBasePath.getPath()).exists());
         }
     }
 
     @Test
     public void testFileSystemInit() throws Exception {
-        File localBasePath = TMP_FOLDER.newFolder();
+        Path localBasePath = new Path(TMP_FOLDER.newFolder().getPath());
         Path remoteBasePath = new Path(TMP_FOLDER.newFolder().getPath());
         ArrayList<ColumnFamilyHandle> columnFamilyHandles = new ArrayList<>(1);
         ArrayList<ColumnFamilyDescriptor> columnFamilyDescriptors = new ArrayList<>(1);
         columnFamilyDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
         DBOptions dbOptions2 =
                 new DBOptions().setCreateIfMissing(true).setAvoidFlushDuringShutdown(true);
-        ForStFlinkFileSystem.setupLocalBasePath(remoteBasePath.toString(), localBasePath.getPath());
-        FileSystem forstFileSystem = ForStFlinkFileSystem.get(remoteBasePath.toUri());
+        FileSystem forstFileSystem =
+                ForStFlinkFileSystem.get(remoteBasePath.toUri(), localBasePath, null);
         dbOptions2.setEnv(new FlinkEnv(remoteBasePath.toString(), forstFileSystem));
         RocksDB db =
                 RocksDB.open(

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendConfigTest.java
@@ -109,7 +109,7 @@ public class ForStStateBackendConfigTest {
         }
         try (ForStResourceContainer container =
                 backend.createOptionsAndResourceContainer(
-                        new File(longInstanceBasePath.toString()))) {
+                        new Path(longInstanceBasePath.toString()))) {
             assertTrue(container.getDbOptions().dbLogDir().isEmpty());
         } finally {
             logFile.delete();
@@ -145,10 +145,9 @@ public class ForStStateBackendConfigTest {
                 createKeyedStateBackend(forStStateBackend, env, IntSerializer.INSTANCE);
 
         try {
-            File instanceBasePath = keyedBackend.getLocalBasePath();
+            Path instanceBasePath = keyedBackend.getLocalBasePath();
             assertThat(
-                    instanceBasePath.getAbsolutePath(),
-                    anyOf(startsWith(testDir1), startsWith(testDir2)));
+                    instanceBasePath.getPath(), anyOf(startsWith(testDir1), startsWith(testDir2)));
 
             //noinspection NullArgumentToVariableArgMethod
             forStStateBackend.setLocalDbStoragePaths(null);
@@ -176,7 +175,8 @@ public class ForStStateBackendConfigTest {
                 forStStateBackend.configure(conf, Thread.currentThread().getContextClassLoader());
 
         ForStResourceContainer resourceContainer =
-                forStStateBackend.createOptionsAndResourceContainer(tempFolder.newFile());
+                forStStateBackend.createOptionsAndResourceContainer(
+                        new Path(tempFolder.newFile().getAbsolutePath()));
         ColumnFamilyOptions columnFamilyOptions = resourceContainer.getColumnOptions();
         assertArrayEquals(compressionTypes, columnFamilyOptions.compressionPerLevel().toArray());
 
@@ -233,9 +233,8 @@ public class ForStStateBackendConfigTest {
                 createKeyedStateBackend(forStBackend, env, IntSerializer.INSTANCE);
 
         try {
-            File instanceBasePath = keyedBackend.getLocalBasePath();
-            assertThat(
-                    instanceBasePath.getAbsolutePath(), startsWith(expectedPath.getAbsolutePath()));
+            Path instanceBasePath = keyedBackend.getLocalBasePath();
+            assertThat(instanceBasePath.getPath(), startsWith(expectedPath.getAbsolutePath()));
 
             //noinspection NullArgumentToVariableArgMethod
             forStBackend.setLocalDbStoragePaths(null);
@@ -289,11 +288,11 @@ public class ForStStateBackendConfigTest {
         ForStKeyedStateBackend<Integer> keyedBackend =
                 createKeyedStateBackend(forStBackend, env, IntSerializer.INSTANCE);
 
-        File localBasePath = keyedBackend.getLocalBasePath();
-        File localForStPath = new File(localBasePath, "db");
+        Path localBasePath = keyedBackend.getLocalBasePath();
+        Path localForStPath = new Path(localBasePath, "db");
 
         // avoid tests without relocate.
-        Assume.assumeTrue(localForStPath.getAbsolutePath().length() <= 255 - "_LOG".length());
+        Assume.assumeTrue(localForStPath.getPath().length() <= 255 - "_LOG".length());
 
         java.nio.file.Path[] relocatedDbLogs;
         try {
@@ -354,8 +353,8 @@ public class ForStStateBackendConfigTest {
                                 cancelStreamRegistry));
 
         try {
-            File instanceBasePath = keyedBackend.getLocalBasePath();
-            assertThat(instanceBasePath.getAbsolutePath(), startsWith(dir1.getAbsolutePath()));
+            Path instanceBasePath = keyedBackend.getLocalBasePath();
+            assertThat(instanceBasePath.getPath(), startsWith(dir1.getAbsolutePath()));
         } finally {
             keyedBackend.dispose();
             keyedBackend.close();

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystemTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystemTest.java
@@ -76,16 +76,16 @@ public class ForStFlinkFileSystemTest {
 
     @Test
     void testReadAndWriteWithByteBuffer() throws Exception {
-        ForStFlinkFileSystem.setupLocalBasePath(tempDir.toString(), tempDir.toString());
         ForStFlinkFileSystem fileSystem =
-                (ForStFlinkFileSystem) ForStFlinkFileSystem.get(new URI(tempDir.toString()));
-        fileSystem.setupLocalBasePath(tempDir.toString(), tempDir.toString());
+                ForStFlinkFileSystem.get(
+                        new URI(tempDir.toString()),
+                        new org.apache.flink.core.fs.Path(tempDir.toString()),
+                        null);
         testReadAndWriteWithByteBuffer(fileSystem);
     }
 
     @TestTemplate
     void testPositionedRead() throws Exception {
-        ForStFlinkFileSystem.setupLocalBasePath(tempDir.toString(), tempDir.toString());
         ForStFlinkFileSystem fileSystem =
                 new ForStFlinkFileSystem(
                         new ByteBufferReadableLocalFileSystem(),
@@ -165,7 +165,6 @@ public class ForStFlinkFileSystemTest {
 
     @TestTemplate
     void testReadExceedingFileSize() throws Exception {
-        ForStFlinkFileSystem.setupLocalBasePath(tempDir.toString(), tempDir.toString());
         ForStFlinkFileSystem fileSystem =
                 new ForStFlinkFileSystem(
                         new ByteBufferReadableLocalFileSystem(),
@@ -192,7 +191,6 @@ public class ForStFlinkFileSystemTest {
                 new org.apache.flink.core.fs.Path(tempDir.toString() + "/remote");
         org.apache.flink.core.fs.Path localPath =
                 new org.apache.flink.core.fs.Path(tempDir.toString() + "/local");
-        ForStFlinkFileSystem.setupLocalBasePath(remotePath.toString(), localPath.toString());
         ForStFlinkFileSystem fileSystem =
                 new ForStFlinkFileSystem(
                         new ByteBufferReadableLocalFileSystem(),
@@ -223,7 +221,6 @@ public class ForStFlinkFileSystemTest {
                 new org.apache.flink.core.fs.Path(tempDir.toString() + "/local");
         org.apache.flink.core.fs.Path cachePath =
                 new org.apache.flink.core.fs.Path(tempDir.toString() + "/tmp-cache");
-        ForStFlinkFileSystem.setupLocalBasePath(remotePath.toString(), localPath.toString());
         BundledCacheLimitPolicy cacheLimitPolicy =
                 new BundledCacheLimitPolicy(
                         new SpaceBasedCacheLimitPolicy(new File(cachePath.toString()), 0, 0),


### PR DESCRIPTION
## What is the purpose of the change

Currently, the `ForSt` needs a `FileSystem` instance from `Flink` side, but it is created by a JNI call from `ForSt`. It is more reasonable to create it in `Flink` side and provide it to `ForSt`.


## Brief change log

 - Use `Path` instead `File` everywhere in `ForSt`
 - Create `ForStFlinkFileSystem` instance and provide it to `ForSt` during initialization.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
