### PR TITLE
[FLINK-35334][flink-table] Split constructor of generated code if it is too large.

### DIFF
--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/DeclarationRewriter.java
@@ -133,6 +133,11 @@ public class DeclarationRewriter implements CodeRewriter {
         }
 
         @Override
+        public Void visitConstructorDeclaration(JavaParser.ConstructorDeclarationContext ctx) {
+            return visitFunctionBody(ctx.constructorBody);
+        }
+
+        @Override
         public Void visitMethodDeclaration(JavaParser.MethodDeclarationContext ctx) {
             if ("void".equals(ctx.typeTypeOrVoid().getText())) {
                 visitMethodBody(ctx.methodBody());
@@ -142,17 +147,21 @@ public class DeclarationRewriter implements CodeRewriter {
 
         @Override
         public Void visitMethodBody(JavaParser.MethodBodyContext ctx) {
+            return visitFunctionBody(ctx.block());
+        }
+
+        public Void visitFunctionBody(JavaParser.BlockContext blockContext) {
             // this condition must be the same with the condition in
             // FunctionSplitter::visitMethodDeclaration
-            if (CodeSplitUtil.getContextTextLength(ctx.block()) <= maxMethodLength) {
+            if (CodeSplitUtil.getContextTextLength(blockContext) <= maxMethodLength) {
                 return null;
             }
 
             hasRewrite = true;
             InnerBlockStatementExtractor extractor = new InnerBlockStatementExtractor();
-            if (ctx.block() != null && ctx.block().blockStatement() != null) {
+            if (blockContext != null && blockContext.blockStatement() != null) {
                 for (JavaParser.BlockStatementContext blockStatementContext :
-                        ctx.block().blockStatement()) {
+                        blockContext.blockStatement()) {
                     extractor.visitBlockStatement(blockStatementContext);
                 }
                 newFields.peek().append(extractor.getNewLocalVariables());

--- a/flink-table/flink-table-code-splitter/src/test/resources/splitter/code/TestSplitJavaCode.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/splitter/code/TestSplitJavaCode.java
@@ -4,6 +4,26 @@ public class TestSplitJavaCode {
 
     public TestSplitJavaCode(int[] b) {
         this.b = b;
+        int b0 = this.b[0] + b[0];
+        System.out.println("b0 = " + b0);
+        int b1 = this.b[1] + b[1];
+        System.out.println("b1 = " + b1);
+        int b2 = this.b[2] + b[2];
+        System.out.println("b2 = " + b2);
+        int b3 = this.b[3] + b[3];
+        System.out.println("b3 = " + b3);
+        int b4 = this.b[4] + b[4];
+        System.out.println("b4 = " + b4);
+        int b5 = this.b[5] + b[5];
+        System.out.println("b5 = " + b5);
+        int b6 = this.b[6] + b[6];
+        System.out.println("b6 = " + b6);
+        int b7 = this.b[7] + b[7];
+        System.out.println("b7 = " + b7);
+        int b8 = this.b[8] + b[8];
+        System.out.println("b8 = " + b8);
+        int b9 = this.b[9] + b[9];
+        System.out.println("b9 = " + b9);
     }
 
     public void myFun1(int a) {

--- a/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestSplitJavaCode.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestSplitJavaCode.java
@@ -1,13 +1,11 @@
 public class TestSplitJavaCode {
-    boolean[] rewrite$16 = new boolean[2];
-    int[][] rewrite$17 = new int[1][];
-    int[] rewrite$18 = new int[6];
+boolean[] rewrite$26 = new boolean[2];
+int[][] rewrite$27 = new int[1][];
+int[] rewrite$28 = new int[16];
 
-    {
-        rewrite$18[5] = 1;
-    }
-
-
+{
+rewrite$28[15] = 1;
+}
 
 
 
@@ -19,20 +17,6 @@ public class TestSplitJavaCode {
 
 
 
-    public TestSplitJavaCode(int[] b) {
-        this.rewrite$17[0] = b;
-    }
-
-    public void myFun1(int a) {
-        rewrite$16[0] = false;
-        myFun1_split6(a);
-
-        myFun1_split7(a);
-
-        myFun1_split8(a);
-
-        myFun1_split9(a);
-        if (rewrite$16[0]) { return; }
 
 
 
@@ -41,109 +25,205 @@ public class TestSplitJavaCode {
 
 
 
-    }
-    void myFun1_split6(int a) {
-
-        this.rewrite$18[5] = a;
-        rewrite$17[0][0] += rewrite$17[0][1];
-        rewrite$17[0][1] += rewrite$17[0][2];
-        rewrite$17[0][2] += rewrite$17[0][3];
-        rewrite$18[0] = rewrite$17[0][0] + rewrite$17[0][1];
-        rewrite$18[1] = rewrite$17[0][1] + rewrite$17[0][2];
-    }
-
-    void myFun1_split7(int a) {
-        rewrite$18[2] = rewrite$17[0][2] + rewrite$17[0][0];
-    }
-
-    void myFun1_split8(int a) {
-        for (int x : rewrite$17[0]) {rewrite$18[3] = x;
-            System.out.println(rewrite$18[3] + rewrite$18[0] + rewrite$18[1] + rewrite$18[2]);
-        }
-    }
-
-    void myFun1_split9(int a) {
-        if (rewrite$18[0] > 0) {
-            myFun1_0_0_rewriteGroup5(a);
-        } else {
-            rewrite$17[0][0] += 50;
-            rewrite$17[0][1] += 100;
-            rewrite$17[0][2] += 150;
-            rewrite$17[0][3] += 200;
-            rewrite$17[0][4] += 250;
-            rewrite$17[0][5] += 300;
-            rewrite$17[0][6] += 350;
-            { rewrite$16[0] = true; return; }
-        }
-    }
-
-
-    void myFun1_0_0_rewriteGroup5(int a) {
-        myFun1_0_0_rewriteGroup5_split10(a);
-
-        myFun1_0_0_rewriteGroup5_split11(a);
-
-    }
-    void myFun1_0_0_rewriteGroup5_split10(int a) {
-
-        rewrite$17[0][0] += 100;
-    }
-
-    void myFun1_0_0_rewriteGroup5_split11(int a) {
-        if (rewrite$18[1] > 0) {
-            myFun1_0_0_rewriteGroup1_2_rewriteGroup4(a);
-        } else {
-            rewrite$17[0][1] += 50;
-        }
-    }
-
-
-    void myFun1_0_0_rewriteGroup1_2_rewriteGroup4(int a) {
-        myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split12(a);
-
-        myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split13(a);
-
-    }
-    void myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split12(int a) {
-
-        rewrite$17[0][1] += 100;
-    }
-
-    void myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split13(int a) {
-        if (rewrite$18[2] > 0) {
-            rewrite$17[0][2] += 100;
-        } else {
-            rewrite$17[0][2] += 50;
-        }
-    }
 
 
 
-    public int myFun2(int[] a) { myFun2Impl(a); return rewrite$18[4]; }
 
-    void myFun2Impl(int[] a) {
-        rewrite$16[1] = false;
-        myFun2Impl_split14(a);
+public TestSplitJavaCode(int[] b) {
+TestSplitJavaCode_split9(b);
 
-        myFun2Impl_split15(a);
-        if (rewrite$16[1]) { return; }
+TestSplitJavaCode_split10(b);
+
+TestSplitJavaCode_split11(b);
+
+TestSplitJavaCode_split12(b);
+
+TestSplitJavaCode_split13(b);
+
+TestSplitJavaCode_split14(b);
+
+TestSplitJavaCode_split15(b);
 
 
 
 
 
-    }
-    void myFun2Impl_split14(int[] a) {
 
-        a[0] += 1;
-        a[1] += 2;
-        a[2] += 3;
-        a[3] += 4;
-        a[4] += 5;
-    }
 
-    void myFun2Impl_split15(int[] a) {
-        { rewrite$18[4] = a[0] + a[1] + a[2] + a[3] + a[4]; { rewrite$16[1] = true; return; } }
-    }
+
+
+
+
+
+
+
+
+}
+void TestSplitJavaCode_split9(int[] b) {
+
+this.rewrite$27[0] = b;
+rewrite$28[0] = this.rewrite$27[0][0] + b[0];
+System.out.println("b0 = " + rewrite$28[0]);
+rewrite$28[1] = this.rewrite$27[0][1] + b[1];
+}
+
+void TestSplitJavaCode_split10(int[] b) {
+System.out.println("b1 = " + rewrite$28[1]);
+rewrite$28[2] = this.rewrite$27[0][2] + b[2];
+System.out.println("b2 = " + rewrite$28[2]);
+}
+
+void TestSplitJavaCode_split11(int[] b) {
+rewrite$28[3] = this.rewrite$27[0][3] + b[3];
+System.out.println("b3 = " + rewrite$28[3]);
+rewrite$28[4] = this.rewrite$27[0][4] + b[4];
+}
+
+void TestSplitJavaCode_split12(int[] b) {
+System.out.println("b4 = " + rewrite$28[4]);
+rewrite$28[5] = this.rewrite$27[0][5] + b[5];
+System.out.println("b5 = " + rewrite$28[5]);
+}
+
+void TestSplitJavaCode_split13(int[] b) {
+rewrite$28[6] = this.rewrite$27[0][6] + b[6];
+System.out.println("b6 = " + rewrite$28[6]);
+rewrite$28[7] = this.rewrite$27[0][7] + b[7];
+}
+
+void TestSplitJavaCode_split14(int[] b) {
+System.out.println("b7 = " + rewrite$28[7]);
+rewrite$28[8] = this.rewrite$27[0][8] + b[8];
+System.out.println("b8 = " + rewrite$28[8]);
+}
+
+void TestSplitJavaCode_split15(int[] b) {
+rewrite$28[9] = this.rewrite$27[0][9] + b[9];
+System.out.println("b9 = " + rewrite$28[9]);
+}
+
+
+public void myFun1(int a) {
+rewrite$26[0] = false;
+myFun1_split16(a);
+
+myFun1_split17(a);
+
+myFun1_split18(a);
+
+myFun1_split19(a);
+if (rewrite$26[0]) { return; }
+
+
+
+
+
+
+
+
+}
+void myFun1_split16(int a) {
+
+this.rewrite$28[15] = a;
+rewrite$27[0][0] += rewrite$27[0][1];
+rewrite$27[0][1] += rewrite$27[0][2];
+rewrite$27[0][2] += rewrite$27[0][3];
+rewrite$28[10] = rewrite$27[0][0] + rewrite$27[0][1];
+rewrite$28[11] = rewrite$27[0][1] + rewrite$27[0][2];
+}
+
+void myFun1_split17(int a) {
+rewrite$28[12] = rewrite$27[0][2] + rewrite$27[0][0];
+}
+
+void myFun1_split18(int a) {
+for (int x : rewrite$27[0]) {rewrite$28[13] = x;
+System.out.println(rewrite$28[13] + rewrite$28[10] + rewrite$28[11] + rewrite$28[12]);
+}
+}
+
+void myFun1_split19(int a) {
+if (rewrite$28[10] > 0) {
+myFun1_0_0_rewriteGroup5(a);
+} else {
+rewrite$27[0][0] += 50;
+rewrite$27[0][1] += 100;
+rewrite$27[0][2] += 150;
+rewrite$27[0][3] += 200;
+rewrite$27[0][4] += 250;
+rewrite$27[0][5] += 300;
+rewrite$27[0][6] += 350;
+{ rewrite$26[0] = true; return; }
+}
+}
+
+
+void myFun1_0_0_rewriteGroup5(int a) {
+myFun1_0_0_rewriteGroup5_split20(a);
+
+myFun1_0_0_rewriteGroup5_split21(a);
+
+}
+void myFun1_0_0_rewriteGroup5_split20(int a) {
+
+rewrite$27[0][0] += 100;
+}
+
+void myFun1_0_0_rewriteGroup5_split21(int a) {
+if (rewrite$28[11] > 0) {
+myFun1_0_0_rewriteGroup1_2_rewriteGroup4(a);
+} else {
+rewrite$27[0][1] += 50;
+}
+}
+
+
+void myFun1_0_0_rewriteGroup1_2_rewriteGroup4(int a) {
+myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split22(a);
+
+myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split23(a);
+
+}
+void myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split22(int a) {
+
+rewrite$27[0][1] += 100;
+}
+
+void myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split23(int a) {
+if (rewrite$28[12] > 0) {
+rewrite$27[0][2] += 100;
+} else {
+rewrite$27[0][2] += 50;
+}
+}
+
+
+
+public int myFun2(int[] a) { myFun2Impl(a); return rewrite$28[14]; }
+
+void myFun2Impl(int[] a) {
+rewrite$26[1] = false;
+myFun2Impl_split24(a);
+
+myFun2Impl_split25(a);
+if (rewrite$26[1]) { return; }
+
+
+
+
+
+}
+void myFun2Impl_split24(int[] a) {
+
+a[0] += 1;
+a[1] += 2;
+a[2] += 3;
+a[3] += 4;
+a[4] += 5;
+}
+
+void myFun2Impl_split25(int[] a) {
+{ rewrite$28[14] = a[0] + a[1] + a[2] + a[3] + a[4]; { rewrite$26[1] = true; return; } }
+}
 
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request aims to split constructor of generated code if it is too large to be compiled.


## Brief change log

- Override visitConstructorDeclaration to split it into multiple void functions.


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

This change is already covered by existing tests, such as *org.apache.flink.table.codesplit.JavaCodeSplitterTest#testSplitJavaCode*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
