### PR TITLE
Bumps org.apache.calcite:calcite-core from 1.16.0 to 1.32.0.

### DIFF
--- a/flink-connectors/flink-sql-connector-hive-3.1.3/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.3/pom.xml
@@ -154,7 +154,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.calcite</groupId>
 			<artifactId>calcite-core</artifactId>
-			<version>1.16.0</version>
+			<version>1.32.0</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Bump org.apache.calcite:calcite-core from 1.16.0 to 1.32.0 in /flink-connectors/flink-sql-connector-hive-3.1.3

In Apache Calcite prior to version 1.32.0 the SQL operators EXISTS_NODE, EXTRACT_XML, XML_TRANSFORM and EXTRACT_VALUE do not restrict XML External Entity references in their configuration, which makes them vulnerable to a potential XML External Entity (XXE) attack. Therefore any client exposing these operators, typically by using Oracle dialect (the first three) or MySQL dialect (the last one), is affected by this vulnerability (the extent of it will depend on the user under which the application is running). From Apache Calcite 1.32.0 onwards, Document Type Declarations and XML External Entity resolution are disabled on the impacted operators.