### PR TITLE
[FLINK-36695][Formats] Bump Parquet dependency to 1.14.4

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-hadoop:1.13.1
-- org.apache.parquet:parquet-column:1.13.1
-- org.apache.parquet:parquet-common:1.13.1
-- org.apache.parquet:parquet-encoding:1.13.1
-- org.apache.parquet:parquet-format-structures:1.13.1
-- org.apache.parquet:parquet-jackson:1.13.1
+- org.apache.parquet:parquet-hadoop:1.14.4
+- org.apache.parquet:parquet-column:1.14.4
+- org.apache.parquet:parquet-common:1.14.4
+- org.apache.parquet:parquet-encoding:1.14.4
+- org.apache.parquet:parquet-format-structures:1.14.4
+- org.apache.parquet:parquet-jackson:1.14.4

--- a/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-parquet/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.parquet:parquet-avro:1.13.1
-- org.apache.parquet:parquet-hadoop:1.13.1
-- org.apache.parquet:parquet-column:1.13.1
-- org.apache.parquet:parquet-common:1.13.1
-- org.apache.parquet:parquet-encoding:1.13.1
-- org.apache.parquet:parquet-format-structures:1.13.1
-- org.apache.parquet:parquet-jackson:1.13.1
+- org.apache.parquet:parquet-avro:1.14.4
+- org.apache.parquet:parquet-hadoop:1.14.4
+- org.apache.parquet:parquet-column:1.14.4
+- org.apache.parquet:parquet-common:1.14.4
+- org.apache.parquet:parquet-encoding:1.14.4
+- org.apache.parquet:parquet-format-structures:1.14.4
+- org.apache.parquet:parquet-jackson:1.14.4
 - commons-pool:commons-pool:1.6

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<properties>
-		<flink.format.parquet.version>1.13.1</flink.format.parquet.version>
+		<flink.format.parquet.version>1.14.4</flink.format.parquet.version>
 	</properties>
 
 	<artifactId>flink-formats</artifactId>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -380,7 +380,7 @@ under the License.
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jdk8</artifactId>
-			<version>2.15.3</version>
+			<version>${jackson-bom.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -377,6 +377,12 @@ under the License.
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jdk8</artifactId>
+			<version>2.15.3</version>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -9,6 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.18.2
 - com.fasterxml.jackson.core:jackson-core:2.18.2
 - com.fasterxml.jackson.core:jackson-databind:2.18.2
+- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2
 - com.google.flatbuffers:flatbuffers-java:1.12.0
 - io.netty:netty-buffer:4.1.100.Final
 - io.netty:netty-common:4.1.100.Final


### PR DESCRIPTION
## What is the purpose of the change

* Bump Parquet dependency

## Brief change log

* Update POM and NOTICE files

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
