### PR TITLE
[FLINK-36709][parquet] fix parquet can not read row with last column is array.

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/NestedPositionUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/NestedPositionUtil.java
@@ -50,12 +50,11 @@ public class NestedPositionUtil {
         int nullValuesCount = 0;
         BooleanArrayList nullRowFlags = new BooleanArrayList(0);
         for (int i = 0; i < fieldDefinitionLevels.length; i++) {
+            // If row has array type field, the field repetition level's count will bigger than the
+            // actual row value count, so we need to skip those value that bigger than row's
+            // repetition level.
             if (fieldRepetitionLevels[i] > rowRepetitionLevel) {
-                throw new IllegalStateException(
-                        format(
-                                "In parquet's row type field repetition level should not larger than row's repetition level. "
-                                        + "Row repetition level is %s, row field repetition level is %s.",
-                                rowRepetitionLevel, fieldRepetitionLevels[i]));
+                continue;
             }
 
             if (fieldDefinitionLevels[i] >= rowDefinitionLevel) {

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/NestedPositionUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/NestedPositionUtil.java
@@ -50,8 +50,8 @@ public class NestedPositionUtil {
         int nullValuesCount = 0;
         BooleanArrayList nullRowFlags = new BooleanArrayList(0);
         for (int i = 0; i < fieldDefinitionLevels.length; i++) {
-            // If a row's last field is an array, the repetition levels for the array's items will be
-            // larger than the parent row's repetition level, so we need to skip those values.
+            // If a row's last field is an array, the repetition levels for the array's items will
+            // be larger than the parent row's repetition level, so we need to skip those values.
             if (fieldRepetitionLevels[i] > rowRepetitionLevel) {
                 continue;
             }

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/NestedPositionUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/NestedPositionUtil.java
@@ -50,9 +50,8 @@ public class NestedPositionUtil {
         int nullValuesCount = 0;
         BooleanArrayList nullRowFlags = new BooleanArrayList(0);
         for (int i = 0; i < fieldDefinitionLevels.length; i++) {
-            // If row has array type field, the field repetition level's count will bigger than the
-            // actual row value count, so we need to skip those value that bigger than row's
-            // repetition level.
+            // If a row's last field is an array, the repetition levels for the array's items will be
+            // larger than the parent row's repetition level, so we need to skip those values.
             if (fieldRepetitionLevels[i] > rowRepetitionLevel) {
                 continue;
             }

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
@@ -151,6 +151,7 @@ class ParquetColumnarRowSplitReaderTest {
                                     Collections.singletonList(
                                             new RowType.RowField("a", new IntType())))),
                     RowType.of(
+                            new IntType(),
                             new ArrayType(
                                     true,
                                     new RowType(
@@ -161,8 +162,7 @@ class ParquetColumnarRowSplitReaderTest {
                                                                     true,
                                                                     new ArrayType(
                                                                             true, new IntType()))),
-                                                    new RowType.RowField("c", new IntType())))),
-                            new IntType()));
+                                                    new RowType.RowField("c", new IntType()))))));
 
     @SuppressWarnings("unchecked")
     private static final DataFormatConverters.DataFormatConverter<RowData, Row>
@@ -829,6 +829,7 @@ class ParquetColumnarRowSplitReaderTest {
                             new Map[] {null, mp1, mp2},
                             new Row[] {Row.of(i), Row.of(i + 1), null},
                             Row.of(
+                                    i,
                                     new Row[] {
                                         Row.of(
                                                 new Integer[][] {
@@ -836,8 +837,7 @@ class ParquetColumnarRowSplitReaderTest {
                                                 },
                                                 i),
                                         null
-                                    },
-                                    i)));
+                                    })));
         }
         return rows;
     }
@@ -888,15 +888,15 @@ class ParquetColumnarRowSplitReaderTest {
                 row2.add(0, i + 1);
                 f4.addGroup(0);
 
-                // add ROW<`f0` ARRAY<ROW<`b` ARRAY<ARRAY<INT>>, `c` INT>>, `f1` INT>>
+                // add ROW<`f0` INT , `f1` INTARRAY<ROW<`b` ARRAY<ARRAY<INT>>, `c` INT>>>>
                 Group f5 = row.addGroup("f5");
-                Group arrayRow = f5.addGroup(0);
+                f5.add(0, i);
+                Group arrayRow = f5.addGroup(1);
                 Group insideRow = arrayRow.addGroup(0).addGroup(0);
                 Group insideArray = insideRow.addGroup(0);
                 createParquetDoubleNestedArray(insideArray, i);
                 insideRow.add(1, i);
                 arrayRow.addGroup(0);
-                f5.add(1, i);
                 writer.write(row);
             }
         } catch (Exception e) {


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*
Fix parquet can not read row with last column is array.

## Brief change log

*(for example:)*
  - fix a corner condition.

## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

  - modify unit test case to cover the situation.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no
