### PR TITLE
[FLINK-36710] Log job ID in RecreateOnResetOperatorCoordinator

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/misc/JobIDLoggingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/JobIDLoggingITCase.java
@@ -149,9 +149,7 @@ class JobIDLoggingITCase {
                 sourceCoordinatorLogging,
                 asList(
                         "Starting split enumerator.*",
-                        "Distributing maxAllowedWatermark.*",
-                        "Source .* registering reader for parallel task.*",
-                        "Closing SourceCoordinator for source .*"));
+                        "Source .* registering reader for parallel task.*"));
 
         assertJobIDPresent(
                 jobID,


### PR DESCRIPTION
This PR fixes `JobIDLoggingITCase` test failures by 
1. Logging job ID from `RecreateOnResetOperatorCoordinator`
2. Removing assertions about optional messages