### PR TITLE
[FLINK-36745][docs] Make FixedSizeSplitFetcherManager and FixedFetcherSizeSourceReader examples match Flink 2.0-preview API

### DIFF
--- a/docs/content.zh/docs/dev/datastream/sources.md
+++ b/docs/content.zh/docs/dev/datastream/sources.md
@@ -294,9 +294,9 @@ public class FixedSizeSplitFetcherManager<E, SplitT extends SourceSplit>
 
     public FixedSizeSplitFetcherManager(
             int numFetchers,
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
-            Supplier<SplitReader<E, SplitT>> splitReaderSupplier) {
-        super(elementsQueue, splitReaderSupplier);
+            Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+            Configuration config) {
+        super(splitReaderSupplier, config);
         this.numFetchers = numFetchers;
         // 创建 numFetchers 个分片提取器.
         for (int i = 0; i < numFetchers; i++) {
@@ -338,16 +338,13 @@ public class FixedFetcherSizeSourceReader<E, T, SplitT extends SourceSplit, Spli
         extends SourceReaderBase<E, T, SplitT, SplitStateT> {
 
     public FixedFetcherSizeSourceReader(
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             Supplier<SplitReader<E, SplitT>> splitFetcherSupplier,
             RecordEmitter<E, T, SplitStateT> recordEmitter,
             Configuration config,
             SourceReaderContext context) {
         super(
-                elementsQueue,
                 new FixedSizeSplitFetcherManager<>(
-                        config.getInteger(SourceConfig.NUM_FETCHERS),
-                        elementsQueue,
+                        config.get(SourceConfig.NUM_FETCHERS),
                         splitFetcherSupplier),
                 recordEmitter,
                 config,

--- a/docs/content.zh/docs/dev/datastream/sources.md
+++ b/docs/content.zh/docs/dev/datastream/sources.md
@@ -345,7 +345,8 @@ public class FixedFetcherSizeSourceReader<E, T, SplitT extends SourceSplit, Spli
         super(
                 new FixedSizeSplitFetcherManager<>(
                         config.get(SourceConfig.NUM_FETCHERS),
-                        splitFetcherSupplier),
+                        splitFetcherSupplier,
+                        config),
                 recordEmitter,
                 config,
                 context);

--- a/docs/content/docs/dev/datastream/sources.md
+++ b/docs/content/docs/dev/datastream/sources.md
@@ -332,7 +332,8 @@ public class FixedFetcherSizeSourceReader<E, T, SplitT extends SourceSplit, Spli
         super(
                 new FixedSizeSplitFetcherManager<>(
                         config.get(SourceConfig.NUM_FETCHERS),
-                        splitFetcherSupplier),
+                        splitFetcherSupplier,
+                        config),
                 recordEmitter,
                 config,
                 context);

--- a/docs/content/docs/dev/datastream/sources.md
+++ b/docs/content/docs/dev/datastream/sources.md
@@ -281,9 +281,9 @@ public class FixedSizeSplitFetcherManager<E, SplitT extends SourceSplit>
 
     public FixedSizeSplitFetcherManager(
             int numFetchers,
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
-            Supplier<SplitReader<E, SplitT>> splitReaderSupplier) {
-        super(elementsQueue, splitReaderSupplier);
+            Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+            Configuration config) {
+        super(splitReaderSupplier, config);
         this.numFetchers = numFetchers;
         // Create numFetchers split fetchers.
         for (int i = 0; i < numFetchers; i++) {
@@ -325,16 +325,13 @@ public class FixedFetcherSizeSourceReader<E, T, SplitT extends SourceSplit, Spli
         extends SourceReaderBase<E, T, SplitT, SplitStateT> {
 
     public FixedFetcherSizeSourceReader(
-            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             Supplier<SplitReader<E, SplitT>> splitFetcherSupplier,
             RecordEmitter<E, T, SplitStateT> recordEmitter,
             Configuration config,
             SourceReaderContext context) {
         super(
-                elementsQueue,
                 new FixedSizeSplitFetcherManager<>(
-                        config.getInteger(SourceConfig.NUM_FETCHERS),
-                        elementsQueue,
+                        config.get(SourceConfig.NUM_FETCHERS),
                         splitFetcherSupplier),
                 recordEmitter,
                 config,


### PR DESCRIPTION
## What is the purpose of the change

Examples on documentation page [Data Sources](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/sources/) have been using the APIs that do not exist anymore in Flink 2.0-preview.

- FixedSizeSplitFetcherManager uses a SplitFetcherManager constructor that accepts elements queue and was removed in Flink 2.0-preview https://issues.apache.org/jira/browse/FLINK-36245
- FixedFetcherSizeSourceReader uses  uses a SourceReaderBase constructor that accepts elements queue and was removed in Flink 2.0-preview https://issues.apache.org/jira/browse/FLINK-36245
- FixedFetcherSizeSourceReader uses getInteger method of Configuration that was removed in in Flink 2.0-preview https://issues.apache.org/jira/browse/FLINK-34082

## Brief change log

  - switch FixedSizeSplitFetcherManager, FixedFetcherSizeSourceReader to use proper constructors of their super classes
  - switch from getInteger to get method of the Configuration class


## Verifying this change

- Since the changes affect the doc examples and there are no tests. I copied the snippets and verified (compiled) them locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
