### PR TITLE
[hotfix] Use Tag to replace some incorrectly used Category annotation for skipping adaptvie-scheduler test

### DIFF
--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopIOFormatsITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopIOFormatsITCase.java
@@ -29,7 +29,6 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
 import org.apache.flink.test.util.JavaProgramTestBase;
-import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
@@ -44,8 +43,8 @@ import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.SequenceFileInputFormat;
-import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -63,7 +62,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 // It is essentially a batch job, but the HadoopInputFormat is an unbounded source.
 // As a result, the test case cannot be set to batch runtime mode and should not run with the
 // adaptive scheduler.
-@Category(FailsWithAdaptiveScheduler.class)
+@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler")
 public class HadoopIOFormatsITCase extends JavaProgramTestBase {
 
     private static final int NUM_PROGRAMS = 2;

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopMapredITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/HadoopMapredITCase.java
@@ -22,12 +22,11 @@ import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.test.hadoopcompatibility.mapred.example.HadoopMapredCompatWordCount;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.JavaProgramTestBase;
-import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.util.OperatingSystem;
 
-import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
@@ -39,7 +38,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 // It is essentially a batch job, but the HadoopInputFormat is an unbounded source.
 // As a result, the test case cannot be set to batch runtime mode and should not run with the
 // adaptive scheduler.
-@Category(FailsWithAdaptiveScheduler.class)
+@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler")
 public class HadoopMapredITCase extends JavaProgramTestBase {
 
     protected String textPath;

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/WordCountMapredITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapred/WordCountMapredITCase.java
@@ -30,7 +30,6 @@ import org.apache.flink.streaming.api.functions.sink.legacy.OutputFormatSinkFunc
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.JavaProgramTestBase;
-import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler;
 import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OperatingSystem;
@@ -41,8 +40,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.mapred.TextOutputFormat;
-import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
@@ -54,7 +53,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 // It is essentially a batch job, but the HadoopInputFormat is an unbounded source.
 // As a result, the test case cannot be set to batch runtime mode and should not run with the
 // adaptive scheduler.
-@Category(FailsWithAdaptiveScheduler.class)
+@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler")
 class WordCountMapredITCase extends JavaProgramTestBase {
 
     private String textPath;

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/HadoopInputOutputITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/HadoopInputOutputITCase.java
@@ -24,11 +24,10 @@ import org.apache.flink.api.java.hadoop.mapreduce.HadoopOutputFormat;
 import org.apache.flink.test.hadoopcompatibility.mapreduce.example.WordCount;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.JavaProgramTestBase;
-import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler;
 import org.apache.flink.util.OperatingSystem;
 
-import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 
 import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -38,7 +37,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 // It is essentially a batch job, but the HadoopInputFormat is an unbounded source.
 // As a result, the test case cannot be set to batch runtime mode and should not run with the
 // adaptive scheduler.
-@Category(FailsWithAdaptiveScheduler.class)
+@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler")
 class HadoopInputOutputITCase extends JavaProgramTestBase {
 
     private String textPath;

--- a/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/WordCountMapreduceITCase.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/test/java/org/apache/flink/test/hadoopcompatibility/mapreduce/WordCountMapreduceITCase.java
@@ -30,7 +30,6 @@ import org.apache.flink.streaming.api.functions.sink.legacy.OutputFormatSinkFunc
 import org.apache.flink.streaming.api.windowing.assigners.GlobalWindows;
 import org.apache.flink.test.testdata.WordCountData;
 import org.apache.flink.test.util.JavaProgramTestBase;
-import org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OperatingSystem;
 
@@ -40,8 +39,8 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 
 import static org.apache.flink.test.util.TestBaseUtils.compareResultsByLinesInMemory;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -51,7 +50,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 // It is essentially a batch job, but the HadoopInputFormat is an unbounded source.
 // As a result, the test case cannot be set to batch runtime mode and should not run with the
 // adaptive scheduler.
-@Category(FailsWithAdaptiveScheduler.class)
+@Tag("org.apache.flink.testutils.junit.FailsWithAdaptiveScheduler")
 class WordCountMapreduceITCase extends JavaProgramTestBase {
 
     private String textPath;


### PR DESCRIPTION
## What is the purpose of the change

*We wanted to skip some batch related tests for adaptive-scheduler in ccb9bc27. Unfortunately, these test classes are based on Junit5, and using `Category` does not take effect. This can be fixed via using `Tag` in Juint5.*


## Brief change log

Use Tag to replace some incorrectly used Category annotation for skipping adaptvie-scheduler test


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
