### PR TITLE
[FLINK-36688][table-planner] Sort metadata keys when reusing source

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
@@ -408,7 +408,7 @@ public final class DynamicSourceUtils {
         relBuilder.push(scan);
     }
 
-    private static Map<String, DataType> extractMetadataMap(DynamicTableSource source) {
+    public static Map<String, DataType> extractMetadataMap(DynamicTableSource source) {
         if (source instanceof SupportsReadingMetadata) {
             return ((SupportsReadingMetadata) source).listReadableMetadata();
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuser.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuser.java
@@ -61,6 +61,7 @@ import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.metadata
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.pickScanWithWatermark;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.projectedFields;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.reusableWithoutAdjust;
+import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.sortMetadataKeys;
 
 /**
  * Reuse sources.
@@ -165,7 +166,7 @@ public class ScanReuser {
             }
 
             int[][] allProjectFields = allProjectFieldSet.toArray(new int[0][]);
-            List<String> allMetaKeys = new ArrayList<>(allMetaKeySet);
+            List<String> allMetaKeys = sortMetadataKeys(allMetaKeySet, pickTable.tableSource());
 
             // 2. Create new source.
             List<SourceAbilitySpec> specs = abilitySpecsWithoutEscaped(pickTable);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuser.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuser.java
@@ -55,13 +55,13 @@ import java.util.stream.Collectors;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.abilitySpecsWithoutEscaped;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.concatProjectedFields;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.createCalcForScan;
+import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.enforceMetadataKeyOrder;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.getAdjustedWatermarkSpec;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.indexOf;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.metadataKeys;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.pickScanWithWatermark;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.projectedFields;
 import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.reusableWithoutAdjust;
-import static org.apache.flink.table.planner.plan.reuse.ScanReuserUtils.sortMetadataKeys;
 
 /**
  * Reuse sources.
@@ -166,7 +166,8 @@ public class ScanReuser {
             }
 
             int[][] allProjectFields = allProjectFieldSet.toArray(new int[0][]);
-            List<String> allMetaKeys = sortMetadataKeys(allMetaKeySet, pickTable.tableSource());
+            List<String> allMetaKeys =
+                    enforceMetadataKeyOrder(allMetaKeySet, pickTable.tableSource());
 
             // 2. Create new source.
             List<SourceAbilitySpec> specs = abilitySpecsWithoutEscaped(pickTable);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
@@ -275,8 +275,7 @@ public class ScanReuserUtils {
 
     public static List<String> sortMetadataKeys(
             Set<String> allUsedMetadataKeys, DynamicTableSource source) {
-        List<String> allOrderedMetadataKeysFromTable =
-                new ArrayList<>(extractMetadataMap(source).keySet());
+        Set<String> allOrderedMetadataKeysFromTable = extractMetadataMap(source).keySet();
 
         return allOrderedMetadataKeysFromTable.stream()
                 .filter(allUsedMetadataKeys::contains)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.reuse;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.planner.connectors.DynamicSourceUtils;
 import org.apache.flink.table.planner.plan.abilities.source.FilterPushDownSpec;
 import org.apache.flink.table.planner.plan.abilities.source.ProjectPushDownSpec;
@@ -50,6 +51,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -58,6 +60,7 @@ import java.util.stream.Stream;
 import scala.Option;
 
 import static org.apache.flink.table.planner.connectors.DynamicSourceUtils.createRequiredMetadataColumns;
+import static org.apache.flink.table.planner.connectors.DynamicSourceUtils.extractMetadataMap;
 
 /** Utils for {@link ScanReuser}. */
 public class ScanReuserUtils {
@@ -268,6 +271,16 @@ public class ScanReuserUtils {
                         .map(col -> col.getMetadataKey().orElse(col.getName()))
                         .collect(Collectors.toList())
                 : meta.getMetadataKeys();
+    }
+
+    public static List<String> sortMetadataKeys(
+            Set<String> allUsedMetadataKeys, DynamicTableSource source) {
+        List<String> allOrderedMetadataKeysFromTable =
+                new ArrayList<>(extractMetadataMap(source).keySet());
+
+        return allOrderedMetadataKeysFromTable.stream()
+                .filter(allUsedMetadataKeys::contains)
+                .collect(Collectors.toList());
     }
 
     public static int[][] concatProjectedFields(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/reuse/ScanReuserUtils.java
@@ -273,7 +273,7 @@ public class ScanReuserUtils {
                 : meta.getMetadataKeys();
     }
 
-    public static List<String> sortMetadataKeys(
+    public static List<String> enforceMetadataKeyOrder(
             Set<String> allUsedMetadataKeys, DynamicTableSource source) {
         Set<String> allOrderedMetadataKeysFromTable = extractMetadataMap(source).keySet();
 

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ScanReuseTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ScanReuseTest.xml
@@ -1351,4 +1351,32 @@ Calc(select=[a1, a2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testReuseWithReadMetadataKeepOrder[isStreaming: true]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.snk1], fields=[origin_ts, partition, offset, id])
++- LogicalProject(origin_ts=[$0], partition=[$1], offset=[$2], id=[$3])
+   +- LogicalProject(origin_ts=[$2], partition=[$3], offset=[$1], id=[$0])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src, metadata=[offset, origin_ts, partition]]])
+
+LogicalSink(table=[default_catalog.default_database.snk2], fields=[id])
++- LogicalProject(id=[$3])
+   +- LogicalProject(origin_ts=[$2], partition=[$3], offset=[$1], id=[$0])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src, metadata=[offset, origin_ts, partition]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, src, project=[id, offset, origin_ts, partition], metadata=[offset, origin_ts, partition]]], fields=[id, offset, origin_ts, partition])(reuse_id=[1])
+
+Sink(table=[default_catalog.default_database.snk1], fields=[origin_ts, partition, offset, id])
++- Calc(select=[origin_ts, partition, offset, id])
+   +- Reused(reference_id=[1])
+
+Sink(table=[default_catalog.default_database.snk2], fields=[id])
++- Calc(select=[id])
+   +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
 </Root>


### PR DESCRIPTION
## What is the purpose of the change

Sort the metadata keys when reusing source.

## Brief change log

  - *Sort metadata keys in `ScanReuser`*
  - *Add tests to verity this pr*

## Verifying this change

New tests are added to verify this fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
