### PR TITLE
[FLINK-36789][table-common] Update FunctionHint and ArgumentHint with traits

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -661,8 +661,10 @@ public static class NamedParameterClass extends ScalarFunction {
     
   // 使用 @ArgumentHint 注解指定参数的名称，参数类型，以及该参数是否是必需的参数
   @FunctionHint(
-          argument = {@ArgumentHint(name = "param1", isOptional = false, type = @DataTypeHint("STRING")),
-                  @ArgumentHint(name = "param2", isOptional = true, type = @DataTypeHint("INTEGER"))}
+    arguments = {
+      @ArgumentHint(name = "param1", isOptional = false, type = @DataTypeHint("STRING")),
+      @ArgumentHint(name = "param2", isOptional = true, type = @DataTypeHint("INTEGER"))
+    }
   )
   public String eval(String s1, Integer s2) {
     return s1 + ", " + s2;
@@ -679,8 +681,10 @@ class NamedParameterClass extends ScalarFunction {
 
   // 使用 @ArgumentHint 注解指定参数的名称，参数类型，以及是否是必需的参数
   @FunctionHint(
-    argument = Array(new ArgumentHint(name = "param1", isOptional = false, `type` = new DataTypeHint("STRING")),
-                  new ArgumentHint(name = "param2", isOptional = true, `type` = new DataTypeHint("INTEGER")))
+    arguments = Array(
+      new ArgumentHint(name = "param1", isOptional = false, `type` = new DataTypeHint("STRING")),
+      new ArgumentHint(name = "param2", isOptional = true, `type` = new DataTypeHint("INTEGER"))
+    )
   )
   def eval(s1: String, s2: Int): String = {
     s1 + ", " + s2
@@ -700,8 +704,10 @@ import org.apache.flink.table.functions.ScalarFunction;
 
 // 使用 @ArgumentHint 注解指定参数的名称，参数类型，以及是否是必需的参数
 @FunctionHint(
-        argument = {@ArgumentHint(name = "param1", isOptional = false, type = @DataTypeHint("STRING")),
-                @ArgumentHint(name = "param2", isOptional = true, type = @DataTypeHint("INTEGER"))}
+  arguments = {
+    @ArgumentHint(name = "param1", isOptional = false, type = @DataTypeHint("STRING")),
+    @ArgumentHint(name = "param2", isOptional = true, type = @DataTypeHint("INTEGER"))
+  }
 )
 public static class NamedParameterClass extends ScalarFunction {
     
@@ -718,8 +724,10 @@ import org.apache.flink.table.functions.ScalarFunction;
 
 // 使用 @ArgumentHint 注解指定参数的名称，参数类型，以及是否是必需的参数
 @FunctionHint(
-  argument = Array(new ArgumentHint(name = "param1", isOptional = false, `type` = new DataTypeHint("STRING")),
-    new ArgumentHint(name = "param2", isOptional = true, `type` = new DataTypeHint("INTEGER")))
+  arguments = Array(
+    new ArgumentHint(name = "param1", isOptional = false, `type` = new DataTypeHint("STRING")),
+    new ArgumentHint(name = "param2", isOptional = true, `type` = new DataTypeHint("INTEGER"))
+  )
 )
 class NamedParameterClass extends ScalarFunction {
 

--- a/docs/content.zh/docs/dev/table/procedures.md
+++ b/docs/content.zh/docs/dev/table/procedures.md
@@ -397,13 +397,15 @@ import org.apache.flink.types.Row;
 
 public static class NamedParameterProcedure extends Procedure {
     
-      @ProcedureHint(
-              argument = {@ArgumentHint(name = "param1", type = @DataTypeHint("INTEGER"), isOptional = false),
-                            @ArgumentHint(name = "param2", type = @DataTypeHint("INTEGER"), isOptional = true)}
-      )
-      public @DataTypeHint("INT") Integer[] call(ProcedureContext context, Integer a, Integer b) {
-        return new Integer[] {a + (b == null ? 0 : b)};
-      }
+  @ProcedureHint(
+    arguments = {
+      @ArgumentHint(name = "param1", type = @DataTypeHint("INTEGER"), isOptional = false),
+      @ArgumentHint(name = "param2", type = @DataTypeHint("INTEGER"), isOptional = true)
+    }
+  )
+  public @DataTypeHint("INT") Integer[] call(ProcedureContext context, Integer a, Integer b) {
+    return new Integer[] {a + (b == null ? 0 : b)};
+  }
 }
 ```
 {{< /tab >}}
@@ -418,15 +420,16 @@ import org.apache.flink.types.Row
 import scala.annotation.varargs
 
 class NamedParameterProcedure extends Procedure {
+
   @ProcedureHint(
-    argument = Array(
+    arguments = Array(
       new ArgumentHint(name = "param1", `type` = new DataTypeHint("INTEGER"), isOptional = false),
       new ArgumentHint(name = "param2", `type` = new DataTypeHint("INTEGER"), isOptional = true)
     )
   )
-    def call(context: ProcedureContext, a: Integer, b: Integer): Array[Integer] = {
-        Array(a + (if (b == null) 0 else b))
-    }
+  def call(context: ProcedureContext, a: Integer, b: Integer): Array[Integer] = {
+    Array(a + (if (b == null) 0 else b))
+  }
 }
 ```
 {{< /tab >}}
@@ -444,8 +447,10 @@ import org.apache.flink.table.procedures.Procedure;
 import org.apache.flink.types.Row;
 
 @ProcedureHint(
-        argument = {@ArgumentHint(name = "param1", type = @DataTypeHint("INTEGER"), isOptional = false),
-                      @ArgumentHint(name = "param2", type = @DataTypeHint("INTEGER"), isOptional = true)}
+  arguments = {
+    @ArgumentHint(name = "param1", type = @DataTypeHint("INTEGER"), isOptional = false),
+    @ArgumentHint(name = "param2", type = @DataTypeHint("INTEGER"), isOptional = true)
+  }
 )
 public static class NamedParameterProcedure extends Procedure {
 
@@ -466,7 +471,7 @@ import org.apache.flink.types.Row
 import scala.annotation.varargs
 
 @ProcedureHint(
-  argument = Array(
+  arguments = Array(
     new ArgumentHint(name = "param1", `type` = new DataTypeHint("INTEGER"), isOptional = false),
     new ArgumentHint(name = "param2", `type` = new DataTypeHint("INTEGER"), isOptional = true)
   )

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -671,8 +671,10 @@ public static class NamedParameterClass extends ScalarFunction {
     
   // Use the @ArgumentHint annotation to specify the name, type, and whether a parameter is required.
   @FunctionHint(
-          argument = {@ArgumentHint(name = "param1", isOptional = false, type = @DataTypeHint("STRING")),
-                  @ArgumentHint(name = "param2", isOptional = true, type = @DataTypeHint("INTEGER"))}
+    arguments = {
+      @ArgumentHint(name = "param1", isOptional = false, type = @DataTypeHint("STRING")),
+      @ArgumentHint(name = "param2", isOptional = true, type = @DataTypeHint("INTEGER"))
+    }
   )
   public String eval(String s1, Integer s2) {
     return s1 + ", " + s2;
@@ -689,8 +691,10 @@ class NamedParameterClass extends ScalarFunction {
 
   // Use the @ArgumentHint annotation to specify the name, type, and whether a parameter is required.
   @FunctionHint(
-    argument = Array(new ArgumentHint(name = "param1", isOptional = false, `type` = new DataTypeHint("STRING")),
-                  new ArgumentHint(name = "param2", isOptional = true, `type` = new DataTypeHint("INTEGER")))
+    arguments = Array(
+      new ArgumentHint(name = "param1", isOptional = false, `type` = new DataTypeHint("STRING")),
+      new ArgumentHint(name = "param2", isOptional = true, `type` = new DataTypeHint("INTEGER"))
+    )
   )
   def eval(s1: String, s2: Int): String = {
     s1 + ", " + s2
@@ -710,8 +714,10 @@ import org.apache.flink.table.functions.ScalarFunction;
 
 // Use the @ArgumentHint annotation to specify the name, type, and whether a parameter is required.
 @FunctionHint(
-        argument = {@ArgumentHint(name = "param1", isOptional = false, type = @DataTypeHint("STRING")),
-                @ArgumentHint(name = "param2", isOptional = true, type = @DataTypeHint("INTEGER"))}
+  arguments = {
+    @ArgumentHint(name = "param1", isOptional = false, type = @DataTypeHint("STRING")),
+    @ArgumentHint(name = "param2", isOptional = true, type = @DataTypeHint("INTEGER"))
+  }
 )
 public static class NamedParameterClass extends ScalarFunction {
     
@@ -728,8 +734,10 @@ import org.apache.flink.table.functions.ScalarFunction;
 
 // Use the @ArgumentHint annotation to specify the name, type, and whether a parameter is required.
 @FunctionHint(
-  argument = Array(new ArgumentHint(name = "param1", isOptional = false, `type` = new DataTypeHint("STRING")),
-    new ArgumentHint(name = "param2", isOptional = true, `type` = new DataTypeHint("INTEGER")))
+  arguments = Array(
+    new ArgumentHint(name = "param1", isOptional = false, `type` = new DataTypeHint("STRING")),
+    new ArgumentHint(name = "param2", isOptional = true, `type` = new DataTypeHint("INTEGER"))
+  )
 )
 class NamedParameterClass extends ScalarFunction {
 

--- a/docs/content/docs/dev/table/procedures.md
+++ b/docs/content/docs/dev/table/procedures.md
@@ -395,14 +395,16 @@ import org.apache.flink.table.procedures.Procedure;
 import org.apache.flink.types.Row;
 
 public static class NamedParameterProcedure extends Procedure {
-    
-      @ProcedureHint(
-              argument = {@ArgumentHint(name = "param1", type = @DataTypeHint("INTEGER"), isOptional = false),
-                            @ArgumentHint(name = "param2", type = @DataTypeHint("INTEGER"), isOptional = true)}
-      )
-      public @DataTypeHint("INT") Integer[] call(ProcedureContext context, Integer a, Integer b) {
-        return new Integer[] {a + (b == null ? 0 : b)};
-      }
+
+  @ProcedureHint(
+    arguments = {
+      @ArgumentHint(name = "param1", type = @DataTypeHint("INTEGER"), isOptional = false),
+      @ArgumentHint(name = "param2", type = @DataTypeHint("INTEGER"), isOptional = true)
+    }
+  )
+  public @DataTypeHint("INT") Integer[] call(ProcedureContext context, Integer a, Integer b) {
+    return new Integer[] {a + (b == null ? 0 : b)};
+  }
 }
 ```
 {{< /tab >}}
@@ -417,15 +419,16 @@ import org.apache.flink.types.Row
 import scala.annotation.varargs
 
 class NamedParameterProcedure extends Procedure {
+
   @ProcedureHint(
-    argument = Array(
+    arguments = Array(
       new ArgumentHint(name = "param1", `type` = new DataTypeHint("INTEGER"), isOptional = false),
       new ArgumentHint(name = "param2", `type` = new DataTypeHint("INTEGER"), isOptional = true)
     )
   )
-    def call(context: ProcedureContext, a: Integer, b: Integer): Array[Integer] = {
-        Array(a + (if (b == null) 0 else b))
-    }
+  def call(context: ProcedureContext, a: Integer, b: Integer): Array[Integer] = {
+    Array(a + (if (b == null) 0 else b))
+  }
 }
 ```
 {{< /tab >}}
@@ -443,8 +446,10 @@ import org.apache.flink.table.procedures.Procedure;
 import org.apache.flink.types.Row;
 
 @ProcedureHint(
-        argument = {@ArgumentHint(name = "param1", type = @DataTypeHint("INTEGER"), isOptional = false),
-                      @ArgumentHint(name = "param2", type = @DataTypeHint("INTEGER"), isOptional = true)}
+  arguments = {
+    @ArgumentHint(name = "param1", type = @DataTypeHint("INTEGER"), isOptional = false),
+    @ArgumentHint(name = "param2", type = @DataTypeHint("INTEGER"), isOptional = true)
+  }
 )
 public static class NamedParameterProcedure extends Procedure {
 
@@ -465,7 +470,7 @@ import org.apache.flink.types.Row
 import scala.annotation.varargs
 
 @ProcedureHint(
-  argument = Array(
+  arguments = Array(
     new ArgumentHint(name = "param1", `type` = new DataTypeHint("INTEGER"), isOptional = false),
     new ArgumentHint(name = "param2", `type` = new DataTypeHint("INTEGER"), isOptional = true)
   )

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/ArgumentHint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/ArgumentHint.java
@@ -31,16 +31,22 @@ import java.lang.annotation.Target;
  * <p>An {@code ArgumentHint} can be used to provide hints about the name, optionality, and data
  * type of argument.
  *
- * <p>It combines the functionality of {@link FunctionHint#argumentNames()} and {@link DataTypeHint}
- * annotations to conveniently group argument-related information together in function declarations.
+ * <p>{@code @ArgumentHint(name = "in1", type = @DataTypeHint("STRING"), isOptional = false)} is a
+ * scalar argument with the data type STRING, named "in1", and cannot be omitted when calling.
  *
- * <p>{@code @ArgumentHint(name = "in1", type = @DataTypeHint("STRING"), isOptional = false} is an
- * argument with the type String, named in1, and cannot be omitted when calling.
+ * @see FunctionHint
  */
 @PublicEvolving
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
 public @interface ArgumentHint {
+
+    /**
+     * The kind of the argument.
+     *
+     * <p>Only applies to {@code ProcessTableFunction}s (PTFs). Others can only take scalar values.
+     */
+    ArgumentTrait[] value() default {ArgumentTrait.SCALAR};
 
     /**
      * The name of the argument.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/ArgumentTrait.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/ArgumentTrait.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.annotation;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.types.inference.StaticArgumentTrait;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Declares traits for {@link ArgumentHint}. They enable basic validation by the framework.
+ *
+ * <p>Some traits have dependencies to other traits, which is why this enum reflects a hierarchy in
+ * which {@link #SCALAR}, {@link #TABLE_AS_ROW}, and {@link #TABLE_AS_SET} are the top-level roots.
+ */
+@PublicEvolving
+public enum ArgumentTrait {
+
+    /**
+     * An argument that accepts a scalar value. For example: f(1), f(true), f('Some string').
+     *
+     * <p>It's the default if no {@link ArgumentHint} is provided.
+     */
+    SCALAR(StaticArgumentTrait.SCALAR),
+
+    /**
+     * An argument that accepts a table "as row" (i.e. with row semantics). This trait only applies
+     * to {@code ProcessTableFunction} (PTF).
+     *
+     * <p>For scalability, input tables are distributed into virtual processors. Each virtual
+     * processor executes a PTF instance and has access only to a share of the entire table. The
+     * argument declaration decides about the size of the share and co-location of data.
+     *
+     * <p>A table with row semantics assumes that there is no correlation between rows and each row
+     * can be processed independently. The framework is free in how to distribute rows among virtual
+     * processors and each virtual processor has access only to the currently processed row.
+     */
+    TABLE_AS_ROW(StaticArgumentTrait.TABLE_AS_ROW),
+
+    /**
+     * An argument that accepts a table "as set" (i.e. with set semantics). This trait only applies
+     * to {@code ProcessTableFunction} (PTF).
+     *
+     * <p>For scalability, input tables are distributed into virtual processors. Each virtual
+     * processor executes a PTF instance and has access only to a share of the entire table. The
+     * argument declaration decides about the size of the share and co-location of data.
+     *
+     * <p>A table with set semantics assumes that there is a correlation between rows. When calling
+     * the function, the PARTITION BY clause defines the columns for correlation. The framework
+     * ensures that all rows belonging to same set are co-located. A PTF instance is able to access
+     * all rows belonging to the same set. In other words: The virtual processor is scoped under a
+     * key context.
+     */
+    TABLE_AS_SET(StaticArgumentTrait.TABLE_AS_SET),
+
+    /**
+     * Defines that a PARTITION BY clause is optional for {@link #TABLE_AS_SET}. By default, it is
+     * mandatory for improving the parallel execution by distributing the table by key.
+     */
+    OPTIONAL_PARTITION_BY(StaticArgumentTrait.OPTIONAL_PARTITION_BY, TABLE_AS_SET);
+
+    private final StaticArgumentTrait staticTrait;
+    private final Set<ArgumentTrait> requirements;
+
+    ArgumentTrait(StaticArgumentTrait staticTrait, ArgumentTrait... requirements) {
+        this.staticTrait = staticTrait;
+        this.requirements = Arrays.stream(requirements).collect(Collectors.toSet());
+    }
+
+    public Set<ArgumentTrait> getRequirements() {
+        return requirements;
+    }
+
+    public StaticArgumentTrait toStaticTrait() {
+        return staticTrait;
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/FunctionHint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/FunctionHint.java
@@ -29,8 +29,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A hint that influences the reflection-based extraction of input types, accumulator types, and
- * output types for constructing the {@link TypeInference} logic of a {@link UserDefinedFunction}.
+ * A hint that influences the reflection-based extraction of arguments, accumulator, and output for
+ * constructing the {@link TypeInference} logic of a {@link UserDefinedFunction}.
  *
  * <p>One or more annotations can be declared on top of a {@link UserDefinedFunction} class or
  * individually for each {@code eval()/accumulate()} method for overloading function signatures. All
@@ -42,18 +42,24 @@ import java.lang.annotation.Target;
  * part and let the default extraction do the rest:
  *
  * <pre>{@code
- * // accepts (INT, STRING) and returns BOOLEAN
+ * // accepts (INT, STRING) and returns BOOLEAN,
+ * // the arguments have names and are optional
  * @FunctionHint(
- *   argument = [(name = "f1", @DataTypeHint("INT"), isOptional = true),
- *      (name = "f2", @DataTypeHint("STRING"), isOptional = true)],
+ *   arguments = {
+ *     @ArgumentHint(type = @DataTypeHint("INT"), name = "in1", isOptional = true),
+ *     @ArgumentHint(type = @DataTypeHint("STRING"), name = "in2", isOptional = true)
+ *   },
  *   output = @DataTypeHint("BOOLEAN")
  * )
  * class X extends ScalarFunction { ... }
  *
- * // accepts (INT, STRING...) and returns BOOLEAN
+ * // accepts (INT, STRING...) and returns BOOLEAN,
+ * // the arguments have names
  * @FunctionHint(
- *   argument = [(name = "f1", @DataTypeHint("INT"), isOptional = false),
- *      (name = "f2", @DataTypeHint("STRING"), isOptional = false)],
+ *   arguments = {
+ *     @ArgumentHint(type = @DataTypeHint("INT"), name = "in1"),
+ *     @ArgumentHint(type = @DataTypeHint("STRING"), name = "in2")
+ *   },
  *   isVarArgs = true,
  *   output = @DataTypeHint("BOOLEAN")
  * )
@@ -122,6 +128,7 @@ import java.lang.annotation.Target;
  * }</pre>
  *
  * @see DataTypeHint
+ * @see ArgumentHint
  */
 @PublicEvolving
 @Retention(RetentionPolicy.RUNTIME)
@@ -131,8 +138,7 @@ public @interface FunctionHint {
 
     // Note to implementers:
     // Because "null" is not supported as an annotation value. Every annotation parameter *must*
-    // have
-    // some representation for unknown values in order to merge multi-level annotations.
+    // have some representation for unknown values in order to merge multi-level annotations.
 
     /**
      * Explicitly lists the argument types that a function takes as input.
@@ -141,8 +147,10 @@ public @interface FunctionHint {
      * used.
      *
      * <p>Note: Specifying the input arguments manually disables the entire reflection-based
-     * extraction around arguments. This means that also {@link #isVarArgs()} and {@link
-     * #argumentNames()} need to be specified manually if required.
+     * extraction around arguments. This means that also {@link #isVarArgs()} needs to be specified
+     * manually if required.
+     *
+     * <p>Use {@link #arguments()} for more control about argument names and argument kinds.
      */
     DataTypeHint[] input() default @DataTypeHint();
 
@@ -157,25 +165,14 @@ public @interface FunctionHint {
     boolean isVarArgs() default false;
 
     /**
-     * Explicitly lists the argument names that a function takes as input.
+     * Explicitly lists the arguments that a function takes as input. Including their names, data
+     * types, kinds, and whether they are optional.
      *
-     * <p>By default, if {@link #input()} is defined, explicit argument names are undefined and this
-     * parameter can be used to provide argument names. If {@link #input()} is not defined, the
-     * reflection-based extraction is used, thus, this parameter is ignored.
+     * <p>It is recommended to use this parameter instead of {@link #input()}. Using both {@link
+     * #input()} and this parameter is not allowed. Specifying the list of arguments manually
+     * disables the entire reflection-based extraction around arguments.
      */
-    String[] argumentNames() default {""};
-
-    /**
-     * Explicitly lists the argument that a function takes as input, including their names, types,
-     * and whether they are optional.
-     *
-     * <p>By default, it is recommended to use this parameter instead of {@link #input()}. If the
-     * type of argumentHint is not defined, it will be considered an invalid argument and an
-     * exception will be thrown. Additionally, both this parameter and {@link #input()} cannot be
-     * defined at the same time. If neither argument nor {@link #input()} are defined,
-     * reflection-based extraction will be used.
-     */
-    ArgumentHint[] argument() default {};
+    ArgumentHint[] arguments() default {};
 
     /**
      * Explicitly defines the intermediate result type that a function uses as accumulator.
@@ -192,4 +189,32 @@ public @interface FunctionHint {
      * used.
      */
     DataTypeHint output() default @DataTypeHint();
+
+    // --------------------------------------------------------------------------------------------
+    // Legacy
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Explicitly lists the argument names that a function takes as input.
+     *
+     * <p>By default, if {@link #input()} is defined, explicit argument names are undefined and this
+     * parameter can be used to provide argument names. If {@link #input()} is not defined, the
+     * reflection-based extraction is used, thus, this parameter is ignored.
+     *
+     * @deprecated Use {@link #arguments()} instead.
+     */
+    @Deprecated
+    String[] argumentNames() default {""};
+
+    /**
+     * Explicitly lists the arguments that a function takes as input. Including their names, data
+     * types, kinds, and whether they are optional.
+     *
+     * <p>It is recommended to use this parameter instead of {@link #input()}. Specifying the list
+     * of arguments manually disables the entire reflection-based extraction around arguments.
+     *
+     * @deprecated Use {@link #arguments()} instead.
+     */
+    @Deprecated
+    ArgumentHint[] argument() default {};
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/ProcedureHint.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/ProcedureHint.java
@@ -29,32 +29,38 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A hint that influences the reflection-based extraction of input types and output types for
- * constructing the {@link TypeInference} logic of a {@link Procedure}.
+ * A hint that influences the reflection-based extraction of arguments and output for constructing
+ * the {@link TypeInference} logic of a {@link Procedure}.
  *
  * <p>One or more annotations can be declared on top of a {@link Procedure} class or individually
  * for each {@code call()} method for overloading function signatures. All hint parameters are
  * optional. If a parameter is not defined, the default reflection-based extraction is used. Hint
  * parameters defined on top of a {@link Procedure} class are inherited by all {@code call()}
- * methods. The {@link DataTypeHint} for the output data type of a {@link Procedure} should always
- * hint the component type of the array returned by {@link Procedure}.
+ * methods. The {@link DataTypeHint} for the output data type should always hint the component type
+ * of the array returned by {@link Procedure}.
  *
  * <p>The following examples show how to explicitly specify procedure signatures as a whole or in
  * part and let the default extraction do the rest:
  *
  * <pre>{@code
- * // accepts (INT, STRING) and returns BOOLEAN
+ * // accepts (INT, STRING) and returns BOOLEAN,
+ * // the arguments have names and are optional
  * @ProcedureHint(
- *   argument = [(name = "f1", @DataTypeHint("INT"), isOptional = true),
- *      (name = "f2", @DataTypeHint("STRING"), isOptional = true)],
+ *   arguments = {
+ *     @ArgumentHint(type = @DataTypeHint("INT"), name = "in1", isOptional = true),
+ *     @ArgumentHint(type = @DataTypeHint("STRING"), name = "in2", isOptional = true)
+ *   },
  *   output = @DataTypeHint("BOOLEAN")
  * )
  * class X implements Procedure { ... }
  *
- * // accepts (INT, STRING...) and returns BOOLEAN
+ * // accepts (INT, STRING...) and returns BOOLEAN,
+ * // the arguments have names
  * @ProcedureHint(
- *   argument = [(name = "f1", @DataTypeHint("INT"), isOptional = false),
- *      (name = "f2", @DataTypeHint("STRING"), isOptional = false)],
+ *   arguments = {
+ *     @ArgumentHint(type = @DataTypeHint("INT"), name = "in1"),
+ *     @ArgumentHint(type = @DataTypeHint("STRING"), name = "in2")
+ *   },
  *   isVarArgs = true,
  *   output = @DataTypeHint("BOOLEAN")
  * )
@@ -114,16 +120,17 @@ import java.lang.annotation.Target;
  * }</pre>
  *
  * @see DataTypeHint
+ * @see ArgumentHint
  */
 @PublicEvolving
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Repeatable(ProcedureHints.class)
 public @interface ProcedureHint {
+
     // Note to implementers:
     // Because "null" is not supported as an annotation value. Every annotation parameter *must*
-    // have
-    // some representation for unknown values in order to merge multi-level annotations.
+    // have some representation for unknown values in order to merge multi-level annotations.
 
     /**
      * Explicitly lists the argument types that a procedure takes as input.
@@ -132,8 +139,10 @@ public @interface ProcedureHint {
      * used.
      *
      * <p>Note: Specifying the input arguments manually disables the entire reflection-based
-     * extraction around arguments. This means that also {@link #isVarArgs()} and {@link
-     * #argumentNames()} need to be specified manually if required.
+     * extraction around arguments. This means that also {@link #isVarArgs()} needs to be specified
+     * manually if required.
+     *
+     * <p>Use {@link #arguments()} for more control about argument names and argument kinds.
      */
     DataTypeHint[] input() default @DataTypeHint();
 
@@ -148,25 +157,14 @@ public @interface ProcedureHint {
     boolean isVarArgs() default false;
 
     /**
-     * Explicitly lists the argument names that a procedure takes as input.
+     * Explicitly lists the arguments that a procedure takes as input. Including their names, data
+     * types, kinds, and whether they are optional.
      *
-     * <p>By default, if {@link #input()} is defined, explicit argument names are undefined and this
-     * parameter can be used to provide argument names. If {@link #input()} is not defined, the
-     * reflection-based extraction is used, thus, this parameter is ignored.
+     * <p>It is recommended to use this parameter instead of {@link #input()}. Using both {@link
+     * #input()} and this parameter is not allowed. Specifying the list of arguments manually
+     * disables the entire reflection-based extraction around arguments.
      */
-    String[] argumentNames() default {""};
-
-    /**
-     * Explicitly lists the argument that a procedure takes as input, including their names, types,
-     * and whether they are optional.
-     *
-     * <p>By default, it is recommended to use this parameter instead of {@link #input()}. If the
-     * type of argumentHint is not defined, it will be considered an invalid argument and an
-     * exception will be thrown. Additionally, both this parameter and {@link #input()} cannot be
-     * defined at the same time. If neither argument nor {@link #input()} are defined,
-     * reflection-based extraction will be used.
-     */
-    ArgumentHint[] argument() default {};
+    ArgumentHint[] arguments() default {};
 
     /**
      * Explicitly defines the result type that a procedure uses as output.
@@ -175,4 +173,32 @@ public @interface ProcedureHint {
      * used.
      */
     DataTypeHint output() default @DataTypeHint();
+
+    // --------------------------------------------------------------------------------------------
+    // Legacy
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Explicitly lists the argument names that a procedure takes as input.
+     *
+     * <p>By default, if {@link #input()} is defined, explicit argument names are undefined and this
+     * parameter can be used to provide argument names. If {@link #input()} is not defined, the
+     * reflection-based extraction is used, thus, this parameter is ignored.
+     *
+     * @deprecated Use {@link #arguments()} instead.
+     */
+    @Deprecated
+    String[] argumentNames() default {""};
+
+    /**
+     * Explicitly lists the arguments that a procedure takes as input. Including their names, data
+     * types, kinds, and whether they are optional.
+     *
+     * <p>It is recommended to use this parameter instead of {@link #input()}. Specifying the list
+     * of arguments manually disables the entire reflection-based extraction around arguments.
+     *
+     * @deprecated Use {@link #arguments()} instead.
+     */
+    @Deprecated
+    ArgumentHint[] argument() default {};
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/BaseMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/BaseMappingExtractor.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.types.extraction;
 
 import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.ArgumentTrait;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
@@ -461,7 +462,17 @@ abstract class BaseMappingExtractor {
         return Arrays.stream(method.getParameters())
                 .skip(offset)
                 .map(parameter -> parameter.getAnnotation(ArgumentHint.class))
-                .map(argumentHint -> argumentHint != null && argumentHint.isOptional())
+                .map(
+                        h -> {
+                            if (h == null) {
+                                return false;
+                            }
+                            final ArgumentTrait[] traits = h.value();
+                            if (traits.length != 1 || traits[0] != ArgumentTrait.SCALAR) {
+                                throw extractionError("Only scalar arguments are supported yet.");
+                            }
+                            return h.isOptional();
+                        })
                 .toArray(Boolean[]::new);
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
@@ -766,7 +766,7 @@ public final class ExtractionUtils {
                                 parameter -> {
                                     ArgumentHint argumentHint =
                                             parameter.getAnnotation(ArgumentHint.class);
-                                    if (argumentHint != null && argumentHint.name() != "") {
+                                    if (argumentHint != null && !argumentHint.name().isEmpty()) {
                                         return argumentHint.name();
                                     } else {
                                         return parameter.getName();
@@ -783,7 +783,7 @@ public final class ExtractionUtils {
             getClassReader(executable.getDeclaringClass()).accept(extractor, 0);
 
             final List<String> extractedNames = extractor.getParameterNames();
-            if (extractedNames.size() == 0) {
+            if (extractedNames.isEmpty()) {
                 return null;
             }
             // remove "this" and additional local variables

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionTemplate.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.types.extraction;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.ArgumentTrait;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.annotation.ProcedureHint;
@@ -70,6 +71,7 @@ final class FunctionTemplate {
                         defaultAsNull(hint, FunctionHint::input),
                         defaultAsNull(hint, FunctionHint::argumentNames),
                         defaultAsNull(hint, FunctionHint::argument),
+                        defaultAsNull(hint, FunctionHint::arguments),
                         hint.isVarArgs()),
                 createResultTemplate(typeFactory, defaultAsNull(hint, FunctionHint::accumulator)),
                 createResultTemplate(typeFactory, defaultAsNull(hint, FunctionHint::output)));
@@ -86,6 +88,7 @@ final class FunctionTemplate {
                         defaultAsNull(hint, ProcedureHint::input),
                         defaultAsNull(hint, ProcedureHint::argumentNames),
                         defaultAsNull(hint, ProcedureHint::argument),
+                        defaultAsNull(hint, ProcedureHint::arguments),
                         hint.isVarArgs()),
                 null,
                 createResultTemplate(typeFactory, defaultAsNull(hint, ProcedureHint::output)));
@@ -183,19 +186,44 @@ final class FunctionTemplate {
             DataTypeFactory typeFactory,
             @Nullable DataTypeHint[] inputs,
             @Nullable String[] argumentNames,
-            @Nullable ArgumentHint[] argumentHints,
+            @Nullable ArgumentHint[] singularArgumentHints,
+            @Nullable ArgumentHint[] pluralArgumentHints,
             boolean isVarArg) {
+        // Deal with #argument() and #arguments()
+        if (singularArgumentHints != null && pluralArgumentHints != null) {
+            throw extractionError(
+                    "Argument hints should only be defined once in the same function hint.");
+        }
+        final ArgumentHint[] argumentHints;
+        if (singularArgumentHints != null) {
+            argumentHints = singularArgumentHints;
+        } else {
+            argumentHints = pluralArgumentHints;
+        }
 
         String[] argumentHintNames;
         DataTypeHint[] argumentHintTypes;
 
+        // Deal with #arguments() and #input()
         if (argumentHints != null && inputs != null) {
             throw extractionError(
                     "Argument and input hints cannot be declared in the same function hint.");
         }
 
-        Boolean[] argumentOptionals = null;
+        Boolean[] argumentOptionals;
         if (argumentHints != null) {
+            final boolean allScalar =
+                    Arrays.stream(argumentHints)
+                            .allMatch(
+                                    h -> {
+                                        final ArgumentTrait[] traits = h.value();
+                                        return traits.length == 1
+                                                && traits[0] == ArgumentTrait.SCALAR;
+                                    });
+            if (!allScalar) {
+                throw extractionError("Only scalar arguments are supported yet.");
+            }
+
             argumentHintNames = new String[argumentHints.length];
             argumentHintTypes = new DataTypeHint[argumentHints.length];
             argumentOptionals = new Boolean[argumentHints.length];

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.types.extraction;
 
 import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.table.annotation.ArgumentHint;
+import org.apache.flink.table.annotation.ArgumentTrait;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.annotation.InputGroup;
@@ -627,7 +628,11 @@ class TypeInferenceExtractorTest {
                                             InputTypeStrategies.explicit(DataTypes.STRING()),
                                             InputTypeStrategies.explicit(DataTypes.INT())
                                         }),
-                                TypeStrategies.explicit(DataTypes.STRING())));
+                                TypeStrategies.explicit(DataTypes.STRING())),
+                TestSpec.forScalarFunction(FunctionHintTableArgScalarFunction.class)
+                        .expectErrorMessage("Only scalar arguments are supported yet."),
+                TestSpec.forScalarFunction(ArgumentHintTableArgScalarFunction.class)
+                        .expectErrorMessage("Only scalar arguments are supported yet."));
     }
 
     private static Stream<TestSpec> procedureSpecs() {
@@ -1758,7 +1763,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintOnMethodProcedure implements Procedure {
         @ProcedureHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1", isOptional = true),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2", isOptional = true)
                 })
@@ -1768,7 +1773,7 @@ class TypeInferenceExtractorTest {
     }
 
     @ProcedureHint(
-            argument = {
+            arguments = {
                 @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1", isOptional = true),
                 @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2", isOptional = true)
             })
@@ -1786,29 +1791,19 @@ class TypeInferenceExtractorTest {
                                 name = "parameter_f1",
                                 isOptional = true)
                         String f1,
-                @ArgumentHint(
-                                type = @DataTypeHint("INT"),
-                                name = "parameter_f2",
-                                isOptional = false)
-                        int f2) {
+                @ArgumentHint(type = @DataTypeHint("INT"), name = "parameter_f2") int f2) {
             return null;
         }
     }
 
     @ProcedureHint(
-            argument = {
-                @ArgumentHint(
-                        type = @DataTypeHint("STRING"),
-                        name = "global_f1",
-                        isOptional = false),
-                @ArgumentHint(
-                        type = @DataTypeHint("INTEGER"),
-                        name = "global_f2",
-                        isOptional = false)
+            arguments = {
+                @ArgumentHint(type = @DataTypeHint("STRING"), name = "global_f1"),
+                @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "global_f2")
             })
     private static class ArgumentHintOnClassAndMethodProcedure implements Procedure {
         @ProcedureHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(
                             type = @DataTypeHint("STRING"),
                             name = "local_f1",
@@ -1825,7 +1820,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintOnMethodAndParameterProcedure implements Procedure {
         @ProcedureHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(
                             type = @DataTypeHint("STRING"),
                             name = "local_f1",
@@ -1852,19 +1847,13 @@ class TypeInferenceExtractorTest {
     }
 
     @ProcedureHint(
-            argument = {
-                @ArgumentHint(
-                        type = @DataTypeHint("STRING"),
-                        name = "global_f1",
-                        isOptional = false),
-                @ArgumentHint(
-                        type = @DataTypeHint("INTEGER"),
-                        name = "global_f2",
-                        isOptional = false)
+            arguments = {
+                @ArgumentHint(type = @DataTypeHint("STRING"), name = "global_f1"),
+                @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "global_f2")
             })
     private static class ArgumentHintOnClassAndMethodAndParameterProcedure implements Procedure {
         @ProcedureHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(
                             type = @DataTypeHint("STRING"),
                             name = "local_f1",
@@ -1888,7 +1877,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintNotNullWithOptionalProcedure implements Procedure {
         @ProcedureHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1", isOptional = true),
                     @ArgumentHint(
                             type = @DataTypeHint("INTEGER NOT NULL"),
@@ -1902,7 +1891,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintNameConflictProcedure implements Procedure {
         @ProcedureHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1", isOptional = true),
                     @ArgumentHint(
                             type = @DataTypeHint("INTEGER NOT NULL"),
@@ -1917,7 +1906,7 @@ class TypeInferenceExtractorTest {
     private static class ArgumentHintOptionalOnPrimitiveParameterConflictProcedure
             implements Procedure {
         @ProcedureHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1", isOptional = true),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2", isOptional = true)
                 })
@@ -1964,7 +1953,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintScalarFunction extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1"),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2")
                 })
@@ -1974,7 +1963,7 @@ class TypeInferenceExtractorTest {
     }
 
     private static class ArgumentHintMissingTypeScalarFunction extends ScalarFunction {
-        @FunctionHint(argument = {@ArgumentHint(name = "f1"), @ArgumentHint(name = "f2")})
+        @FunctionHint(arguments = {@ArgumentHint(name = "f1"), @ArgumentHint(name = "f2")})
         public String eval(String f1, Integer f2) {
             return "";
         }
@@ -1982,7 +1971,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintMissingNameScalarFunction extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING")),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"))
                 })
@@ -1993,7 +1982,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintMissingPartialNameScalarFunction extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "in1"),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"))
                 })
@@ -2004,7 +1993,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintNameConflictScalarFunction extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(name = "in1", type = @DataTypeHint("STRING")),
                     @ArgumentHint(name = "in1", type = @DataTypeHint("INTEGER"))
                 })
@@ -2023,7 +2012,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentsAndInputsScalarFunction extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1"),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2")
                 },
@@ -2044,13 +2033,13 @@ class TypeInferenceExtractorTest {
     }
 
     @FunctionHint(
-            argument = {
+            arguments = {
                 @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1"),
                 @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2")
             })
     private static class InvalidFunctionHintOnClassAndMethod extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1"),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2")
                 },
@@ -2061,13 +2050,13 @@ class TypeInferenceExtractorTest {
     }
 
     @FunctionHint(
-            argument = {
+            arguments = {
                 @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1", isOptional = true),
                 @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2", isOptional = true)
             })
     private static class ValidFunctionHintOnClassAndMethod extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1"),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2")
                 })
@@ -2077,12 +2066,12 @@ class TypeInferenceExtractorTest {
     }
 
     @FunctionHint(
-            argument = {
+            arguments = {
                 @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1"),
                 @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2")
             })
     @FunctionHint(
-            argument = {
+            arguments = {
                 @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f1"),
                 @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2")
             })
@@ -2094,7 +2083,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentsHintScalarFunctionWithOverloadedFunction extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1"),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2")
                 })
@@ -2103,7 +2092,7 @@ class TypeInferenceExtractorTest {
         }
 
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1"),
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f2")
                 })
@@ -2114,7 +2103,7 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintNotNullTypeWithOptionalsScalarFunction extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(
                             type = @DataTypeHint("STRING NOT NULL"),
                             name = "f1",
@@ -2128,12 +2117,34 @@ class TypeInferenceExtractorTest {
 
     private static class ArgumentHintVariableLengthScalarFunction extends ScalarFunction {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "f1"),
                     @ArgumentHint(type = @DataTypeHint("INTEGER"), name = "f2")
                 },
                 isVarArgs = true)
         public String eval(String f1, Integer... f2) {
+            return "";
+        }
+    }
+
+    @FunctionHint(
+            arguments = {
+                @ArgumentHint(
+                        value = ArgumentTrait.TABLE_AS_ROW,
+                        type = @DataTypeHint("ROW<i INT>"))
+            })
+    private static class FunctionHintTableArgScalarFunction extends ScalarFunction {
+        public String eval(Row table) {
+            return "";
+        }
+    }
+
+    private static class ArgumentHintTableArgScalarFunction extends ScalarFunction {
+        public String eval(
+                @ArgumentHint(
+                                value = ArgumentTrait.TABLE_AS_ROW,
+                                type = @DataTypeHint("ROW<i INT>"))
+                        Row table) {
             return "";
         }
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestProcedureCatalogFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestProcedureCatalogFactory.java
@@ -225,7 +225,7 @@ public class TestProcedureCatalogFactory implements CatalogFactory {
 
         @ProcedureHint(
                 output = @DataTypeHint("STRING"),
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "c", isOptional = true),
                     @ArgumentHint(type = @DataTypeHint("INT"), name = "d", isOptional = true)
                 })

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -1599,7 +1599,7 @@ public class FunctionITCase extends StreamingTestBase {
     public static class NamedArgumentsScalarFunction extends ScalarFunction {
         @FunctionHint(
                 output = @DataTypeHint("STRING"),
-                argument = {
+                arguments = {
                     @ArgumentHint(name = "in1", type = @DataTypeHint("int")),
                     @ArgumentHint(name = "in2", type = @DataTypeHint("int"))
                 })
@@ -1612,7 +1612,7 @@ public class FunctionITCase extends StreamingTestBase {
     public static class NamedArgumentsWithOverloadedScalarFunction extends ScalarFunction {
         @FunctionHint(
                 output = @DataTypeHint("STRING"),
-                argument = {
+                arguments = {
                     @ArgumentHint(name = "in1", type = @DataTypeHint("int")),
                     @ArgumentHint(name = "in2", type = @DataTypeHint("int"))
                 })
@@ -1622,7 +1622,7 @@ public class FunctionITCase extends StreamingTestBase {
 
         @FunctionHint(
                 output = @DataTypeHint("STRING"),
-                argument = {
+                arguments = {
                     @ArgumentHint(name = "in1", type = @DataTypeHint("string")),
                     @ArgumentHint(name = "in2", type = @DataTypeHint("string"))
                 })
@@ -1635,7 +1635,7 @@ public class FunctionITCase extends StreamingTestBase {
     public static class NamedArgumentsScalarFunctionWithOptionalArguments extends ScalarFunction {
         @FunctionHint(
                 output = @DataTypeHint("STRING"),
-                argument = {
+                arguments = {
                     @ArgumentHint(name = "in1", type = @DataTypeHint("STRING"), isOptional = true),
                     @ArgumentHint(name = "in2", type = @DataTypeHint("STRING"), isOptional = true)
                 })
@@ -1775,7 +1775,7 @@ public class FunctionITCase extends StreamingTestBase {
     public static class NamedArgumentsTableFunctionWithOptionalArguments
             extends TableFunction<Object> {
         @FunctionHint(
-                argument = {
+                arguments = {
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "in1", isOptional = true),
                     @ArgumentHint(type = @DataTypeHint("STRING"), name = "in2", isOptional = true)
                 },
@@ -1940,7 +1940,7 @@ public class FunctionITCase extends StreamingTestBase {
 
         @FunctionHint(
                 output = @DataTypeHint("STRING"),
-                argument = {
+                arguments = {
                     @ArgumentHint(name = "in1", type = @DataTypeHint("STRING"), isOptional = true),
                     @ArgumentHint(name = "in2", type = @DataTypeHint("STRING"), isOptional = true)
                 },


### PR DESCRIPTION
## What is the purpose of the change

Cleans up `@FunctionHint` and `@ProcedureHint` to comply with FLIP-387. It adds the modification for `@ArgumentHint` required for FLIP-440.


## Brief change log

- Deprecation of `FunctionHint.argumentNames`
- Deprecation of `FunctionHint.argument`
- Deprecation of `ProcedureHint.argumentNames`
- Deprecation of `ProcedureHint.argument`
- Adding of `ArgumentHint.value` with `ArgumentTraits`

## Verifying this change

This change added tests and can be verified as follows: `TypeInferenceExtractorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes 
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
