### PR TITLE
[FLINK-36783][table-planner] Use validated SqlNode in 'asQuery' while converting SqlCreateTableAS to CreateTableASOperation

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -104,16 +104,18 @@ class SqlCreateTableConverter {
                 UnresolvedIdentifier.of(sqlCreateTableAs.fullTableName());
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
+        SqlNode asQuerySqlNode = sqlCreateTableAs.getAsQuery();
+        SqlNode validatedAsQuery = flinkPlanner.validate(asQuerySqlNode);
+
         PlannerQueryOperation query =
                 (PlannerQueryOperation)
                         SqlNodeToOperationConversion.convert(
-                                        flinkPlanner, catalogManager, sqlCreateTableAs.getAsQuery())
+                                        flinkPlanner, catalogManager, validatedAsQuery)
                                 .orElseThrow(
                                         () ->
                                                 new TableException(
                                                         "CTAS unsupported node type "
-                                                                + sqlCreateTableAs
-                                                                        .getAsQuery()
+                                                                + validatedAsQuery
                                                                         .getClass()
                                                                         .getSimpleName()));
         ResolvedCatalogTable tableWithResolvedSchema =
@@ -125,7 +127,7 @@ class SqlCreateTableConverter {
                         catalogManager,
                         flinkPlanner,
                         query,
-                        sqlCreateTableAs.getAsQuery(),
+                        validatedAsQuery,
                         tableWithResolvedSchema);
 
         CreateTableOperation createTableOperation =

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.xml
@@ -16,6 +16,50 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testCreateTableAsSelectWithOrderKeyNotProjected">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.MyCtasSource], fields=[b, c, d])
++- LogicalProject(b=[$0], c=[$1], d=[$2])
+   +- LogicalSort(sort0=[$3], dir0=[ASC-nulls-first])
+      +- LogicalProject(b=[$1], c=[$2], d=[$3], a=[$0])
+         +- LogicalValues(tuples=[[{ 1, 1, 2, _UTF-16LE'd1' }]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.MyCtasSource], fields=[b, c, d])
++- Calc(select=[b, c, d])
+   +- Sort(orderBy=[a ASC])
+      +- Exchange(distribution=[single])
+         +- Values(tuples=[[{ 1, 1, 2, _UTF-16LE'd1' }]], values=[a, b, c, d])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.MyCtasSource], fields=[b, c, d])
++- Calc(select=[b, c, d])
+   +- Sort(orderBy=[a ASC])
+      +- Exchange(distribution=[single])
+         +- Values(tuples=[[{ 1, 1, 2, _UTF-16LE'd1' }]], values=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDistribution">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b])
++- LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
+   +- LogicalProject(a=[$0], b=[$1])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink], fields=[a, b])
++- Sort(orderBy=[a ASC])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[a, b])
+         +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testManagedTableSinkWithEnableCheckpointing">
     <Resource name="ast">
       <![CDATA[
@@ -43,25 +87,6 @@ Sink(table=[default_catalog.default_database.sink], fields=[a, b])
          +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
 ]]>
     </Resource>
-  </TestCase>
-  <TestCase name="testDistribution">
-	<Resource name="ast">
-		<![CDATA[
-LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b])
-+- LogicalSort(sort0=[$0], dir0=[ASC-nulls-first])
-   +- LogicalProject(a=[$0], b=[$1])
-      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-	</Resource>
-	<Resource name="optimized exec plan">
-		<![CDATA[
-Sink(table=[default_catalog.default_database.sink], fields=[a, b])
-+- Sort(orderBy=[a ASC])
-   +- Exchange(distribution=[single])
-      +- Calc(select=[a, b])
-         +- BoundedStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
-]]>
-	</Resource>
   </TestCase>
   <TestCase name="testManagedTableSinkWithDisableCheckpointing">
     <Resource name="ast">

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableSinkTest.scala
@@ -174,4 +174,18 @@ class TableSinkTest extends TableTestBase {
 
     util.verifyAstPlan(stmtSet)
   }
+
+  @Test
+  def testCreateTableAsSelectWithOrderKeyNotProjected(): Unit = {
+    util.verifyExplainInsert(s"""
+                                |create table MyCtasSource
+                                |WITH (
+                                |   'connector' = 'values'
+                                |) as select b, c, d from
+                                |  (values
+                                |    (1, 1, 2, 'd1')
+                                |  ) as V(a, b, c, d)
+                                |  order by a
+                                |""".stripMargin)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSinkITCase.scala
@@ -30,6 +30,8 @@ import org.apache.flink.table.planner.utils.TableTestUtil
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.junit.jupiter.api.{BeforeEach, Test}
 
+import scala.collection.convert.ImplicitConversions._
+
 class TableSinkITCase extends BatchTestBase {
 
   @BeforeEach
@@ -159,5 +161,26 @@ class TableSinkITCase extends BatchTestBase {
                         |""".stripMargin)
           .await())
       .hasRootCauseMessage("\nExpecting actual not to be null")
+  }
+
+  @Test
+  def testCreateTableAsSelectWithOrderKeyNotProjected(): Unit = {
+    tEnv
+      .executeSql(s"""
+                     |create table MyCtasTable
+                     |WITH (
+                     |   'connector' = 'values'
+                     |) as select b, c, d from
+                     |  (values
+                     |    (1, 1, 2, 'd1'),
+                     |    (2, 2, 4, 'd2')
+                     |  ) as V(a, b, c, d)
+                     |  order by a
+                     |""".stripMargin)
+      .await()
+
+    val expected = List("+I[1, 2, d1]", "+I[2, 4, d2]")
+    assertThat(TestValuesTableFactory.getResultsAsStrings("MyCtasTable").toSeq)
+      .isEqualTo(expected)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

When `SqlOrderBy` and `SqlSelect` are validated together, `SqlSelect` gets rewritten and updated in place (as seen in `SqlValidatorImpl#performUnconditionalRewrites`). 
This bug was caused by validation of `SqlOrderBy` and `SqlSelect` multi times, which led to `SqlSelect` being incorrectly updated to a pattern like:
```
SELECT `V`.`b`, `V`.`c`, `V`.`d`
FROM (VALUES ROW(1, 1, 2, 'd1'),
ROW(2, 2, 4, 'd2')) AS `V` (`a`, `b`, `c`, `d`)
ORDER BY `V`.`a`
ORDER BY `a`
``` 

This pull request aims to prevent the multiple validations of `SqlOrderBy` and `SqlSelect`.

## Brief change log

  - *Update logic in SqlCreateTableConverter to avoid validating SqlOrderBy and SqlSelect multi times*
  - *Add tests to verify this bug*


## Verifying this change

Some tests in batch mode are added to verify this fix. (Sort in streaming mode is not supported yet).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
