### PR TITLE
[FLINK-36815][API] Fix series bugs of DSv2

### DIFF
--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/ExecutionEnvironment.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/ExecutionEnvironment.java
@@ -21,7 +21,7 @@ package org.apache.flink.datastream.api;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.connector.dsv2.Source;
-import org.apache.flink.datastream.api.stream.NonKeyedPartitionStream;
+import org.apache.flink.datastream.api.stream.NonKeyedPartitionStream.ProcessConfigurableAndNonKeyedPartitionStream;
 
 /**
  * This is the context in which a program is executed.
@@ -51,5 +51,6 @@ public interface ExecutionEnvironment {
     /** Set the execution mode for this environment. */
     ExecutionEnvironment setExecutionMode(RuntimeExecutionMode runtimeMode);
 
-    <OUT> NonKeyedPartitionStream<OUT> fromSource(Source<OUT> source, String sourceName);
+    <OUT> ProcessConfigurableAndNonKeyedPartitionStream<OUT> fromSource(
+            Source<OUT> source, String sourceName);
 }

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/context/TaskInfo.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/context/TaskInfo.java
@@ -43,4 +43,21 @@ public interface TaskInfo {
      * @return The name of current task.
      */
     String getTaskName();
+
+    /**
+     * Gets the number of this parallel subtask. The numbering starts from 0 and goes up to
+     * parallelism-1 (parallelism as returned by {@link #getParallelism()}).
+     *
+     * @return The index of the parallel subtask.
+     */
+    int getIndexOfThisSubtask();
+
+    /**
+     * Gets the attempt number of this parallel subtask. First attempt is numbered 0. The attempt
+     * number corresponds to the number of times this task has been restarted(after
+     * failure/cancellation) since the job was initially started.
+     *
+     * @return The attempt number of the subtask.
+     */
+    int getAttemptNumber();
 }

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/OneInputStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/OneInputStreamProcessFunction.java
@@ -27,6 +27,18 @@ import org.apache.flink.datastream.api.context.PartitionedContext;
 @Experimental
 public interface OneInputStreamProcessFunction<IN, OUT> extends ProcessFunction {
     /**
+     * Initialization method for the function. It is called before the actual working methods (like
+     * processRecord) and thus suitable for one time setup work.
+     *
+     * <p>By default, this method does nothing.
+     *
+     * @throws Exception Implementations may forward exceptions, which are caught by the runtime.
+     *     When the runtime catches an exception, it aborts the task and lets the fail-over logic
+     *     decide whether to retry the task execution.
+     */
+    default void open(NonPartitionedContext<OUT> ctx) throws Exception {}
+
+    /**
      * Process record and emit data through {@link Collector}.
      *
      * @param record to process.

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/ProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/ProcessFunction.java
@@ -29,18 +29,6 @@ import java.util.Set;
 @Experimental
 public interface ProcessFunction extends Function {
     /**
-     * Initialization method for the function. It is called before the actual working methods (like
-     * processRecord) and thus suitable for one time setup work.
-     *
-     * <p>By default, this method does nothing.
-     *
-     * @throws Exception Implementations may forward exceptions, which are caught by the runtime.
-     *     When the runtime catches an exception, it aborts the task and lets the fail-over logic
-     *     decide whether to retry the task execution.
-     */
-    default void open() throws Exception {}
-
-    /**
      * Explicitly declares states upfront. Each specific state must be declared in this method
      * before it can be used.
      *

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputBroadcastStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputBroadcastStreamProcessFunction.java
@@ -30,6 +30,18 @@ import org.apache.flink.datastream.api.context.PartitionedContext;
 @Experimental
 public interface TwoInputBroadcastStreamProcessFunction<IN1, IN2, OUT> extends ProcessFunction {
     /**
+     * Initialization method for the function. It is called before the actual working methods (like
+     * processRecord) and thus suitable for one time setup work.
+     *
+     * <p>By default, this method does nothing.
+     *
+     * @throws Exception Implementations may forward exceptions, which are caught by the runtime.
+     *     When the runtime catches an exception, it aborts the task and lets the fail-over logic
+     *     decide whether to retry the task execution.
+     */
+    default void open(NonPartitionedContext<OUT> ctx) throws Exception {}
+
+    /**
      * Process record from non-broadcast input and emit data through {@link Collector}.
      *
      * @param record to process.

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputNonBroadcastStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoInputNonBroadcastStreamProcessFunction.java
@@ -27,6 +27,18 @@ import org.apache.flink.datastream.api.context.PartitionedContext;
 @Experimental
 public interface TwoInputNonBroadcastStreamProcessFunction<IN1, IN2, OUT> extends ProcessFunction {
     /**
+     * Initialization method for the function. It is called before the actual working methods (like
+     * processRecord) and thus suitable for one time setup work.
+     *
+     * <p>By default, this method does nothing.
+     *
+     * @throws Exception Implementations may forward exceptions, which are caught by the runtime.
+     *     When the runtime catches an exception, it aborts the task and lets the fail-over logic
+     *     decide whether to retry the task execution.
+     */
+    default void open(NonPartitionedContext<OUT> ctx) throws Exception {}
+
+    /**
      * Process record from the first input and emit data through {@link Collector}.
      *
      * @param record to process.

--- a/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputStreamProcessFunction.java
+++ b/flink-datastream-api/src/main/java/org/apache/flink/datastream/api/function/TwoOutputStreamProcessFunction.java
@@ -27,6 +27,18 @@ import org.apache.flink.datastream.api.context.TwoOutputNonPartitionedContext;
 @Experimental
 public interface TwoOutputStreamProcessFunction<IN, OUT1, OUT2> extends ProcessFunction {
     /**
+     * Initialization method for the function. It is called before the actual working methods (like
+     * processRecord) and thus suitable for one time setup work.
+     *
+     * <p>By default, this method does nothing.
+     *
+     * @throws Exception Implementations may forward exceptions, which are caught by the runtime.
+     *     When the runtime catches an exception, it aborts the task and lets the fail-over logic
+     *     decide whether to retry the task execution.
+     */
+    default void open(TwoOutputNonPartitionedContext<OUT1, OUT2> ctx) throws Exception {}
+
+    /**
      * Process and emit record to the first/second output through {@link Collector}s.
      *
      * @param record to process.

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImpl.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/ExecutionEnvironmentImpl.java
@@ -42,8 +42,9 @@ import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.core.execution.PipelineExecutorFactory;
 import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
 import org.apache.flink.datastream.api.ExecutionEnvironment;
-import org.apache.flink.datastream.api.stream.NonKeyedPartitionStream;
+import org.apache.flink.datastream.api.stream.NonKeyedPartitionStream.ProcessConfigurableAndNonKeyedPartitionStream;
 import org.apache.flink.datastream.impl.stream.NonKeyedPartitionStreamImpl;
+import org.apache.flink.datastream.impl.utils.StreamUtils;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
@@ -161,7 +162,8 @@ public class ExecutionEnvironmentImpl implements ExecutionEnvironment {
     }
 
     @Override
-    public <OUT> NonKeyedPartitionStream<OUT> fromSource(Source<OUT> source, String sourceName) {
+    public <OUT> ProcessConfigurableAndNonKeyedPartitionStream<OUT> fromSource(
+            Source<OUT> source, String sourceName) {
         if (source instanceof WrappedSource) {
             org.apache.flink.api.connector.source.Source<OUT, ?, ?> innerSource =
                     ((WrappedSource<OUT>) source).getWrappedSource();
@@ -176,7 +178,8 @@ public class ExecutionEnvironmentImpl implements ExecutionEnvironment {
                             resolvedTypeInfo,
                             getParallelism(),
                             false);
-            return new NonKeyedPartitionStreamImpl<>(this, sourceTransformation);
+            return StreamUtils.wrapWithConfigureHandle(
+                    new NonKeyedPartitionStreamImpl<>(this, sourceTransformation));
         } else if (source instanceof FromDataSource) {
             Collection<OUT> data = ((FromDataSource<OUT>) source).getData();
             TypeInformation<OUT> outType = extractTypeInfoFromCollection(data);

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/context/DefaultRuntimeContext.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/context/DefaultRuntimeContext.java
@@ -38,9 +38,13 @@ public class DefaultRuntimeContext implements RuntimeContext {
             int parallelism,
             int maxParallelism,
             String taskName,
+            int indexOfSubtask,
+            int attemptNumber,
             MetricGroup metricGroup) {
         this.jobInfo = new DefaultJobInfo(jobName, jobType);
-        this.taskInfo = new DefaultTaskInfo(parallelism, maxParallelism, taskName);
+        this.taskInfo =
+                new DefaultTaskInfo(
+                        parallelism, maxParallelism, taskName, indexOfSubtask, attemptNumber);
         this.metricGroup = metricGroup;
     }
 

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/context/DefaultTaskInfo.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/context/DefaultTaskInfo.java
@@ -28,10 +28,21 @@ public class DefaultTaskInfo implements TaskInfo {
 
     private final String taskName;
 
-    public DefaultTaskInfo(int parallelism, int maxParallelism, String taskName) {
+    private final int indexOfSubtask;
+
+    private final int attemptNumber;
+
+    public DefaultTaskInfo(
+            int parallelism,
+            int maxParallelism,
+            String taskName,
+            int indexOfSubtask,
+            int attemptNumber) {
         this.parallelism = parallelism;
         this.maxParallelism = maxParallelism;
         this.taskName = taskName;
+        this.indexOfSubtask = indexOfSubtask;
+        this.attemptNumber = attemptNumber;
     }
 
     @Override
@@ -47,5 +58,15 @@ public class DefaultTaskInfo implements TaskInfo {
     @Override
     public String getTaskName() {
         return taskName;
+    }
+
+    @Override
+    public int getIndexOfThisSubtask() {
+        return indexOfSubtask;
+    }
+
+    @Override
+    public int getAttemptNumber() {
+        return attemptNumber;
     }
 }

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/ProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/ProcessOperator.java
@@ -63,6 +63,8 @@ public class ProcessOperator<IN, OUT>
                         taskInfo.getNumberOfParallelSubtasks(),
                         taskInfo.getMaxNumberOfParallelSubtasks(),
                         taskInfo.getTaskName(),
+                        taskInfo.getIndexOfThisSubtask(),
+                        taskInfo.getAttemptNumber(),
                         operatorContext.getMetricGroup());
         partitionedContext =
                 new DefaultPartitionedContext(

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/ProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/ProcessOperator.java
@@ -76,6 +76,7 @@ public class ProcessOperator<IN, OUT>
                         getOperatorStateBackend());
         outputCollector = getOutputCollector();
         nonPartitionedContext = getNonPartitionedContext();
+        userFunction.open();
     }
 
     @Override
@@ -104,5 +105,11 @@ public class ProcessOperator<IN, OUT>
     protected NonPartitionedContext<OUT> getNonPartitionedContext() {
         return new DefaultNonPartitionedContext<>(
                 context, partitionedContext, outputCollector, false, null);
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        userFunction.close();
     }
 }

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/ProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/ProcessOperator.java
@@ -76,7 +76,7 @@ public class ProcessOperator<IN, OUT>
                         getOperatorStateBackend());
         outputCollector = getOutputCollector();
         nonPartitionedContext = getNonPartitionedContext();
-        userFunction.open();
+        userFunction.open(nonPartitionedContext);
     }
 
     @Override

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperator.java
@@ -80,6 +80,7 @@ public class TwoInputBroadcastProcessOperator<IN1, IN2, OUT>
                         operatorContext,
                         getOperatorStateBackend());
         this.nonPartitionedContext = getNonPartitionedContext();
+        this.userFunction.open();
     }
 
     @Override
@@ -121,5 +122,11 @@ public class TwoInputBroadcastProcessOperator<IN1, IN2, OUT>
 
     protected ProcessingTimeManager getProcessingTimeManager() {
         return UnsupportedProcessingTimeManager.INSTANCE;
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        userFunction.close();
     }
 }

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperator.java
@@ -68,6 +68,8 @@ public class TwoInputBroadcastProcessOperator<IN1, IN2, OUT>
                         taskInfo.getNumberOfParallelSubtasks(),
                         taskInfo.getMaxNumberOfParallelSubtasks(),
                         taskInfo.getTaskName(),
+                        taskInfo.getIndexOfThisSubtask(),
+                        taskInfo.getAttemptNumber(),
                         operatorContext.getMetricGroup());
         this.partitionedContext =
                 new DefaultPartitionedContext(

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputBroadcastProcessOperator.java
@@ -80,7 +80,7 @@ public class TwoInputBroadcastProcessOperator<IN1, IN2, OUT>
                         operatorContext,
                         getOperatorStateBackend());
         this.nonPartitionedContext = getNonPartitionedContext();
-        this.userFunction.open();
+        this.userFunction.open(this.nonPartitionedContext);
     }
 
     @Override

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperator.java
@@ -83,6 +83,7 @@ public class TwoInputNonBroadcastProcessOperator<IN1, IN2, OUT>
                         operatorContext,
                         operatorStateBackend);
         this.nonPartitionedContext = getNonPartitionedContext();
+        this.userFunction.open();
     }
 
     @Override
@@ -124,5 +125,11 @@ public class TwoInputNonBroadcastProcessOperator<IN1, IN2, OUT>
 
     protected ProcessingTimeManager getProcessingTimeManager() {
         return UnsupportedProcessingTimeManager.INSTANCE;
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        userFunction.close();
     }
 }

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperator.java
@@ -83,7 +83,7 @@ public class TwoInputNonBroadcastProcessOperator<IN1, IN2, OUT>
                         operatorContext,
                         operatorStateBackend);
         this.nonPartitionedContext = getNonPartitionedContext();
-        this.userFunction.open();
+        this.userFunction.open(this.nonPartitionedContext);
     }
 
     @Override

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoInputNonBroadcastProcessOperator.java
@@ -71,6 +71,8 @@ public class TwoInputNonBroadcastProcessOperator<IN1, IN2, OUT>
                         taskInfo.getNumberOfParallelSubtasks(),
                         taskInfo.getMaxNumberOfParallelSubtasks(),
                         taskInfo.getTaskName(),
+                        taskInfo.getIndexOfThisSubtask(),
+                        taskInfo.getAttemptNumber(),
                         operatorContext.getMetricGroup());
         this.partitionedContext =
                 new DefaultPartitionedContext(

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperator.java
@@ -80,6 +80,8 @@ public class TwoOutputProcessOperator<IN, OUT_MAIN, OUT_SIDE>
                         taskInfo.getNumberOfParallelSubtasks(),
                         taskInfo.getMaxNumberOfParallelSubtasks(),
                         taskInfo.getTaskName(),
+                        taskInfo.getIndexOfThisSubtask(),
+                        taskInfo.getAttemptNumber(),
                         operatorContext.getMetricGroup());
         this.partitionedContext =
                 new DefaultPartitionedContext(

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperator.java
@@ -92,7 +92,7 @@ public class TwoOutputProcessOperator<IN, OUT_MAIN, OUT_SIDE>
                         operatorContext,
                         operatorStateStore);
         this.nonPartitionedContext = getNonPartitionedContext();
-        this.userFunction.open();
+        this.userFunction.open(this.nonPartitionedContext);
     }
 
     @Override

--- a/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperator.java
+++ b/flink-datastream/src/main/java/org/apache/flink/datastream/impl/operators/TwoOutputProcessOperator.java
@@ -92,6 +92,7 @@ public class TwoOutputProcessOperator<IN, OUT_MAIN, OUT_SIDE>
                         operatorContext,
                         operatorStateStore);
         this.nonPartitionedContext = getNonPartitionedContext();
+        this.userFunction.open();
     }
 
     @Override
@@ -149,5 +150,11 @@ public class TwoOutputProcessOperator<IN, OUT_MAIN, OUT_SIDE>
             setTimestamp(timestamp);
             output.collect(outputTag, reuse.replace(record));
         }
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        userFunction.close();
     }
 }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/context/DefaultNonPartitionedContextTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/context/DefaultNonPartitionedContextTest.java
@@ -55,6 +55,8 @@ class DefaultNonPartitionedContextTest {
                         1,
                         2,
                         "mock-task",
+                        0,
+                        0,
                         operatorRuntimeContext.getMetricGroup());
 
         DefaultNonPartitionedContext<Integer> nonPartitionedContext =
@@ -105,6 +107,8 @@ class DefaultNonPartitionedContextTest {
                         1,
                         2,
                         "mock-task",
+                        0,
+                        0,
                         operatorRuntimeContext.getMetricGroup());
         DefaultNonPartitionedContext<Integer> nonPartitionedContext =
                 new DefaultNonPartitionedContext<>(

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/context/DefaultTaskInfoTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/context/DefaultTaskInfoTest.java
@@ -26,9 +26,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DefaultTaskInfoTest {
     @Test
     void testTaskInfo() {
-        DefaultTaskInfo taskInfo = new DefaultTaskInfo(1, 2, "taskName");
+        DefaultTaskInfo taskInfo = new DefaultTaskInfo(1, 2, "taskName", 0, 0);
         assertThat(taskInfo.getParallelism()).isEqualTo(1);
         assertThat(taskInfo.getMaxParallelism()).isEqualTo(2);
         assertThat(taskInfo.getTaskName()).isEqualTo("taskName");
+        assertThat(taskInfo.getIndexOfThisSubtask()).isEqualTo(0);
+        assertThat(taskInfo.getAttemptNumber()).isEqualTo(0);
     }
 }

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/context/DefaultTwoOutputNonPartitionedContextTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/context/DefaultTwoOutputNonPartitionedContextTest.java
@@ -60,6 +60,8 @@ class DefaultTwoOutputNonPartitionedContextTest {
                         1,
                         2,
                         "mock-task",
+                        0,
+                        0,
                         operatorRuntimeContext.getMetricGroup());
         DefaultTwoOutputNonPartitionedContext<Integer, Long> nonPartitionedContext =
                 new DefaultTwoOutputNonPartitionedContext<>(
@@ -118,6 +120,8 @@ class DefaultTwoOutputNonPartitionedContextTest {
                         1,
                         2,
                         "mock-task",
+                        0,
+                        0,
                         operatorRuntimeContext.getMetricGroup());
         DefaultTwoOutputNonPartitionedContext<Integer, Long> nonPartitionedContext =
                 new DefaultTwoOutputNonPartitionedContext<>(

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/functions/ProcessFunctionTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/functions/ProcessFunctionTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.datastream.api.common.Collector;
 import org.apache.flink.datastream.api.context.NonPartitionedContext;
 import org.apache.flink.datastream.api.context.PartitionedContext;
+import org.apache.flink.datastream.api.context.TwoOutputNonPartitionedContext;
 import org.apache.flink.datastream.api.function.OneInputStreamProcessFunction;
 import org.apache.flink.datastream.api.function.ProcessFunction;
 import org.apache.flink.datastream.api.function.TwoInputBroadcastStreamProcessFunction;
@@ -51,7 +52,7 @@ public class ProcessFunctionTest {
         OneInputStreamProcessFunction<Integer, Integer> processFunction =
                 new OneInputStreamProcessFunction<>() {
                     @Override
-                    public void open() throws Exception {
+                    public void open(NonPartitionedContext<Integer> ctx) throws Exception {
                         openInvoked.set(true);
                     }
 
@@ -86,7 +87,7 @@ public class ProcessFunctionTest {
                 new TwoInputBroadcastStreamProcessFunction<>() {
 
                     @Override
-                    public void open() throws Exception {
+                    public void open(NonPartitionedContext<Integer> ctx) throws Exception {
                         openInvoked.set(true);
                     }
 
@@ -126,7 +127,7 @@ public class ProcessFunctionTest {
                 new TwoInputNonBroadcastStreamProcessFunction<>() {
 
                     @Override
-                    public void open() throws Exception {
+                    public void open(NonPartitionedContext<Integer> ctx) throws Exception {
                         openInvoked.set(true);
                     }
 
@@ -167,7 +168,8 @@ public class ProcessFunctionTest {
                 new TwoOutputStreamProcessFunction<>() {
 
                     @Override
-                    public void open() throws Exception {
+                    public void open(TwoOutputNonPartitionedContext<Integer, Integer> ctx)
+                            throws Exception {
                         openInvoked.set(true);
                     }
 

--- a/flink-datastream/src/test/java/org/apache/flink/datastream/impl/functions/ProcessFunctionTest.java
+++ b/flink-datastream/src/test/java/org/apache/flink/datastream/impl/functions/ProcessFunctionTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.datastream.impl.functions;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.datastream.api.common.Collector;
+import org.apache.flink.datastream.api.context.NonPartitionedContext;
+import org.apache.flink.datastream.api.context.PartitionedContext;
+import org.apache.flink.datastream.api.function.OneInputStreamProcessFunction;
+import org.apache.flink.datastream.api.function.ProcessFunction;
+import org.apache.flink.datastream.api.function.TwoInputBroadcastStreamProcessFunction;
+import org.apache.flink.datastream.api.function.TwoInputNonBroadcastStreamProcessFunction;
+import org.apache.flink.datastream.api.function.TwoOutputStreamProcessFunction;
+import org.apache.flink.datastream.impl.operators.ProcessOperator;
+import org.apache.flink.datastream.impl.operators.TwoInputBroadcastProcessOperator;
+import org.apache.flink.datastream.impl.operators.TwoInputNonBroadcastProcessOperator;
+import org.apache.flink.datastream.impl.operators.TwoOutputProcessOperator;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
+import org.apache.flink.util.OutputTag;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link ProcessFunction}. */
+public class ProcessFunctionTest {
+    @Test
+    void testOneInputStreamProcessFunctionOpenAndCloseInvoked() throws Exception {
+        AtomicBoolean openInvoked = new AtomicBoolean(false);
+        AtomicBoolean closeInvoked = new AtomicBoolean(false);
+
+        OneInputStreamProcessFunction<Integer, Integer> processFunction =
+                new OneInputStreamProcessFunction<>() {
+                    @Override
+                    public void open() throws Exception {
+                        openInvoked.set(true);
+                    }
+
+                    @Override
+                    public void processRecord(
+                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            throws Exception {}
+
+                    @Override
+                    public void close() throws Exception {
+                        closeInvoked.set(true);
+                    }
+                };
+
+        ProcessOperator<Integer, Integer> processOperator = new ProcessOperator<>(processFunction);
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                new OneInputStreamOperatorTestHarness<>(processOperator)) {
+            testHarness.open();
+            assertThat(openInvoked).isTrue();
+            testHarness.close();
+            assertThat(closeInvoked).isTrue();
+        }
+    }
+
+    @Test
+    void testTwoInputBroadcastStreamProcessFunctionOpenAndCloseInvoked() throws Exception {
+        AtomicBoolean openInvoked = new AtomicBoolean(false);
+        AtomicBoolean closeInvoked = new AtomicBoolean(false);
+
+        TwoInputBroadcastStreamProcessFunction<Integer, Integer, Integer> processFunction =
+                new TwoInputBroadcastStreamProcessFunction<>() {
+
+                    @Override
+                    public void open() throws Exception {
+                        openInvoked.set(true);
+                    }
+
+                    @Override
+                    public void processRecordFromNonBroadcastInput(
+                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            throws Exception {}
+
+                    @Override
+                    public void processRecordFromBroadcastInput(
+                            Integer record, NonPartitionedContext<Integer> ctx) throws Exception {}
+
+                    @Override
+                    public void close() throws Exception {
+                        closeInvoked.set(true);
+                    }
+                };
+
+        TwoInputBroadcastProcessOperator<Integer, Integer, Integer> processOperator =
+                new TwoInputBroadcastProcessOperator<>(processFunction);
+
+        try (TwoInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                new TwoInputStreamOperatorTestHarness<>(processOperator)) {
+            testHarness.open();
+            assertThat(openInvoked).isTrue();
+            testHarness.close();
+            assertThat(closeInvoked).isTrue();
+        }
+    }
+
+    @Test
+    void testTwoInputNonBroadcastStreamProcessFunctionOpenAndCloseInvoked() throws Exception {
+        AtomicBoolean openInvoked = new AtomicBoolean(false);
+        AtomicBoolean closeInvoked = new AtomicBoolean(false);
+
+        TwoInputNonBroadcastStreamProcessFunction<Integer, Integer, Integer> processFunction =
+                new TwoInputNonBroadcastStreamProcessFunction<>() {
+
+                    @Override
+                    public void open() throws Exception {
+                        openInvoked.set(true);
+                    }
+
+                    @Override
+                    public void processRecordFromFirstInput(
+                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            throws Exception {}
+
+                    @Override
+                    public void processRecordFromSecondInput(
+                            Integer record, Collector<Integer> output, PartitionedContext ctx)
+                            throws Exception {}
+
+                    @Override
+                    public void close() throws Exception {
+                        closeInvoked.set(true);
+                    }
+                };
+
+        TwoInputNonBroadcastProcessOperator<Integer, Integer, Integer> processOperator =
+                new TwoInputNonBroadcastProcessOperator<>(processFunction);
+
+        try (TwoInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                new TwoInputStreamOperatorTestHarness<>(processOperator)) {
+            testHarness.open();
+            assertThat(openInvoked).isTrue();
+            testHarness.close();
+            assertThat(closeInvoked).isTrue();
+        }
+    }
+
+    @Test
+    void testTwoOutputStreamProcessFunctionOpenAndCloseInvoked() throws Exception {
+        AtomicBoolean openInvoked = new AtomicBoolean(false);
+        AtomicBoolean closeInvoked = new AtomicBoolean(false);
+
+        TwoOutputStreamProcessFunction<Integer, Integer, Integer> processFunction =
+                new TwoOutputStreamProcessFunction<>() {
+
+                    @Override
+                    public void open() throws Exception {
+                        openInvoked.set(true);
+                    }
+
+                    @Override
+                    public void processRecord(
+                            Integer record,
+                            Collector<Integer> output1,
+                            Collector<Integer> output2,
+                            PartitionedContext ctx)
+                            throws Exception {}
+
+                    @Override
+                    public void close() throws Exception {
+                        closeInvoked.set(true);
+                    }
+                };
+
+        TwoOutputProcessOperator<Integer, Integer, Integer> processOperator =
+                new TwoOutputProcessOperator<>(
+                        processFunction, new OutputTag<Integer>("side-output", Types.INT));
+
+        try (OneInputStreamOperatorTestHarness<Integer, Integer> testHarness =
+                new OneInputStreamOperatorTestHarness<>(processOperator)) {
+            testHarness.open();
+            assertThat(openInvoked).isTrue();
+            testHarness.close();
+            assertThat(closeInvoked).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix series bugs of DSv2.

1. The DSv2 org.apache.flink.datastream.api.ExecutionEnvironment#fromSource method return a 
NonKeyedPartitionStream, which does not allow users to set source configurations, such as operator name or parallelism.

2. The org.apache.flink.datastream.api.context.TaskInfo lack subtaskIndex and attemptNumber.

3. The open and close methods of org.apache.flink.datastream.api.function.ProcessFunction are not being called.

4. The open method of org.apache.flink.datastream.api.function.ProcessFunction lacks relevant information, such as the current TaskInfo.

## Brief change log
- Make ExecutionEnvironment#fromSource return ProcessConfigurableAndNonKeyedPartitionStream
- Introduce subtask index and attempt id in TaskInfo for DSv2
- Open and close user function in DSv2 ProcessOperator
- Introduce a NonPartitionedContext parameter in Open method of UserFunction for DSv2


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
