### PR TITLE
[FLINK-36643][filesystems] Update aws-java-sdk-core to 1.12.779 [1.20]

### DIFF
--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<fs.s3.aws.version>1.12.319</fs.s3.aws.version>
+		<fs.s3.aws.version>1.12.779</fs.s3.aws.version>
 		<japicmp.skip>true</japicmp.skip>
 	</properties>
 

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -3,12 +3,12 @@ Copyright 2014-2024 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.amazonaws:aws-java-sdk-core:1.12.319
-- com.amazonaws:aws-java-sdk-dynamodb:1.12.319
-- com.amazonaws:aws-java-sdk-kms:1.12.319
-- com.amazonaws:aws-java-sdk-s3:1.12.319
-- com.amazonaws:aws-java-sdk-sts:1.12.319
-- com.amazonaws:jmespath-java:1.12.319
+- com.amazonaws:aws-java-sdk-core:1.12.779
+- com.amazonaws:aws-java-sdk-dynamodb:1.12.779
+- com.amazonaws:aws-java-sdk-kms:1.12.779
+- com.amazonaws:aws-java-sdk-s3:1.12.779
+- com.amazonaws:aws-java-sdk-sts:1.12.779
+- com.amazonaws:jmespath-java:1.12.779
 - com.fasterxml.jackson.core:jackson-annotations:2.15.3
 - com.fasterxml.jackson.core:jackson-core:2.15.3
 - com.fasterxml.jackson.core:jackson-databind:2.15.3

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -6,12 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.amazonaws:aws-java-sdk-core:1.12.319
-- com.amazonaws:aws-java-sdk-dynamodb:1.12.319
-- com.amazonaws:aws-java-sdk-kms:1.12.319
-- com.amazonaws:aws-java-sdk-s3:1.12.319
-- com.amazonaws:aws-java-sdk-sts:1.12.319
-- com.amazonaws:jmespath-java:1.12.319
+- com.amazonaws:aws-java-sdk-core:1.12.779
+- com.amazonaws:aws-java-sdk-dynamodb:1.12.779
+- com.amazonaws:aws-java-sdk-kms:1.12.779
+- com.amazonaws:aws-java-sdk-s3:1.12.779
+- com.amazonaws:aws-java-sdk-sts:1.12.779
+- com.amazonaws:jmespath-java:1.12.779
 - com.facebook.airlift:configuration:0.201
 - com.facebook.airlift:log:0.201
 - com.facebook.airlift:stats:0.201

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<properties>
 		<!-- for testing (will override Hadoop's default dependency on too low SDK versions that
 			do not work with our httpcomponents version) -->
-		<aws.sdk.version>1.12.319</aws.sdk.version>
+		<aws.sdk.version>1.12.779</aws.sdk.version>
 		<surefire.module.config><!--
 			CommonTestUtils#setEnv
 			-->--add-opens=java.base/java.util=ALL-UNNAMED


### PR DESCRIPTION
## What is the purpose of the change

This is backport of #25600. 

The current version of `aws-java-sdk-core`, used in the `flink-s3-fs-base` module, has a high severity vulnerability ([CVE-2024-21634](https://nvd.nist.gov/vuln/detail/CVE-2024-21634)).

To address this we need to update to version 1.12.773 or higher, 1.12.779 is the current latest version.

## Brief change log

Update the `aws-java-sdk-core` version used in `flink-s3-fs-base` to 1.12.779. 

## Verifying this change

This change is already covered by existing tests in the `flink-s3-fs-base` module.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
