### PR TITLE
remove the CHARACTER_FILTER.filterCharacters function when notify dimension values.

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
+++ b/flink-metrics/flink-metrics-prometheus/src/main/java/org/apache/flink/metrics/prometheus/AbstractPrometheusReporter.java
@@ -104,7 +104,7 @@ public abstract class AbstractPrometheusReporter implements MetricReporter {
             final String key = dimension.getKey();
             dimensionKeys.add(
                     CHARACTER_FILTER.filterCharacters(key.substring(1, key.length() - 1)));
-            dimensionValues.add(labelValueCharactersFilter.filterCharacters(dimension.getValue()));
+            dimensionValues.add(dimension.getValue());
         }
 
         final String scopedMetricName = getScopedName(metricName, group);


### PR DESCRIPTION
## What is the purpose of the change

remove the CHARACTER_FILTER.filterCharacters function when notify dimension values.

The CHARACTER_FILTER.filterCharacters was added because Prometheus gateway does not support invalid characters in metric names. However, for metric values, the Prometheus gateway does not have such restrictions. 

Refer to the documentation: https://prometheus.io/docs/instrumenting/writing_exporters.
 
Therefore, removing this functionality will have no impact and will also support Chinese characters in metric values, making it easier to filter metric values with Chinese characters.