### PR TITLE
[FLINK-36824][table] Backport from Calcite 1.37.0 support table function calls in FROM clause without TABLE() wrapper

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/window-agg.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/window-agg.md
@@ -76,8 +76,7 @@ Flink SQL> SELECT * FROM Bid;
 
 -- tumbling window aggregation
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -88,8 +87,7 @@ Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
 
 -- hopping window aggregation
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES))
+  FROM HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -102,8 +100,7 @@ Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
 
 -- cumulative window aggregation
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES))
+  FROM CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -120,8 +117,7 @@ Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
 
 -- session window aggregation with partition keys
 Flink SQL> SELECT window_start, window_end, supplier_id, SUM(price) AS total_price
-           FROM TABLE(
-               SESSION(TABLE Bid PARTITION BY supplier_id, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES))
+           FROM SESSION(TABLE Bid PARTITION BY supplier_id, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES)
            GROUP BY window_start, window_end, supplier_id;
 +------------------+------------------+-------------+-------------+
 |     window_start |       window_end | supplier_id | total_price |
@@ -134,8 +130,7 @@ Flink SQL> SELECT window_start, window_end, supplier_id, SUM(price) AS total_pri
 
 -- session window aggregation without partition keys
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-           FROM TABLE(
-               SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES))
+           FROM SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES)
            GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -155,8 +150,7 @@ Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
 
 ```sql
 Flink SQL> SELECT window_start, window_end, supplier_id, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end, GROUPING SETS ((supplier_id), ());
 +------------------+------------------+-------------+-------------+
 |     window_start |       window_end | supplier_id | total_price |
@@ -184,8 +178,7 @@ Flink SQL> SELECT window_start, window_end, supplier_id, SUM(price) AS total_pri
 
 ```sql
 SELECT window_start, window_end, supplier_id, SUM(price) AS total_price
-FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
 GROUP BY window_start, window_end, ROLLUP (supplier_id);
 ```
 
@@ -199,13 +192,11 @@ GROUP BY window_start, window_end, ROLLUP (supplier_id);
 
 ```sql
 SELECT window_start, window_end, item, supplier_id, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end, CUBE (supplier_id, item);
 
 SELECT window_start, window_end, item, supplier_id, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end, GROUPING SETS (
       (supplier_id, item),
       (supplier_id      ),
@@ -231,14 +222,12 @@ SELECT window_start, window_end, item, supplier_id, SUM(price) AS total_price
 CREATE VIEW window1 AS
 -- Note: The window start and window end fields of inner Window TVF are optional in the select clause. However, if they appear in the clause, they need to be aliased to prevent name conflicting with the window start and window end of the outer Window TVF.
 SELECT window_start AS window_5mintumble_start, window_end AS window_5mintumble_end, window_time AS rowtime, SUM(price) AS partial_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES)
   GROUP BY supplier_id, window_start, window_end, window_time;
 
 -- tumbling 10 minutes on the first window
 SELECT window_start, window_end, SUM(partial_price) AS total_price
-  FROM TABLE(
-      TUMBLE(TABLE window1, DESCRIPTOR(rowtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE window1, DESCRIPTOR(rowtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 ```
 

--- a/docs/content.zh/docs/dev/table/sql/queries/window-topn.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/window-topn.md
@@ -90,8 +90,7 @@ Flink SQL> SELECT *
     SELECT *, ROW_NUMBER() OVER (PARTITION BY window_start, window_end ORDER BY price DESC) as rownum
     FROM (
       SELECT window_start, window_end, supplier_id, SUM(price) as price, COUNT(*) as cnt
-      FROM TABLE(
-        TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+      FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
       GROUP BY window_start, window_end, supplier_id
     )
   ) WHERE rownum <= 3;
@@ -117,8 +116,7 @@ Flink SQL> SELECT *
 Flink SQL> SELECT *
   FROM (
     SELECT *, ROW_NUMBER() OVER (PARTITION BY window_start, window_end ORDER BY price DESC) as rownum
-    FROM TABLE(
-               TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+    FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   ) WHERE rownum <= 3;
 +------------------+-------+------+-------------+------------------+------------------+--------+
 |          bidtime | price | item | supplier_id |     window_start |       window_end | rownum |

--- a/docs/content.zh/docs/dev/table/sql/queries/window-tvf.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/window-tvf.md
@@ -101,15 +101,14 @@ Flink SQL> SELECT * FROM Bid;
 | 2020-04-15 08:17 |  6.00 | F    |
 +------------------+-------+------+
 
-Flink SQL> SELECT * FROM TABLE(
-   TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES));
+Flink SQL> SELECT * FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-Flink SQL> SELECT * FROM TABLE(
+Flink SQL> SELECT * FROM 
    TUMBLE(
      DATA => TABLE Bid,
      TIMECOL => DESCRIPTOR(bidtime),
-     SIZE => INTERVAL '10' MINUTES));
+     SIZE => INTERVAL '10' MINUTES);
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |            window_time  |
 +------------------+-------+------+------------------+------------------+-------------------------+
@@ -123,8 +122,7 @@ Flink SQL> SELECT * FROM TABLE(
 
 -- apply aggregation on the tumbling windowed table
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -165,16 +163,15 @@ HOP(TABLE data, DESCRIPTOR(timecol), slide, size [, offset ])
 下面是 `Bid` 表的调用示例：
 
 ```sql
-> SELECT * FROM TABLE(
-    HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES));
+> SELECT * FROM HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-> SELECT * FROM TABLE(
+> SELECT * FROM 
     HOP(
       DATA => TABLE Bid,
       TIMECOL => DESCRIPTOR(bidtime),
       SLIDE => INTERVAL '5' MINUTES,
-      SIZE => INTERVAL '10' MINUTES));
+      SIZE => INTERVAL '10' MINUTES);
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |           window_time   |
 +------------------+-------+------+------------------+------------------+-------------------------+
@@ -194,8 +191,7 @@ HOP(TABLE data, DESCRIPTOR(timecol), slide, size [, offset ])
 
 -- apply aggregation on the hopping windowed table
 > SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES))
+  FROM HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -238,16 +234,16 @@ CUMULATE(TABLE data, DESCRIPTOR(timecol), step, size)
 下面是 `Bid` 表的调用示例：
 
 ```sql
-> SELECT * FROM TABLE(
-    CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES));
+> SELECT * FROM 
+    CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-> SELECT * FROM TABLE(
+> SELECT * FROM 
     CUMULATE(
       DATA => TABLE Bid,
       TIMECOL => DESCRIPTOR(bidtime),
       STEP => INTERVAL '2' MINUTES,
-      SIZE => INTERVAL '10' MINUTES));
+      SIZE => INTERVAL '10' MINUTES);
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |            window_time  |
 +------------------+-------+------+------------------+------------------+-------------------------+
@@ -272,8 +268,7 @@ CUMULATE(TABLE data, DESCRIPTOR(timecol), step, size)
 
 -- apply aggregation on the cumulating windowed table
 > SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES))
+  FROM CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -350,11 +345,10 @@ Flink SQL> SELECT * FROM Bid;
 +------------------+-------+------+
 
 -- session window with partition keys
-> SELECT * FROM TABLE(
-    SESSION(TABLE Bid PARTITION BY item, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES));
+> SELECT * FROM SESSION(TABLE Bid PARTITION BY item, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-> SELECT * FROM TABLE(
+> SELECT * FROM 
     SESSION(
       DATA => TABLE Bid PARTITION BY item,
       TIMECOL => DESCRIPTOR(bidtime),
@@ -371,8 +365,7 @@ Flink SQL> SELECT * FROM Bid;
 
 -- apply aggregation on the session windowed table with partition keys
 > SELECT window_start, window_end, item, SUM(price) AS total_price
-  FROM TABLE(
-      SESSION(TABLE Bid PARTITION BY item, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES))
+  FROM SESSION(TABLE Bid PARTITION BY item, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES)
   GROUP BY item, window_start, window_end;
 +------------------+------------------+------+-------------+
 |     window_start |       window_end | item | total_price |
@@ -383,11 +376,10 @@ Flink SQL> SELECT * FROM Bid;
 +------------------+------------------+------+-------------+
 
 -- session window without partition keys
-> SELECT * FROM TABLE(
-    SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES));
+> SELECT * FROM SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-> SELECT * FROM TABLE(
+> SELECT * FROM 
     SESSION(
       DATA => TABLE Bid,
       TIMECOL => DESCRIPTOR(bidtime),
@@ -404,8 +396,7 @@ Flink SQL> SELECT * FROM Bid;
 
 -- apply aggregation on the session windowed table without partition keys
 > SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-      SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES))
+  FROM SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -435,16 +426,16 @@ Flink SQL> SELECT * FROM Bid;
 -- NOTE: Currently Flink doesn't support evaluating individual window table-valued function,
 --  window table-valued function should be used with aggregate operation,
 --  this example is just used for explaining the syntax and the data produced by table-valued function.
-Flink SQL> SELECT * FROM TABLE(
-   TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES));
+Flink SQL> SELECT * FROM 
+   TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first and `OFFSET` should be wrapped with double quotes
-Flink SQL> SELECT * FROM TABLE(
+Flink SQL> SELECT * FROM 
    TUMBLE(
      DATA => TABLE Bid,
      TIMECOL => DESCRIPTOR(bidtime),
      SIZE => INTERVAL '10' MINUTES,
-     `OFFSET` => INTERVAL '1' MINUTES));
+     `OFFSET` => INTERVAL '1' MINUTES);
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |            window_time  |
 +------------------+-------+------+------------------+------------------+-------------------------+
@@ -458,8 +449,7 @@ Flink SQL> SELECT * FROM TABLE(
 
 -- apply aggregation on the tumbling windowed table
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |

--- a/docs/content/docs/dev/table/sql/queries/window-agg.md
+++ b/docs/content/docs/dev/table/sql/queries/window-agg.md
@@ -76,8 +76,7 @@ Flink SQL> SELECT * FROM Bid;
 
 -- tumbling window aggregation
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -88,8 +87,7 @@ Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
 
 -- hopping window aggregation
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES))
+  FROM HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -102,8 +100,7 @@ Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
 
 -- cumulative window aggregation
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES))
+  FROM CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -120,8 +117,7 @@ Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
 
 -- session window aggregation with partition keys
 Flink SQL> SELECT window_start, window_end, supplier_id, SUM(price) AS total_price
-           FROM TABLE(
-               SESSION(TABLE Bid PARTITION BY supplier_id, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES))
+           FROM SESSION(TABLE Bid PARTITION BY supplier_id, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES)
            GROUP BY window_start, window_end, supplier_id;
 +------------------+------------------+-------------+-------------+
 |     window_start |       window_end | supplier_id | total_price |
@@ -134,8 +130,7 @@ Flink SQL> SELECT window_start, window_end, supplier_id, SUM(price) AS total_pri
 
 -- session window aggregation without partition keys
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-           FROM TABLE(
-               SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES))
+           FROM SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES)
            GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -155,8 +150,7 @@ Window aggregations with `GROUPING SETS` require both the `window_start` and `wi
 
 ```sql
 Flink SQL> SELECT window_start, window_end, supplier_id, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end, GROUPING SETS ((supplier_id), ());
 +------------------+------------------+-------------+-------------+
 |     window_start |       window_end | supplier_id | total_price |
@@ -184,8 +178,7 @@ For example, the following query is equivalent to the one above.
 
 ```sql
 SELECT window_start, window_end, supplier_id, SUM(price) AS total_price
-FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
 GROUP BY window_start, window_end, ROLLUP (supplier_id);
 ```
 
@@ -199,13 +192,11 @@ For example, the following two queries are equivalent.
 
 ```sql
 SELECT window_start, window_end, item, supplier_id, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end, CUBE (supplier_id, item);
 
 SELECT window_start, window_end, item, supplier_id, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end, GROUPING SETS (
       (supplier_id, item),
       (supplier_id      ),
@@ -231,14 +222,12 @@ The following shows a cascading window aggregation where the first window aggreg
 CREATE VIEW window1 AS
 -- Note: The window start and window end fields of inner Window TVF are optional in the select clause. However, if they appear in the clause, they need to be aliased to prevent name conflicting with the window start and window end of the outer Window TVF.
 SELECT window_start AS window_5mintumble_start, window_end AS window_5mintumble_end, window_time AS rowtime, SUM(price) AS partial_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES)
   GROUP BY supplier_id, window_start, window_end, window_time;
 
 -- tumbling 10 minutes on the first window
 SELECT window_start, window_end, SUM(partial_price) AS total_price
-  FROM TABLE(
-      TUMBLE(TABLE window1, DESCRIPTOR(rowtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE window1, DESCRIPTOR(rowtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 ```
 

--- a/docs/content/docs/dev/table/sql/queries/window-topn.md
+++ b/docs/content/docs/dev/table/sql/queries/window-topn.md
@@ -89,8 +89,7 @@ Flink SQL> SELECT *
     SELECT *, ROW_NUMBER() OVER (PARTITION BY window_start, window_end ORDER BY price DESC) as rownum
     FROM (
       SELECT window_start, window_end, supplier_id, SUM(price) as price, COUNT(*) as cnt
-      FROM TABLE(
-        TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+      FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
       GROUP BY window_start, window_end, supplier_id
     )
   ) WHERE rownum <= 3;
@@ -116,8 +115,7 @@ The following example shows how to calculate Top 3 items which have the highest 
 Flink SQL> SELECT *
   FROM (
     SELECT bidtime, price, item, supplier_id, window_start, window_end, ROW_NUMBER() OVER (PARTITION BY window_start, window_end ORDER BY price DESC) as rownum
-    FROM TABLE(
-               TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+    FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   ) WHERE rownum <= 3;
 +------------------+-------+------+-------------+------------------+------------------+--------+
 |          bidtime | price | item | supplier_id |     window_start |       window_end | rownum |

--- a/docs/content/docs/dev/table/sql/queries/window-tvf.md
+++ b/docs/content/docs/dev/table/sql/queries/window-tvf.md
@@ -101,15 +101,14 @@ Flink SQL> SELECT * FROM Bid;
 | 2020-04-15 08:17 |  6.00 | F    |
 +------------------+-------+------+
 
-Flink SQL> SELECT * FROM TABLE(
-   TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES));
+Flink SQL> SELECT * FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-Flink SQL> SELECT * FROM TABLE(
+Flink SQL> SELECT * FROM 
    TUMBLE(
      DATA => TABLE Bid,
      TIMECOL => DESCRIPTOR(bidtime),
-     SIZE => INTERVAL '10' MINUTES));
+     SIZE => INTERVAL '10' MINUTES);
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |            window_time  |
 +------------------+-------+------+------------------+------------------+-------------------------+
@@ -123,8 +122,7 @@ Flink SQL> SELECT * FROM TABLE(
 
 -- apply aggregation on the tumbling windowed table
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -165,16 +163,15 @@ HOP(TABLE data, DESCRIPTOR(timecol), slide, size [, offset ])
 Here is an example invocation on the `Bid` table:
 
 ```sql
-> SELECT * FROM TABLE(
-    HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES));
+> SELECT * FROM HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-> SELECT * FROM TABLE(
+> SELECT * FROM 
     HOP(
       DATA => TABLE Bid,
       TIMECOL => DESCRIPTOR(bidtime),
       SLIDE => INTERVAL '5' MINUTES,
-      SIZE => INTERVAL '10' MINUTES));
+      SIZE => INTERVAL '10' MINUTES);
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |           window_time   |
 +------------------+-------+------+------------------+------------------+-------------------------+
@@ -194,8 +191,7 @@ Here is an example invocation on the `Bid` table:
 
 -- apply aggregation on the hopping windowed table
 > SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES))
+  FROM HOP(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES, INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -238,16 +234,16 @@ CUMULATE(TABLE data, DESCRIPTOR(timecol), step, size)
 Here is an example invocation on the Bid table:
 
 ```sql
-> SELECT * FROM TABLE(
-    CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES));
+> SELECT * FROM 
+    CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-> SELECT * FROM TABLE(
+> SELECT * FROM 
     CUMULATE(
       DATA => TABLE Bid,
       TIMECOL => DESCRIPTOR(bidtime),
       STEP => INTERVAL '2' MINUTES,
-      SIZE => INTERVAL '10' MINUTES));
+      SIZE => INTERVAL '10' MINUTES);
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |            window_time  |
 +------------------+-------+------+------------------+------------------+-------------------------+
@@ -272,8 +268,7 @@ Here is an example invocation on the Bid table:
 
 -- apply aggregation on the cumulating windowed table
 > SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES))
+  FROM CUMULATE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '2' MINUTES, INTERVAL '10' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -351,11 +346,10 @@ Flink SQL> SELECT * FROM Bid;
 +------------------+-------+------+
 
 -- session window with partition keys
-> SELECT * FROM TABLE(
-    SESSION(TABLE Bid PARTITION BY item, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES));
+> SELECT * FROM SESSION(TABLE Bid PARTITION BY item, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-> SELECT * FROM TABLE(
+> SELECT * FROM 
     SESSION(
       DATA => TABLE Bid PARTITION BY item,
       TIMECOL => DESCRIPTOR(bidtime),
@@ -372,8 +366,7 @@ Flink SQL> SELECT * FROM Bid;
 
 -- apply aggregation on the session windowed table with partition keys
 > SELECT window_start, window_end, item, SUM(price) AS total_price
-  FROM TABLE(
-    SESSION(TABLE Bid PARTITION BY item, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES))
+  FROM SESSION(TABLE Bid PARTITION BY item, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES)
   GROUP BY item, window_start, window_end;
 +------------------+------------------+------+-------------+
 |     window_start |       window_end | item | total_price |
@@ -384,11 +377,10 @@ Flink SQL> SELECT * FROM Bid;
 +------------------+------------------+------+-------------+
 
 -- session window without partition keys
-> SELECT * FROM TABLE(
-    SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES));
+> SELECT * FROM SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first
-> SELECT * FROM TABLE(
+> SELECT * FROM 
     SESSION(
       DATA => TABLE Bid,
       TIMECOL => DESCRIPTOR(bidtime),
@@ -405,8 +397,7 @@ Flink SQL> SELECT * FROM Bid;
 
 -- apply aggregation on the session windowed table without partition keys
 > SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-      SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES))
+  FROM SESSION(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '5' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |
@@ -436,16 +427,16 @@ We show an example to describe how to use offset in Tumble window in the followi
 -- NOTE: Currently Flink doesn't support evaluating individual window table-valued function,
 --  window table-valued function should be used with aggregate operation,
 --  this example is just used for explaining the syntax and the data produced by table-valued function.
-Flink SQL> SELECT * FROM TABLE(
-   TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES));
+Flink SQL> SELECT * FROM 
+   TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES);
 -- or with the named params
 -- note: the DATA param must be the first and `OFFSET` should be wrapped with double quotes
-Flink SQL> SELECT * FROM TABLE(
+Flink SQL> SELECT * FROM 
    TUMBLE(
      DATA => TABLE Bid,
      TIMECOL => DESCRIPTOR(bidtime),
      SIZE => INTERVAL '10' MINUTES,
-     `OFFSET` => INTERVAL '1' MINUTES));
+     `OFFSET` => INTERVAL '1' MINUTES);
 +------------------+-------+------+------------------+------------------+-------------------------+
 |          bidtime | price | item |     window_start |       window_end |            window_time  |
 +------------------+-------+------+------------------+------------------+-------------------------+
@@ -459,8 +450,7 @@ Flink SQL> SELECT * FROM TABLE(
 
 -- apply aggregation on the tumbling windowed table
 Flink SQL> SELECT window_start, window_end, SUM(price) AS total_price
-  FROM TABLE(
-    TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES))
+  FROM TUMBLE(TABLE Bid, DESCRIPTOR(bidtime), INTERVAL '10' MINUTES, INTERVAL '1' MINUTES)
   GROUP BY window_start, window_end;
 +------------------+------------------+-------------+
 |     window_start |       window_end | total_price |

--- a/flink-table/flink-sql-parser/src/main/codegen/templates/Parser.jj
+++ b/flink-table/flink-sql-parser/src/main/codegen/templates/Parser.jj
@@ -2171,12 +2171,20 @@ SqlNode TableRef3(ExprContext exprContext, boolean lateral) :
 {
     (
         LOOKAHEAD(2)
-        tableName = CompoundTableIdentifier()
-        ( tableRef = TableHints(tableName) | { tableRef = tableName; } )
-        [ tableRef = ExtendTable(tableRef) ]
-        tableRef = Over(tableRef)
-        [ tableRef = Snapshot(tableRef) ]
-        [ tableRef = MatchRecognize(tableRef) ]
+        tableName = CompoundTableIdentifier() { s = span(); }
+        (
+            // Table call syntax like FROM a.b() instead of FROM TABLE(a.b())
+            // Three tokens needed to disambiguate EXTEND syntax from CALCITE-493.
+            // Example: "FROM EventLog(lastGCTime TIME)".
+            LOOKAHEAD(3)
+            tableRef = ImplicitTableFunctionCallArgs(tableName)
+        |
+            ( tableRef = TableHints(tableName) | { tableRef = tableName; } )
+            [ tableRef = ExtendTable(tableRef) ]
+            tableRef = Over(tableRef)
+            [ tableRef = Snapshot(tableRef) ]
+            [ tableRef = MatchRecognize(tableRef) ]
+        )
     |
         LOOKAHEAD(2)
         [ <LATERAL> { lateral = true; } ]
@@ -2382,6 +2390,38 @@ void AddCompoundIdentifierType(List<SqlNode> list, List<SqlNode> extendList) :
             extendList.add(type.withNullable(nullable, getPos()));
         }
         list.add(name);
+    }
+}
+
+SqlNode ImplicitTableFunctionCallArgs(SqlIdentifier name) :
+{
+    final List<SqlNode> tableFuncArgs = new ArrayList<SqlNode>();
+    final SqlNode call;
+    final Span s;
+}
+{
+    // Table call syntax like FROM a.b() instead of FROM TABLE(a.b())
+    // We've already parsed the name, so we don't use NamedRoutineCall.
+    { s = span(); }
+    <LPAREN>
+    [
+        AddArg0(tableFuncArgs, ExprContext.ACCEPT_CURSOR)
+        (
+            <COMMA> {
+                // a comma-list can't appear where only a query is expected
+                checkNonQueryExpression(ExprContext.ACCEPT_CURSOR);
+            }
+            AddArg(tableFuncArgs, ExprContext.ACCEPT_CURSOR)
+        )*
+    ]
+    <RPAREN>
+    {
+        final SqlParserPos pos = s.end(this);
+        call = createCall(name, pos,
+            SqlFunctionCategory.USER_DEFINED_TABLE_FUNCTION, null,
+            tableFuncArgs);
+        return SqlStdOperatorTable.COLLECTION_TABLE.createCall(pos,
+            call);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -26,6 +26,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParserFixture;
 import org.apache.calcite.sql.parser.SqlParserTest;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -3425,6 +3426,13 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                         + "INNER JOIN (SELECT *\n"
                         + "FROM UNNEST(`ITEM`.`RELATED`) AS `I` (`RELS`)) AS `RELATIONS` ON TRUE";
         sql(sql1).ok(expected1);
+    }
+
+    @Test
+    void testOuterApplyFunctionFails() {
+        final String sql = "select * from dept outer apply ramp(deptno)^)^";
+        sql(sql).withConformance(SqlConformanceEnum.SQL_SERVER_2008)
+                .fails("(?s).*Encountered \"\\)\" at .*");
     }
 
     /** Matcher that invokes the #validate() of the {@link ExtendedSqlNode} instance. * */

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.runtime.stream.sql;
 
 import org.apache.flink.api.common.serialization.SerializerConfigImpl;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
@@ -33,6 +34,8 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.dataview.MapView;
 import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogDescriptor;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -65,6 +68,8 @@ import org.apache.flink.util.UserClassLoaderJarTestUtils;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.lang.invoke.MethodHandle;
 import java.math.BigDecimal;
@@ -73,6 +78,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -1035,45 +1041,49 @@ public class FunctionITCase extends StreamingTestBase {
         assertThat(TestCollectionTableFactory.getResult()).isEqualTo(sinkData);
     }
 
-    @Test
-    void testDynamicCatalogTableFunctionWithoutTableWrapper() throws Exception {
+    @ParameterizedTest(name = "{index}: With table wrapper ({0})")
+    @ValueSource(booleans = {true, false})
+    void testDynamicCatalogTableFunction(final boolean withTableWrapper) throws Exception {
         final Row[] sinkData =
                 new Row[] {Row.of("Test is a string"), Row.of("42"), Row.of((String) null)};
+        final String catalogName = "cat";
+        final String databaseName = "db";
+        final String simpleFunctionName = "DynamicTableFunction";
+        final String functionNameWithDb = databaseName + "." + simpleFunctionName;
+        final String fullFunctionName = catalogName + "." + functionNameWithDb;
 
         TestCollectionTableFactory.reset();
 
+        Configuration configuration = new Configuration();
+        configuration.setString("type", "generic_in_memory");
+        tEnv().createCatalog(catalogName, CatalogDescriptor.of(catalogName, configuration));
+        tEnv().getCatalog(catalogName)
+                .get()
+                .createDatabase(
+                        databaseName,
+                        new CatalogDatabaseImpl(new HashMap<>(), databaseName),
+                        false);
+        tEnv().createFunction(fullFunctionName, DynamicTableFunction.class);
+        tEnv().useCatalog(catalogName);
+        tEnv().useDatabase(databaseName);
         tEnv().executeSql("CREATE TABLE SinkTable(s STRING) WITH ('connector' = 'COLLECTION')");
 
-        tEnv().createFunction("DynamicTableFunction", DynamicTableFunction.class);
         tEnv().executeSql(
                         "INSERT INTO SinkTable "
-                                + "SELECT T1.s FROM DynamicTableFunction('Test') AS T1(s) "
+                                + "SELECT T1.s FROM "
+                                + getTableFunctionAsTable(
+                                        simpleFunctionName, "'Test'", withTableWrapper)
+                                + " AS T1(s) "
                                 + "UNION ALL "
-                                + "SELECT CAST(T2.i AS STRING) FROM DynamicTableFunction(42) AS T2(i)"
+                                + "SELECT CAST(T2.i AS STRING) FROM "
+                                + getTableFunctionAsTable(
+                                        functionNameWithDb, "42", withTableWrapper)
+                                + " AS T2(i)"
                                 + "UNION ALL "
-                                + "SELECT CAST(T3.i AS STRING) FROM DynamicTableFunction(CAST(NULL AS INT)) AS T3(i)")
-                .await();
-
-        assertThat(TestCollectionTableFactory.getResult()).containsExactlyInAnyOrder(sinkData);
-    }
-
-    @Test
-    void testDynamicCatalogTableFunction() throws Exception {
-        final Row[] sinkData =
-                new Row[] {Row.of("Test is a string"), Row.of("42"), Row.of((String) null)};
-
-        TestCollectionTableFactory.reset();
-
-        tEnv().executeSql("CREATE TABLE SinkTable(s STRING) WITH ('connector' = 'COLLECTION')");
-
-        tEnv().createFunction("DynamicTableFunction", DynamicTableFunction.class);
-        tEnv().executeSql(
-                        "INSERT INTO SinkTable "
-                                + "SELECT T1.s FROM TABLE(DynamicTableFunction('Test')) AS T1(s) "
-                                + "UNION ALL "
-                                + "SELECT CAST(T2.i AS STRING) FROM TABLE(DynamicTableFunction(42)) AS T2(i)"
-                                + "UNION ALL "
-                                + "SELECT CAST(T3.i AS STRING) FROM TABLE(DynamicTableFunction(CAST(NULL AS INT))) AS T3(i)")
+                                + "SELECT CAST(T3.i AS STRING) FROM "
+                                + getTableFunctionAsTable(
+                                        fullFunctionName, "CAST(NULL AS INT)", withTableWrapper)
+                                + " AS T3(i)")
                 .await();
 
         assertThat(TestCollectionTableFactory.getResult()).containsExactlyInAnyOrder(sinkData);
@@ -2206,5 +2216,13 @@ public class FunctionITCase extends StreamingTestBase {
 
     private interface FunctionCreator {
         void createFunction(TableEnvironment environment);
+    }
+
+    private static String getTableFunctionAsTable(
+            final String functionName, final String input, final boolean withTableWrapper) {
+        if (withTableWrapper) {
+            return "TABLE(" + functionName + "(" + input + "))";
+        }
+        return functionName + "(" + input + ")";
     }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/WindowTableFunctionITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/WindowTableFunctionITCase.scala
@@ -45,7 +45,7 @@ class WindowTableFunctionITCase extends BatchTestBase {
     checkResult(
       """
         |SELECT *
-        |FROM TABLE(TUMBLE(TABLE Table3WithTimestamp, DESCRIPTOR(ts), INTERVAL '3' SECOND))
+        |FROM TUMBLE(TABLE Table3WithTimestamp, DESCRIPTOR(ts), INTERVAL '3' SECOND)
         |""".stripMargin,
       Seq(
         row(
@@ -246,12 +246,12 @@ class WindowTableFunctionITCase extends BatchTestBase {
     checkResult(
       """
         |SELECT *
-        |FROM TABLE(
+        |FROM 
         |  HOP(
         |    TABLE Table3WithTimestamp,
         |    DESCRIPTOR(ts),
         |    INTERVAL '5' SECOND,
-        |    INTERVAL '9' SECOND))
+        |    INTERVAL '9' SECOND)
         |""".stripMargin,
       Seq(
         row(
@@ -605,12 +605,12 @@ class WindowTableFunctionITCase extends BatchTestBase {
     checkResult(
       """
         |SELECT *
-        |FROM TABLE(
+        |FROM 
         |  CUMULATE(
         |    TABLE Table3WithTimestamp,
         |    DESCRIPTOR(ts),
         |    INTERVAL '3' SECOND,
-        |    INTERVAL '9' SECOND))
+        |    INTERVAL '9' SECOND)
         |""".stripMargin,
       Seq(
         row(
@@ -1021,12 +1021,12 @@ class WindowTableFunctionITCase extends BatchTestBase {
         |  b,
         |  SUM(a),
         |  window_start
-        |FROM TABLE(
+        |FROM 
         |  HOP(
         |    TABLE Table3WithTimestamp,
         |    DESCRIPTOR(ts),
         |    INTERVAL '5' SECOND,
-        |    INTERVAL '9' SECOND))
+        |    INTERVAL '9' SECOND)
         |GROUP BY window_start, window_end, b
         |""".stripMargin,
       Seq(
@@ -1064,12 +1064,12 @@ class WindowTableFunctionITCase extends BatchTestBase {
         |  window_start,
         |  window_end,
         |  window_time
-        |FROM TABLE(
+        |FROM 
         |  HOP(
         |    TABLE T,
         |    DESCRIPTOR(ts),
         |    INTERVAL '5' SECOND,
-        |    INTERVAL '10' SECOND))
+        |    INTERVAL '10' SECOND)
         |GROUP BY window_start, window_end, window_time, b
         |""".stripMargin,
       Seq(
@@ -1195,12 +1195,12 @@ class WindowTableFunctionITCase extends BatchTestBase {
         |SELECT *
         |FROM (
         |  SELECT window_start, window_end, v
-        |  FROM TABLE(TUMBLE(TABLE T1, DESCRIPTOR(ts), INTERVAL '10' SECOND))
+        |  FROM TUMBLE(TABLE T1, DESCRIPTOR(ts), INTERVAL '10' SECOND)
         |  GROUP BY window_start, window_end, v
         |) L
         |LEFT JOIN (
         |  SELECT window_start, window_end, v
-        |  FROM TABLE(TUMBLE(TABLE T2, DESCRIPTOR(ts), INTERVAL '10' SECOND))
+        |  FROM TUMBLE(TABLE T2, DESCRIPTOR(ts), INTERVAL '10' SECOND)
         |   GROUP BY window_start, window_end, v
         |) R
         |ON L.window_start = R.window_start AND L.window_end = R.window_end AND L.v = R.v
@@ -1233,12 +1233,12 @@ class WindowTableFunctionITCase extends BatchTestBase {
         |FROM (
         |SELECT *,
         |  RANK() OVER(PARTITION BY window_start, window_end ORDER BY ts) as rownum
-        |FROM TABLE(
+        |FROM 
         |  CUMULATE(
         |    TABLE Table3WithTimestamp,
         |    DESCRIPTOR(ts),
         |    INTERVAL '3' SECOND,
-        |    INTERVAL '9' SECOND))
+        |    INTERVAL '9' SECOND)
         |)
         |WHERE rownum <= 1
         |""".stripMargin,


### PR DESCRIPTION

## What is the purpose of the change
The PR ports feature from Calcite 1.37 https://issues.apache.org/jira/browse/CALCITE-6254


## Verifying this change

This change added tests and can be verified as follows:
Some existing tests were changed (`TABLE` wrapper was removed for some tests for windows also one more test was added to `flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java`)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (docs)
