### PR TITLE
[FLINK-36825][table] Introduce FastTop1Function in Rank with Async State API

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/asyncprocessing/AsyncStateKeyedProcessOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/asyncprocessing/AsyncStateKeyedProcessOperator.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.asyncprocessing;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.asyncprocessing.operators.AbstractAsyncStateUdfStreamOperator;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.api.SimpleTimerService;
+import org.apache.flink.streaming.api.TimeDomain;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A {@link StreamOperator} for executing {@link KeyedProcessFunction KeyedProcessFunctions}.
+ *
+ * <p>This class is nearly identical with {@link KeyedProcessOperator}, but extending from {@link
+ * AbstractAsyncStateUdfStreamOperator} to integrate with asynchronous state access. Another
+ * difference is this class is internal.
+ */
+@Internal
+public class AsyncStateKeyedProcessOperator<K, IN, OUT>
+        extends AbstractAsyncStateUdfStreamOperator<OUT, KeyedProcessFunction<K, IN, OUT>>
+        implements OneInputStreamOperator<IN, OUT>, Triggerable<K, VoidNamespace> {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient TimestampedCollector<OUT> collector;
+
+    private transient ContextImpl context;
+
+    private transient OnTimerContextImpl onTimerContext;
+
+    public AsyncStateKeyedProcessOperator(KeyedProcessFunction<K, IN, OUT> function) {
+        super(function);
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        collector = new TimestampedCollector<>(output);
+
+        InternalTimerService<VoidNamespace> internalTimerService =
+                getInternalTimerService("user-timers", VoidNamespaceSerializer.INSTANCE, this);
+
+        TimerService timerService = new SimpleTimerService(internalTimerService);
+
+        context = new ContextImpl(userFunction, timerService);
+        onTimerContext = new OnTimerContextImpl(userFunction, timerService);
+    }
+
+    @Override
+    public void onEventTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
+        collector.setAbsoluteTimestamp(timer.getTimestamp());
+        invokeUserFunction(TimeDomain.EVENT_TIME, timer);
+    }
+
+    @Override
+    public void onProcessingTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
+        collector.eraseTimestamp();
+        invokeUserFunction(TimeDomain.PROCESSING_TIME, timer);
+    }
+
+    @Override
+    public void processElement(StreamRecord<IN> element) throws Exception {
+        collector.setTimestamp(element);
+        context.element = element;
+        userFunction.processElement(element.getValue(), context, collector);
+        context.element = null;
+    }
+
+    private void invokeUserFunction(TimeDomain timeDomain, InternalTimer<K, VoidNamespace> timer)
+            throws Exception {
+        onTimerContext.timeDomain = timeDomain;
+        onTimerContext.timer = timer;
+        userFunction.onTimer(timer.getTimestamp(), onTimerContext, collector);
+        onTimerContext.timeDomain = null;
+        onTimerContext.timer = null;
+    }
+
+    private class ContextImpl extends KeyedProcessFunction<K, IN, OUT>.Context {
+
+        private final TimerService timerService;
+
+        private StreamRecord<IN> element;
+
+        ContextImpl(KeyedProcessFunction<K, IN, OUT> function, TimerService timerService) {
+            function.super();
+            this.timerService = checkNotNull(timerService);
+        }
+
+        @Override
+        public Long timestamp() {
+            checkState(element != null);
+
+            if (element.hasTimestamp()) {
+                return element.getTimestamp();
+            } else {
+                return null;
+            }
+        }
+
+        @Override
+        public TimerService timerService() {
+            return timerService;
+        }
+
+        @Override
+        public <X> void output(OutputTag<X> outputTag, X value) {
+            if (outputTag == null) {
+                throw new IllegalArgumentException("OutputTag must not be null.");
+            }
+
+            output.collect(outputTag, new StreamRecord<>(value, element.getTimestamp()));
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public K getCurrentKey() {
+            return (K) AsyncStateKeyedProcessOperator.this.getCurrentKey();
+        }
+    }
+
+    private class OnTimerContextImpl extends KeyedProcessFunction<K, IN, OUT>.OnTimerContext {
+
+        private final TimerService timerService;
+
+        private TimeDomain timeDomain;
+
+        private InternalTimer<K, VoidNamespace> timer;
+
+        OnTimerContextImpl(KeyedProcessFunction<K, IN, OUT> function, TimerService timerService) {
+            function.super();
+            this.timerService = checkNotNull(timerService);
+        }
+
+        @Override
+        public Long timestamp() {
+            checkState(timer != null);
+            return timer.getTimestamp();
+        }
+
+        @Override
+        public TimerService timerService() {
+            return timerService;
+        }
+
+        @Override
+        public <X> void output(OutputTag<X> outputTag, X value) {
+            if (outputTag == null) {
+                throw new IllegalArgumentException("OutputTag must not be null.");
+            }
+
+            output.collect(outputTag, new StreamRecord<>(value, timer.getTimestamp()));
+        }
+
+        @Override
+        public TimeDomain timeDomain() {
+            checkState(timeDomain != null);
+            return timeDomain;
+        }
+
+        @Override
+        public K getCurrentKey() {
+            return timer.getKey();
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -23,8 +23,11 @@ import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.asyncprocessing.AsyncStateKeyedProcessOperator;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.codegen.EqualiserCodeGenerator;
 import org.apache.flink.table.planner.codegen.sort.ComparatorCodeGenerator;
@@ -56,6 +59,8 @@ import org.apache.flink.table.runtime.operators.rank.RankRange;
 import org.apache.flink.table.runtime.operators.rank.RankType;
 import org.apache.flink.table.runtime.operators.rank.RetractableTopNFunction;
 import org.apache.flink.table.runtime.operators.rank.UpdatableTopNFunction;
+import org.apache.flink.table.runtime.operators.rank.asyncprocessing.AbstractAsyncSyncStateTopNFunction;
+import org.apache.flink.table.runtime.operators.rank.asyncprocessing.AsyncStateFastTop1Function;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils;
 import org.apache.flink.table.runtime.util.StateConfigUtil;
@@ -233,6 +238,8 @@ public class StreamExecRank extends ExecNodeBase<RowData>
         long stateRetentionTime =
                 StateMetadata.getStateTtlForOneInputOperator(config, stateMetadataList);
         StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(stateRetentionTime);
+        boolean enableAsyncState =
+                config.get(ExecutionConfigOptions.TABLE_EXEC_ASYNC_STATE_ENABLED);
 
         AbstractTopNFunction processFunction;
         if (rankStrategy instanceof RankProcessStrategy.AppendFastStrategy) {
@@ -250,17 +257,31 @@ public class StreamExecRank extends ExecNodeBase<RowData>
                                 generateUpdateBefore,
                                 outputRankNumber);
             } else if (RankUtil.isTop1(rankRange)) {
-                processFunction =
-                        new FastTop1Function(
-                                ttlConfig,
-                                inputRowTypeInfo,
-                                sortKeyComparator,
-                                sortKeySelector,
-                                rankType,
-                                rankRange,
-                                generateUpdateBefore,
-                                outputRankNumber,
-                                cacheSize);
+                if (enableAsyncState) {
+                    processFunction =
+                            new AsyncStateFastTop1Function(
+                                    ttlConfig,
+                                    inputRowTypeInfo,
+                                    sortKeyComparator,
+                                    sortKeySelector,
+                                    rankType,
+                                    rankRange,
+                                    generateUpdateBefore,
+                                    outputRankNumber,
+                                    cacheSize);
+                } else {
+                    processFunction =
+                            new FastTop1Function(
+                                    ttlConfig,
+                                    inputRowTypeInfo,
+                                    sortKeyComparator,
+                                    sortKeySelector,
+                                    rankType,
+                                    rankRange,
+                                    generateUpdateBefore,
+                                    outputRankNumber,
+                                    cacheSize);
+                }
             } else {
                 processFunction =
                         new AppendOnlyTopNFunction(
@@ -276,17 +297,31 @@ public class StreamExecRank extends ExecNodeBase<RowData>
             }
         } else if (rankStrategy instanceof RankProcessStrategy.UpdateFastStrategy) {
             if (RankUtil.isTop1(rankRange)) {
-                processFunction =
-                        new FastTop1Function(
-                                ttlConfig,
-                                inputRowTypeInfo,
-                                sortKeyComparator,
-                                sortKeySelector,
-                                rankType,
-                                rankRange,
-                                generateUpdateBefore,
-                                outputRankNumber,
-                                cacheSize);
+                if (enableAsyncState) {
+                    processFunction =
+                            new AsyncStateFastTop1Function(
+                                    ttlConfig,
+                                    inputRowTypeInfo,
+                                    sortKeyComparator,
+                                    sortKeySelector,
+                                    rankType,
+                                    rankRange,
+                                    generateUpdateBefore,
+                                    outputRankNumber,
+                                    cacheSize);
+                } else {
+                    processFunction =
+                            new FastTop1Function(
+                                    ttlConfig,
+                                    inputRowTypeInfo,
+                                    sortKeyComparator,
+                                    sortKeySelector,
+                                    rankType,
+                                    rankRange,
+                                    generateUpdateBefore,
+                                    outputRankNumber,
+                                    cacheSize);
+                }
             } else {
                 RankProcessStrategy.UpdateFastStrategy updateFastStrategy =
                         (RankProcessStrategy.UpdateFastStrategy) rankStrategy;
@@ -342,9 +377,14 @@ public class StreamExecRank extends ExecNodeBase<RowData>
                     String.format("rank strategy:%s is not supported.", rankStrategy));
         }
 
-        KeyedProcessOperator<RowData, RowData, RowData> operator =
-                new KeyedProcessOperator<>(processFunction);
-        processFunction.setKeyContext(operator);
+        StreamOperator<RowData> operator;
+        if (processFunction instanceof AbstractAsyncSyncStateTopNFunction) {
+            operator = new AsyncStateKeyedProcessOperator<>(processFunction);
+            processFunction.setKeyContext(operator);
+        } else {
+            operator = new KeyedProcessOperator<>(processFunction);
+            processFunction.setKeyContext(operator);
+        }
 
         OneInputTransformation<RowData, RowData> transform =
                 ExecNodeUtil.createOneInputTransformation(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/HarnessTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/HarnessTestBase.scala
@@ -21,14 +21,13 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.runtime.state.CheckpointStorage
-import org.apache.flink.runtime.state.StateBackend
+import org.apache.flink.runtime.state.{CheckpointStorage, StateBackend}
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend
-import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage
-import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage
+import org.apache.flink.runtime.state.storage.{FileSystemCheckpointStorage, JobManagerCheckpointStorage}
 import org.apache.flink.state.rocksdb.EmbeddedRocksDBStateBackend
 import org.apache.flink.streaming.api.datastream.DataStream
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator
+import org.apache.flink.streaming.api.operators.{OneInputStreamOperator, SimpleOperatorFactory}
+import org.apache.flink.streaming.api.operators.asyncprocessing.AsyncStateKeyedProcessOperator
 import org.apache.flink.streaming.api.transformations.{OneInputTransformation, PartitionTransformation}
 import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.streaming.util.{KeyedOneInputStreamOperatorTestHarness, OneInputStreamOperatorTestHarness}
@@ -126,6 +125,14 @@ class HarnessTestBase(mode: StateBackendMode) extends StreamingTestBase {
 
   def dropWatermarks(elements: Array[AnyRef]): util.Collection[AnyRef] = {
     elements.filter(e => !e.isInstanceOf[Watermark]).toList
+  }
+
+  protected def isAsyncStateOperator(
+      testHarness: KeyedOneInputStreamOperatorTestHarness[RowData, RowData, RowData]): Boolean = {
+    testHarness.getOperatorFactory
+      .asInstanceOf[SimpleOperatorFactory[_]]
+      .getOperator
+      .isInstanceOf[AsyncStateKeyedProcessOperator[_, _, _]]
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
@@ -21,33 +21,42 @@ import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.scala._
 import org.apache.flink.table.api.bridge.scala.internal.StreamTableEnvironmentImpl
+import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.data.RowData
 import org.apache.flink.table.planner.JInt
 import org.apache.flink.table.planner.runtime.utils.{JavaUserDefinedTableFunctions, StreamingEnvUtil}
-import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
+import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.{HEAP_BACKEND, ROCKSDB_BACKEND, StateBackendMode}
 import org.apache.flink.table.runtime.util.RowDataHarnessAssertor
 import org.apache.flink.table.runtime.util.StreamRecordUtils.binaryRecord
-import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension
+import org.apache.flink.testutils.junit.extensions.parameterized.{ParameterizedTestExtension, Parameters}
 import org.apache.flink.types.Row
 import org.apache.flink.types.RowKind._
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.{BeforeEach, TestTemplate}
 import org.junit.jupiter.api.extension.ExtendWith
 
 import java.lang.{Long => JLong}
 import java.time.Duration
+import java.util
 import java.util.concurrent.ConcurrentLinkedQueue
 
+import scala.collection.JavaConversions._
 import scala.collection.mutable
 
 @ExtendWith(Array(classOf[ParameterizedTestExtension]))
-class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
+class RankHarnessTest(mode: StateBackendMode, enableAsyncState: Boolean)
+  extends HarnessTestBase(mode) {
 
   @BeforeEach
   override def before(): Unit = {
     super.before()
     val setting = EnvironmentSettings.newInstance().inStreamingMode().build()
     this.tEnv = StreamTableEnvironmentImpl.create(env, setting)
+
+    tEnv.getConfig.set(
+      ExecutionConfigOptions.TABLE_EXEC_ASYNC_STATE_ENABLED,
+      Boolean.box(enableAsyncState))
   }
 
   @TestTemplate
@@ -91,6 +100,8 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
         DataTypes.STRING().getLogicalType,
         DataTypes.BIGINT().getLogicalType
       ))
+
+    assertThat(isAsyncStateOperator(testHarness)).isFalse
 
     testHarness.open()
 
@@ -186,6 +197,8 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
         DataTypes.BIGINT().getLogicalType,
         DataTypes.STRING().getLogicalType))
 
+    assertThat(isAsyncStateOperator(testHarness)).isFalse
+
     testHarness.open()
 
     // set TtlTimeProvider with 1
@@ -253,6 +266,9 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
         DataTypes.INT().getLogicalType,
         DataTypes.INT().getLogicalType,
         DataTypes.BIGINT().getLogicalType))
+
+    assertThat(isAsyncStateOperator(testHarness)).isFalse
+
     (testHarness, assertor)
   }
 
@@ -450,5 +466,129 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
 
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
     testHarness.close()
+  }
+
+  def prepareTop1Tester(query: String, operatorNameIdentifier: String)
+      : (KeyedOneInputStreamOperatorTestHarness[RowData, RowData, RowData], RowDataHarnessAssertor) = {
+    val sourceDDL =
+      s"""
+         |CREATE TEMPORARY TABLE T(
+         |  a STRING PRIMARY KEY NOT ENFORCED,
+         |  b BIGINT
+         |) WITH (
+         |  'connector' = 'values',
+         |  'changelog-mode' = 'I'
+         |)
+         |""".stripMargin
+    tEnv.executeSql(sourceDDL)
+
+    val t1 = tEnv.sqlQuery(query)
+
+    val testHarness =
+      createHarnessTester(t1.toRetractStream[Row], operatorNameIdentifier)
+    val assertor = new RowDataHarnessAssertor(
+      Array(
+        DataTypes.STRING().getLogicalType,
+        DataTypes.BIGINT().getLogicalType,
+        DataTypes.BIGINT().getLogicalType))
+
+    (testHarness, assertor)
+  }
+
+  @TestTemplate
+  def testAppendFastTop1(): Unit = {
+    tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
+    val query =
+      """
+        |SELECT a, b, rn
+        |FROM
+        |(
+        |    SELECT a, b,
+        |        ROW_NUMBER() OVER (PARTITION BY a ORDER BY b DESC) AS rn
+        |    FROM T
+        |) t1
+        |WHERE rn <= 1
+      """.stripMargin
+    val (testHarness, assertor) =
+      prepareTop1Tester(query, "Rank(strategy=[AppendFastStrategy")
+
+    if (enableAsyncState) {
+      assertThat(isAsyncStateOperator(testHarness)).isTrue
+    } else {
+      assertThat(isAsyncStateOperator(testHarness)).isFalse
+    }
+
+    testHarness.open()
+
+    testHarness.processElement(binaryRecord(INSERT, "a", 2L: JLong))
+    testHarness.processElement(binaryRecord(INSERT, "a", 1L: JLong))
+    testHarness.processElement(binaryRecord(INSERT, "a", 3L: JLong))
+
+    val result = dropWatermarks(testHarness.getOutput.toArray)
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+    expectedOutput.add(binaryRecord(INSERT, "a", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "a", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "a", 3L: JLong))
+
+    assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+
+    testHarness.close()
+  }
+
+  @TestTemplate
+  def testUpdateFastTop1(): Unit = {
+    tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
+    val query =
+      """
+        |SELECT a, b, rn
+        |FROM
+        |(
+        |    SELECT a, b,
+        |        ROW_NUMBER() OVER (PARTITION BY a ORDER BY b DESC) AS rn
+        |    FROM (
+        |       select a, count(*) as b from T group by a
+        |    ) t1
+        |) t2
+        |WHERE rn <= 1
+      """.stripMargin
+    val (testHarness, assertor) =
+      prepareTop1Tester(query, "Rank(strategy=[UpdateFastStrategy")
+
+    if (enableAsyncState) {
+      assertThat(isAsyncStateOperator(testHarness)).isTrue
+    } else {
+      assertThat(isAsyncStateOperator(testHarness)).isFalse
+    }
+
+    testHarness.open()
+
+    testHarness.processElement(binaryRecord(INSERT, "a", 2L: JLong))
+    testHarness.processElement(binaryRecord(UPDATE_AFTER, "a", 3L: JLong))
+    testHarness.processElement(binaryRecord(UPDATE_AFTER, "a", 4L: JLong))
+
+    val result = dropWatermarks(testHarness.getOutput.toArray)
+
+    val expectedOutput = new ConcurrentLinkedQueue[Object]()
+    expectedOutput.add(binaryRecord(INSERT, "a", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "a", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "a", 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "a", 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "a", 4L: JLong))
+
+    assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
+
+    testHarness.close()
+  }
+}
+
+object RankHarnessTest {
+
+  @Parameters(name = "StateBackend={0}, EnableAsyncState = {1}")
+  def parameters(): util.Collection[Array[java.lang.Object]] = {
+    Seq[Array[AnyRef]](
+      Array(HEAP_BACKEND, Boolean.box(false)),
+      Array(HEAP_BACKEND, Boolean.box(true)),
+      Array(ROCKSDB_BACKEND, Boolean.box(false)))
   }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunction.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
  *
  * <p>The input stream should only contain INSERT messages.
  */
-public class AppendOnlyTopNFunction extends AbstractTopNFunction {
+public class AppendOnlyTopNFunction extends AbstractSyncStateTopNFunction {
 
     private static final long serialVersionUID = -4708453213104128011L;
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -53,7 +53,7 @@ import java.util.TreeMap;
  *
  * <p>Input stream can contain any change kind: INSERT, DELETE, UPDATE_BEFORE and UPDATE_AFTER.
  */
-public class RetractableTopNFunction extends AbstractTopNFunction {
+public class RetractableTopNFunction extends AbstractSyncStateTopNFunction {
 
     private static final long serialVersionUID = 1365312180599454480L;
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AbstractAsyncSyncStateTopNFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AbstractAsyncSyncStateTopNFunction.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank.asyncprocessing;
+
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
+import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.operators.rank.AbstractTopNFunction;
+import org.apache.flink.table.runtime.operators.rank.RankRange;
+import org.apache.flink.table.runtime.operators.rank.RankType;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+
+/**
+ * Base class for TopN Function with async state api.
+ *
+ * <p>Currently, only constant rank end is supported in async state rank.
+ */
+public abstract class AbstractAsyncSyncStateTopNFunction extends AbstractTopNFunction {
+
+    public AbstractAsyncSyncStateTopNFunction(
+            StateTtlConfig ttlConfig,
+            InternalTypeInfo<RowData> inputRowType,
+            GeneratedRecordComparator generatedSortKeyComparator,
+            RowDataKeySelector sortKeySelector,
+            RankType rankType,
+            RankRange rankRange,
+            boolean generateUpdateBefore,
+            boolean outputRankNumber) {
+        super(
+                ttlConfig,
+                inputRowType,
+                generatedSortKeyComparator,
+                sortKeySelector,
+                rankType,
+                rankRange,
+                generateUpdateBefore,
+                outputRankNumber);
+        if (!isConstantRankEnd) {
+            throw new UnsupportedOperationException(
+                    "Variable rank end is not supported in rank with async state api.");
+        }
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AsyncStateFastTop1Function.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/asyncprocessing/AsyncStateFastTop1Function.java
@@ -16,20 +16,30 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.runtime.operators.rank;
+package org.apache.flink.table.runtime.operators.rank.asyncprocessing;
 
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.serialization.SerializerConfigImpl;
 import org.apache.flink.api.common.state.StateTtlConfig;
-import org.apache.flink.api.common.state.ValueState;
-import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.state.StateFutureUtils;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.runtime.operators.asyncprocessing.AsyncStateProcessingOperator;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
+import org.apache.flink.table.runtime.operators.rank.AppendOnlyTopNFunction;
+import org.apache.flink.table.runtime.operators.rank.FastTop1Function;
+import org.apache.flink.table.runtime.operators.rank.RankRange;
+import org.apache.flink.table.runtime.operators.rank.RankType;
+import org.apache.flink.table.runtime.operators.rank.UpdatableTopNFunction;
 import org.apache.flink.table.runtime.operators.rank.utils.FastTop1Helper;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.util.Collector;
@@ -39,8 +49,10 @@ import org.apache.flink.util.Collector;
  * UpdatableTopNFunction} when only Top-1 is desired. This function can handle updating stream
  * because the RankProcessStrategy is inferred as UpdateFastStrategy, i.e., 1) the upsert key of
  * input steam contains partition key; 2) the sort field is updated monotonely under the upsert key.
+ *
+ * <p>Different with {@link FastTop1Function}, this function is used with async state api.
  */
-public class FastTop1Function extends AbstractSyncStateTopNFunction
+public class AsyncStateFastTop1Function extends AbstractAsyncSyncStateTopNFunction
         implements CheckpointedFunction {
 
     private static final long serialVersionUID = 1L;
@@ -51,9 +63,9 @@ public class FastTop1Function extends AbstractSyncStateTopNFunction
     // a map state stores list of records
     private transient ValueState<RowData> dataState;
 
-    private transient FastTop1Helper helper;
+    private transient AsyncStateFastTop1Helper helper;
 
-    public FastTop1Function(
+    public AsyncStateFastTop1Function(
             StateTtlConfig ttlConfig,
             InternalTypeInfo<RowData> inputRowType,
             GeneratedRecordComparator generatedSortKeyComparator,
@@ -86,34 +98,44 @@ public class FastTop1Function extends AbstractSyncStateTopNFunction
         if (ttlConfig.isEnabled()) {
             valueStateDescriptor.enableTimeToLive(ttlConfig);
         }
-        dataState = getRuntimeContext().getState(valueStateDescriptor);
+        dataState =
+                ((StreamingRuntimeContext) getRuntimeContext()).getValueState(valueStateDescriptor);
 
-        helper = new SyncStateFastTop1Helper();
+        helper = new AsyncStateFastTop1Helper();
 
         // metrics
         helper.registerMetric();
     }
 
     @Override
-    public void processElement(RowData input, Context ctx, Collector<RowData> out)
+    public void processElement(
+            RowData input,
+            KeyedProcessFunction<RowData, RowData, RowData>.Context ctx,
+            Collector<RowData> out)
             throws Exception {
         helper.accRequestCount();
 
         // load state under current key if necessary
         RowData currentKey = (RowData) keyContext.getCurrentKey();
-        RowData prevRow = helper.getPrevRowFromCache(currentKey);
-        if (prevRow == null) {
-            prevRow = dataState.value();
+
+        RowData prevRowFromCache = helper.getPrevRowFromCache(currentKey);
+        StateFuture<RowData> prevRowFuture;
+        if (prevRowFromCache == null) {
+            prevRowFuture = dataState.asyncValue();
         } else {
             helper.accHitCount();
+            prevRowFuture = StateFutureUtils.completedFuture(prevRowFromCache);
         }
 
-        // first row under current key.
-        if (prevRow == null) {
-            helper.processAsFirstRow(input, currentKey, out);
-        } else {
-            helper.processWithPrevRow(input, currentKey, prevRow, out);
-        }
+        prevRowFuture.thenAccept(
+                prevRow -> {
+                    // first row under current key.
+                    if (prevRow == null) {
+                        helper.processAsFirstRow(input, currentKey, out);
+                    } else {
+                        helper.processWithPrevRow(input, currentKey, prevRow, out);
+                    }
+                });
     }
 
     @Override
@@ -126,20 +148,24 @@ public class FastTop1Function extends AbstractSyncStateTopNFunction
         // nothing to do
     }
 
-    private class SyncStateFastTop1Helper extends FastTop1Helper {
-
-        public SyncStateFastTop1Helper() {
+    private class AsyncStateFastTop1Helper extends FastTop1Helper {
+        public AsyncStateFastTop1Helper() {
             super(
-                    FastTop1Function.this,
+                    AsyncStateFastTop1Function.this,
                     inputRowSer,
                     cacheSize,
-                    FastTop1Function.this.getDefaultTopNSize());
+                    AsyncStateFastTop1Function.this.getDefaultTopNSize());
         }
 
         @Override
         public void flushBufferToState(RowData currentKey, RowData value) throws Exception {
-            keyContext.setCurrentKey(currentKey);
-            FastTop1Function.this.dataState.update(value);
+            ((AsyncStateProcessingOperator) keyContext)
+                    .asyncProcessWithKey(
+                            currentKey,
+                            () -> {
+                                // no need to wait this async request to end
+                                AsyncStateFastTop1Function.this.dataState.asyncUpdate(value);
+                            });
         }
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/utils/FastTop1Helper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/rank/utils/FastTop1Helper.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.rank.utils;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.rank.AbstractTopNFunction;
+import org.apache.flink.table.runtime.operators.rank.FastTop1Function;
+import org.apache.flink.table.runtime.operators.rank.TopNBufferCacheRemovalListener;
+import org.apache.flink.table.runtime.operators.rank.asyncprocessing.AsyncStateFastTop1Function;
+import org.apache.flink.util.Collector;
+
+import org.apache.flink.shaded.guava32.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava32.com.google.common.cache.CacheBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A helper to help do the logic 'Top-1' in {@link FastTop1Function} and {@link
+ * AsyncStateFastTop1Function}.
+ */
+public abstract class FastTop1Helper extends AbstractTopNFunction.AbstractTopNHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FastTop1Helper.class);
+
+    private final TypeSerializer<RowData> inputRowSer;
+
+    // the kvMap stores mapping from partition key to its current top-1 value
+    private final Cache<RowData, RowData> kvCache;
+
+    private final long topNSize;
+
+    public FastTop1Helper(
+            AbstractTopNFunction topNFunction,
+            TypeSerializer<RowData> inputRowSer,
+            long cacheSize,
+            long topNSize) {
+        super(topNFunction);
+
+        this.inputRowSer = inputRowSer;
+        this.topNSize = topNSize;
+
+        int lruCacheSize = Math.max(1, (int) (cacheSize / topNSize));
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        if (ttlConfig.isEnabled()) {
+            cacheBuilder.expireAfterWrite(
+                    ttlConfig.getTimeToLive().toMillis(), TimeUnit.MILLISECONDS);
+        }
+
+        this.kvCache =
+                cacheBuilder
+                        .maximumSize(lruCacheSize)
+                        .removalListener(
+                                new TopNBufferCacheRemovalListener<>(
+                                        keyContext, this::flushBufferToState))
+                        .build();
+
+        LOG.info("Top-1 operator is using LRU caches key-size: {}", lruCacheSize);
+    }
+
+    @Nullable
+    public RowData getPrevRowFromCache(RowData currentKey) {
+        return kvCache.getIfPresent(currentKey);
+    }
+
+    public void processAsFirstRow(RowData input, RowData currentKey, Collector<RowData> out) {
+        kvCache.put(currentKey, inputRowSer.copy(input));
+        if (outputRankNumber) {
+            collectInsert(out, input, 1);
+        } else {
+            collectInsert(out, input);
+        }
+    }
+
+    public void processWithPrevRow(
+            RowData input, RowData currentKey, RowData prevRow, Collector<RowData> out)
+            throws Exception {
+        RowData curSortKey = sortKeySelector.getKey(input);
+        RowData oldSortKey = sortKeySelector.getKey(prevRow);
+        int compare = sortKeyComparator.compare(curSortKey, oldSortKey);
+        // current sort key is higher than old sort key
+        if (compare < 0) {
+            kvCache.put(currentKey, inputRowSer.copy(input));
+            // Note: partition key is unique key if only top-1 is desired,
+            //  thus emitting UB and UA here
+            if (outputRankNumber) {
+                collectUpdateBefore(out, prevRow, 1);
+                collectUpdateAfter(out, input, 1);
+            } else {
+                collectUpdateBefore(out, prevRow);
+                collectUpdateAfter(out, input);
+            }
+        }
+    }
+
+    public void flushAllCacheToState() throws Exception {
+        for (Map.Entry<RowData, RowData> entry : kvCache.asMap().entrySet()) {
+            flushBufferToState(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public abstract void flushBufferToState(RowData currentKey, RowData value) throws Exception;
+
+    public void registerMetric() {
+        registerMetric(kvCache.size() * topNSize);
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyFirstNFunctionTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,12 +30,14 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 
 /** Tests for {@link AppendOnlyFirstNFunction}. */
 class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
+
     @Override
     AbstractTopNFunction createFunction(
             RankType rankType,
             RankRange rankRange,
             boolean generateUpdateBefore,
-            boolean outputRankNumber) {
+            boolean outputRankNumber,
+            boolean enableAsyncState) {
         return new AppendOnlyFirstNFunction(
                 ttlConfig,
                 inputRowType,
@@ -48,7 +50,12 @@ class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    @Test
+    boolean supportedAsyncState() {
+        return false;
+    }
+
+    @Override
+    @TestTemplate
     void testDisableGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
@@ -72,7 +79,7 @@ class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    @Test
+    @TestTemplate
     void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
@@ -96,7 +103,7 @@ class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    @Test
+    @TestTemplate
     void testOutputRankNumberWithConstantRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
@@ -120,7 +127,7 @@ class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    @Test
+    @TestTemplate
     void testConstantRankRangeWithOffset() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(2, 2), true, false);
@@ -142,7 +149,7 @@ class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    @Test
+    @TestTemplate
     void testConstantRankRangeWithoutOffset() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, false);
@@ -166,7 +173,7 @@ class AppendOnlyFirstNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    @Test
+    @TestTemplate
     void testOutputRankNumberWithVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), false, true);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +37,8 @@ class AppendOnlyTopNFunctionTest extends TopNFunctionTestBase {
             RankType rankType,
             RankRange rankRange,
             boolean generateUpdateBefore,
-            boolean outputRankNumber) {
+            boolean outputRankNumber,
+            boolean enableAsyncState) {
         return new AppendOnlyTopNFunction(
                 ttlConfig,
                 inputRowType,
@@ -50,7 +51,12 @@ class AppendOnlyTopNFunctionTest extends TopNFunctionTestBase {
                 cacheSize);
     }
 
-    @Test
+    @Override
+    boolean supportedAsyncState() {
+        return false;
+    }
+
+    @TestTemplate
     void testVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, false);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/FastTop1FunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/FastTop1FunctionTest.java
@@ -21,8 +21,11 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.rank.asyncprocessing.AsyncStateFastTop1Function;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,24 +34,45 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
-/** Tests for {@link FastTop1Function}. */
+/** Tests for {@link FastTop1Function} and {@link AsyncStateFastTop1Function}. */
+@ExtendWith(ParameterizedTestExtension.class)
 public class FastTop1FunctionTest extends TopNFunctionTestBase {
+
     @Override
     AbstractTopNFunction createFunction(
             RankType rankType,
             RankRange rankRange,
             boolean generateUpdateBefore,
-            boolean outputRankNumber) {
-        return new FastTop1Function(
-                ttlConfig,
-                inputRowType,
-                generatedSortKeyComparator,
-                sortKeySelector,
-                rankType,
-                rankRange,
-                generateUpdateBefore,
-                outputRankNumber,
-                cacheSize);
+            boolean outputRankNumber,
+            boolean enableAsyncState) {
+        if (enableAsyncState) {
+            return new AsyncStateFastTop1Function(
+                    ttlConfig,
+                    inputRowType,
+                    generatedSortKeyComparator,
+                    sortKeySelector,
+                    rankType,
+                    rankRange,
+                    generateUpdateBefore,
+                    outputRankNumber,
+                    cacheSize);
+        } else {
+            return new FastTop1Function(
+                    ttlConfig,
+                    inputRowType,
+                    generatedSortKeyComparator,
+                    sortKeySelector,
+                    rankType,
+                    rankRange,
+                    generateUpdateBefore,
+                    outputRankNumber,
+                    cacheSize);
+        }
+    }
+
+    @Override
+    boolean supportedAsyncState() {
+        return true;
     }
 
     @Override
@@ -173,7 +197,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
 
     // ------------ Tests with UPDATE input records ---------------
 
-    @Test
+    @TestTemplate
     void testVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, false);
@@ -199,7 +223,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testOutputRankNumberWithUpdateInputs() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, true);
@@ -228,7 +252,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testSortKeyChangesWhenOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, true);
@@ -262,7 +286,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testSortKeyChangesWhenOutputRankNumberAndNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, true);
@@ -292,7 +316,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testSortKeyChangesWhenNotOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), true, false);
@@ -321,7 +345,7 @@ public class FastTop1FunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testSortKeyChangesWhenNotOutputRankNumberAndNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 1), false, false);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +46,8 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
             RankType rankType,
             RankRange rankRange,
             boolean generateUpdateBefore,
-            boolean outputRankNumber) {
+            boolean outputRankNumber,
+            boolean enableAsyncState) {
         return new RetractableTopNFunction(
                 ttlConfig,
                 inputRowType,
@@ -59,7 +60,12 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 outputRankNumber);
     }
 
-    @Test
+    @Override
+    boolean supportedAsyncState() {
+        return false;
+    }
+
+    @TestTemplate
     void testProcessRetractMessageWithNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
@@ -98,7 +104,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testProcessRetractMessageWithGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
@@ -142,7 +148,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testConstantRankRangeWithoutOffsetWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
@@ -198,7 +204,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
         testHarness.close();
     }
 
-    @Test
+    @TestTemplate
     void testConstantRankRangeWithoutOffsetWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, false);
@@ -242,7 +248,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
         testHarness.close();
     }
 
-    @Test
+    @TestTemplate
     void testVariableRankRangeWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, true);
@@ -279,7 +285,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testVariableRankRangeWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, false);
@@ -305,7 +311,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testDisableGenerateUpdateBeforeWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
@@ -338,7 +344,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testDisableGenerateUpdateBeforeWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
@@ -365,7 +371,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testCleanIdleState() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
@@ -408,7 +414,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testConstantRankRangeWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 3), false, false);
@@ -433,7 +439,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testConstantRankRangeWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 3), false, true);
@@ -458,7 +464,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testRetractRecordOutOfRankRangeWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
@@ -487,7 +493,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testRetractRecordOutOfRankRangeWithRowNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
@@ -516,7 +522,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testRetractAndThenDeleteRecordWithoutRowNumber() throws Exception {
         AbstractTopNFunction func =
                 new RetractableTopNFunction(
@@ -557,7 +563,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testRetractAnStaledRecordWithRowNumber() throws Exception {
         StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(1_000);
         AbstractTopNFunction func =

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.operators.KeyedProcessOperator;
+import org.apache.flink.streaming.api.operators.asyncprocessing.AsyncStateKeyedProcessOperator;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
@@ -40,10 +41,16 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.utils.HandwrittenSelectorUtil;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
@@ -51,9 +58,19 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** Base Tests for all subclass of {@link AbstractTopNFunction}. */
+@ExtendWith(ParameterizedTestExtension.class)
 abstract class TopNFunctionTestBase {
+
+    @Parameters(name = "EnableAsyncState = {0}")
+    public static List<Boolean> enableAsyncState() {
+        return Arrays.asList(false, true);
+    }
+
+    @Parameter protected boolean enableAsyncState;
 
     StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(10_000_000);
     long cacheSize = 10000L;
@@ -127,9 +144,18 @@ abstract class TopNFunctionTestBase {
             HandwrittenSelectorUtil.getRowDataSelector(
                     new int[] {rowKeyIdx}, inputRowType.toRowFieldTypes());
 
+    @BeforeEach
+    void beforeEach() {
+        if (!supportedAsyncState()) {
+            assumeFalse(enableAsyncState);
+        }
+    }
+
     /** RankEnd column must be long, int or short type, but could not be string type yet. */
-    @Test
+    @TestTemplate
     void testInvalidVariableRankRangeWithIntType() throws Exception {
+        // rank with async state does not support variable rank range yet
+        assumeFalse(enableAsyncState);
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(0), true, false);
         OneInputStreamOperatorTestHarness<RowData, RowData> testHarness = createTestHarness(func);
@@ -137,7 +163,7 @@ abstract class TopNFunctionTestBase {
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 
-    @Test
+    @TestTemplate
     void testNotSupportRank() throws Exception {
         assertThatThrownBy(
                         () ->
@@ -146,7 +172,7 @@ abstract class TopNFunctionTestBase {
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 
-    @Test
+    @TestTemplate
     void testNotSupportDenseRank() throws Exception {
         assertThatThrownBy(
                         () ->
@@ -158,7 +184,7 @@ abstract class TopNFunctionTestBase {
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 
-    @Test
+    @TestTemplate
     void testNotSupportWithoutRankEnd() throws Exception {
         assertThatThrownBy(
                         () ->
@@ -170,7 +196,7 @@ abstract class TopNFunctionTestBase {
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 
-    @Test
+    @TestTemplate
     void testDisableGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);
@@ -203,7 +229,7 @@ abstract class TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testDisableGenerateUpdateBeforeAndOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
@@ -235,7 +261,7 @@ abstract class TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testOutputRankNumberWithConstantRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
@@ -269,7 +295,7 @@ abstract class TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testConstantRankRangeWithOffset() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(2, 2), true, false);
@@ -294,7 +320,7 @@ abstract class TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testOutputRankNumberWithVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, true);
@@ -322,7 +348,7 @@ abstract class TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testConstantRankRangeWithoutOffset() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, false);
@@ -366,18 +392,49 @@ abstract class TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
+    @TestTemplate
+    void testNotSupportConstantRankRangeWithAsyncState() {
+        assumeTrue(enableAsyncState);
+        assertThatThrownBy(
+                        () ->
+                                createFunction(
+                                        RankType.ROW_NUMBER, new VariableRankRange(0), true, false))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
     OneInputStreamOperatorTestHarness<RowData, RowData> createTestHarness(
             AbstractTopNFunction rankFunction) throws Exception {
-        KeyedProcessOperator<RowData, RowData, RowData> operator =
-                new KeyedProcessOperator<>(rankFunction);
-        rankFunction.setKeyContext(operator);
-        return new KeyedOneInputStreamOperatorTestHarness<>(
-                operator, keySelector, keySelector.getProducedType());
+        if (enableAsyncState) {
+            AsyncStateKeyedProcessOperator<RowData, RowData, RowData> operator =
+                    new AsyncStateKeyedProcessOperator<>(rankFunction);
+            rankFunction.setKeyContext(operator);
+            return new KeyedOneInputStreamOperatorTestHarness<>(
+                    operator, keySelector, keySelector.getProducedType());
+        } else {
+            KeyedProcessOperator<RowData, RowData, RowData> operator =
+                    new KeyedProcessOperator<>(rankFunction);
+            rankFunction.setKeyContext(operator);
+            return new KeyedOneInputStreamOperatorTestHarness<>(
+                    operator, keySelector, keySelector.getProducedType());
+        }
+    }
+
+    final AbstractTopNFunction createFunction(
+            RankType rankType,
+            RankRange rankRange,
+            boolean generateUpdateBefore,
+            boolean outputRankNumber) {
+        return createFunction(
+                rankType, rankRange, generateUpdateBefore, outputRankNumber, enableAsyncState);
     }
 
     abstract AbstractTopNFunction createFunction(
             RankType rankType,
             RankRange rankRange,
             boolean generateUpdateBefore,
-            boolean outputRankNumber);
+            boolean outputRankNumber,
+            boolean enableAsyncState);
+
+    /** TODO remove this method after all rank function support async state. */
+    abstract boolean supportedAsyncState();
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.table.runtime.operators.rank;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.table.data.RowData;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +39,8 @@ class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
             RankType rankType,
             RankRange rankRange,
             boolean generateUpdateBefore,
-            boolean outputRankNumber) {
+            boolean outputRankNumber,
+            boolean enableAsyncState) {
         return new UpdatableTopNFunction(
                 ttlConfig,
                 inputRowType,
@@ -53,7 +54,12 @@ class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
                 cacheSize);
     }
 
-    @Test
+    @Override
+    boolean supportedAsyncState() {
+        return false;
+    }
+
+    @TestTemplate
     void testVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, false);
@@ -80,7 +86,7 @@ class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
     }
 
     @Override
-    @Test
+    @TestTemplate
     void testOutputRankNumberWithVariableRankRange() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, true);
@@ -109,7 +115,7 @@ class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testSortKeyChangesWhenOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
@@ -153,7 +159,7 @@ class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testSortKeyChangesWhenOutputRankNumberAndNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, true);
@@ -189,7 +195,7 @@ class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testSortKeyChangesWhenNotOutputRankNumber() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, false);
@@ -219,7 +225,7 @@ class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
                 "output wrong.", expectedOutput, testHarness.getOutput());
     }
 
-    @Test
+    @TestTemplate
     void testSortKeyChangesWhenNotOutputRankNumberAndNotGenerateUpdateBefore() throws Exception {
         AbstractTopNFunction func =
                 createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false, false);


### PR DESCRIPTION
## What is the purpose of the change

Introduce FastTop1Function in Rank with Async State API.

## Brief change log

  - *Add async fast top1 function and fast top1 helper*
  - *Add ITs and HarnessTests*

## Verifying this change

Existent tests and new added tests can verify this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  A independent pr will be introduced later.
