### PR TITLE
[FLINK-36838][state] Join background threads when ForSt state backend quit

### DIFF
--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendV2Test.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateBackendV2Test.java
@@ -43,7 +43,7 @@ import static org.apache.flink.state.forst.ForStOptions.REMOTE_DIRECTORY;
 
 /** Tests for the async keyed state backend part of {@link ForStStateBackend}. */
 @ExtendWith(ParameterizedTestExtension.class)
-class ForStStateBackendTestV2 extends StateBackendTestV2Base<ForStStateBackend> {
+class ForStStateBackendV2Test extends StateBackendTestV2Base<ForStStateBackend> {
 
     @TempDir private static java.nio.file.Path tempFolder;
     @TempDir private static java.nio.file.Path tempFolderForForStLocal;
@@ -94,7 +94,6 @@ class ForStStateBackendTestV2 extends StateBackendTestV2Base<ForStStateBackend> 
         if (hasRemoteDir) {
             config.set(REMOTE_DIRECTORY, tempFolderForForstRemote.toString());
         }
-        backend.configure(config, Thread.currentThread().getContextClassLoader());
-        return new ForStStateBackend();
+        return backend.configure(config, Thread.currentThread().getContextClassLoader());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently there is an issue in the forst db core, where the background cannot properly quit when db close. Thus we manually join those threads in backend side. This is a temporary solution until the forst db fix the bug.

## Brief change log

 - Set background threads count to 0 when quit.
 - A minor hotfix for Forst tests which could verify this change.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
