### PR TITLE
[FLINK-36840][table] Add correct call syntax for functions without ()

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ExpressionSerializationTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ExpressionSerializationTest.java
@@ -349,9 +349,11 @@ public class ExpressionSerializationTest {
                         .withField("f0", DataTypes.TIMESTAMP())
                         .withField("f1", DataTypes.TIMESTAMP())
                         .expectStr("TIMESTAMPDIFF(DAY, `f0`, `f1`)"),
-                TestSpec.forExpr(Expressions.currentDate()).expectStr("CURRENT_DATE()"),
-                TestSpec.forExpr(Expressions.currentTime()).expectStr("CURRENT_TIME()"),
-                TestSpec.forExpr(Expressions.currentTimestamp()).expectStr("CURRENT_TIMESTAMP()"),
+                TestSpec.forExpr(Expressions.currentDate()).expectStr("CURRENT_DATE"),
+                TestSpec.forExpr(Expressions.currentTime()).expectStr("CURRENT_TIME"),
+                TestSpec.forExpr(Expressions.currentTimestamp()).expectStr("CURRENT_TIMESTAMP"),
+                TestSpec.forExpr(Expressions.localTimestamp()).expectStr("LOCALTIMESTAMP"),
+                TestSpec.forExpr(Expressions.localTime()).expectStr("LOCALTIME"),
                 TestSpec.forExpr(Expressions.dateFormat($("f0"), lit("yyyy-MM-dd")))
                         .withField("f0", DataTypes.TIMESTAMP(3))
                         .expectStr("DATE_FORMAT(`f0`, 'yyyy-MM-dd')"),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -2155,6 +2155,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("currentDate")
                     .sqlName("CURRENT_DATE")
+                    .callSyntax(SqlCallSyntax.NO_PARENTHESIS)
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(DATE().notNull()))
                     .build();
@@ -2163,6 +2164,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("currentTime")
                     .sqlName("CURRENT_TIME")
+                    .callSyntax(SqlCallSyntax.NO_PARENTHESIS)
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIME().notNull()))
                     .build();
@@ -2170,6 +2172,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition LOCAL_TIME =
             BuiltInFunctionDefinition.newBuilder()
                     .name("localTime")
+                    .callSyntax(SqlCallSyntax.NO_PARENTHESIS)
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIME().notNull()))
                     .build();
@@ -2178,6 +2181,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("currentTimestamp")
                     .sqlName("CURRENT_TIMESTAMP")
+                    .callSyntax(SqlCallSyntax.NO_PARENTHESIS)
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIMESTAMP_LTZ(3).notNull()))
                     .build();
@@ -2201,6 +2205,7 @@ public final class BuiltInFunctionDefinitions {
     public static final BuiltInFunctionDefinition LOCAL_TIMESTAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("localTimestamp")
+                    .callSyntax(SqlCallSyntax.NO_PARENTHESIS)
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIMESTAMP(3).notNull()))
                     .build();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
@@ -71,7 +71,7 @@ public interface SqlCallSyntax {
             };
 
     /**
-     * Function syntax for functions without parameters (e.g., CURRENT_DATE, LOCALTIMESTAMP,
+     * Function syntax for functions without parenthesis (e.g., CURRENT_DATE, LOCALTIMESTAMP,
      * LOCALTIME, CURRENT_TIMESTAMP, CURRENT_TIME).
      */
     SqlCallSyntax NO_PARENTHESIS = (sqlName, operands) -> sqlName;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
@@ -71,6 +71,12 @@ public interface SqlCallSyntax {
             };
 
     /**
+     * Function syntax for functions without parameters (e.g., CURRENT_DATE, LOCALTIMESTAMP,
+     * LOCALTIME, CURRENT_TIMESTAMP, CURRENT_TIME).
+     */
+    SqlCallSyntax NO_PARENTHESIS = (sqlName, operands) -> sqlName;
+
+    /**
      * Function syntax for handling DISTINCT aggregates. Special case. It does not have a syntax
      * itself, but modifies the syntax of the nested call.
      */


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

For Table API, there are 5 time-related functions that can't be called right now. This maps these the function calls for CURRENT_DATE, LOCALTIMESTAMP, LOCALTIME, CURRENT_TIMESTAMP, CURRENT_TIME currectly. These function do not support parenthesis when being called.


## Brief change log

  - Add NO_PARENTHESIS call syntax
  - Use it for CURRENT_DATE, LOCALTIMESTAMP, LOCALTIME, CURRENT_TIMESTAMP, CURRENT_TIME 
  - Update serialization tests


## Verifying this change

This change added tests and can be verified as follows:

  - Added serialization tests to make sure the table api call get's mapped to the proper SQL Function

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
