### PR TITLE
[FLINK-36072][runtime] Sort-merge shuffle supports accumulating small buffers to reduce network overhead.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/AbstractCompositeBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/AbstractCompositeBuffer.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import org.apache.flink.core.memory.MemorySegment;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * An implementation of {@link Buffer} which contains multiple partial buffers for network data
+ * communication.
+ */
+public abstract class AbstractCompositeBuffer implements Buffer {
+
+    protected final DataType dataType;
+
+    protected final int length;
+
+    protected final boolean isCompressed;
+
+    protected final List<Buffer> partialBuffers = new ArrayList<>();
+
+    protected int currentLength;
+
+    protected ByteBufAllocator allocator;
+
+    protected AbstractCompositeBuffer(DataType dataType, int length, boolean isCompressed) {
+        this.dataType = dataType;
+        this.length = length;
+        this.isCompressed = isCompressed;
+    }
+
+    @Override
+    public boolean isBuffer() {
+        return dataType.isBuffer();
+    }
+
+    @Override
+    public void recycleBuffer() {
+        for (Buffer partialBuffer : partialBuffers) {
+            partialBuffer.recycleBuffer();
+        }
+    }
+
+    @Override
+    public Buffer retainBuffer() {
+        for (Buffer partialBuffer : partialBuffers) {
+            partialBuffer.retainBuffer();
+        }
+        return this;
+    }
+
+    @Override
+    public int getSize() {
+        return currentLength;
+    }
+
+    @Override
+    public int readableBytes() {
+        return currentLength;
+    }
+
+    @Override
+    public void setAllocator(ByteBufAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    @Override
+    public boolean isCompressed() {
+        return isCompressed;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return dataType;
+    }
+
+    public abstract void addPartialBuffer(Buffer buffer);
+
+    public List<Buffer> getPartialBuffers() {
+        return Collections.unmodifiableList(partialBuffers);
+    }
+
+    public int missingLength() {
+        return length - currentLength;
+    }
+
+    @Override
+    public MemorySegment getMemorySegment() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getMemorySegmentOffset() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BufferRecycler getRecycler() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setRecycler(BufferRecycler bufferRecycler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRecycled() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Buffer readOnlySlice() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Buffer readOnlySlice(int index, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getMaxCapacity() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getReaderIndex() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setReaderIndex(int readerIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSize(int writerIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuffer getNioBufferReadable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuffer getNioBuffer(int index, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCompressed(boolean isCompressed) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDataType(DataType dataType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int refCnt() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/BufferResponseDecoder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/BufferResponseDecoder.java
@@ -23,9 +23,13 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse.MESSAGE_HEADER_LENGTH;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** The decoder for {@link BufferResponse}. */
 class BufferResponseDecoder extends NettyMessageDecoder {
@@ -35,6 +39,16 @@ class BufferResponseDecoder extends NettyMessageDecoder {
 
     /** The accumulation buffer of message header. */
     private ByteBuf messageHeaderBuffer;
+
+    /**
+     * Accumulates bytes for a partial buffer size.
+     *
+     * <p>In scenarios such as Sort-merge shuffle, where small buffers are merged, each small buffer
+     * size is written sequentially in the data stream. This list temporarily holds the bytes needed
+     * to form a full integer representation of a buffer's size when there aren't sufficient bytes
+     * to read an integer directly from the incoming data buffer.
+     */
+    private List<Byte> partialSizeBytes;
 
     /**
      * The BufferResponse message that has its message header decoded, but still not received all
@@ -62,6 +76,9 @@ class BufferResponseDecoder extends NettyMessageDecoder {
 
         if (bufferResponse != null) {
             int remainingBufferSize = bufferResponse.bufferSize - decodedDataBufferSize;
+
+            decodePartialBufferSizes(data);
+
             int actualBytesToDecode = Math.min(data.readableBytes(), remainingBufferSize);
 
             // For the case of data buffer really exists in BufferResponse now.
@@ -85,6 +102,81 @@ class BufferResponseDecoder extends NettyMessageDecoder {
         }
 
         return DecodingResult.NOT_FINISHED;
+    }
+
+    /**
+     * Decodes the sizes of partial buffers from the provided ByteBuf. This function processes the
+     * incoming data and accumulates bytes until a full integer can be formed to represent the size
+     * of each buffer.
+     *
+     * @param data the ByteBuf containing the incoming data.
+     */
+    private void decodePartialBufferSizes(ByteBuf data) {
+        // If partial buffers are present and not all are processed yet
+        if (bufferResponse.numOfPartialBuffers > 0
+                && bufferResponse.getPartialBufferSizes().size()
+                        < bufferResponse.numOfPartialBuffers) {
+
+            // Continue completing the current partial buffer size if necessary
+            accumulatePartialSizeBytes(data);
+
+            // Process remaining partial buffer sizes when possible
+            readRemainingBufferSizes(data);
+        }
+    }
+
+    /**
+     * Accumulates bytes to form a complete integer size for a partial buffer. If enough bytes are
+     * accumulated, forms an integer and adds it to bufferResponse list.
+     *
+     * @param data the ByteBuf containing the incoming data.
+     */
+    private void accumulatePartialSizeBytes(ByteBuf data) {
+        if (partialSizeBytes != null) {
+            while (partialSizeBytes.size() < Integer.BYTES && data.isReadable()) {
+                partialSizeBytes.add(data.readByte());
+            }
+            if (partialSizeBytes.size() == Integer.BYTES) {
+                int size = buildIntFromBytes(partialSizeBytes);
+                bufferResponse.getPartialBufferSizes().add(size);
+                partialSizeBytes = null;
+            }
+        }
+    }
+
+    /**
+     * Reads remaining complete partial buffer sizes directly from the ByteBuf if possible. Prepares
+     * for partially available sizes by initializing byte accumulator.
+     *
+     * @param data the ByteBuf containing the incoming data.
+     */
+    private void readRemainingBufferSizes(ByteBuf data) {
+        while (data.isReadable()
+                && bufferResponse.getPartialBufferSizes().size()
+                        < bufferResponse.numOfPartialBuffers) {
+            if (data.readableBytes() >= Integer.BYTES) {
+                bufferResponse.getPartialBufferSizes().add(data.readInt());
+            } else {
+                partialSizeBytes = new ArrayList<>();
+                while (data.isReadable()) {
+                    partialSizeBytes.add(data.readByte());
+                }
+            }
+        }
+    }
+
+    /**
+     * Converts a list of four bytes into an integer.
+     *
+     * @param byteList the list containing four bytes.
+     * @return the constructed integer.
+     */
+    private int buildIntFromBytes(List<Byte> byteList) {
+        checkState(byteList.size() == Integer.BYTES);
+        return ((byteList.get(0) & 0xFF) << 24)
+                | ((byteList.get(1) & 0xFF) << 16)
+                | ((byteList.get(2) & 0xFF) << 8)
+                | (byteList.get(3) & 0xFF);
     }
 
     private void decodeMessageHeader(ByteBuf data) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FileRegionBuffer;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionIndexSet;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
@@ -50,6 +51,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.ProtocolException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -266,10 +269,11 @@ public abstract class NettyMessage {
 
         static final byte ID = 0;
 
-        // receiver ID (16), sequence number (4), backlog (4), dataType (1), isCompressed (1),
-        // buffer size (4)
+        // receiver ID (16), sequence number (4), backlog (4), subpartition id (4), partial buffers
+        // number (4), dataType (1), isCompressed (1), buffer size (4)
         static final int MESSAGE_HEADER_LENGTH =
                 InputChannelID.getByteBufLength()
+                        + Integer.BYTES
                         + Integer.BYTES
                         + Integer.BYTES
                         + Integer.BYTES
@@ -293,6 +297,10 @@ public abstract class NettyMessage {
 
         final int bufferSize;
 
+        final int numOfPartialBuffers;
+
+        private List<Integer> partialBufferSizes = new ArrayList<>();
+
         private BufferResponse(
                 @Nullable Buffer buffer,
                 Buffer.DataType dataType,
@@ -300,6 +308,7 @@ public abstract class NettyMessage {
                 int sequenceNumber,
                 InputChannelID receiverId,
                 int subpartitionId,
+                int numOfPartialBuffers,
                 int backlog,
                 int bufferSize) {
             this.buffer = buffer;
@@ -310,6 +319,7 @@ public abstract class NettyMessage {
             this.subpartitionId = subpartitionId;
             this.backlog = backlog;
             this.bufferSize = bufferSize;
+            this.numOfPartialBuffers = numOfPartialBuffers;
         }
 
         BufferResponse(
@@ -317,6 +327,7 @@ public abstract class NettyMessage {
                 int sequenceNumber,
                 InputChannelID receiverId,
                 int subpartitionId,
+                int numOfPartialBuffers,
                 int backlog) {
             this.buffer = checkNotNull(buffer);
             checkArgument(
@@ -330,6 +341,7 @@ public abstract class NettyMessage {
             this.subpartitionId = subpartitionId;
             this.backlog = backlog;
             this.bufferSize = buffer.getSize();
+            this.numOfPartialBuffers = numOfPartialBuffers;
         }
 
         boolean isBuffer() {
@@ -345,6 +357,10 @@ public abstract class NettyMessage {
             if (buffer != null) {
                 buffer.recycleBuffer();
             }
+        }
+
+        public List<Integer> getPartialBufferSizes() {
+            return partialBufferSizes;
         }
 
         // --------------------------------------------------------------------
@@ -396,15 +412,36 @@ public abstract class NettyMessage {
         private ByteBuf fillHeader(ByteBufAllocator allocator) {
             // only allocate header buffer - we will combine it with the data buffer below
             ByteBuf headerBuf =
-                    allocateBuffer(allocator, ID, MESSAGE_HEADER_LENGTH, bufferSize, false);
+                    allocateBuffer(
+                            allocator,
+                            ID,
+                            MESSAGE_HEADER_LENGTH + Integer.BYTES * numOfPartialBuffers,
+                            bufferSize,
+                            false);
 
             receiverId.writeTo(headerBuf);
             headerBuf.writeInt(subpartitionId);
+            headerBuf.writeInt(numOfPartialBuffers);
             headerBuf.writeInt(sequenceNumber);
             headerBuf.writeInt(backlog);
             headerBuf.writeByte(dataType.ordinal());
             headerBuf.writeBoolean(isCompressed);
             headerBuf.writeInt(buffer.readableBytes());
+
+            if (numOfPartialBuffers > 0) {
+                checkArgument(
+                        buffer instanceof FullyFilledBuffer,
+                        "Partial buffers are only supported for fully filled buffers.");
+                List<Buffer> partialBuffers = ((FullyFilledBuffer) buffer).getPartialBuffers();
+                checkArgument(
+                        partialBuffers.size() == numOfPartialBuffers,
+                        "Mismatched number of partial buffers");
+                for (int i = 0; i < numOfPartialBuffers; i++) {
+                    int bytes = partialBuffers.get(i).readableBytes();
+                    headerBuf.writeInt(bytes);
+                }
+            }
+
             return headerBuf;
         }
 
@@ -422,6 +459,7 @@ public abstract class NettyMessage {
                 ByteBuf messageHeader, NetworkBufferAllocator bufferAllocator) {
             InputChannelID receiverId = InputChannelID.fromByteBuf(messageHeader);
             int subpartitionId = messageHeader.readInt();
+            int numOfPartialBuffers = messageHeader.readInt();
             int sequenceNumber = messageHeader.readInt();
             int backlog = messageHeader.readInt();
             Buffer.DataType dataType = Buffer.DataType.values()[messageHeader.readByte()];
@@ -456,6 +494,7 @@ public abstract class NettyMessage {
                     sequenceNumber,
                     receiverId,
                     subpartitionId,
+                    numOfPartialBuffers,
                     backlog,
                     size);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.io.network.netty;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.io.network.NetworkSequenceViewReader;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.ErrorResponse;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.PartitionRequestListener;
@@ -340,6 +341,11 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
                                     next.getSequenceNumber(),
                                     reader.getReceiverId(),
                                     nextSubpartitionId,
+                                    next.buffer() instanceof FullyFilledBuffer
+                                            ? ((FullyFilledBuffer) next.buffer())
+                                                    .getPartialBuffers()
+                                                    .size()
+                                            : 0,
                                     next.buffersInBacklog());
 
                     // Write and flush and wait until this is done before

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileReader.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferHeader;
@@ -28,6 +30,7 @@ import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.function.Consumer;
 
@@ -47,14 +50,20 @@ class PartitionedFileReader {
     /** Target {@link PartitionedFile} to read. */
     private final PartitionedFile partitionedFile;
 
-    /** Target subpartition to read. */
-    private final int targetSubpartition;
+    /** Target subpartitions to read. */
+    private final ResultSubpartitionIndexSet subpartitionIndexSet;
 
     /** Data file channel of the target {@link PartitionedFile}. */
     private final FileChannel dataFileChannel;
 
     /** Index file channel of the target {@link PartitionedFile}. */
     private final FileChannel indexFileChannel;
+
+    /**
+     * Records the shift position of the subpartition write order. For example, if the write order
+     * of subpartitions is [4, 5, 0, 1, 2, 3], then this value would be 4.
+     */
+    private final int subpartitionOrderRotationIndex;
 
     /** Next data region to be read. */
     private int nextRegionToRead;
@@ -65,33 +74,145 @@ class PartitionedFileReader {
     /** Number of remaining bytes in the current data region read. */
     private long currentRegionRemainingBytes;
 
+    /** A queue storing pairs of file offsets and sizes to be read. */
+    private final Queue<Tuple2<Long, Long>> offsetAndSizesToRead = new ArrayDeque<>();
+
     PartitionedFileReader(
             PartitionedFile partitionedFile,
-            int targetSubpartition,
+            ResultSubpartitionIndexSet subpartitionIndexSet,
             FileChannel dataFileChannel,
             FileChannel indexFileChannel,
             ByteBuffer headerBuffer,
-            ByteBuffer indexEntryBuffer) {
+            ByteBuffer indexEntryBuffer,
+            int subpartitionOrderRotationIndex) {
         checkArgument(checkNotNull(dataFileChannel).isOpen(), "Data file channel must be opened.");
         checkArgument(
                 checkNotNull(indexFileChannel).isOpen(), "Index file channel must be opened.");
 
         this.partitionedFile = checkNotNull(partitionedFile);
-        this.targetSubpartition = targetSubpartition;
+        this.subpartitionIndexSet = subpartitionIndexSet;
         this.dataFileChannel = dataFileChannel;
         this.indexFileChannel = indexFileChannel;
         this.headerBuf = headerBuffer;
         this.indexEntryBuf = indexEntryBuffer;
+        this.subpartitionOrderRotationIndex = subpartitionOrderRotationIndex;
     }
 
-    private void moveToNextReadableRegion(ByteBuffer indexEntryBuf) throws IOException {
-        while (currentRegionRemainingBytes <= 0
-                && nextRegionToRead < partitionedFile.getNumRegions()) {
-            partitionedFile.getIndexEntry(
-                    indexFileChannel, indexEntryBuf, nextRegionToRead, targetSubpartition);
-            nextOffsetToRead = indexEntryBuf.getLong();
-            currentRegionRemainingBytes = indexEntryBuf.getLong();
-            ++nextRegionToRead;
+    private void moveToNextReadablePosition(ByteBuffer indexEntryBuf) throws IOException {
+        while (currentRegionRemainingBytes <= 0 && hasNextPositionToRead()) {
+            if (!offsetAndSizesToRead.isEmpty()) {
+                Tuple2<Long, Long> offsetAndSize = offsetAndSizesToRead.poll();
+                nextOffsetToRead = offsetAndSize.f0;
+                currentRegionRemainingBytes = offsetAndSize.f1;
+            } else {
+                // move to next region which has buffers
+                if (nextRegionToRead < partitionedFile.getNumRegions()) {
+                    updateReadableOffsetAndSize(indexEntryBuf, offsetAndSizesToRead);
+                    ++nextRegionToRead;
+                }
+            }
+        }
+    }
+
+    private boolean hasNextPositionToRead() {
+        return !offsetAndSizesToRead.isEmpty()
+                || nextRegionToRead < partitionedFile.getNumRegions();
+    }
+
+    /**
+     * Updates the readable offsets and sizes for subpartitions based on a given index buffer. This
+     * method handles cases where the subpartition range is split by a rotation index, ensuring that
+     * all necessary index entries are processed.
+     *
+     * <p>The method operates in the following way:
+     *
+     * <ol>
+     *   <li>It checks if the range of subpartition indices requires handling of a wrap around the
+     *       rotation index.
+     *   <li>If no wrap is necessary (when the range does not cross the rotation point), it directly
+     *       updates readable offsets and sizes for the entire range.
+     *   <li>If a wrap is necessary, it splits the process into two updates:
+     *       <ul>
+     *         <li>Firstly, it updates from the rotation index to the end subpartition.
+     *         <li>Secondly, it updates from the start subpartition to just before the rotation
+     *             index.
+     *       </ul>
+     * </ol>
+     *
+     * <p>This ensures that all relevant subpartitions are correctly processed and offsets and sizes
+     * are added to the queue for subsequent reading.
+     *
+     * @param indexEntryBuf A ByteBuffer containing index entries which provide offset and size
+     *     information.
+     * @param offsetAndSizesToRead A queue to store the updated offsets and sizes.
+     * @throws IOException If an I/O error occurs when accessing the index file channel.
+     */
+    @VisibleForTesting
+    void updateReadableOffsetAndSize(
+            ByteBuffer indexEntryBuf, Queue<Tuple2<Long, Long>> offsetAndSizesToRead)
+            throws IOException {
+        int startSubpartition = subpartitionIndexSet.getStartIndex();
+        int endSubpartition = subpartitionIndexSet.getEndIndex();
+
+        if (startSubpartition >= subpartitionOrderRotationIndex
+                || endSubpartition < subpartitionOrderRotationIndex) {
+            updateReadableOffsetAndSize(
+                    startSubpartition, endSubpartition, indexEntryBuf, offsetAndSizesToRead);
+        } else {
+            updateReadableOffsetAndSize(
+                    subpartitionOrderRotationIndex,
+                    endSubpartition,
+                    indexEntryBuf,
+                    offsetAndSizesToRead);
+            updateReadableOffsetAndSize(
+                    startSubpartition,
+                    subpartitionOrderRotationIndex - 1,
+                    indexEntryBuf,
+                    offsetAndSizesToRead);
+        }
+    }
+
+    /**
+     * Updates the readable offsets and sizes for a specified range of subpartitions. If offsets are
+     * contiguous, they are merged into a single entry. If not contiguous, each subpartition's
+     * offset and size must come from the same buffer, and individual tuples are added for each
+     * entry.
+     *
+     * @param startSubpartition The starting index of the subpartition range to be processed.
+     * @param endSubpartition The ending index of the subpartition range to be processed.
+     * @param indexEntryBuf A ByteBuffer containing the index entries to read offsets and sizes.
+     * @param offsetAndSizesToRead A queue to store the updated offsets and sizes.
+     * @throws IOException If an I/O error occurs during reading of index entries.
+     * @throws IllegalStateException If offsets are not contiguous and not from a single buffer.
+     */
+    private void updateReadableOffsetAndSize(
+            int startSubpartition,
+            int endSubpartition,
+            ByteBuffer indexEntryBuf,
+            Queue<Tuple2<Long, Long>> offsetAndSizesToRead)
+            throws IOException {
+        partitionedFile.getIndexEntry(
+                indexFileChannel, indexEntryBuf, nextRegionToRead, startSubpartition);
+        long startPartitionOffset = indexEntryBuf.getLong();
+        long startPartitionSize = indexEntryBuf.getLong();
+
+        partitionedFile.getIndexEntry(
+                indexFileChannel, indexEntryBuf, nextRegionToRead, endSubpartition);
+        long endPartitionOffset = indexEntryBuf.getLong();
+        long endPartitionSize = indexEntryBuf.getLong();
+
+        if (startPartitionOffset != endPartitionOffset) {
+            offsetAndSizesToRead.add(
+                    Tuple2.of(
+                            startPartitionOffset,
+                            endPartitionOffset + endPartitionSize - startPartitionOffset));
+        } else if (startPartitionSize != 0) {
+            checkArgument(
+                    startPartitionSize == endPartitionSize,
+                    "Offsets need to be either contiguous or all the same.");
+            for (int i = startSubpartition; i <= endSubpartition; i++) {
+                offsetAndSizesToRead.add(Tuple2.of(startPartitionOffset, startPartitionSize));
+            }
         }
     }
 
@@ -164,12 +285,12 @@ class PartitionedFileReader {
     }
 
     boolean hasRemaining() throws IOException {
-        moveToNextReadableRegion(indexEntryBuf);
+        moveToNextReadablePosition(indexEntryBuf);
         return currentRegionRemainingBytes > 0;
     }
 
     void initRegionIndex(ByteBuffer initIndexEntryBuffer) throws IOException {
-        moveToNextReadableRegion(initIndexEntryBuffer);
+        moveToNextReadablePosition(initIndexEntryBuffer);
     }
 
     /** Gets read priority of this file reader. Smaller value indicates higher priority. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -536,8 +536,16 @@ public class SortMergeResultPartition extends ResultPartition {
     protected ResultSubpartitionView createSubpartitionView(
             int subpartitionIndex, BufferAvailabilityListener availabilityListener)
             throws IOException {
+        throw new IllegalStateException(
+                "This method should not be called for a sort merge result partition.");
+    }
+
+    @Override
+    public ResultSubpartitionView createSubpartitionView(
+            ResultSubpartitionIndexSet indexSet, BufferAvailabilityListener availabilityListener)
+            throws IOException {
         synchronized (lock) {
-            checkElementIndex(subpartitionIndex, numSubpartitions, "Subpartition not found.");
+            checkElementIndex(indexSet.getEndIndex(), numSubpartitions, "Subpartition not found.");
             checkState(!isReleased(), "Partition released.");
             checkState(isFinished(), "Trying to read unfinished blocking partition.");
 
@@ -546,7 +554,7 @@ public class SortMergeResultPartition extends ResultPartition {
             }
 
             return readScheduler.createSubpartitionReader(
-                    availabilityListener, subpartitionIndex, resultFile);
+                    availabilityListener, indexSet, resultFile, subpartitionOrder[0]);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
 import org.apache.flink.runtime.io.network.buffer.FileRegionBuffer;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.logger.NetworkActionsLogger;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
@@ -44,7 +45,10 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -73,6 +77,8 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     private volatile boolean isReleased;
 
     private final ChannelStatePersister channelStatePersister;
+
+    private final Deque<BufferAndBacklog> toBeConsumedBuffers = new ArrayDeque<>();
 
     public LocalInputChannel(
             SingleInputGate inputGate,
@@ -116,6 +122,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
     @Override
     protected void requestSubpartitions() throws IOException {
+        checkState(toBeConsumedBuffers.isEmpty());
 
         boolean retriggerRequest = false;
         boolean notifyDataAvailable = false;
@@ -226,6 +233,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     public Optional<BufferAndAvailability> getNextBuffer() throws IOException {
         checkError();
 
+        if (!toBeConsumedBuffers.isEmpty()) {
+            return getBufferAndAvailability(toBeConsumedBuffers.removeFirst());
+        }
+
         ResultSubpartitionView subpartitionView = this.subpartitionView;
         if (subpartitionView == null) {
             // There is a possible race condition between writing a EndOfPartitionEvent (1) and
@@ -267,6 +278,27 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 
         Buffer buffer = next.buffer();
 
+        if (buffer instanceof FullyFilledBuffer) {
+            List<Buffer> partialBuffers = ((FullyFilledBuffer) buffer).getPartialBuffers();
+            int seq = next.getSequenceNumber();
+            for (Buffer partialBuffer : partialBuffers) {
+                toBeConsumedBuffers.add(
+                        new BufferAndBacklog(
+                                partialBuffer,
+                                next.buffersInBacklog(),
+                                buffer.getDataType(),
+                                seq++));
+            }
+
+            return getBufferAndAvailability(toBeConsumedBuffers.removeFirst());
+        }
+
+        return getBufferAndAvailability(next);
+    }
+
+    private Optional<BufferAndAvailability> getBufferAndAvailability(BufferAndBacklog next)
+            throws IOException {
+        Buffer buffer = next.buffer();
         if (buffer instanceof FileRegionBuffer) {
             buffer = ((FileRegionBuffer) buffer).readInto(inputGate.getUnpooledSegment());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -53,7 +53,6 @@ import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration
 import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
 import org.apache.flink.runtime.throughput.BufferDebloater;
 import org.apache.flink.runtime.throughput.ThroughputCalculator;
-import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.clock.SystemClock;
 import org.apache.flink.util.function.SupplierWithException;
 
@@ -149,25 +148,13 @@ public class SingleInputGateFactory {
             @Nonnull InputGateDeploymentDescriptor igdd,
             @Nonnull PartitionProducerStateProvider partitionProducerStateProvider,
             @Nonnull InputChannelMetrics metrics) {
-        // This variable describes whether it is supported to have one input channel consume
-        // multiple subpartitions, if multiple subpartitions from the same partition are
-        // assigned to this input gate.
-        //
-        // For now this function is only supported in the new mode of Hybrid Shuffle.
-        boolean isSharedInputChannelSupported =
-                igdd.getConsumedPartitionType().isHybridResultPartition()
-                        && tieredStorageConfiguration != null;
-
         GateBuffersSpec gateBuffersSpec =
                 createGateBuffersSpec(
                         maxRequiredBuffersPerGate,
                         configuredNetworkBuffersPerChannel,
                         floatingNetworkBuffersPerGate,
                         igdd.getConsumedPartitionType(),
-                        calculateNumChannels(
-                                igdd.getShuffleDescriptors().length,
-                                igdd.getConsumedSubpartitionIndexRange().size(),
-                                isSharedInputChannelSupported),
+                        igdd.getShuffleDescriptors().length,
                         tieredStorageConfiguration != null);
         SupplierWithException<BufferPool, IOException> bufferPoolFactory =
                 createBufferPoolFactory(
@@ -192,10 +179,7 @@ public class SingleInputGateFactory {
                         gateIndex,
                         igdd.getConsumedResultId(),
                         igdd.getConsumedPartitionType(),
-                        calculateNumChannels(
-                                igdd.getShuffleDescriptors().length,
-                                subpartitionIndexSet.size(),
-                                isSharedInputChannelSupported),
+                        igdd.getShuffleDescriptors().length,
                         partitionProducerStateProvider,
                         bufferPoolFactory,
                         bufferDecompressor,
@@ -206,13 +190,7 @@ public class SingleInputGateFactory {
                                 owningTaskName, gateIndex, networkInputGroup.addGroup(gateIndex)));
 
         createInputChannelsAndTieredStorageService(
-                owningTaskName,
-                igdd,
-                inputGate,
-                subpartitionIndexSet,
-                gateBuffersSpec,
-                metrics,
-                isSharedInputChannelSupported);
+                owningTaskName, igdd, inputGate, subpartitionIndexSet, gateBuffersSpec, metrics);
         return inputGate;
     }
 
@@ -245,18 +223,12 @@ public class SingleInputGateFactory {
             SingleInputGate inputGate,
             ResultSubpartitionIndexSet subpartitionIndexSet,
             GateBuffersSpec gateBuffersSpec,
-            InputChannelMetrics metrics,
-            boolean isSharedInputChannelSupported) {
+            InputChannelMetrics metrics) {
         ShuffleDescriptor[] shuffleDescriptors =
                 inputGateDeploymentDescriptor.getShuffleDescriptors();
 
         // Create the input channels. There is one input channel for each consumed subpartition.
-        InputChannel[] inputChannels =
-                new InputChannel
-                        [calculateNumChannels(
-                                shuffleDescriptors.length,
-                                subpartitionIndexSet.size(),
-                                isSharedInputChannelSupported)];
+        InputChannel[] inputChannels = new InputChannel[shuffleDescriptors.length];
 
         ChannelStatistics channelStatistics = new ChannelStatistics();
 
@@ -266,51 +238,26 @@ public class SingleInputGateFactory {
         for (ShuffleDescriptor descriptor : shuffleDescriptors) {
             TieredStoragePartitionId partitionId =
                     TieredStorageIdMappingUtils.convertId(descriptor.getResultPartitionID());
-            if (isSharedInputChannelSupported) {
-                inputChannels[channelIdx] =
-                        createInputChannel(
-                                inputGate,
-                                channelIdx,
-                                gateBuffersSpec.getEffectiveExclusiveBuffersPerChannel(),
-                                descriptor,
-                                subpartitionIndexSet,
-                                channelStatistics,
-                                metrics);
-                if (tieredStorageConfiguration != null) {
-                    addTierShuffleDescriptors(tierShuffleDescriptors, descriptor);
+            inputChannels[channelIdx] =
+                    createInputChannel(
+                            inputGate,
+                            channelIdx,
+                            gateBuffersSpec.getEffectiveExclusiveBuffersPerChannel(),
+                            descriptor,
+                            subpartitionIndexSet,
+                            channelStatistics,
+                            metrics);
+            if (tieredStorageConfiguration != null) {
+                addTierShuffleDescriptors(tierShuffleDescriptors, descriptor);
 
-                    tieredStorageConsumerSpecs.add(
-                            new TieredStorageConsumerSpec(
-                                    inputGate.getInputGateIndex(),
-                                    partitionId,
-                                    new TieredStorageInputChannelId(channelIdx),
-                                    subpartitionIndexSet));
-                }
-                channelIdx++;
-            } else {
-                for (int subpartitionIndex : subpartitionIndexSet.values()) {
-                    inputChannels[channelIdx] =
-                            createInputChannel(
-                                    inputGate,
-                                    channelIdx,
-                                    gateBuffersSpec.getEffectiveExclusiveBuffersPerChannel(),
-                                    descriptor,
-                                    new ResultSubpartitionIndexSet(subpartitionIndex),
-                                    channelStatistics,
-                                    metrics);
-                    if (tieredStorageConfiguration != null) {
-                        addTierShuffleDescriptors(tierShuffleDescriptors, descriptor);
-
-                        tieredStorageConsumerSpecs.add(
-                                new TieredStorageConsumerSpec(
-                                        inputGate.getInputGateIndex(),
-                                        partitionId,
-                                        new TieredStorageInputChannelId(channelIdx),
-                                        new ResultSubpartitionIndexSet(subpartitionIndex)));
-                    }
-                    channelIdx++;
-                }
+                tieredStorageConsumerSpecs.add(
+                        new TieredStorageConsumerSpec(
+                                inputGate.getInputGateIndex(),
+                                partitionId,
+                                new TieredStorageInputChannelId(channelIdx),
+                                subpartitionIndexSet));
             }
+            channelIdx++;
         }
 
         inputGate.setInputChannels(inputChannels);
@@ -371,17 +318,6 @@ public class SingleInputGateFactory {
                                 subpartitionIndexSet,
                                 channelStatistics,
                                 metrics));
-    }
-
-    private static int calculateNumChannels(
-            int numShuffleDescriptors,
-            int numSubpartitions,
-            boolean isSharedInputChannelSupported) {
-        if (isSharedInputChannelSupported) {
-            return numShuffleDescriptors;
-        } else {
-            return MathUtils.checkedDownCast(((long) numShuffleDescriptors) * numSubpartitions);
-        }
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferDecompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferListener;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.AddCredit;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
@@ -62,10 +63,12 @@ import org.apache.flink.shaded.netty4.io.netty.channel.unix.Errors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.io.network.netty.PartitionRequestQueueTest.blockChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createRemoteInputChannel;
@@ -84,6 +87,27 @@ import static org.mockito.Mockito.when;
 /** Test for {@link CreditBasedPartitionRequestClientHandler}. */
 class CreditBasedPartitionRequestClientHandlerTest {
 
+    private static Stream<Arguments> bufferDescriptors() {
+        return Stream.of(
+                Arguments.of(false, 1), // Scenario with a regular Buffer
+                Arguments.of(true, 1), // FullyFilledBuffer with 1 partial buffer
+                Arguments.of(true, 3) // FullyFilledBuffer with 3 partial buffers
+                );
+    }
+
+    private static Stream<Arguments> bufferDescriptorsWithCompression() {
+        return Stream.of(
+                Arguments.of(false, 1, "LZ4"),
+                Arguments.of(false, 1, "LZO"),
+                Arguments.of(false, 1, "ZSTD"),
+                Arguments.of(true, 1, "LZ4"),
+                Arguments.of(true, 1, "LZO"),
+                Arguments.of(true, 1, "ZSTD"),
+                Arguments.of(true, 3, "LZ4"),
+                Arguments.of(true, 3, "LZO"),
+                Arguments.of(true, 3, "ZSTD"));
+    }
+
     /**
      * Tests a fix for FLINK-1627.
      *
@@ -95,10 +119,12 @@ class CreditBasedPartitionRequestClientHandlerTest {
      *
      * @see <a href="https://issues.apache.org/jira/browse/FLINK-1627">FLINK-1627</a>
      */
-    @Test
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
     @Timeout(60)
     @SuppressWarnings("unchecked")
-    void testReleaseInputChannelDuringDecode() throws Exception {
+    void testReleaseInputChannelDuringDecode(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         // Mocks an input channel in a state as it was released during a decode.
         final BufferProvider bufferProvider = mock(BufferProvider.class);
         when(bufferProvider.requestBuffer()).thenReturn(null);
@@ -115,7 +141,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
 
         final BufferResponse receivedBuffer =
                 createBufferResponse(
-                        TestBufferFactory.createBuffer(TestBufferFactory.BUFFER_SIZE),
+                        createBuffer(
+                                isFullyFilled, numOfPartialBuffers, TestBufferFactory.BUFFER_SIZE),
                         0,
                         inputChannel.getInputChannelId(),
                         2,
@@ -129,8 +156,9 @@ class CreditBasedPartitionRequestClientHandlerTest {
      *
      * <p>FLINK-1761 discovered an IndexOutOfBoundsException, when receiving buffers of size 0.
      */
-    @Test
-    void testReceiveEmptyBuffer() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReceiveEmptyBuffer(boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
         // Minimal mock of a remote input channel
         final BufferProvider bufferProvider = mock(BufferProvider.class);
         when(bufferProvider.requestBuffer()).thenReturn(TestBufferFactory.createBuffer(0));
@@ -139,9 +167,6 @@ class CreditBasedPartitionRequestClientHandlerTest {
         when(inputChannel.getInputChannelId()).thenReturn(new InputChannelID());
         when(inputChannel.getBufferProvider()).thenReturn(bufferProvider);
 
-        // An empty buffer of size 0
-        final Buffer emptyBuffer = TestBufferFactory.createBuffer(0);
-
         final CreditBasedPartitionRequestClientHandler client =
                 new CreditBasedPartitionRequestClientHandler();
         client.addInputChannel(inputChannel);
@@ -149,7 +174,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
         final int backlog = 2;
         final BufferResponse receivedBuffer =
                 createBufferResponse(
-                        emptyBuffer,
+                        createBuffer(isFullyFilled, numOfPartialBuffers, 0),
                         0,
                         inputChannel.getInputChannelId(),
                         backlog,
@@ -167,9 +192,11 @@ class CreditBasedPartitionRequestClientHandlerTest {
      * Verifies that {@link RemoteInputChannel#onBuffer(Buffer, int, int, int)} is called when a
      * {@link BufferResponse} is received.
      */
-    @Test
-    void testReceiveBuffer() throws Exception {
-        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReceiveBuffer(boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        final NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, 32 * numOfPartialBuffers);
         final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
         final RemoteInputChannel inputChannel =
                 InputChannelBuilder.newBuilder().buildRemoteChannel(inputGate);
@@ -186,14 +213,14 @@ class CreditBasedPartitionRequestClientHandlerTest {
             final int backlog = 2;
             final BufferResponse bufferResponse =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
                             0,
                             inputChannel.getInputChannelId(),
                             backlog,
                             new NetworkBufferAllocator(handler));
             handler.channelRead(mock(ChannelHandlerContext.class), bufferResponse);
 
-            assertThat(inputChannel.getNumberOfQueuedBuffers()).isOne();
+            assertThat(inputChannel.getNumberOfQueuedBuffers()).isEqualTo(numOfPartialBuffers);
             assertThat(inputChannel.getSenderBacklog()).isEqualTo(2);
         } finally {
             releaseResource(inputGate, networkBufferPool);
@@ -203,9 +230,14 @@ class CreditBasedPartitionRequestClientHandlerTest {
     /**
      * Verifies that {@link BufferResponse} of compressed {@link Buffer} can be handled correctly.
      */
-    @ParameterizedTest
-    @ValueSource(strings = {"LZ4", "LZO", "ZSTD"})
-    void testReceiveCompressedBuffer(final String compressionCodec) throws Exception {
+    @ParameterizedTest(
+            name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}, compressionCodec={2}")
+    @MethodSource("bufferDescriptorsWithCompression")
+    void testReceiveCompressedBuffer(
+            final boolean isFullyFilled,
+            final int numOfPartialBuffers,
+            final String compressionCodec)
+            throws Exception {
         int bufferSize = 1024;
         BufferCompressor compressor =
                 new BufferCompressor(bufferSize, CompressionCodec.valueOf(compressionCodec));
@@ -229,11 +261,11 @@ class CreditBasedPartitionRequestClientHandlerTest {
                     new CreditBasedPartitionRequestClientHandler();
             handler.addInputChannel(inputChannel);
 
-            Buffer buffer =
-                    compressor.compressToOriginalBuffer(TestBufferFactory.createBuffer(bufferSize));
             BufferResponse bufferResponse =
                     createBufferResponse(
-                            buffer,
+                            compressBuffer(
+                                    compressor,
+                                    createBuffer(isFullyFilled, numOfPartialBuffers, bufferSize)),
                             0,
                             inputChannel.getInputChannelId(),
                             2,
@@ -299,8 +331,10 @@ class CreditBasedPartitionRequestClientHandlerTest {
      * Verifies that {@link RemoteInputChannel#onError(Throwable)} is called when a {@link
      * BufferResponse} is received but no available buffer in input channel.
      */
-    @Test
-    void testThrowExceptionForNoAvailableBuffer() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testThrowExceptionForNoAvailableBuffer(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         final SingleInputGate inputGate = createSingleInputGate(1);
         final RemoteInputChannel inputChannel =
                 spy(InputChannelBuilder.newBuilder().buildRemoteChannel(inputGate));
@@ -315,7 +349,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
 
         final BufferResponse bufferResponse =
                 createBufferResponse(
-                        TestBufferFactory.createBuffer(TestBufferFactory.BUFFER_SIZE),
+                        createBuffer(
+                                isFullyFilled, numOfPartialBuffers, TestBufferFactory.BUFFER_SIZE),
                         0,
                         inputChannel.getInputChannelId(),
                         2,
@@ -382,8 +417,10 @@ class CreditBasedPartitionRequestClientHandlerTest {
      * and verifies the behaviour of credit notification by triggering channel's writability
      * changed.
      */
-    @Test
-    void testNotifyCreditAvailable() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testNotifyCreditAvailable(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         final CreditBasedPartitionRequestClientHandler handler =
                 new CreditBasedPartitionRequestClientHandler();
         final NetworkBufferAllocator allocator = new NetworkBufferAllocator(handler);
@@ -395,7 +432,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
                         mock(ConnectionID.class),
                         mock(PartitionRequestClientFactory.class));
 
-        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+        final NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, 32 * numOfPartialBuffers);
         final SingleInputGate inputGate = createSingleInputGate(2, networkBufferPool);
         final RemoteInputChannel[] inputChannels = new RemoteInputChannel[2];
         inputChannels[0] = createRemoteInputChannel(inputGate, client);
@@ -428,14 +466,14 @@ class CreditBasedPartitionRequestClientHandlerTest {
             // requesting (backlog + numExclusiveBuffers - numAvailableBuffers) floating buffers
             final BufferResponse bufferResponse1 =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
                             0,
                             inputChannels[0].getInputChannelId(),
                             1,
                             allocator);
             final BufferResponse bufferResponse2 =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
                             0,
                             inputChannels[1].getInputChannelId(),
                             1,
@@ -468,8 +506,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
             // un-writable channel
             final BufferResponse bufferResponse3 =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
-                            1,
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
+                            numOfPartialBuffers,
                             inputChannels[0].getInputChannelId(),
                             1,
                             allocator);
@@ -508,8 +546,10 @@ class CreditBasedPartitionRequestClientHandlerTest {
      * Verifies that {@link RemoteInputChannel} is enqueued in the pipeline, but {@link AddCredit}
      * message is not sent actually when this input channel is released.
      */
-    @Test
-    void testNotifyCreditAvailableAfterReleased() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testNotifyCreditAvailableAfterReleased(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         final CreditBasedPartitionRequestClientHandler handler =
                 new CreditBasedPartitionRequestClientHandler();
         final EmbeddedChannel channel = new EmbeddedChannel(handler);
@@ -520,7 +560,8 @@ class CreditBasedPartitionRequestClientHandlerTest {
                         mock(ConnectionID.class),
                         mock(PartitionRequestClientFactory.class));
 
-        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32);
+        final NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, 32 * numOfPartialBuffers);
         final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
         final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
         try {
@@ -539,7 +580,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
             // Trigger request floating buffers via buffer response to notify credits available
             final BufferResponse bufferResponse =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(32),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, 32),
                             0,
                             inputChannel.getInputChannelId(),
                             1,
@@ -564,32 +605,47 @@ class CreditBasedPartitionRequestClientHandlerTest {
         }
     }
 
-    @Test
-    void testReadBufferResponseBeforeReleasingChannel() throws Exception {
-        testReadBufferResponseWithReleasingOrRemovingChannel(false, true);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReadBufferResponseBeforeReleasingChannel(
+            boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        testReadBufferResponseWithReleasingOrRemovingChannel(
+                isFullyFilled, false, true, numOfPartialBuffers);
     }
 
-    @Test
-    void testReadBufferResponseBeforeRemovingChannel() throws Exception {
-        testReadBufferResponseWithReleasingOrRemovingChannel(true, true);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReadBufferResponseBeforeRemovingChannel(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
+        testReadBufferResponseWithReleasingOrRemovingChannel(
+                isFullyFilled, true, true, numOfPartialBuffers);
     }
 
-    @Test
-    void testReadBufferResponseAfterReleasingChannel() throws Exception {
-        testReadBufferResponseWithReleasingOrRemovingChannel(false, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReadBufferResponseAfterReleasingChannel(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
+        testReadBufferResponseWithReleasingOrRemovingChannel(
+                isFullyFilled, false, false, numOfPartialBuffers);
     }
 
-    @Test
-    void testReadBufferResponseAfterRemovingChannel() throws Exception {
-        testReadBufferResponseWithReleasingOrRemovingChannel(true, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testReadBufferResponseAfterRemovingChannel(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
+        testReadBufferResponseWithReleasingOrRemovingChannel(
+                isFullyFilled, true, false, numOfPartialBuffers);
     }
 
-    @Test
-    void testDoNotFailHandlerOnSingleChannelFailure() throws Exception {
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testDoNotFailHandlerOnSingleChannelFailure(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
         // Setup
         final int bufferSize = 1024;
         final String expectedMessage = "test exception on buffer";
-        final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize);
+        final NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, bufferSize * numOfPartialBuffers);
         final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
         final RemoteInputChannel inputChannel =
                 new TestRemoteInputChannelForError(inputGate, expectedMessage);
@@ -604,7 +660,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
 
             final BufferResponse bufferResponse =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(bufferSize),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, bufferSize),
                             0,
                             inputChannel.getInputChannelId(),
                             1,
@@ -717,11 +773,16 @@ class CreditBasedPartitionRequestClientHandlerTest {
     }
 
     private void testReadBufferResponseWithReleasingOrRemovingChannel(
-            boolean isRemoved, boolean readBeforeReleasingOrRemoving) throws Exception {
+            boolean isFullyFilled,
+            boolean isRemoved,
+            boolean readBeforeReleasingOrRemoving,
+            int numOfPartialBuffers)
+            throws Exception {
 
         int bufferSize = 1024;
 
-        NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize);
+        NetworkBufferPool networkBufferPool =
+                new NetworkBufferPool(10, bufferSize * numOfPartialBuffers);
         SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
         RemoteInputChannel inputChannel = new InputChannelBuilder().buildRemoteChannel(inputGate);
         inputGate.setInputChannels(inputChannel);
@@ -743,7 +804,7 @@ class CreditBasedPartitionRequestClientHandlerTest {
 
             BufferResponse bufferResponse =
                     createBufferResponse(
-                            TestBufferFactory.createBuffer(bufferSize),
+                            createBuffer(isFullyFilled, numOfPartialBuffers, bufferSize),
                             0,
                             inputChannel.getInputChannelId(),
                             1,
@@ -796,17 +857,77 @@ class CreditBasedPartitionRequestClientHandlerTest {
             int backlog,
             NetworkBufferAllocator allocator)
             throws IOException {
-        // Mock buffer to serialize
-        BufferResponse resp =
-                new BufferResponse(buffer, sequenceNumber, receivingChannelId, 0, backlog);
+        // Check if the buffer is an instance of FullyFilledBuffer
+        if (buffer instanceof FullyFilledBuffer) {
+            FullyFilledBuffer fullyFilledBuffer = (FullyFilledBuffer) buffer;
+            int partialBuffers = fullyFilledBuffer.getPartialBuffers().size();
 
-        ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);
+            BufferResponse resp =
+                    new BufferResponse(
+                            buffer, sequenceNumber, receivingChannelId, 0, partialBuffers, backlog);
 
-        // Skip general header bytes
-        serialized.readBytes(NettyMessage.FRAME_HEADER_LENGTH);
+            ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);
 
-        // Deserialize the bytes to construct the BufferResponse.
-        return BufferResponse.readFrom(serialized, allocator);
+            // Skip general header bytes
+            serialized.readBytes(NettyMessage.FRAME_HEADER_LENGTH);
+
+            // Deserialize the bytes to construct the BufferResponse.
+            BufferResponse bufferResponse = BufferResponse.readFrom(serialized, allocator);
+
+            // Add partial buffer sizes to the response
+            for (Buffer partialBuffer : fullyFilledBuffer.getPartialBuffers()) {
+                bufferResponse.getPartialBufferSizes().add(partialBuffer.getSize());
+            }
+            return bufferResponse;
+        } else {
+            // Construct BufferResponse normally when there are no partial buffers
+            BufferResponse resp =
+                    new BufferResponse(buffer, sequenceNumber, receivingChannelId, 0, 0, backlog);
+
+            ByteBuf serialized = resp.write(UnpooledByteBufAllocator.DEFAULT);
+
+            // Skip general header bytes
+            serialized.readBytes(NettyMessage.FRAME_HEADER_LENGTH);
+
+            // Deserialize the bytes to construct the BufferResponse.
+            return BufferResponse.readFrom(serialized, allocator);
+        }
+    }
+
+    private static Buffer createBuffer(
+            boolean isFullyFilled, int numOfPartialBuffers, int bufferSize) {
+        if (!isFullyFilled) {
+            return TestBufferFactory.createBuffer(bufferSize);
+        } else {
+            return createFullyFilledBuffer(numOfPartialBuffers, bufferSize);
+        }
+    }
+
+    private static FullyFilledBuffer createFullyFilledBuffer(
+            int numOfPartialBuffers, int bufferSize) {
+        FullyFilledBuffer buffer =
+                new FullyFilledBuffer(
+                        Buffer.DataType.DATA_BUFFER, bufferSize * numOfPartialBuffers, false);
+
+        for (int i = 0; i < numOfPartialBuffers; i++) {
+            buffer.addPartialBuffer(TestBufferFactory.createBuffer(bufferSize));
+        }
+        return buffer;
+    }
+
+    private static Buffer compressBuffer(BufferCompressor compressor, Buffer buffer) {
+        if (buffer instanceof FullyFilledBuffer) {
+            FullyFilledBuffer fullyFilledBuffer = (FullyFilledBuffer) buffer;
+            FullyFilledBuffer newFullyFilledBuffer =
+                    new FullyFilledBuffer(buffer.getDataType(), buffer.getSize(), true);
+            for (Buffer partialBuffer : fullyFilledBuffer.getPartialBuffers()) {
+                newFullyFilledBuffer.addPartialBuffer(
+                        compressor.compressToOriginalBuffer(partialBuffer));
+            }
+            return newFullyFilledBuffer;
+        } else {
+            return compressor.compressToOriginalBuffer(buffer);
+        }
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.TestingPartitionRequestClient;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.FullyFilledBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
@@ -35,14 +36,16 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.verifyBufferResponseHeader;
@@ -69,11 +72,12 @@ class NettyMessageClientDecoderDelegateTest {
 
     private InputChannelID releasedInputChannelId;
 
-    @BeforeEach
-    void setup() throws IOException, InterruptedException {
+    private void setup(int numOfPartialBuffers) throws IOException, InterruptedException {
         CreditBasedPartitionRequestClientHandler handler =
                 new CreditBasedPartitionRequestClientHandler();
-        networkBufferPool = new NetworkBufferPool(NUMBER_OF_BUFFER_RESPONSES, BUFFER_SIZE);
+        networkBufferPool =
+                new NetworkBufferPool(
+                        NUMBER_OF_BUFFER_RESPONSES, numOfPartialBuffers * BUFFER_SIZE);
         channel = new EmbeddedChannel(new NettyMessageClientDecoderDelegate(handler));
 
         inputGate = createSingleInputGate(1, networkBufferPool);
@@ -110,42 +114,63 @@ class NettyMessageClientDecoderDelegateTest {
         }
     }
 
+    private static Stream<Arguments> bufferDescriptors() {
+        return Stream.of(
+                Arguments.of(false, 1), // Scenario with a regular Buffer
+                Arguments.of(true, 1), // FullyFilledBuffer with 1 partial buffer
+                Arguments.of(true, 3) // FullyFilledBuffer with 3 partial buffers
+                );
+    }
+
     /** Verifies that the client side decoder works well for unreleased input channels. */
-    @Test
-    void testClientMessageDecode() throws Exception {
-        testNettyMessageClientDecoding(false, false, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testClientMessageDecode(boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        setup(numOfPartialBuffers);
+        testNettyMessageClientDecoding(isFullyFilled, numOfPartialBuffers, false, false, false);
     }
 
     /**
      * Verifies that the client side decoder works well for empty buffers. Empty buffers should not
      * consume data buffers of the input channels.
      */
-    @Test
-    void testClientMessageDecodeWithEmptyBuffers() throws Exception {
-        testNettyMessageClientDecoding(true, false, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testClientMessageDecodeWithEmptyBuffers(boolean isFullyFilled, int numOfPartialBuffers)
+            throws Exception {
+        setup(numOfPartialBuffers);
+        testNettyMessageClientDecoding(isFullyFilled, numOfPartialBuffers, true, false, false);
     }
 
     /**
      * Verifies that the client side decoder works well with buffers sent to a released input
      * channel. The data buffer part should be discarded before reading the next message.
      */
-    @Test
-    void testClientMessageDecodeWithReleasedInputChannel() throws Exception {
-        testNettyMessageClientDecoding(false, true, false);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testClientMessageDecodeWithReleasedInputChannel(
+            boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        setup(numOfPartialBuffers);
+        testNettyMessageClientDecoding(isFullyFilled, numOfPartialBuffers, false, true, false);
     }
 
     /**
      * Verifies that the client side decoder works well with buffers sent to a removed input
      * channel. The data buffer part should be discarded before reading the next message.
      */
-    @Test
-    void testClientMessageDecodeWithRemovedInputChannel() throws Exception {
-        testNettyMessageClientDecoding(false, false, true);
+    @ParameterizedTest(name = "{index} => isFullyFilled={0}, numOfPartialBuffers={1}")
+    @MethodSource("bufferDescriptors")
+    void testClientMessageDecodeWithRemovedInputChannel(
+            boolean isFullyFilled, int numOfPartialBuffers) throws Exception {
+        setup(numOfPartialBuffers);
+        testNettyMessageClientDecoding(isFullyFilled, numOfPartialBuffers, false, false, true);
     }
 
     // ------------------------------------------------------------------------------------------------------------------
 
     private void testNettyMessageClientDecoding(
+            boolean isFullyFilled,
+            int numOfPartialBuffers,
             boolean hasEmptyBuffer,
             boolean hasBufferForReleasedChannel,
             boolean hasBufferForRemovedChannel)
@@ -156,6 +181,8 @@ class NettyMessageClientDecoderDelegateTest {
         try {
             List<BufferResponse> messages =
                     createMessageList(
+                            isFullyFilled,
+                            numOfPartialBuffers,
                             hasEmptyBuffer,
                             hasBufferForReleasedChannel,
                             hasBufferForRemovedChannel);
@@ -179,6 +206,8 @@ class NettyMessageClientDecoderDelegateTest {
     }
 
     private List<BufferResponse> createMessageList(
+            boolean isFullyFilled,
+            int numOfPartialBuffers,
             boolean hasEmptyBuffer,
             boolean hasBufferForRemovedChannel,
             boolean hasBufferForReleasedChannel) {
@@ -188,6 +217,8 @@ class NettyMessageClientDecoderDelegateTest {
 
         for (int i = 0; i < NUMBER_OF_BUFFER_RESPONSES - 1; i++) {
             addBufferResponse(
+                    isFullyFilled,
+                    numOfPartialBuffers,
                     messages,
                     inputChannelId,
                     Buffer.DataType.DATA_BUFFER,
@@ -197,10 +228,18 @@ class NettyMessageClientDecoderDelegateTest {
 
         if (hasEmptyBuffer) {
             addBufferResponse(
-                    messages, inputChannelId, Buffer.DataType.DATA_BUFFER, 0, seqNumber++);
+                    isFullyFilled,
+                    numOfPartialBuffers,
+                    messages,
+                    inputChannelId,
+                    Buffer.DataType.DATA_BUFFER,
+                    0,
+                    seqNumber++);
         }
         if (hasBufferForReleasedChannel) {
             addBufferResponse(
+                    isFullyFilled,
+                    numOfPartialBuffers,
                     messages,
                     releasedInputChannelId,
                     Buffer.DataType.DATA_BUFFER,
@@ -209,6 +248,8 @@ class NettyMessageClientDecoderDelegateTest {
         }
         if (hasBufferForRemovedChannel) {
             addBufferResponse(
+                    isFullyFilled,
+                    numOfPartialBuffers,
                     messages,
                     new InputChannelID(),
                     Buffer.DataType.DATA_BUFFER,
@@ -216,32 +257,80 @@ class NettyMessageClientDecoderDelegateTest {
                     seqNumber++);
         }
 
-        addBufferResponse(messages, inputChannelId, Buffer.DataType.EVENT_BUFFER, 32, seqNumber++);
         addBufferResponse(
-                messages, inputChannelId, Buffer.DataType.DATA_BUFFER, BUFFER_SIZE, seqNumber);
+                isFullyFilled,
+                numOfPartialBuffers,
+                messages,
+                inputChannelId,
+                Buffer.DataType.EVENT_BUFFER,
+                32,
+                seqNumber++);
+        addBufferResponse(
+                isFullyFilled,
+                numOfPartialBuffers,
+                messages,
+                inputChannelId,
+                Buffer.DataType.DATA_BUFFER,
+                BUFFER_SIZE,
+                seqNumber);
 
         return messages;
     }
 
     private void addBufferResponse(
+            boolean isFullyFilled,
+            int numOfPartialBuffers,
             List<BufferResponse> messages,
             InputChannelID inputChannelId,
             Buffer.DataType dataType,
             int bufferSize,
             int seqNumber) {
 
-        Buffer buffer = createDataBuffer(bufferSize, dataType);
-        messages.add(new BufferResponse(buffer, seqNumber, inputChannelId, 0, 1));
+        Buffer buffer = createDataBuffer(isFullyFilled, numOfPartialBuffers, bufferSize, dataType);
+        BufferResponse bufferResponse =
+                new BufferResponse(
+                        buffer,
+                        seqNumber,
+                        inputChannelId,
+                        0,
+                        isFullyFilled ? numOfPartialBuffers : 0,
+                        1);
+        if (isFullyFilled) {
+            for (int i = 0; i < numOfPartialBuffers; i++) {
+                bufferResponse.getPartialBufferSizes().add(bufferSize);
+            }
+        }
+        messages.add(bufferResponse);
     }
 
-    private Buffer createDataBuffer(int size, Buffer.DataType dataType) {
-        MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
-        NetworkBuffer buffer = new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE, dataType);
-        for (int i = 0; i < size / 4; ++i) {
-            buffer.writeInt(i);
-        }
+    private Buffer createDataBuffer(
+            boolean isFullyFilled, int numOfPartialBuffers, int size, Buffer.DataType dataType) {
+        if (!isFullyFilled) {
+            MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
+            NetworkBuffer buffer =
+                    new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE, dataType);
+            for (int i = 0; i < size / 4; ++i) {
+                buffer.writeInt(i);
+            }
 
-        return buffer;
+            return buffer;
+        } else {
+            FullyFilledBuffer fullyFilledBuffer =
+                    new FullyFilledBuffer(dataType, numOfPartialBuffers * size, false);
+
+            for (int i = 0; i < numOfPartialBuffers; i++) {
+                MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(size);
+                NetworkBuffer buffer =
+                        new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE, dataType);
+                for (int num = 0; num < size / 4; ++num) {
+                    buffer.writeInt(num);
+                }
+
+                fullyFilledBuffer.addPartialBuffer(buffer);
+            }
+
+            return fullyFilledBuffer;
+        }
     }
 
     private ByteBuf[] encodeMessages(List<BufferResponse> messages) throws Exception {
@@ -334,7 +423,12 @@ class NettyMessageClientDecoderDelegateTest {
             if (expected.bufferSize == 0 || !expected.receiverId.equals(inputChannelId)) {
                 assertThat(actual.getBuffer()).isNull();
             } else {
-                assertThat(actual.getBuffer()).isEqualTo(expected.getBuffer());
+                Buffer buffer = expected.getBuffer();
+                if (buffer instanceof FullyFilledBuffer) {
+                    assertThat(actual.getBuffer()).isEqualTo(buffer.asByteBuf());
+                } else {
+                    assertThat(actual.getBuffer()).isEqualTo(buffer);
+                }
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
@@ -189,6 +189,7 @@ class NettyMessageClientSideSerializationTest {
                         random.nextInt(Integer.MAX_VALUE),
                         inputChannelId,
                         random.nextInt(Integer.MAX_VALUE),
+                        0,
                         random.nextInt(Integer.MAX_VALUE));
         BufferResponse actual = encodeAndDecode(expected, channel);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/DataBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/DataBufferTest.java
@@ -460,7 +460,9 @@ class DataBufferTest {
     }
 
     public static int[] getRandomSubpartitionOrder(int numSubpartitions) {
-        Random random = new Random(1111);
+        // Removed explicit random seed to enhance variability in test cases
+        // This allows for more diverse execution paths and helps uncover hidden bugs
+        Random random = new Random();
         int[] subpartitionReadOrder = new int[numSubpartitions];
         int shift = random.nextInt(numSubpartitions);
         for (int i = 0; i < numSubpartitions; ++i) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionedFileWriteReadTest.java
@@ -30,6 +30,8 @@ import org.apache.flink.util.IOUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -43,6 +45,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +65,7 @@ class PartitionedFileWriteReadTest {
         int bufferSize = 1024;
         int numBuffers = 1000;
         int numRegions = 10;
+        Random random = new Random(1111);
 
         List<Buffer>[] buffersWritten = new List[numSubpartitions];
         List<Buffer>[] buffersRead = new List[numSubpartitions];
@@ -71,6 +76,7 @@ class PartitionedFileWriteReadTest {
             regionStat[subpartition] = new ArrayList<>();
         }
 
+        int[] writeOrder = DataBufferTest.getRandomSubpartitionOrder(numSubpartitions);
         PartitionedFile partitionedFile =
                 createPartitionedFile(
                         numSubpartitions,
@@ -79,7 +85,10 @@ class PartitionedFileWriteReadTest {
                         numRegions,
                         buffersWritten,
                         regionStat,
-                        createPartitionedFileWriter(numSubpartitions));
+                        createPartitionedFileWriter(numSubpartitions),
+                        subpartitionIndex -> subpartitionIndex,
+                        random.nextBoolean(),
+                        writeOrder);
 
         FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
         FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
@@ -87,11 +96,12 @@ class PartitionedFileWriteReadTest {
             PartitionedFileReader fileReader =
                     new PartitionedFileReader(
                             partitionedFile,
-                            subpartition,
+                            new ResultSubpartitionIndexSet(subpartition),
                             dataFileChannel,
                             indexFileChannel,
                             BufferReaderWriterUtil.allocatedHeaderBuffer(),
-                            createAndConfigIndexEntryBuffer());
+                            createAndConfigIndexEntryBuffer(),
+                            writeOrder[0]);
             while (fileReader.hasRemaining()) {
                 final int subIndex = subpartition;
                 fileReader.readCurrentRegion(
@@ -111,6 +121,211 @@ class PartitionedFileWriteReadTest {
         }
     }
 
+    @ParameterizedTest
+    @CsvSource({"true, true", "true, false", "false, true", "false, false"})
+    void testComputeReadablePosition(boolean randomSubpartitionOrder, boolean broadcastRegion)
+            throws IOException {
+        int numSubpartitions = 10;
+        int bufferSize = 1024;
+        int numBuffers = 1000;
+        int numRegions = 1;
+
+        List<Buffer>[] buffersWritten = new List[numSubpartitions];
+        List<Buffer>[] buffersRead = new List[numSubpartitions];
+        List<Tuple2<Long, Long>>[] regionStat = new List[numSubpartitions];
+        for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+            buffersWritten[subpartition] = new ArrayList<>();
+            buffersRead[subpartition] = new ArrayList<>();
+            regionStat[subpartition] = new ArrayList<>();
+        }
+
+        int[] writeOrder =
+                randomSubpartitionOrder
+                        ? DataBufferTest.getRandomSubpartitionOrder(numSubpartitions)
+                        : new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        PartitionedFile nonBroadcastPartitionedFile =
+                createPartitionedFile(
+                        numSubpartitions,
+                        bufferSize,
+                        numBuffers,
+                        numRegions,
+                        buffersWritten,
+                        regionStat,
+                        createPartitionedFileWriter(numSubpartitions),
+                        subpartitionIndex -> subpartitionIndex,
+                        broadcastRegion,
+                        writeOrder);
+
+        FileChannel dataFileChannel =
+                openFileChannel(nonBroadcastPartitionedFile.getDataFilePath());
+        FileChannel indexFileChannel =
+                openFileChannel(nonBroadcastPartitionedFile.getIndexFilePath());
+
+        verifyReadablePosition(
+                0,
+                numSubpartitions - 1,
+                writeOrder[0],
+                dataFileChannel,
+                indexFileChannel,
+                nonBroadcastPartitionedFile,
+                regionStat,
+                broadcastRegion);
+
+        verifyReadablePosition(
+                0,
+                writeOrder[0],
+                writeOrder[0],
+                dataFileChannel,
+                indexFileChannel,
+                nonBroadcastPartitionedFile,
+                regionStat,
+                broadcastRegion);
+
+        verifyReadablePosition(
+                writeOrder[0],
+                numSubpartitions - 1,
+                writeOrder[0],
+                dataFileChannel,
+                indexFileChannel,
+                nonBroadcastPartitionedFile,
+                regionStat,
+                broadcastRegion);
+    }
+
+    private void verifyReadablePosition(
+            int start,
+            int end,
+            int subpartitionOrderRotationIndex,
+            FileChannel dataFileChannel,
+            FileChannel indexFileChannel,
+            PartitionedFile partitionedFile,
+            List<Tuple2<Long, Long>>[] regionStat,
+            boolean isBroadcastRegion)
+            throws IOException {
+        PartitionedFileReader fileReader =
+                new PartitionedFileReader(
+                        partitionedFile,
+                        new ResultSubpartitionIndexSet(start, end),
+                        dataFileChannel,
+                        indexFileChannel,
+                        BufferReaderWriterUtil.allocatedHeaderBuffer(),
+                        createAndConfigIndexEntryBuffer(),
+                        subpartitionOrderRotationIndex);
+
+        Queue<Tuple2<Long, Long>> offsetAndSizesToRead = new ArrayDeque<>();
+        fileReader.updateReadableOffsetAndSize(
+                createAndConfigIndexEntryBuffer(), offsetAndSizesToRead);
+
+        if (isBroadcastRegion) {
+            assertThat(offsetAndSizesToRead).hasSize(end - start + 1);
+            for (Tuple2<Long, Long> tuple2 : offsetAndSizesToRead) {
+                assertThat(tuple2.f0).isEqualTo(regionStat[start].get(0).f0);
+                assertThat(tuple2.f1).isEqualTo(regionStat[start].get(0).f1);
+            }
+            return;
+        }
+
+        if (start >= subpartitionOrderRotationIndex || end <= subpartitionOrderRotationIndex - 1) {
+            assertThat(offsetAndSizesToRead).hasSize(1);
+
+            Tuple2<Long, Long> offsetAndSize = offsetAndSizesToRead.poll();
+            assertThat(offsetAndSize.f0).isEqualTo(regionStat[start].get(0).f0);
+
+            long expectedSize = 0L;
+            for (int i = start; i <= end; i++) {
+                expectedSize += regionStat[i].get(0).f1;
+            }
+            assertThat(offsetAndSize.f1).isEqualTo(expectedSize);
+        } else {
+            assertThat(offsetAndSizesToRead).hasSize(2);
+
+            Tuple2<Long, Long> offsetAndSize1 = offsetAndSizesToRead.poll();
+            Tuple2<Long, Long> offsetAndSize2 = offsetAndSizesToRead.poll();
+            assertThat(offsetAndSize1.f0)
+                    .isEqualTo(regionStat[subpartitionOrderRotationIndex].get(0).f0);
+            assertThat(offsetAndSize2.f0).isEqualTo(regionStat[start].get(0).f0);
+
+            long expectedSize = 0L;
+            for (int i = subpartitionOrderRotationIndex; i <= end; i++) {
+                expectedSize += regionStat[i].get(0).f1;
+            }
+            assertThat(offsetAndSize1.f1).isEqualTo(expectedSize);
+
+            expectedSize = 0L;
+            for (int i = start; i < subpartitionOrderRotationIndex; i++) {
+                expectedSize += regionStat[i].get(0).f1;
+            }
+            assertThat(offsetAndSize2.f1).isEqualTo(expectedSize);
+        }
+    }
+
+    @Test
+    void testWriteAndReadPartitionedFileForSubpartitionRange() throws Exception {
+        int numSubpartitions = 10;
+        int bufferSize = 1024;
+        int numBuffers = 1000;
+        int numRegions = 10;
+
+        List<Buffer>[] buffersWritten = new List[numSubpartitions];
+        List<Buffer>[] buffersRead = new List[numSubpartitions / 2];
+        List<Tuple2<Long, Long>>[] regionStat = new List[numSubpartitions];
+        for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+            if (subpartition % 2 == 0) {
+                buffersWritten[subpartition / 2] = new ArrayList<>();
+                buffersRead[subpartition / 2] = new ArrayList<>();
+            }
+            regionStat[subpartition] = new ArrayList<>();
+        }
+
+        int[] writeOrder = DataBufferTest.getRandomSubpartitionOrder(numSubpartitions);
+        PartitionedFile partitionedFile =
+                createPartitionedFile(
+                        numSubpartitions,
+                        bufferSize,
+                        numBuffers,
+                        numRegions,
+                        buffersWritten,
+                        regionStat,
+                        createPartitionedFileWriter(numSubpartitions),
+                        subpartitionIndex -> subpartitionIndex / 2,
+                        false,
+                        writeOrder);
+
+        FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
+        FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
+
+        for (int subpartition = 0; subpartition < numSubpartitions; subpartition += 2) {
+            PartitionedFileReader fileReader =
+                    new PartitionedFileReader(
+                            partitionedFile,
+                            new ResultSubpartitionIndexSet(subpartition, subpartition + 1),
+                            dataFileChannel,
+                            indexFileChannel,
+                            BufferReaderWriterUtil.allocatedHeaderBuffer(),
+                            createAndConfigIndexEntryBuffer(),
+                            writeOrder[0]);
+            while (fileReader.hasRemaining()) {
+                final int subIndex = subpartition;
+                fileReader.readCurrentRegion(
+                        allocateBuffers(bufferSize),
+                        FreeingBufferRecycler.INSTANCE,
+                        buffer -> addReadBuffer(buffer, buffersRead[subIndex / 2]));
+            }
+        }
+        IOUtils.closeAllQuietly(dataFileChannel, indexFileChannel);
+
+        for (int subpartition = 0; subpartition < numSubpartitions; subpartition += 2) {
+            assertThat(buffersWritten[subpartition / 2])
+                    .hasSameSizeAs(buffersRead[subpartition / 2]);
+
+            for (int i = 0; i < buffersRead[subpartition / 2].size(); ++i) {
+                assertBufferEquals(
+                        buffersWritten[subpartition / 2].get(i),
+                        buffersRead[subpartition / 2].get(i));
+            }
+        }
+    }
+
     private PartitionedFile createPartitionedFile(
             int numSubpartitions,
             int bufferSize,
@@ -118,12 +333,14 @@ class PartitionedFileWriteReadTest {
             int numRegions,
             List<Buffer>[] buffersWritten,
             List<Tuple2<Long, Long>>[] regionStat,
-            PartitionedFileWriter fileWriter)
+            PartitionedFileWriter fileWriter,
+            Function<Integer, Integer> writtenIndexRetriever,
+            boolean isBroadcastRegion,
+            int[] writeOrder)
             throws IOException {
         Random random = new Random(1111);
         long currentOffset = 0L;
         for (int region = 0; region < numRegions; ++region) {
-            boolean isBroadcastRegion = random.nextBoolean();
             fileWriter.startNewRegion(isBroadcastRegion);
             List<BufferWithSubpartition>[] bufferWithSubpartitions = new List[numSubpartitions];
             for (int i = 0; i < numSubpartitions; i++) {
@@ -134,26 +351,34 @@ class PartitionedFileWriteReadTest {
                 Buffer buffer = createBuffer(random, bufferSize);
                 if (isBroadcastRegion) {
                     for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
-                        buffersWritten[subpartition].add(buffer);
                         bufferWithSubpartitions[subpartition].add(
                                 new BufferWithSubpartition(buffer, subpartition));
                     }
                 } else {
                     int subpartition = random.nextInt(numSubpartitions);
-                    buffersWritten[subpartition].add(buffer);
                     bufferWithSubpartitions[subpartition].add(
                             new BufferWithSubpartition(buffer, subpartition));
                 }
             }
 
-            int[] writeOrder = DataBufferTest.getRandomSubpartitionOrder(numSubpartitions);
             for (int index = 0; index < numSubpartitions; ++index) {
                 int subpartition = writeOrder[index];
                 fileWriter.writeBuffers(bufferWithSubpartitions[subpartition]);
+
+                List<Buffer> writtenBuffer =
+                        bufferWithSubpartitions[subpartition].stream()
+                                .map(BufferWithSubpartition::getBuffer)
+                                .collect(Collectors.toList());
+                int writtenIndex = writtenIndexRetriever.apply(subpartition);
+                buffersWritten[writtenIndex].addAll(writtenBuffer);
                 long totalBytes = getTotalBytes(bufferWithSubpartitions[subpartition]);
                 if (isBroadcastRegion) {
                     for (int j = 0; j < numSubpartitions; j++) {
                         regionStat[j].add(Tuple2.of(currentOffset, totalBytes));
+
+                        if (j != writtenIndex) {
+                            buffersWritten[j].addAll(writtenBuffer);
+                        }
                     }
                     currentOffset += totalBytes;
                     break;
@@ -235,11 +460,12 @@ class PartitionedFileWriteReadTest {
             PartitionedFileReader fileReader =
                     new PartitionedFileReader(
                             partitionedFile,
-                            subpartition,
+                            new ResultSubpartitionIndexSet(subpartition),
                             dataFileChannel,
                             indexFileChannel,
                             BufferReaderWriterUtil.allocatedHeaderBuffer(),
-                            createAndConfigIndexEntryBuffer());
+                            createAndConfigIndexEntryBuffer(),
+                            0);
             int bufferIndex = 0;
             while (fileReader.hasRemaining()) {
                 final int subIndex = subpartition;
@@ -335,11 +561,12 @@ class PartitionedFileWriteReadTest {
         PartitionedFileReader partitionedFileReader =
                 new PartitionedFileReader(
                         partitionedFile,
-                        1,
+                        new ResultSubpartitionIndexSet(1),
                         dataFileChannel,
                         indexFileChannel,
                         BufferReaderWriterUtil.allocatedHeaderBuffer(),
-                        createAndConfigIndexEntryBuffer());
+                        createAndConfigIndexEntryBuffer(),
+                        0);
 
         partitionedFileReader.readCurrentRegion(
                 allocateBuffers(bufferSize),
@@ -359,6 +586,7 @@ class PartitionedFileWriteReadTest {
         final int bufferSize = 1024;
         final int numBuffers = 100;
         final int numRegions = 10;
+        Random random = new Random(1111);
 
         List<Buffer>[] buffersWritten = new List[numSubpartitions];
         List<Buffer>[] buffersRead = new List[numSubpartitions];
@@ -369,6 +597,7 @@ class PartitionedFileWriteReadTest {
             regionStat[subpartition] = new ArrayList<>();
         }
 
+        int[] writeOrder = DataBufferTest.getRandomSubpartitionOrder(numSubpartitions);
         PartitionedFile partitionedFile =
                 createPartitionedFile(
                         numSubpartitions,
@@ -380,7 +609,10 @@ class PartitionedFileWriteReadTest {
                         createPartitionedFileWriter(
                                 numSubpartitions,
                                 PartitionedFile.INDEX_ENTRY_SIZE * numSubpartitions,
-                                PartitionedFile.INDEX_ENTRY_SIZE * numSubpartitions));
+                                PartitionedFile.INDEX_ENTRY_SIZE * numSubpartitions),
+                        subpartitionIndex -> subpartitionIndex,
+                        random.nextBoolean(),
+                        writeOrder);
 
         FileChannel dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
         FileChannel indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -947,7 +947,8 @@ class SingleInputGateTest extends InputGateTestBase {
                         netEnv,
                         localLocation,
                         new TestingConnectionManager(),
-                        new TestingResultPartitionManager(new NoOpResultSubpartitionView()));
+                        new TestingResultPartitionManager(new NoOpResultSubpartitionView()),
+                        partitionIds.length);
 
         for (InputChannel channel : gate.inputChannels()) {
             if (channel instanceof ChannelStateHolder) {
@@ -960,8 +961,7 @@ class SingleInputGateTest extends InputGateTestBase {
                             getInputChannelsInPartition(gate, partitionIds[i]).stream()
                                     .map(InputChannel::getConsumedSubpartitionIndexSet)
                                     .collect(Collectors.toList()))
-                    .containsExactlyInAnyOrder(
-                            new ResultSubpartitionIndexSet(0), new ResultSubpartitionIndexSet(1));
+                    .containsExactly(new ResultSubpartitionIndexSet(new IndexRange(0, 1)));
         }
 
         assertChannelsType(gate, LocalRecoveredInputChannel.class, partitionIds[0]);
@@ -1263,7 +1263,8 @@ class SingleInputGateTest extends InputGateTestBase {
                         netEnv,
                         ResourceID.generate(),
                         new TestingConnectionManager(),
-                        new TestingResultPartitionManager(new NoOpResultSubpartitionView()));
+                        new TestingResultPartitionManager(new NoOpResultSubpartitionView()),
+                        partitionIds.length * subpartitionRandSize);
         gate.setup();
 
         for (InputChannel inputChannel : gate.inputChannels()) {
@@ -1323,7 +1324,8 @@ class SingleInputGateTest extends InputGateTestBase {
                 netEnv,
                 ResourceID.generate(),
                 null,
-                null);
+                null,
+                partitionIds.length);
     }
 
     static SingleInputGate createSingleInputGate(
@@ -1333,25 +1335,29 @@ class SingleInputGateTest extends InputGateTestBase {
             NettyShuffleEnvironment netEnv,
             ResourceID localLocation,
             ConnectionManager connectionManager,
-            ResultPartitionManager resultPartitionManager)
+            ResultPartitionManager resultPartitionManager,
+            int numOfChannels)
             throws IOException {
 
-        ShuffleDescriptorAndIndex[] channelDescs =
-                new ShuffleDescriptorAndIndex[] {
-                    // Local
-                    new ShuffleDescriptorAndIndex(
-                            createRemoteWithIdAndLocation(partitionIds[0], localLocation), 0),
-                    // Remote
-                    new ShuffleDescriptorAndIndex(
-                            createRemoteWithIdAndLocation(partitionIds[1], ResourceID.generate()),
-                            1),
-                    // Unknown
+        ShuffleDescriptorAndIndex[] channelDescs = new ShuffleDescriptorAndIndex[numOfChannels];
+
+        // Local
+        channelDescs[0] =
+                new ShuffleDescriptorAndIndex(
+                        createRemoteWithIdAndLocation(partitionIds[0], localLocation), 0);
+        // Remote
+        channelDescs[1] =
+                new ShuffleDescriptorAndIndex(
+                        createRemoteWithIdAndLocation(partitionIds[1], ResourceID.generate()), 1);
+        // Unknown
+        for (int i = 2; i < numOfChannels; i++) {
+            channelDescs[i] =
                     new ShuffleDescriptorAndIndex(
                             new UnknownShuffleDescriptor(
                                     new ResultPartitionID(
                                             partitionIds[2], createExecutionAttemptId())),
-                            2)
-                };
+                            i);
+        }
 
         InputGateDeploymentDescriptor gateDesc =
                 new InputGateDeploymentDescriptor(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

https://issues.apache.org/jira/browse/FLINK-36072
Optimizing the Overhead of the Network Layer in Adaptive Execution Scenarios


## Brief change log

  - On the downstream side, enable a single input gate to support a single input channel consuming multiple subpartitions.
  - On the upstream side, enable sort-merge shuffle could use single partition reader to read multiple subpartitions
  - On the upstream side, enable sort-merge shuffle supports accumulating small buffers to reduce network overhead.


## Verifying this change



This change added tests and can be verified such as CreditBasedPartitionRequestClientHandlerTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
