### PR TITLE
solve bash-java-utils.sh can't get "env.java.home" in "config.yaml" since 1.20

### DIFF
--- a/flink-dist/src/test/bin/runSetJavaRun.sh
+++ b/flink-dist/src/test/bin/runSetJavaRun.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+USAGE="Usage: runSetJavaRun.sh"
+
+bin=`dirname "$0"`
+bin=`cd "$bin"; pwd`
+
+FLINK_CONF_DIR="${bin}/../resources"
+FLINK_CONF="$FLINK_CONF_DIR/config.yaml"
+
+. ${bin}/../../main/flink-bin/bin/bash-java-utils.sh > /dev/null
+
+setJavaRun "$FLINK_CONF"
+echo "$JAVA_RUN"

--- a/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
 import org.apache.flink.shaded.guava32.com.google.common.collect.Sets;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -43,7 +44,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.allOf;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.MATCHER;
 
 /**
  * Tests for BashJavaUtils.
@@ -57,6 +60,8 @@ class BashJavaUtilsITCase extends JavaBashTestBase {
             "src/test/bin/runBashJavaUtilsCmd.sh";
     private static final String RUN_EXTRACT_LOGGING_OUTPUTS_SCRIPT =
             "src/test/bin/runExtractLoggingOutputs.sh";
+    private static final String RUN_SET_JAVA_RUN_SCRIPT =
+            "src/test/bin/runSetJavaRun.sh";
 
     @TempDir private Path tmpDir;
 
@@ -351,6 +356,16 @@ class BashJavaUtilsITCase extends JavaBashTestBase {
                 Arrays.asList(executeScript(commands).split(System.lineSeparator()));
 
         assertThat(actualOutput).isEqualTo(expectedOutput);
+    }
+
+    @Test
+    void testSetJavaRun() throws Exception {
+        String[] commands = {RUN_SET_JAVA_RUN_SCRIPT};
+        List<String> lines =
+                Arrays.asList(executeScript(commands).split(System.lineSeparator()));
+
+        assertThat(lines).hasSize(1);
+        assertThat(lines.get(0)).containsSubsequence("jdk");
     }
 
     private Configuration loadConfiguration(List<String> lines) throws IOException {

--- a/flink-dist/src/test/resources/config.yaml
+++ b/flink-dist/src/test/resources/config.yaml
@@ -1,0 +1,27 @@
+env:
+  java:
+    opts:
+      all: --add-exports=java.base/sun.net.util=ALL-UNNAMED --add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED
+    home: \usr\local\jdk2
+env.java.home: \usr\local\jdk
+jobmanager:
+  bind-host: localhost
+  rpc:
+    address: localhost
+    port: 6123
+  memory:
+    process:
+      size: 1600m
+  execution:
+    failover-strategy: region
+taskmanager:
+  bind-host: localhost
+  host: localhost
+  numberOfTaskSlots: 1
+  memory:
+    process:
+      size: 1728m
+parallelism:
+  default: 1
+rest:
+  address: localhost


### PR DESCRIPTION
edit "flink-dist\src\main\flink-bin\bin\bash-java-utils.sh" to solve bug(start script can not get config for "env.java.home" in "config.yaml" correctly since 1.20)


