### PR TITLE
[FLINK-34974][state] Support getOrCreateKeyedState for AsyncKeyedStateBackend

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
@@ -75,24 +75,6 @@ public interface AsyncKeyedStateBackend<K>
             throws Exception;
 
     /**
-     * Creates and returns a new state.
-     *
-     * @param <N> the type of namespace for partitioning.
-     * @param <S> The type of the public API state.
-     * @param <SV> The type of the stored state value.
-     * @param defaultNamespace the default namespace for this state.
-     * @param namespaceSerializer the serializer for namespace.
-     * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
-     * @throws Exception Exceptions may occur during initialization of the state.
-     */
-    @Nonnull
-    <N, S extends State, SV> S createState(
-            @Nonnull N defaultNamespace,
-            @Nonnull TypeSerializer<N> namespaceSerializer,
-            @Nonnull StateDescriptor<SV> stateDesc)
-            throws Exception;
-
-    /**
      * Creates and returns a new state for internal usage.
      *
      * @param <N> the type of namespace for partitioning.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AsyncKeyedStateBackend.java
@@ -56,6 +56,25 @@ public interface AsyncKeyedStateBackend<K>
     void setup(@Nonnull StateRequestHandler stateRequestHandler);
 
     /**
+     * Creates or retrieves a keyed state backed by this state backend.
+     *
+     * @param <N> the type of namespace for partitioning.
+     * @param <S> The type of the public API state.
+     * @param <SV> The type of the stored state value.
+     * @param defaultNamespace the default namespace for this state.
+     * @param namespaceSerializer the serializer for namespace.
+     * @param stateDesc The {@code StateDescriptor} that contains the name of the state.
+     * @return A new key/value state backed by this backend.
+     * @throws Exception Exceptions may occur during initialization of the state and should be
+     *     forwarded.
+     */
+    <N, S extends State, SV> S getOrCreateKeyedState(
+            N defaultNamespace,
+            TypeSerializer<N> namespaceSerializer,
+            StateDescriptor<SV> stateDesc)
+            throws Exception;
+
+    /**
      * Creates and returns a new state.
      *
      * @param <N> the type of namespace for partitioning.
@@ -120,6 +139,20 @@ public interface AsyncKeyedStateBackend<K>
      */
     default boolean requiresLegacySynchronousTimerSnapshots(SnapshotType checkpointType) {
         return true;
+    }
+
+    /**
+     * Whether it's safe to reuse key-values from the state-backend, e.g for the purpose of
+     * optimization.
+     *
+     * <p>NOTE: this method should not be used to check for {@link InternalPriorityQueue}, as the
+     * priority queue could be stored on different locations, e.g ForSt state-backend could store
+     * that on JVM heap if configuring HEAP as the time-service factory.
+     *
+     * @return returns ture if safe to reuse the key-values from the state-backend.
+     */
+    default boolean isSafeToReuseKVState() {
+        return false;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/DefaultKeyedStateStore.java
@@ -43,7 +43,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
     public <T> ValueState<T> getValueState(@Nonnull ValueStateDescriptor<T> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
-            return asyncKeyedStateBackend.createState(
+            return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
@@ -54,7 +54,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
     public <T> ListState<T> getListState(@Nonnull ListStateDescriptor<T> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
-            return asyncKeyedStateBackend.createState(
+            return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
@@ -66,7 +66,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
             @Nonnull MapStateDescriptor<UK, UV> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
-            return asyncKeyedStateBackend.createState(
+            return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
@@ -78,7 +78,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
             @Nonnull ReducingStateDescriptor<T> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
-            return asyncKeyedStateBackend.createState(
+            return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);
@@ -90,7 +90,7 @@ public class DefaultKeyedStateStore implements KeyedStateStore {
             @Nonnull AggregatingStateDescriptor<IN, ACC, OUT> stateProperties) {
         Preconditions.checkNotNull(stateProperties, "The state properties must not be null");
         try {
-            return asyncKeyedStateBackend.createState(
+            return asyncKeyedStateBackend.getOrCreateKeyedState(
                     VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateProperties);
         } catch (Exception e) {
             throw new RuntimeException("Error while getting state", e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/AsyncKeyedStateBackendAdaptor.java
@@ -74,35 +74,6 @@ public class AsyncKeyedStateBackendAdaptor<K> implements AsyncKeyedStateBackend<
             TypeSerializer<N> namespaceSerializer,
             StateDescriptor<SV> stateDesc)
             throws Exception {
-        org.apache.flink.api.common.state.StateDescriptor rawStateDesc =
-                StateDescriptorUtils.transformFromV2ToV1(stateDesc);
-        org.apache.flink.api.common.state.State rawState =
-                keyedStateBackend.getOrCreateKeyedState(namespaceSerializer, rawStateDesc);
-        switch (rawStateDesc.getType()) {
-            case VALUE:
-                return (S) new ValueStateAdaptor((InternalValueState) rawState);
-            case LIST:
-                return (S) new ListStateAdaptor<>((InternalListState) rawState);
-            case REDUCING:
-                return (S) new ReducingStateAdaptor<>((InternalReducingState) rawState);
-            case AGGREGATING:
-                return (S) new AggregatingStateAdaptor<>((InternalAggregatingState) rawState);
-            case MAP:
-                return (S) new MapStateAdaptor<>((InternalMapState) rawState);
-            default:
-                throw new UnsupportedOperationException(
-                        String.format("Unsupported state type: %s", rawStateDesc.getType()));
-        }
-    }
-
-    @Nonnull
-    @Override
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public <N, S extends State, SV> S createState(
-            @Nonnull N defaultNamespace,
-            @Nonnull TypeSerializer<N> namespaceSerializer,
-            @Nonnull StateDescriptor<SV> stateDesc)
-            throws Exception {
         return createStateInternal(defaultNamespace, namespaceSerializer, stateDesc);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamOperatorStateHandler.java
@@ -415,7 +415,7 @@ public class StreamOperatorStateHandler {
             throws Exception {
 
         if (asyncKeyedStateBackend != null) {
-            return asyncKeyedStateBackend.createState(
+            return asyncKeyedStateBackend.getOrCreateKeyedState(
                     defaultNamespace, namespaceSerializer, stateDescriptor);
         } else {
             throw new IllegalStateException(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -110,7 +110,7 @@ class AsyncExecutionControllerTest {
 
         try {
             valueState =
-                    asyncKeyedStateBackend.createState(
+                    asyncKeyedStateBackend.getOrCreateKeyedState(
                             VoidNamespace.INSTANCE,
                             VoidNamespaceSerializer.INSTANCE,
                             stateDescriptor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -143,16 +143,6 @@ public class StateBackendTestUtils {
 
         @Nonnull
         @Override
-        @SuppressWarnings("unchecked")
-        public <N, S extends org.apache.flink.api.common.state.v2.State, SV> S createState(
-                @Nonnull N defaultNamespace,
-                @Nonnull TypeSerializer<N> namespaceSerializer,
-                @Nonnull org.apache.flink.runtime.state.v2.StateDescriptor<SV> stateDesc) {
-            return (S) innerStateSupplier.get();
-        }
-
-        @Nonnull
-        @Override
         public <N, S extends InternalKeyedState, SV> S createStateInternal(
                 @Nonnull N defaultNamespace,
                 @Nonnull TypeSerializer<N> namespaceSerializer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -131,6 +131,16 @@ public class StateBackendTestUtils {
             // do nothing
         }
 
+        @Override
+        public <N, S extends org.apache.flink.api.common.state.v2.State, SV>
+                S getOrCreateKeyedState(
+                        N defaultNamespace,
+                        TypeSerializer<N> namespaceSerializer,
+                        org.apache.flink.runtime.state.v2.StateDescriptor<SV> stateDesc)
+                        throws Exception {
+            return (S) innerStateSupplier.get();
+        }
+
         @Nonnull
         @Override
         @SuppressWarnings("unchecked")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
@@ -184,16 +184,6 @@ public class AbstractKeyedStateTestBase {
 
                 @Nonnull
                 @Override
-                public <N, S extends State, SV> S createState(
-                        @Nonnull N defaultNamespace,
-                        @Nonnull TypeSerializer<N> namespaceSerializer,
-                        @Nonnull StateDescriptor<SV> stateDesc)
-                        throws Exception {
-                    return null;
-                }
-
-                @Nonnull
-                @Override
                 public <N, S extends InternalKeyedState, SV> S createStateInternal(
                         @Nonnull N defaultNamespace,
                         @Nonnull TypeSerializer<N> namespaceSerializer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
@@ -173,6 +173,15 @@ public class AbstractKeyedStateTestBase {
                 @Override
                 public void setup(@Nonnull StateRequestHandler stateRequestHandler) {}
 
+                @Override
+                public <N, S extends State, SV> S getOrCreateKeyedState(
+                        N defaultNamespace,
+                        TypeSerializer<N> namespaceSerializer,
+                        StateDescriptor<SV> stateDesc)
+                        throws Exception {
+                    return null;
+                }
+
                 @Nonnull
                 @Override
                 public <N, S extends State, SV> S createState(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AsyncKeyedStateBackendAdaptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AsyncKeyedStateBackendAdaptorTest.java
@@ -63,7 +63,7 @@ public class AsyncKeyedStateBackendAdaptorTest {
                 new ValueStateDescriptor<>("testState", BasicTypeInfo.INT_TYPE_INFO);
 
         org.apache.flink.api.common.state.v2.ValueState<Integer> valueState =
-                adaptor.createState(
+                adaptor.getOrCreateKeyedState(
                         VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
 
         // test synchronous interfaces.
@@ -102,7 +102,7 @@ public class AsyncKeyedStateBackendAdaptorTest {
                 new ListStateDescriptor<>("testState", BasicTypeInfo.INT_TYPE_INFO);
 
         org.apache.flink.api.common.state.v2.ListState<Integer> listState =
-                adaptor.createState(
+                adaptor.getOrCreateKeyedState(
                         VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
 
         // test synchronous interfaces.
@@ -154,7 +154,7 @@ public class AsyncKeyedStateBackendAdaptorTest {
                         "testState", BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO);
 
         org.apache.flink.api.common.state.v2.MapState<Integer, Integer> mapState =
-                adaptor.createState(
+                adaptor.getOrCreateKeyedState(
                         VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, descriptor);
 
         final HashMap<Integer, Integer> groundTruth =
@@ -247,7 +247,7 @@ public class AsyncKeyedStateBackendAdaptorTest {
                         "testState", Integer::sum, BasicTypeInfo.INT_TYPE_INFO);
 
         InternalReducingState<String, Long, Integer> reducingState =
-                adaptor.createState(0L, LongSerializer.INSTANCE, descriptor);
+                adaptor.getOrCreateKeyedState(0L, LongSerializer.INSTANCE, descriptor);
 
         // test synchronous interfaces.
         reducingState.clear();
@@ -353,7 +353,7 @@ public class AsyncKeyedStateBackendAdaptorTest {
                         BasicTypeInfo.INT_TYPE_INFO);
 
         InternalAggregatingState<String, Long, Integer, Integer, String> aggState =
-                adaptor.createState(0L, LongSerializer.INSTANCE, descriptor);
+                adaptor.getOrCreateKeyedState(0L, LongSerializer.INSTANCE, descriptor);
 
         // test synchronous interfaces.
         aggState.clear();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/StateBackendTestV2Base.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/StateBackendTestV2Base.java
@@ -229,7 +229,7 @@ public abstract class StateBackendTestV2Base<B extends AbstractStateBackend> {
                     new ValueStateDescriptor<>("test", BasicTypeInfo.INT_TYPE_INFO);
 
             ValueState<Integer> valueState =
-                    backend.createState(
+                    backend.getOrCreateKeyedState(
                             VoidNamespace.INSTANCE,
                             VoidNamespaceSerializer.INSTANCE,
                             stateDescriptor);
@@ -318,7 +318,7 @@ public abstract class StateBackendTestV2Base<B extends AbstractStateBackend> {
                     new ValueStateDescriptor<>("test", BasicTypeInfo.INT_TYPE_INFO);
 
             ValueState<Integer> valueState =
-                    backend.createState(
+                    backend.getOrCreateKeyedState(
                             VoidNamespace.INSTANCE,
                             VoidNamespaceSerializer.INSTANCE,
                             stateDescriptor);
@@ -432,7 +432,7 @@ public abstract class StateBackendTestV2Base<B extends AbstractStateBackend> {
             kvId.enableTimeToLive(StateTtlConfig.newBuilder(Duration.ofSeconds(1)).build());
 
             ValueState<Long> state =
-                    backend.createState(
+                    backend.getOrCreateKeyedState(
                             VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
             RecordContext recordContext = aec.buildContext("record-1", 1L);
             recordContext.retain();

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContextTest.java
@@ -493,7 +493,7 @@ class StreamingRuntimeContextTest {
                                     return null;
                                 })
                 .when(asyncKeyedStateBackend)
-                .createState(
+                .getOrCreateKeyedState(
                         any(),
                         any(TypeSerializer.class),
                         any(org.apache.flink.runtime.state.v2.StateDescriptor.class));

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStKeyedStateBackend.java
@@ -249,9 +249,8 @@ public class ForStKeyedStateBackend<K> implements AsyncKeyedStateBackend<K> {
     }
 
     @Nonnull
-    @Override
     @SuppressWarnings("unchecked")
-    public <N, S extends State, SV> S createState(
+    protected <N, S extends State, SV> S createState(
             @Nonnull N defaultNamespace,
             @Nonnull TypeSerializer<N> namespaceSerializer,
             @Nonnull StateDescriptor<SV> stateDesc)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Support `getOrCreateKeyedState()` and  `isSafeToReuseKVState()` for AsyncKeyedStateBackend.


## Brief change log

- Add `getOrCreateKeyedState()` and `isSafeToReuseKVState()`  to `AsyncKeyedStateBackend`
- Implement `getOrCreateKeyedState()` and `isSafeToReuseKVState()`  in subclasses.


## Verifying this change



This change is already covered by existing tests, such as *(please describe tests)*.
- `AbstractKeyedStateTestBase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
