### PR TITLE
[FLINK-36455] Sinks retry synchronously [1.19]

### DIFF
--- a/docs/layouts/shortcodes/generated/common_miscellaneous_section.html
+++ b/docs/layouts/shortcodes/generated/common_miscellaneous_section.html
@@ -26,5 +26,11 @@
             <td>String</td>
             <td>Directories for temporary files, separated by",", "|", or the system's java.io.File.pathSeparator.</td>
         </tr>
+        <tr>
+            <td><h5>sink.committer.retries</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>The number of retries a Flink application attempts for committable operations (such as transactions) on retriable errors, as specified by the sink connector, before Flink fails and potentially restarts.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/SinkOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SinkOptions.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/** Configuration options for sinks. */
+@PublicEvolving
+public class SinkOptions {
+    /**
+     * The number of retries on a committable (e.g., transaction) before Flink application fails and
+     * potentially restarts.
+     */
+    @Documentation.Section(Documentation.Sections.COMMON_MISCELLANEOUS)
+    public static final ConfigOption<Integer> COMMITTER_RETRIES =
+            key("sink.committer.retries")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "The number of retries a Flink application attempts for committable operations (such as transactions) on retriable errors, as specified by the sink connector, before Flink fails and potentially restarts.");
+
+    private SinkOptions() {}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/CommitterOperator.java
@@ -22,12 +22,14 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.CommitterInitContext;
+import org.apache.flink.configuration.SinkOptions;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.InternalSinkCommitterMetricGroup;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -65,7 +67,6 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
         implements OneInputStreamOperator<CommittableMessage<CommT>, CommittableMessage<CommT>>,
                 BoundedOneInput {
 
-    private static final long RETRY_DELAY = 1000;
     private final SimpleVersionedSerializer<CommT> committableSerializer;
     private final FunctionWithException<CommitterInitContext, Committer<CommT>, IOException>
             committerSupplier;
@@ -76,6 +77,7 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
     private Committer<CommT> committer;
     private CommittableCollector<CommT> committableCollector;
     private long lastCompletedCheckpointId = -1;
+    private int maxRetries;
 
     private boolean endInput = false;
 
@@ -111,6 +113,7 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
         super.setup(containingTask, config, output);
         metricGroup = InternalSinkCommitterMetricGroup.wrap(getMetricGroup());
         committableCollector = CommittableCollector.of(metricGroup);
+        maxRetries = config.getConfiguration().get(SinkOptions.COMMITTER_RETRIES);
     }
 
     @Override
@@ -161,41 +164,42 @@ class CommitterOperator<CommT> extends AbstractStreamOperator<CommittableMessage
 
     private void commitAndEmitCheckpoints() throws IOException, InterruptedException {
         long completedCheckpointId = endInput ? EOI : lastCompletedCheckpointId;
-        do {
-            for (CheckpointCommittableManager<CommT> manager :
-                    committableCollector.getCheckpointCommittablesUpTo(completedCheckpointId)) {
-                commitAndEmit(manager);
-            }
-            // !committableCollector.isFinished() indicates that we should retry
-            // Retry should be done here if this is a final checkpoint (indicated by endInput)
-            // WARN: this is an endless retry, may make the job stuck while finishing
-        } while (!committableCollector.isFinished() && endInput);
-
-        if (!committableCollector.isFinished()) {
-            // if not endInput, we can schedule retrying later
-            retryWithDelay();
+        for (CheckpointCommittableManager<CommT> checkpointManager :
+                committableCollector.getCheckpointCommittablesUpTo(completedCheckpointId)) {
+            // ensure that all committables of the first checkpoint are fully committed before
+            // attempting the next committable
+            commitAndEmit(checkpointManager);
+            committableCollector.remove(checkpointManager);
         }
-        committableCollector.compact();
     }
 
     private void commitAndEmit(CheckpointCommittableManager<CommT> committableManager)
             throws IOException, InterruptedException {
-        Collection<CommittableWithLineage<CommT>> committed = committableManager.commit(committer);
-        if (emitDownstream && committableManager.isFinished()) {
-            int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
-            int numberOfSubtasks = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
-            output.collect(
-                    new StreamRecord<>(committableManager.getSummary(subtaskId, numberOfSubtasks)));
-            for (CommittableWithLineage<CommT> committable : committed) {
-                output.collect(new StreamRecord<>(committable.withSubtaskId(subtaskId)));
-            }
+        committableManager.commit(committer, maxRetries);
+        if (emitDownstream) {
+            emit(committableManager);
         }
     }
 
-    private void retryWithDelay() {
-        processingTimeService.registerTimer(
-                processingTimeService.getCurrentProcessingTime() + RETRY_DELAY,
-                ts -> commitAndEmitCheckpoints());
+    private void emit(CheckpointCommittableManager<CommT> committableManager) {
+        int subtaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
+        int numberOfSubtasks = getRuntimeContext().getTaskInfo().getNumberOfParallelSubtasks();
+        long checkpointId = committableManager.getCheckpointId();
+        Collection<CommT> committables = committableManager.getSuccessfulCommittables();
+        output.collect(
+                new StreamRecord<>(
+                        new CommittableSummary<>(
+                                subtaskId,
+                                numberOfSubtasks,
+                                checkpointId,
+                                committables.size(),
+                                0,
+                                0)));
+        for (CommT committable : committables) {
+            output.collect(
+                    new StreamRecord<>(
+                            new CommittableWithLineage<>(committable, checkpointId, subtaskId)));
+        }
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
@@ -20,8 +20,6 @@ package org.apache.flink.streaming.runtime.operators.sink.committables;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.sink2.Committer;
-import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
-import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -50,12 +48,6 @@ public interface CheckpointCommittableManager<CommT> {
     /** Returns the number of upstream subtasks belonging to the checkpoint. */
     int getNumberOfSubtasks();
 
-    /**
-     * Returns a summary of the current commit progress for the emitting subtask identified by the
-     * parameters.
-     */
-    CommittableSummary<CommT> getSummary(int emittingSubtaskId, int emittingNumberOfSubtasks);
-
     boolean isFinished();
 
     /**
@@ -69,8 +61,10 @@ public interface CheckpointCommittableManager<CommT> {
      * checkpoint have been received.
      *
      * @param committer used to commit to the external system
-     * @return successfully committed committables with meta information
+     * @param maxRetries
      */
-    Collection<CommittableWithLineage<CommT>> commit(Committer<CommT> committer)
+    void commit(Committer<CommT> committer, int maxRetries)
             throws IOException, InterruptedException;
+
+    Collection<CommT> getSuccessfulCommittables();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -132,7 +133,7 @@ public class CommittableCollector<CommT> {
      */
     public Collection<? extends CheckpointCommittableManager<CommT>> getCheckpointCommittablesUpTo(
             long checkpointId) {
-        return checkpointCommittables.headMap(checkpointId, true).values();
+        return new ArrayList<>(checkpointCommittables.headMap(checkpointId, true).values());
     }
 
     /**
@@ -208,9 +209,9 @@ public class CommittableCollector<CommT> {
         return checkNotNull(committables, "Unknown checkpoint for %s", committable);
     }
 
-    /** Removes all metadata about checkpoints of which all committables are fully committed. */
-    public void compact() {
-        checkpointCommittables.values().removeIf(CheckpointCommittableManagerImpl::isFinished);
+    /** Removes the manager for a specific checkpoint and all it's metadata. */
+    public void remove(CheckpointCommittableManager<CommT> manager) {
+        checkpointCommittables.remove(manager.getCheckpointId());
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
@@ -66,6 +66,13 @@ public class CommittableCollector<CommT> {
             SinkCommitterMetricGroup metricGroup) {
         this.checkpointCommittables = new TreeMap<>(checkNotNull(checkpointCommittables));
         this.metricGroup = metricGroup;
+        this.metricGroup.setCurrentPendingCommittablesGauge(this::getNumPending);
+    }
+
+    private int getNumPending() {
+        return checkpointCommittables.values().stream()
+                .mapToInt(m -> (int) m.getPendingRequests().count())
+                .sum();
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/SubtaskCommittableManager.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.streaming.runtime.operators.sink.committables.CommitRequestState.COMMITTED;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -138,6 +139,12 @@ class SubtaskCommittableManager<CommT> {
         return requests.stream().filter(c -> !c.isFinished());
     }
 
+    Stream<CommT> getSuccessfulCommittables() {
+        return getRequests().stream()
+                .filter(c -> c.getState() == COMMITTED)
+                .map(CommitRequestImpl::getCommittable);
+    }
+
     /**
      * Iterates through all currently registered {@link #requests} and returns all {@link
      * CommittableWithLineage} that could be successfully committed.
@@ -184,7 +191,7 @@ class SubtaskCommittableManager<CommT> {
         return checkpointId;
     }
 
-    Deque<CommitRequestImpl<CommT>> getRequests() {
+    Collection<CommitRequestImpl<CommT>> getRequests() {
         return requests;
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java
@@ -63,6 +63,7 @@ class GlobalCommitterOperatorTest {
             if (commitOnInput) {
                 assertThat(committer.committed).containsExactly(1, 2);
             } else {
+                // 3PC behavior
                 assertThat(committer.committed).isEmpty();
                 testHarness.notifyOfCompletedCheckpoint(cid + 1);
                 assertThat(committer.committed).containsExactly(1, 2);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializerTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 import org.apache.flink.streaming.api.connector.sink2.IntegerSerializer;
-import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
@@ -205,11 +204,10 @@ class CommittableCollectorSerializerTest {
                                     checkpointCommittableManager.getSubtaskCommittableManager(
                                             subtaskId);
 
-                            SinkV2Assertions.assertThat(
-                                            checkpointCommittableManager.getSummary(
-                                                    subtaskId, numberOfSubtasks))
-                                    .hasSubtaskId(subtaskId)
-                                    .hasNumberOfSubtasks(numberOfSubtasks);
+                            assertThat(checkpointCommittableManager)
+                                    .returns(
+                                            numberOfSubtasks,
+                                            CheckpointCommittableManagerImpl::getNumberOfSubtasks);
 
                             assertPendingRequests(
                                     subtaskCommittableManager, expectedPendingRequestCount);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.runtime.operators.sink.committables;
 import org.apache.flink.metrics.groups.SinkCommitterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.MetricsGroupTestUtils;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
-import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 
 import org.junit.jupiter.api.Test;
 
@@ -59,7 +58,8 @@ class CommittableCollectorTest {
         Optional<CheckpointCommittableManager<Integer>> endOfInputCommittable =
                 committableCollector.getEndOfInputCommittable();
         assertThat(endOfInputCommittable).isPresent();
-        SinkV2Assertions.assertThat(endOfInputCommittable.get().getSummary(1, 1))
-                .hasCheckpointId(EOI);
+        assertThat(endOfInputCommittable)
+                .get()
+                .returns(EOI, CheckpointCommittableManager::getCheckpointId);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/deprecated/TestSinkV2.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/sink/deprecated/TestSinkV2.java
@@ -406,17 +406,17 @@ public class TestSinkV2<InputT> implements Sink<InputT> {
     /** A {@link Committer} that always re-commits the committables data it received. */
     public static class RetryOnceCommitter extends DefaultCommitter {
 
-        private final Set<CommitRequest<String>> seen = new LinkedHashSet<>();
+        private final Set<String> seen = new LinkedHashSet<>();
 
         @Override
         public void commit(Collection<CommitRequest<String>> committables) {
             committables.forEach(
                     c -> {
-                        if (seen.remove(c)) {
+                        if (seen.remove(c.getCommittable())) {
                             checkNotNull(committedData);
                             committedData.add(c);
                         } else {
-                            seen.add(c);
+                            seen.add(c.getCommittable());
                             c.retryLater();
                         }
                     });


### PR DESCRIPTION
Unchanged backport of #25661 based on #25746 (needs to be reviewed/merged first).