### PR TITLE
[FLINK-36857] Bump scala version to 2.12.20

### DIFF
--- a/flink-dist-scala/src/main/resources/META-INF/NOTICE
+++ b/flink-dist-scala/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
-- org.scala-lang:scala-compiler:2.12.7
-- org.scala-lang:scala-library:2.12.7
-- org.scala-lang:scala-reflect:2.12.7
-- org.scala-lang.modules:scala-xml_2.12:1.0.6
+- org.scala-lang:scala-compiler:2.12.20
+- org.scala-lang:scala-library:2.12.20
+- org.scala-lang:scala-reflect:2.12.20
+- org.scala-lang.modules:scala-xml_2.12:2.3.0

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -39,7 +39,6 @@ under the License.
 	<properties>
 		<pekko.version>1.1.2</pekko.version>
 		<scala.binary.version>2.12</scala.binary.version>
-		<scala.version>2.12.16</scala.version>
 	</properties>
 
 	<dependencies>

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -17,7 +17,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.pekko:pekko-protobuf-v3_2.12:1.1.2
 - org.apache.pekko:pekko-slf4j_2.12:1.1.2
 - org.apache.pekko:pekko-stream_2.12:1.1.2
-- org.scala-lang:scala-library:2.12.16
+- org.scala-lang:scala-library:2.12.20
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 

--- a/flink-table/flink-table-planner-loader-bundle/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-loader-bundle/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
-- org.scala-lang:scala-compiler:2.12.7
-- org.scala-lang:scala-library:2.12.7
-- org.scala-lang:scala-reflect:2.12.7
+- org.scala-lang:scala-compiler:2.12.20
+- org.scala-lang:scala-library:2.12.20
+- org.scala-lang:scala-reflect:2.12.20

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@ under the License.
 		<scala.macros.version>2.1.1</scala.macros.version>
 		<!-- Default scala versions, must be overwritten by build profiles, so we set something
 		invalid here -->
-		<scala.version>2.12.7</scala.version>
+		<scala.version>2.12.20</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
 		<!-- keep FlinkTestcontainersConfigurator.configureZookeeperContainer in sync -->
@@ -944,7 +944,7 @@ under the License.
 		<profile>
 			<id>scala-2.12</id>
 			<properties>
-				<scala.version>2.12.7</scala.version>
+				<scala.version>2.12.20</scala.version>
 				<scala.binary.version>2.12</scala.binary.version>
 			</properties>
 			<activation>
@@ -1071,8 +1071,6 @@ under the License.
 			</activation>
 
 			<properties>
-				<!-- Bump Scala because 2.12.7 doesn't compile on Java 17. -->
-				<scala.version>2.12.15</scala.version>
 				<surefire.excludedGroups.jdk>org.apache.flink.testutils.junit.FailsOnJava17</surefire.excludedGroups.jdk>
 			</properties>
 
@@ -1127,11 +1125,6 @@ under the License.
 			<activation>
 				<jdk>[21,)</jdk>
 			</activation>
-
-			<properties>
-				<!-- Bump Scala because before 2.12.18 doesn't compile on Java 21. -->
-				<scala.version>2.12.18</scala.version>
-			</properties>
 
 			<build>
 				<pluginManagement>


### PR DESCRIPTION
## What is the purpose of the change

Since minimum java version was bumped to 11 at https://github.com/apache/flink/commit/50716d6ad8008c6080e9211d212f8c948dd8b614

and also it was discussed at https://issues.apache.org/jira/browse/FLINK-36181#comment-17878101

## Brief change log

pom and NOTICE files


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
