### PR TITLE
[FLINK-36612][core] Fix TypeSerializer to detect lombok boolean with is prefix

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -2046,7 +2046,9 @@ public class TypeExtractor {
                 }
                 // check for setters (<FieldName>_$eq for scala)
                 if ((methodNameLow.equals("set" + fieldNameLow)
-                                || methodNameLow.equals(fieldNameLow + "_$eq"))
+                                || methodNameLow.equals(fieldNameLow + "_$eq")
+                                || (fieldNameLow.startsWith("is")
+                                        && methodNameLow.equals("set" + fieldNameLow.substring(2))))
                         && m.getParameterCount() == 1
                         && // one parameter of the field's type
                         (m.getGenericParameterTypes()[0].equals(fieldType)

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
@@ -940,6 +940,7 @@ public class PojoTypeExtractionTest {
     @NoArgsConstructor
     public static class TestLombok {
         private int age = 10;
+        private boolean isHealthy;
         private String name;
     }
 
@@ -950,6 +951,7 @@ public class PojoTypeExtractionTest {
 
         PojoTypeInfo<TestLombok> pti = (PojoTypeInfo<TestLombok>) ti;
         assertThat(pti.getTypeAt(0)).isEqualTo(BasicTypeInfo.INT_TYPE_INFO);
-        assertThat(pti.getTypeAt(1)).isEqualTo(BasicTypeInfo.STRING_TYPE_INFO);
+        assertThat(pti.getTypeAt(1)).isEqualTo(BasicTypeInfo.BOOLEAN_TYPE_INFO);
+        assertThat(pti.getTypeAt(2)).isEqualTo(BasicTypeInfo.STRING_TYPE_INFO);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

At the moment Flink not detecting Lombok generated setter correctly. For example `boolean isHealthy` field is generating `boolean isHealthy()` function and not `boolean isIsHealthy()`. In this PR I've added support for that.

## Brief change log

Fix TypeSerializer to detect lombok boolean with `is` prefix.

## Verifying this change

Modified existing automated test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?no
  - If yes, how is the feature documented? not applicable
