### PR TITLE
[FLINK-36860][State/v2] Make internal list state inherit the internal merging state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/StateRequestType.java
@@ -112,5 +112,8 @@ public enum StateRequestType {
     AGGREGATING_GET,
 
     /** Add element to aggregating state by {@link AggregatingState#asyncAdd(Object)}. */
-    AGGREGATING_ADD
+    AGGREGATING_ADD,
+
+    /** Defined by different state backends. */
+    CUSTOMIZED
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AbstractListState.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
 import org.apache.flink.runtime.state.v2.internal.InternalListState;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -82,5 +83,17 @@ public class AbstractListState<K, N, V> extends AbstractKeyedState<K, N, V>
     @Override
     public void addAll(List<V> values) {
         handleRequestSync(StateRequestType.LIST_ADD_ALL, values);
+    }
+
+    @Override
+    public StateFuture<Void> asyncMergeNamespaces(N target, Collection<N> sources) {
+        throw new UnsupportedOperationException(
+                getClass() + " has not implement the asyncMergeNamespaces().");
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) {
+        throw new UnsupportedOperationException(
+                getClass() + " has not implement the mergeNamespaces().");
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/CompleteStateIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/CompleteStateIterator.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.state.v2.StateFuture;
 import org.apache.flink.api.common.state.v2.StateIterator;
 import org.apache.flink.core.state.StateFutureUtils;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,9 +37,14 @@ public class CompleteStateIterator<T> implements StateIterator<T> {
     final Iterator<T> iterator;
     final boolean empty;
 
-    public CompleteStateIterator(Iterable<T> iterable) {
-        this.iterator = iterable.iterator();
-        this.empty = !iterator.hasNext();
+    public CompleteStateIterator(@Nullable Iterable<T> iterable) {
+        if (iterable == null) {
+            this.iterator = Collections.emptyIterator();
+            this.empty = true;
+        } else {
+            this.iterator = iterable.iterator();
+            this.empty = !iterator.hasNext();
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/ListStateAdaptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/adaptor/ListStateAdaptor.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.state.v2.StateIterator;
 import org.apache.flink.core.state.StateFutureUtils;
 import org.apache.flink.runtime.state.v2.internal.InternalListState;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -112,6 +113,25 @@ public class ListStateAdaptor<K, N, V>
             delegatedState.add(value);
         } catch (Exception e) {
             throw new RuntimeException("Error while adding value to raw ListState", e);
+        }
+    }
+
+    @Override
+    public StateFuture<Void> asyncMergeNamespaces(N target, Collection<N> sources) {
+        try {
+            delegatedState.mergeNamespaces(target, sources);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while merging namespaces in raw ListState", e);
+        }
+        return StateFutureUtils.completedVoidFuture();
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) {
+        try {
+            delegatedState.mergeNamespaces(target, sources);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while merging namespaces in raw ListState", e);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/internal/InternalAggregatingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/internal/InternalAggregatingState.java
@@ -31,4 +31,4 @@ import org.apache.flink.api.common.state.v2.AggregatingState;
 public interface InternalAggregatingState<K, N, IN, ACC, OUT>
         extends InternalMergingState<K, N, IN, ACC, OUT, OUT>,
                 AggregatingState<IN, OUT>,
-                InternalKeyedState<K, N, ACC> {}
+                InternalStateAccessible<ACC> {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/internal/InternalAppendingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/internal/InternalAppendingState.java
@@ -18,7 +18,6 @@
 package org.apache.flink.runtime.state.v2.internal;
 
 import org.apache.flink.api.common.state.v2.AppendingState;
-import org.apache.flink.api.common.state.v2.StateFuture;
 
 /**
  * This class defines the internal interface for appending state.
@@ -31,32 +30,4 @@ import org.apache.flink.api.common.state.v2.StateFuture;
  * @param <SYNCOUT> Type of the value that can be retrieved from the state by synchronous interface.
  */
 public interface InternalAppendingState<K, N, IN, SV, OUT, SYNCOUT>
-        extends InternalKeyedState<K, N, SV>, AppendingState<IN, OUT, SYNCOUT> {
-    /**
-     * Get internally stored value.
-     *
-     * @return internally stored value.
-     */
-    StateFuture<SV> asyncGetInternal();
-
-    /**
-     * Update internally stored value.
-     *
-     * @param valueToStore new value to store.
-     */
-    StateFuture<Void> asyncUpdateInternal(SV valueToStore);
-
-    /**
-     * Get internally stored value.
-     *
-     * @return internally stored value.
-     */
-    SV getInternal();
-
-    /**
-     * Update internally stored value.
-     *
-     * @param valueToStore new value to store.
-     */
-    void updateInternal(SV valueToStore);
-}
+        extends InternalKeyedState<K, N, SV>, AppendingState<IN, OUT, SYNCOUT> {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/internal/InternalReducingState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/internal/InternalReducingState.java
@@ -27,4 +27,6 @@ import org.apache.flink.api.common.state.v2.ReducingState;
  * @param <T> Type of the value in the operator state.
  */
 public interface InternalReducingState<K, N, T>
-        extends InternalAggregatingState<K, N, T, T, T>, ReducingState<T> {}
+        extends InternalAggregatingState<K, N, T, T, T>,
+                ReducingState<T>,
+                InternalStateAccessible<T> {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/internal/InternalStateAccessible.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/internal/InternalStateAccessible.java
@@ -18,17 +18,34 @@
 
 package org.apache.flink.runtime.state.v2.internal;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.state.v2.ListState;
-import org.apache.flink.api.common.state.v2.StateIterator;
+import org.apache.flink.api.common.state.v2.StateFuture;
 
-/**
- * This class defines the internal interface for list state.
- *
- * @param <K> The type of key the state is associated to.
- * @param <N> The namespace type.
- * @param <V> The type of the intermediate state.
- */
-@Internal
-public interface InternalListState<K, N, V>
-        extends InternalMergingState<K, N, V, V, StateIterator<V>, Iterable<V>>, ListState<V> {}
+public interface InternalStateAccessible<SV> {
+    /**
+     * Get internally stored value.
+     *
+     * @return internally stored value.
+     */
+    StateFuture<SV> asyncGetInternal();
+
+    /**
+     * Update internally stored value.
+     *
+     * @param valueToStore new value to store.
+     */
+    StateFuture<Void> asyncUpdateInternal(SV valueToStore);
+
+    /**
+     * Get internally stored value.
+     *
+     * @return internally stored value.
+     */
+    SV getInternal();
+
+    /**
+     * Update internally stored value.
+     *
+     * @param valueToStore new value to store.
+     */
+    void updateInternal(SV valueToStore);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ttl/TtlListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ttl/TtlListState.java
@@ -123,6 +123,16 @@ class TtlListState<K, N, T>
         return withTs;
     }
 
+    @Override
+    public StateFuture<Void> asyncMergeNamespaces(N target, Collection<N> sources) {
+        return original.asyncMergeNamespaces(target, sources);
+    }
+
+    @Override
+    public void mergeNamespaces(N target, Collection<N> sources) {
+        original.mergeNamespaces(target, sources);
+    }
+
     private class IteratorWithCleanup implements Iterator<T> {
         private final Iterator<TtlValue<T>> originalIterator;
         private boolean anyUnexpired = false;

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBMultiRawMergePutRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBMultiRawMergePutRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.core.state.InternalStateFuture;
+
+import org.forstdb.RocksDB;
+import org.forstdb.RocksDBException;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * The Put access request for ForStDB.
+ *
+ * @param <K> The type of key in put access request.
+ * @param <N> The type of namespace in put access request.
+ * @param <V> The type of value in put access request.
+ */
+public class ForStDBMultiRawMergePutRequest<K, N, V> extends ForStDBPutRequest<K, N, V> {
+
+    final Collection<byte[]> rawValue;
+
+    ForStDBMultiRawMergePutRequest(
+            ContextKey<K, N> key,
+            Collection<byte[]> value,
+            ForStInnerTable<K, N, V> table,
+            InternalStateFuture<Void> future) {
+        super(key, null, true, table, future);
+        this.rawValue = value;
+    }
+
+    @Override
+    public void process(ForStDBWriteBatchWrapper writeBatchWrapper, RocksDB db)
+            throws IOException, RocksDBException {
+        byte[] key = buildSerializedKey();
+        for (byte[] value : rawValue) {
+            writeBatchWrapper.merge(table.getColumnFamilyHandle(), key, value);
+        }
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBRawGetRequest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStDBRawGetRequest.java
@@ -16,19 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.v2.internal;
+package org.apache.flink.state.forst;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.state.v2.ListState;
-import org.apache.flink.api.common.state.v2.StateIterator;
+import org.apache.flink.core.state.InternalStateFuture;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
- * This class defines the internal interface for list state.
+ * The Get access request for ForStDB.
  *
- * @param <K> The type of key the state is associated to.
- * @param <N> The namespace type.
- * @param <V> The type of the intermediate state.
+ * @param <K> The type of key in get access request.
+ * @param <N> The type of namespace in get access request.
+ * @param <V> The type of value returned by get request.
  */
-@Internal
-public interface InternalListState<K, N, V>
-        extends InternalMergingState<K, N, V, V, StateIterator<V>, Iterable<V>>, ListState<V> {}
+public class ForStDBRawGetRequest<K, N, V> extends ForStDBGetRequest<K, N, List<V>, byte[]> {
+
+    ForStDBRawGetRequest(
+            ContextKey<K, N> key,
+            ForStInnerTable<K, N, List<V>> table,
+            InternalStateFuture<byte[]> future) {
+        super(key, table, future);
+    }
+
+    @Override
+    public void completeStateFuture(byte[] bytesValue) throws IOException {
+        future.complete(bytesValue);
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateRequestType.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStStateRequestType.java
@@ -16,19 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.state.v2.internal;
-
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.state.v2.ListState;
-import org.apache.flink.api.common.state.v2.StateIterator;
+package org.apache.flink.state.forst;
 
 /**
- * This class defines the internal interface for list state.
- *
- * @param <K> The type of key the state is associated to.
- * @param <N> The namespace type.
- * @param <V> The type of the intermediate state.
+ * ForSt customized state request other than {@link
+ * org.apache.flink.runtime.asyncprocessing.StateRequestType}.
  */
-@Internal
-public interface InternalListState<K, N, V>
-        extends InternalMergingState<K, N, V, V, StateIterator<V>, Iterable<V>>, ListState<V> {}
+public enum ForStStateRequestType {
+    /** Get the list in raw bytes without deserialization. */
+    LIST_GET_RAW,
+
+    /** Merge a list of raw bytes. */
+    MERGE_ALL_RAW
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStListStateTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStListStateTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.runtime.state.v2.ListStateDescriptor;
+import org.apache.flink.runtime.state.v2.internal.InternalListState;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link ForStListState}. */
+public class ForStListStateTest extends ForStStateTestBase {
+
+    @Test
+    public void testMergeNamespace() throws Exception {
+        ListStateDescriptor<Integer> descriptor =
+                new ListStateDescriptor<>("testState", BasicTypeInfo.INT_TYPE_INFO);
+        InternalListState<String, Integer, Integer> listState =
+                keyedBackend.createState(1, IntSerializer.INSTANCE, descriptor);
+
+        setCurrentContext("test", "test");
+        for (int i = 0; i < 10; i++) {
+            listState.setCurrentNamespace(i);
+            listState.asyncAdd(i);
+        }
+        drain();
+
+        setCurrentContext("test", "test");
+        for (int i = 0; i < 10; i++) {
+            listState.setCurrentNamespace(i);
+            Iterable<Integer> list = listState.get();
+            assertThat(list).containsExactly(i);
+        }
+        drain();
+
+        // 1~20
+        ArrayList<Integer> namespaces = new ArrayList<>();
+        for (int i = 1; i < 20; i++) {
+            namespaces.add(i);
+        }
+
+        setCurrentContext("test", "test");
+        listState
+                .asyncMergeNamespaces(0, namespaces)
+                .thenAccept(
+                        (e) -> {
+                            listState.setCurrentNamespace(0);
+                            Iterable<Integer> list = listState.get();
+                            assertThat(list).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                            for (int i = 1; i < 10; i++) {
+                                listState.setCurrentNamespace(i);
+                                assertThat(listState.get()).isNullOrEmpty();
+                            }
+                        });
+        drain();
+
+        // test sync method
+        setCurrentContext("test", "test");
+        for (int i = 10; i < 20; i++) {
+            listState.setCurrentNamespace(i);
+            listState.add(i);
+        }
+        drain();
+
+        setCurrentContext("test", "test");
+        listState.mergeNamespaces(0, namespaces);
+        listState.setCurrentNamespace(0);
+        Iterable<Integer> list = listState.get();
+        assertThat(list)
+                .containsExactly(
+                        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19);
+
+        for (int i = 1; i < 20; i++) {
+            listState.setCurrentNamespace(i);
+            assertThat(listState.get()).isNullOrEmpty();
+        }
+        drain();
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateTestBase.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst;
+
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
+import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.apache.flink.state.forst.ForStTestUtils.createKeyedStateBackend;
+
+/**
+ * A base class for all forst state tests, providing building the AEC and StateBackend logic, and
+ * some tool methods.
+ */
+public class ForStStateTestBase {
+
+    protected ForStKeyedStateBackend<String> keyedBackend;
+
+    protected AsyncExecutionController<String> aec;
+
+    protected MailboxExecutor mailboxExecutor;
+
+    protected RecordContext<String> context;
+
+    @BeforeEach
+    public void setup(@TempDir File temporaryFolder) throws IOException {
+        FileSystem.initialize(new Configuration(), null);
+        Configuration configuration = new Configuration();
+        configuration.set(ForStOptions.REMOTE_DIRECTORY, temporaryFolder.toURI().toString());
+        ForStStateBackend forStStateBackend =
+                new ForStStateBackend().configure(configuration, null);
+
+        keyedBackend =
+                createKeyedStateBackend(
+                        forStStateBackend,
+                        getMockEnvironment(temporaryFolder),
+                        StringSerializer.INSTANCE);
+
+        mailboxExecutor =
+                new MailboxExecutorImpl(
+                        new TaskMailboxImpl(), 0, StreamTaskActionExecutor.IMMEDIATE);
+
+        aec =
+                new AsyncExecutionController<>(
+                        mailboxExecutor,
+                        (a, b) -> {},
+                        keyedBackend.createStateExecutor(),
+                        1,
+                        100,
+                        0,
+                        1,
+                        null);
+        keyedBackend.setup(aec);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        keyedBackend.close();
+    }
+
+    protected void setCurrentContext(Object record, String key) {
+        context = aec.buildContext(record, key);
+        context.retain();
+        aec.setCurrentContext(context);
+    }
+
+    protected void drain() {
+        context.release();
+        aec.drainInflightRecords(0);
+    }
+
+    private static MockEnvironment getMockEnvironment(File tempDir) {
+        return MockEnvironment.builder()
+                .setUserCodeClassLoader(ForStStateBackendConfigTest.class.getClassLoader())
+                .setTaskManagerRuntimeInfo(
+                        new TestingTaskManagerRuntimeInfo(new Configuration(), tempDir))
+                .build();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

There is a internal state interface hierarchy for state v2, which is pretty much like the one for state v1. Currently the `InternalListState` does not extend from `InternalMergingState` for convenience of class type parameter signature. However, the table implementation depends on the inheritance, so this PR adds it back.

## Brief change log

 - Extract a `InternalStateAccessible` interface from `InternalAppendingState`
 - Make `InternalListState` inherit `InternalMergingState`
 - Implement necessary methods from `InternalMergingState` for existing List States.

 - Also, a hotfix fixing the state adaptor

## Verifying this change

This change added tests `ForStListStateTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
