### PR TITLE
[FLINK-36859][Runtime] Fix wrong epoch/watermark firing in async state processing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/EpochManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/EpochManager.java
@@ -111,7 +111,8 @@ public class EpochManager {
      * @param epoch the specific epoch
      */
     public void completeOneRecord(Epoch epoch) {
-        if (--epoch.ongoingRecordCount == 0) {
+        // Only the epoch that is not active can trigger finish.
+        if (--epoch.ongoingRecordCount == 0 && epoch != activeEpoch) {
             tryFinishInQueue();
         }
     }
@@ -181,11 +182,13 @@ public class EpochManager {
         /**
          * Try to finish this epoch.
          *
-         * @return whether this epoch has been finished.
+         * @return whether this epoch has been normally finished.
          */
         boolean tryFinish() {
             if (this.status == EpochStatus.FINISHED) {
-                return true;
+                // This epoch has been finished for some reason, but it is not finished here.
+                // Preventing recursive call of #tryFinishInQueue().
+                return false;
             }
             if (ongoingRecordCount == 0 && this.status == EpochStatus.CLOSED) {
                 this.status = EpochStatus.FINISHED;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/EpochManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/EpochManagerTest.java
@@ -57,5 +57,15 @@ class EpochManagerTest {
         assertThat(epochManager.outputQueue.size()).isEqualTo(0);
         assertThat(epochManager.activeEpoch.ongoingRecordCount).isEqualTo(0);
         assertThat(epochManager.activeEpoch.status).isEqualTo(EpochStatus.OPEN);
+
+        // Test if in the action there is a record processing. Should not be any error.
+        epochManager.onNonRecord(
+                () -> {
+                    output.incrementAndGet();
+                    Epoch epoch4 = epochManager.onRecord();
+                    epochManager.completeOneRecord(epoch4);
+                },
+                ParallelMode.PARALLEL_BETWEEN_EPOCH);
+        assertThat(output.get()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, we use `EpochManager` to manage the watermark in async state processing. We found an issue when a watermark reached and no further input reach for a while, the epoch/watermark will be triggered twice. Current PR fix this.

## Brief change log

 - Stricter conditions to ensure no recursive call of triggering.

## Verifying this change

This change modified test `EpochManagerTest` that can verify this.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
