### PR TITLE
[FLINK-36856][runtime] CollectSinkOperatorFactory batch size and socket timeout config fix

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -51,6 +51,7 @@ import org.apache.flink.api.java.io.TextOutputFormat;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.RpcOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.fs.FileSystem.WriteMode;
@@ -109,6 +110,7 @@ import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.OutputTag;
 import org.apache.flink.util.Preconditions;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -1439,8 +1441,13 @@ public class DataStream<T> {
         String accumulatorName = "dataStreamCollect_" + UUID.randomUUID().toString();
 
         StreamExecutionEnvironment env = getExecutionEnvironment();
+        MemorySize maxBatchSize =
+                env.getConfiguration().get(CollectSinkOperatorFactory.MAX_BATCH_SIZE);
+        Duration socketTimeout =
+                env.getConfiguration().get(CollectSinkOperatorFactory.SOCKET_TIMEOUT);
         CollectSinkOperatorFactory<T> factory =
-                new CollectSinkOperatorFactory<>(serializer, accumulatorName);
+                new CollectSinkOperatorFactory<>(
+                        serializer, accumulatorName, maxBatchSize, socketTimeout);
         CollectSinkOperator<T> operator = (CollectSinkOperator<T>) factory.getOperator();
         long resultFetchTimeout =
                 env.getConfiguration().get(RpcOptions.ASK_TIMEOUT_DURATION).toMillis();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkFunction.java
@@ -167,6 +167,10 @@ public class CollectSinkFunction<IN> extends RichSinkFunction<IN>
         this.accumulatorName = accumulatorName;
     }
 
+    public long getMaxBytesPerBatch() {
+        return maxBytesPerBatch;
+    }
+
     private void initBuffer() {
         if (buffer != null) {
             return;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorFactory.java
@@ -58,6 +58,10 @@ public class CollectSinkOperatorFactory<IN> extends SimpleUdfStreamOperatorFacto
         this.socketTimeoutMillis = (int) socketTimeout.toMillis();
     }
 
+    public int getSocketTimeoutMillis() {
+        return socketTimeoutMillis;
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public <T extends StreamOperator<Object>> T createStreamOperator(

--- a/flink-tests/src/test/java/org/apache/flink/api/datastream/DataStreamCollectTestITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/datastream/DataStreamCollectTestITCase.java
@@ -18,10 +18,16 @@
 package org.apache.flink.api.datastream;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.collect.CollectSinkFunction;
+import org.apache.flink.streaming.api.operators.collect.CollectSinkOperator;
+import org.apache.flink.streaming.api.operators.collect.CollectSinkOperatorFactory;
+import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.TestLogger;
@@ -30,6 +36,7 @@ import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -109,6 +116,31 @@ public class DataStreamCollectTestITCase extends TestLogger {
                 "Failed to collect the correct number of elements from the stream",
                 1,
                 results.size());
+    }
+
+    @Test
+    public void testAsyncCollectWithSinkConfigs() {
+        Configuration configuration = new Configuration();
+        configuration.set(CollectSinkOperatorFactory.SOCKET_TIMEOUT, Duration.ofMillis(2));
+        configuration.set(CollectSinkOperatorFactory.MAX_BATCH_SIZE, new MemorySize(3));
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+
+        final DataStream<Integer> stream = env.fromData(1, 2, 3, 4, 5);
+        stream.collectAsync();
+
+        List<Transformation<?>> transformations = env.getTransformations();
+        Assert.assertEquals(1, transformations.size());
+        LegacySinkTransformation<?> transformation =
+                (LegacySinkTransformation<?>) transformations.get(transformations.size() - 1);
+        CollectSinkOperatorFactory<?> collectSinkOperatorFactory =
+                (CollectSinkOperatorFactory<?>) transformation.getOperatorFactory();
+        CollectSinkFunction<?> collectSinkFunction =
+                ((CollectSinkFunction<?>)
+                        ((CollectSinkOperator<?>) collectSinkOperatorFactory.getOperator())
+                                .getUserFunction());
+        Assert.assertEquals(2, collectSinkOperatorFactory.getSocketTimeoutMillis());
+        Assert.assertEquals(3, collectSinkFunction.getMaxBytesPerBatch());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This is basically a backport of 1.20 from https://github.com/apache/flink/pull/25755.

`CollectSinkOperatorFactory` is not respecting `collect-sink.batch-size.max` and `collect-sink.socket-timeout` configuration but only the default value used. As a result state reading can blow up. In this PR I've changed `CollectSinkOperatorFactory` to read the mentioned 2 parameters.

## Brief change log

`CollectSinkOperatorFactory` is now reading the mentioned 2 parameters.

## Verifying this change

Trivial change + manual with state reading.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
