### PR TITLE
[hotfix] [docs] Fix the google-java-format level in docs in line with PR 25714

### DIFF
--- a/docs/content.zh/docs/flinkDev/ide_setup.md
+++ b/docs/content.zh/docs/flinkDev/ide_setup.md
@@ -87,7 +87,7 @@ IntelliJ 提供了插件设置来安装 Scala 插件。如果尚未安装，请�
                                                                                                                                                                                                                                               
 你可以通过以下步骤来将 IDE 配置为在保存时自动应用格式设置：
 
-1. 下载 [google-java-format plugin v1.7.0.6](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/115957)
+1. 下载 [google-java-format v1.24.0.0](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/614263)
 2. 打开 Settings → Plugins，点击齿轮图标并选择 "Install Plugin from Disk"。导航到下载的 zip 文件并选择它。
 3. 在插件设置中，启用插件并将代码样式更改为 "AOSP"（4 个空格的缩进）。
 4. 请记住不要将此插件更新为更高版本！

--- a/docs/content/docs/flinkDev/ide_setup.md
+++ b/docs/content/docs/flinkDev/ide_setup.md
@@ -124,7 +124,7 @@ install them, and restart the IDE if prompted:
 
 You will also need to install the [google-java-format](https://github.com/google/google-java-format)
 plugin. However, a specific version of this plugin is required. Download
-[google-java-format v1.7.0.6](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/115957)
+[google-java-format v1.24.0.0](https://plugins.jetbrains.com/plugin/8527-google-java-format/versions/stable/614263)
 and install it as follows. Make sure to never update this plugin.
 
 1. Go to "Settings" → "Plugins".


### PR DESCRIPTION
After  [https://github.com/apache/flink/pull/25714](https://github.com/apache/flink/pull/25714) the level of google-java-format required changed. The documentation refers to this level in the IDE setup. This is a hotfix to amend the documentation so it refers to the correct version in line with 25714.