### PR TITLE
[FLINK-36871][runtime] add rescale metrics in scheduler

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1271,7 +1271,12 @@ Whether these metrics are reported depends on the [metrics.job.status.enable]({{
     </tr>
     <tr>
       <td>numRestarts</td>
-      <td>The total number of restarts since this job was submitted, including full restarts and fine-grained restarts.</td>
+      <td>The total number of restarts since this job was submitted, including full restarts, fine-grained restarts and restarts triggered by rescaling.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>numRescales</td>
+      <td>The total number of restarts triggered by rescaling, including scale up and scale down.</td>
       <td>Gauge</td>
     </tr>
   </tbody>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1262,7 +1262,12 @@ Whether these metrics are reported depends on the [metrics.job.status.enable]({{
     </tr>
     <tr>
       <td>numRestarts</td>
-      <td>The total number of restarts since this job was submitted, including full restarts and fine-grained restarts.</td>
+      <td>The total number of restarts since this job was submitted, including full restarts, fine-grained restarts and restarts triggered by rescaling.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>numRescales</td>
+      <td>The total number of restarts triggered by rescaling, including scale up and scale down.</td>
       <td>Gauge</td>
     </tr>
   </tbody>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -52,6 +52,7 @@ public class MetricNames {
     public static final String NUM_PENDING_TASK_MANAGERS = "numPendingTaskManagers";
 
     public static final String NUM_RESTARTS = "numRestarts";
+    public static final String NUM_RESCALES = "numRescales";
 
     public static final String MEMORY_USED = "Used";
     public static final String MEMORY_COMMITTED = "Committed";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -224,6 +224,12 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
     }
 
     @Override
+    protected long getNumberOfRescales() {
+        // It is always 0 for DefaultScheduler.
+        return 0;
+    }
+
+    @Override
     protected void cancelAllPendingSlotRequestsInternal() {
         getSchedulingTopology()
                 .getVertices()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -595,6 +595,8 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
 
     protected abstract long getNumberOfRestarts();
 
+    protected abstract long getNumberOfRescales();
+
     protected MarkPartitionFinishedStrategy getMarkPartitionFinishedStrategy() {
         // blocking partition always need mark finished.
         return ResultPartitionType::isBlockingOrBlockingPersistentResultPartition;
@@ -641,6 +643,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
                 jobManagerJobMetricGroup,
                 executionGraph,
                 this::getNumberOfRestarts,
+                this::getNumberOfRescales,
                 deploymentStateTimeMetrics,
                 executionGraph::registerJobStatusListener,
                 executionGraph.getStatusTimestamp(JobStatus.INITIALIZING),
@@ -653,6 +656,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
             MetricGroup metrics,
             JobStatusProvider jobStatusProvider,
             Gauge<Long> numberOfRestarts,
+            Gauge<Long> numberOfRescales,
             DeploymentStateTimeMetrics deploymentTimeMetrics,
             Consumer<JobStatusListener> jobStatusListenerRegistrar,
             long initializationTimestamp,
@@ -660,6 +664,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         metrics.gauge(DownTimeGauge.METRIC_NAME, new DownTimeGauge(jobStatusProvider));
         metrics.gauge(UpTimeGauge.METRIC_NAME, new UpTimeGauge(jobStatusProvider));
         metrics.gauge(MetricNames.NUM_RESTARTS, numberOfRestarts::getValue);
+        metrics.gauge(MetricNames.NUM_RESCALES, numberOfRescales::getValue);
 
         final JobStatusMetrics jobStatusMetrics =
                 new JobStatusMetrics(initializationTimestamp, jobStatusMetricsSettings);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -403,6 +403,8 @@ public class AdaptiveScheduler
 
     private int numRestarts = 0;
 
+    private int numRescales = 0;
+
     private final MutableVertexAttemptNumberStore vertexAttemptNumberStore =
             new DefaultVertexAttemptNumberStore();
 
@@ -556,6 +558,7 @@ public class AdaptiveScheduler
                 jobManagerJobMetricGroup,
                 jobStatusStore,
                 () -> (long) numRestarts,
+                () -> (long) numRescales,
                 deploymentTimeMetrics,
                 tmpJobStatusListeners::add,
                 initializationTimestamp,
@@ -1266,7 +1269,11 @@ public class AdaptiveScheduler
                         forcedRestart,
                         userCodeClassLoader,
                         failureCollection));
+
         numRestarts++;
+        if (failureCollection.isEmpty()) {
+            numRescales++;
+        }
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockRestartingContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/MockRestartingContext.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive;
+
+import org.apache.flink.core.testutils.CompletedScheduledFuture;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
+import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
+import org.apache.flink.runtime.scheduler.exceptionhistory.ExceptionHistoryEntry;
+import org.apache.flink.runtime.scheduler.exceptionhistory.RootExceptionHistoryEntry;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.Consumer;
+
+import static org.apache.flink.runtime.scheduler.adaptive.WaitingForResourcesTest.assertNonNull;
+
+/** Mock the {@link StateWithExecutionGraph.Context} for restarting state. */
+class MockRestartingContext extends MockStateWithExecutionGraphContext
+        implements Restarting.Context {
+
+    private final StateValidator<ExecutingTest.CancellingArguments> cancellingStateValidator =
+            new StateValidator<>("Cancelling");
+
+    private final StateValidator<ExecutionGraph> waitingForResourcesStateValidator =
+            new StateValidator<>("WaitingForResources");
+
+    private final StateValidator<ExecutionGraph> creatingExecutionGraphStateValidator =
+            new StateValidator<>("CreatingExecutionGraph");
+
+    public void setExpectCancelling(Consumer<ExecutingTest.CancellingArguments> asserter) {
+        cancellingStateValidator.expectInput(asserter);
+    }
+
+    public void setExpectWaitingForResources() {
+        waitingForResourcesStateValidator.expectInput(assertNonNull());
+    }
+
+    public void setExpectCreatingExecutionGraph() {
+        creatingExecutionGraphStateValidator.expectInput(assertNonNull());
+    }
+
+    @Override
+    public void goToCanceling(
+            ExecutionGraph executionGraph,
+            ExecutionGraphHandler executionGraphHandler,
+            OperatorCoordinatorHandler operatorCoordinatorHandler,
+            List<ExceptionHistoryEntry> failureCollection) {
+        cancellingStateValidator.validateInput(
+                new ExecutingTest.CancellingArguments(
+                        executionGraph, executionGraphHandler, operatorCoordinatorHandler));
+        hadStateTransition = true;
+    }
+
+    @Override
+    public void archiveFailure(RootExceptionHistoryEntry failure) {}
+
+    @Override
+    public void goToWaitingForResources(@Nullable ExecutionGraph previousExecutionGraph) {
+        waitingForResourcesStateValidator.validateInput(previousExecutionGraph);
+        hadStateTransition = true;
+    }
+
+    @Override
+    public void goToCreatingExecutionGraph(@Nullable ExecutionGraph previousExecutionGraph) {
+        creatingExecutionGraphStateValidator.validateInput(previousExecutionGraph);
+        hadStateTransition = true;
+    }
+
+    @Override
+    public ScheduledFuture<?> runIfState(State expectedState, Runnable action, Duration delay) {
+        if (!hadStateTransition) {
+            action.run();
+        }
+        return CompletedScheduledFuture.create(null);
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        cancellingStateValidator.close();
+        waitingForResourcesStateValidator.close();
+        creatingExecutionGraphStateValidator.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add numRescales metrics in Scheduler to distinguish the restart caused by auto scaler.

## Brief change log

  - add numRescales metrics in Scheduler
  - change the interfaces in Context to distinguish whether a goToRestarting is trigged due to failure


## Verifying this change
  - Add test cases for the new metrics.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (o)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
