### PR TITLE
[FLINK-36868][State] Provide file system methods with string parameters for ForSt JNI

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
 - com.ververica:frocksdbjni:8.10.0-ververica-beta-1.0
-- com.ververica:forstjni:0.1.3-beta
+- com.ververica:forstjni:0.1.4-beta
 - commons-cli:commons-cli:1.5.0
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.15.1

--- a/flink-state-backends/flink-statebackend-forst/pom.xml
+++ b/flink-state-backends/flink-statebackend-forst/pom.xml
@@ -63,7 +63,7 @@ under the License.
 		<dependency>
 			<groupId>com.ververica</groupId>
 			<artifactId>forstjni</artifactId>
-			<version>0.1.3-beta</version>
+			<version>0.1.4-beta</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/ForStResourceContainer.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.state.forst.fs.ForStFlinkFileSystem;
+import org.apache.flink.state.forst.fs.StringifiedForStFileSystem;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
@@ -100,7 +101,7 @@ public final class ForStResourceContainer implements AutoCloseable {
     @Nullable private final ForStOptionsFactory optionsFactory;
 
     /** The ForSt file system. Null when remote dir is not set. */
-    @Nullable private ForStFlinkFileSystem forstFileSystem;
+    @Nullable private ForStFlinkFileSystem forStFileSystem;
 
     /**
      * The shared resource among ForSt instances. This resource is not part of the 'handlesToClose',
@@ -190,7 +191,10 @@ public final class ForStResourceContainer implements AutoCloseable {
         // configured,
         //  fallback to local directory currently temporarily.
         if (remoteForStPath != null) {
-            flinkEnv = new FlinkEnv(remoteForStPath.toString(), forstFileSystem);
+            flinkEnv =
+                    new FlinkEnv(
+                            remoteForStPath.toString(),
+                            new StringifiedForStFileSystem(forStFileSystem));
             opt.setEnv(flinkEnv);
         }
 
@@ -341,19 +345,19 @@ public final class ForStResourceContainer implements AutoCloseable {
                         "Cache base path is not configured, set to local base path: {}",
                         cacheBasePath);
             }
-            forstFileSystem =
+            forStFileSystem =
                     ForStFlinkFileSystem.get(
                             remoteForStPath.toUri(),
                             localForStPath,
                             ForStFlinkFileSystem.getFileBasedCache(
                                     cacheBasePath, cacheCapacity, cacheReservedSize));
         } else {
-            forstFileSystem = null;
+            forStFileSystem = null;
         }
     }
 
     public ForStFlinkFileSystem getFileSystem() {
-        return forstFileSystem;
+        return forStFileSystem;
     }
 
     private static void prepareDirectories(Path basePath, Path dbPath) throws IOException {

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFileStatus.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFileStatus.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.fs;
+
+import org.apache.flink.core.fs.FileStatus;
+
+/**
+ * A wrapper of {@link FileStatus} just for ForSt. It delegates all the methods from {@link
+ * FileStatus} and provide a version of primitive types. This class is used by JNI.
+ */
+public class ForStFileStatus {
+
+    private final FileStatus fileStatus;
+
+    public ForStFileStatus(FileStatus fileStatus) {
+        this.fileStatus = fileStatus;
+    }
+
+    public long getLen() {
+        return fileStatus.getLen();
+    }
+
+    public long getBlockSize() {
+        return fileStatus.getBlockSize();
+    }
+
+    public short getReplication() {
+        return fileStatus.getReplication();
+    }
+
+    public long getModificationTime() {
+        return fileStatus.getModificationTime();
+    }
+
+    public long getAccessTime() {
+        return fileStatus.getAccessTime();
+    }
+
+    public boolean isDir() {
+        return fileStatus.isDir();
+    }
+
+    public String getPath() {
+        return fileStatus.getPath().toString();
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/ForStFlinkFileSystem.java
@@ -373,4 +373,8 @@ public class ForStFlinkFileSystem extends FileSystem {
         }
         return Tuple2.of(false, null);
     }
+
+    public int link(Path src, Path dst) throws IOException {
+        return -1;
+    }
 }

--- a/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/StringifiedForStFileSystem.java
+++ b/flink-state-backends/flink-statebackend-forst/src/main/java/org/apache/flink/state/forst/fs/StringifiedForStFileSystem.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.forst.fs;
+
+import org.apache.flink.core.fs.Path;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+
+/**
+ * A {@link ForStFlinkFileSystem} stringifies all the parameters of all methods. This class is used
+ * by JNI.
+ */
+public class StringifiedForStFileSystem {
+
+    private ForStFlinkFileSystem fileSystem;
+
+    public StringifiedForStFileSystem(ForStFlinkFileSystem fileSystem) {
+        this.fileSystem = fileSystem;
+    }
+
+    public static StringifiedForStFileSystem get(String uri) throws IOException {
+        return new StringifiedForStFileSystem(ForStFlinkFileSystem.get(URI.create(uri)));
+    }
+
+    public boolean exists(final String path) throws IOException {
+        return fileSystem.exists(new Path(path));
+    }
+
+    public ForStFileStatus getFileStatus(String path) throws IOException {
+        return new ForStFileStatus(fileSystem.getFileStatus(new Path(path)));
+    }
+
+    public ForStFileStatus[] listStatus(String path) throws IOException {
+        return Arrays.stream(fileSystem.listStatus(new Path(path)))
+                .map(ForStFileStatus::new)
+                .toArray(ForStFileStatus[]::new);
+    }
+
+    public boolean delete(String path, boolean recursive) throws IOException {
+        return fileSystem.delete(new Path(path), recursive);
+    }
+
+    public boolean mkdirs(String path) throws IOException {
+        return fileSystem.mkdirs(new Path(path));
+    }
+
+    public boolean rename(String src, String dst) throws IOException {
+        return fileSystem.rename(new Path(src), new Path(dst));
+    }
+
+    public ByteBufferReadableFSDataInputStream open(String path) throws IOException {
+        return fileSystem.open(new Path(path));
+    }
+
+    public ByteBufferWritableFSDataOutputStream create(String path) throws IOException {
+        return fileSystem.create(new Path(path));
+    }
+
+    public int link(String src, String dst) throws IOException {
+        return fileSystem.link(new Path(src), new Path(dst));
+    }
+}

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStResourceContainerTest.java
@@ -19,10 +19,10 @@
 package org.apache.flink.state.forst;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.state.forst.fs.ForStFlinkFileSystem;
+import org.apache.flink.state.forst.fs.StringifiedForStFileSystem;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.forstdb.BlockBasedTableConfig;
@@ -331,9 +331,11 @@ public class ForStResourceContainerTest {
         columnFamilyDescriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
         DBOptions dbOptions2 =
                 new DBOptions().setCreateIfMissing(true).setAvoidFlushDuringShutdown(true);
-        FileSystem forstFileSystem =
+        ForStFlinkFileSystem fileSystem =
                 ForStFlinkFileSystem.get(remoteBasePath.toUri(), localBasePath, null);
-        dbOptions2.setEnv(new FlinkEnv(remoteBasePath.toString(), forstFileSystem));
+        dbOptions2.setEnv(
+                new FlinkEnv(
+                        remoteBasePath.toString(), new StringifiedForStFileSystem(fileSystem)));
         RocksDB db =
                 RocksDB.open(
                         dbOptions2,


### PR DESCRIPTION
## What is the purpose of the change

Currently, the ForSt core use `ForStFlinkFileSystem` via JNI to manipulate files. However, the parameter and return value contains `Path`, which introduces redundant JNI call to convert from/to std::string. This PR provides methods with string directly.

## Brief change log

- Introduce proxy classes with string input and output. 
- Bump ForSt version to 0.1.4-beta which uses the stringified methods.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
