### PR TITLE
[hotfix] [gitignore] ignore .vscode folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ scalastyle-output.xml
 .idea/*
 !.idea/vcs.xml
 !.idea/icon.png
+.vscode
 .metadata
 .settings
 .project


### PR DESCRIPTION
If you use VS code on the Flink folder then it generates a folder called .vscode. This folder should not be checked into Flink. At some later stage we may want to enforce some vscode formatting or the like. But for now we should make sure it dos not get checked into Git.  
