### PR TITLE
[BP-1.19][FLINK-36451][runtime] Replaces LeaderElection#hasLeadership with LeaderElection#runAsLeader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
@@ -177,12 +177,9 @@ public final class DefaultDispatcherRunner implements DispatcherRunner, LeaderCo
                 newDispatcherLeaderProcess
                         .getLeaderAddressFuture()
                         .thenAccept(
-                                leaderAddress -> {
-                                    if (leaderElection.hasLeadership(leaderSessionID)) {
+                                leaderAddress ->
                                         leaderElection.confirmLeadership(
-                                                leaderSessionID, leaderAddress);
-                                    }
-                                }));
+                                                leaderSessionID, leaderAddress)));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunner.java
@@ -176,9 +176,9 @@ public final class DefaultDispatcherRunner implements DispatcherRunner, LeaderCo
         FutureUtils.assertNoException(
                 newDispatcherLeaderProcess
                         .getLeaderAddressFuture()
-                        .thenAccept(
+                        .thenCompose(
                                 leaderAddress ->
-                                        leaderElection.confirmLeadership(
+                                        leaderElection.confirmLeadershipAsync(
                                                 leaderSessionID, leaderAddress)));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.highavailability.JobResultStore;
 import org.apache.flink.runtime.jobmaster.factories.JobMasterServiceProcessFactory;
 import org.apache.flink.runtime.leaderelection.LeaderContender;
 import org.apache.flink.runtime.leaderelection.LeaderElection;
-import org.apache.flink.runtime.leaderelection.LeadershipLostException;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -256,26 +255,10 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
         sequentialOperation =
                 sequentialOperation.thenCompose(
                         unused ->
-                                supplyAsyncIfValidLeader(
-                                                leaderSessionId,
-                                                () ->
-                                                        jobResultStore.hasJobResultEntryAsync(
-                                                                getJobID()),
-                                                () ->
-                                                        FutureUtils.completedExceptionally(
-                                                                new LeadershipLostException(
-                                                                        "The leadership is lost.")))
-                                        .handle(
-                                                (hasJobResult, throwable) -> {
-                                                    if (throwable
-                                                            instanceof LeadershipLostException) {
-                                                        printLogIfNotValidLeader(
-                                                                "verify job result entry",
-                                                                leaderSessionId);
-                                                        return null;
-                                                    } else if (throwable != null) {
-                                                        ExceptionUtils.rethrow(throwable);
-                                                    }
+                                jobResultStore
+                                        .hasJobResultEntryAsync(getJobID())
+                                        .thenAccept(
+                                                hasJobResult -> {
                                                     if (hasJobResult) {
                                                         handleJobAlreadyDoneIfValidLeader(
                                                                 leaderSessionId);
@@ -283,7 +266,6 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
                                                         createNewJobMasterServiceProcessIfValidLeader(
                                                                 leaderSessionId);
                                                     }
-                                                    return null;
                                                 }));
         handleAsyncOperationError(sequentialOperation, "Could not start the job manager.");
     }
@@ -515,19 +497,6 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
                 () ->
                         printLogIfNotValidLeader(
                                 noLeaderFallbackCommandDescription, expectedLeaderId));
-    }
-
-    private <T> CompletableFuture<T> supplyAsyncIfValidLeader(
-            UUID expectedLeaderId,
-            Supplier<CompletableFuture<T>> supplier,
-            Supplier<CompletableFuture<T>> noLeaderFallback) {
-        final CompletableFuture<T> resultFuture = new CompletableFuture<>();
-        runIfValidLeader(
-                expectedLeaderId,
-                () -> FutureUtils.forward(supplier.get(), resultFuture),
-                () -> FutureUtils.forward(noLeaderFallback.get(), resultFuture));
-
-        return resultFuture;
     }
 
     @GuardedBy("lock")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterServiceLeadershipRunner.java
@@ -356,8 +356,7 @@ public class JobMasterServiceLeadershipRunner implements JobManagerRunner, Leade
         FutureUtils.assertNoException(
                 leaderAddressFuture.thenAccept(
                         address ->
-                                runIfValidLeader(
-                                        leaderSessionId,
+                                runIfStateRunning(
                                         () -> {
                                             LOG.debug("Confirm leadership {}.", leaderSessionId);
                                             leaderElection.confirmLeadership(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.leaderelection;
 import org.apache.flink.util.Preconditions;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * {@code DefaultLeaderElection} implements the {@link LeaderElection} based on the {@link
@@ -43,13 +44,14 @@ class DefaultLeaderElection implements LeaderElection {
     }
 
     @Override
-    public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
-        parentService.confirmLeadership(componentId, leaderSessionID, leaderAddress);
+    public CompletableFuture<Void> confirmLeadershipAsync(
+            UUID leaderSessionID, String leaderAddress) {
+        return parentService.confirmLeadershipAsync(componentId, leaderSessionID, leaderAddress);
     }
 
     @Override
-    public boolean hasLeadership(UUID leaderSessionId) {
-        return parentService.hasLeadership(componentId, leaderSessionId);
+    public CompletableFuture<Boolean> hasLeadershipAsync(UUID leaderSessionId) {
+        return parentService.hasLeadershipAsync(componentId, leaderSessionId);
     }
 
     @Override
@@ -81,7 +83,7 @@ class DefaultLeaderElection implements LeaderElection {
          * the {@link LeaderContender} that is associated with the {@code componentId}. The
          * information is only propagated to the HA backend if the leadership is still acquired.
          */
-        abstract void confirmLeadership(
+        abstract CompletableFuture<Void> confirmLeadershipAsync(
                 String componentId, UUID leaderSessionID, String leaderAddress);
 
         /**
@@ -91,6 +93,7 @@ class DefaultLeaderElection implements LeaderElection {
          * @return {@code true} if the service has leadership with the passed {@code
          *     leaderSessionID} acquired; {@code false} otherwise.
          */
-        abstract boolean hasLeadership(String componentId, UUID leaderSessionID);
+        abstract CompletableFuture<Boolean> hasLeadershipAsync(
+                String componentId, UUID leaderSessionID);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElection.java
@@ -78,7 +78,8 @@ class DefaultLeaderElection implements LeaderElection {
 
         /**
          * Confirms the leadership with the {@code leaderSessionID} and {@code leaderAddress} for
-         * the {@link LeaderContender} that is associated with the {@code componentId}.
+         * the {@link LeaderContender} that is associated with the {@code componentId}. The
+         * information is only propagated to the HA backend if the leadership is still acquired.
          */
         abstract void confirmLeadership(
                 String componentId, UUID leaderSessionID, String leaderAddress);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElection.java
@@ -33,6 +33,8 @@ public interface LeaderElection extends AutoCloseable {
      * Confirms that the {@link LeaderContender} has accepted the leadership identified by the given
      * leader session id. It also publishes the leader address under which the leader is reachable.
      *
+     * <p>The data is only confirmed if the leadership is still acquired.
+     *
      * <p>The intention of this method is to establish an order between setting the new leader
      * session ID in the {@link LeaderContender} and publishing the new leader session ID and the
      * related leader address to the leader retrieval services.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElection.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.leaderelection;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * {@code LeaderElection} serves as a proxy between {@code LeaderElectionService} and {@link
@@ -42,7 +43,7 @@ public interface LeaderElection extends AutoCloseable {
      * @param leaderSessionID The new leader session ID
      * @param leaderAddress The address of the new leader
      */
-    void confirmLeadership(UUID leaderSessionID, String leaderAddress);
+    CompletableFuture<Void> confirmLeadershipAsync(UUID leaderSessionID, String leaderAddress);
 
     /**
      * Returns {@code true} if the service's {@link LeaderContender} has the leadership under the
@@ -51,7 +52,7 @@ public interface LeaderElection extends AutoCloseable {
      * @param leaderSessionId identifying the current leader
      * @return true if the associated {@link LeaderContender} is the leader, otherwise false
      */
-    boolean hasLeadership(UUID leaderSessionId);
+    CompletableFuture<Boolean> hasLeadershipAsync(UUID leaderSessionId);
 
     /**
      * Closes the {@code LeaderElection} by deregistering the {@link LeaderContender} from the

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -28,10 +28,10 @@ import java.util.UUID;
  * instantiate its own leader election service.
  *
  * <p>Once a contender has been granted leadership he has to confirm the received leader session ID
- * by calling the method {@link LeaderElection#confirmLeadership(UUID, String)}. This will notify
- * the leader election service, that the contender has accepted the leadership specified and that
- * the leader session id as well as the leader address can now be published for leader retrieval
- * services.
+ * by calling the method {@link LeaderElection#confirmLeadershipAsync(UUID, String)}. This will
+ * notify the leader election service, that the contender has accepted the leadership specified and
+ * that the leader session id as well as the leader address can now be published for leader
+ * retrieval services.
  */
 public interface LeaderElectionService {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElection.java
@@ -19,10 +19,12 @@
 package org.apache.flink.runtime.leaderelection;
 
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
 
 import javax.annotation.Nullable;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * {@code StandaloneLeaderElection} implements {@link LeaderElection} for non-HA cases. This
@@ -53,12 +55,16 @@ public class StandaloneLeaderElection implements LeaderElection {
     }
 
     @Override
-    public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {}
+    public CompletableFuture<Void> confirmLeadershipAsync(
+            UUID leaderSessionID, String leaderAddress) {
+        return FutureUtils.completedVoidFuture();
+    }
 
     @Override
-    public boolean hasLeadership(UUID leaderSessionId) {
+    public CompletableFuture<Boolean> hasLeadershipAsync(UUID leaderSessionId) {
         synchronized (lock) {
-            return this.leaderContender != null && this.sessionID.equals(leaderSessionId);
+            return CompletableFuture.completedFuture(
+                    this.leaderContender != null && this.sessionID.equals(leaderSessionId));
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerServiceImpl.java
@@ -266,7 +266,7 @@ public class ResourceManagerServiceImpl implements ResourceManagerService, Leade
                 .thenAcceptAsync(
                         (isStillLeader) -> {
                             if (isStillLeader) {
-                                leaderElection.confirmLeadership(
+                                leaderElection.confirmLeadershipAsync(
                                         newLeaderSessionID, newLeaderResourceManager.getAddress());
                             }
                         },

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -1204,7 +1204,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
                 "{} was granted leadership with leaderSessionID={}",
                 getRestBaseUrl(),
                 leaderSessionID);
-        leaderElection.confirmLeadership(leaderSessionID, getRestBaseUrl());
+        leaderElection.confirmLeadershipAsync(leaderSessionID, getRestBaseUrl());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/DefaultDispatcherRunnerTest.java
@@ -273,7 +273,7 @@ public class DefaultDispatcherRunnerTest extends TestLogger {
             // complete the confirmation future after losing the leadership
             contenderConfirmationFuture.complete("leader address");
 
-            assertThat(leaderElection.hasLeadership(leaderSessionId), is(false));
+            assertThat(leaderElection.hasLeadershipAsync(leaderSessionId).get(), is(false));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedHaServicesTest.java
@@ -140,7 +140,7 @@ public class EmbeddedHaServicesTest extends TestLogger {
 
         final UUID leaderId = leaderContender.getLeaderSessionFuture().get();
 
-        leaderElection.confirmLeadership(leaderId, ADDRESS);
+        leaderElection.confirmLeadershipAsync(leaderId, ADDRESS).get();
 
         final LeaderInformation leaderInformation =
                 leaderRetrievalListener.getLeaderInformationFuture().get();
@@ -172,20 +172,20 @@ public class EmbeddedHaServicesTest extends TestLogger {
 
         final UUID oldLeaderSessionId = leaderContender.getLeaderSessionFuture().get();
 
-        assertThat(leaderElection.hasLeadership(oldLeaderSessionId), is(true));
+        assertThat(leaderElection.hasLeadershipAsync(oldLeaderSessionId).get(), is(true));
 
         embeddedHaServices.getDispatcherLeaderService().revokeLeadership().get();
-        assertThat(leaderElection.hasLeadership(oldLeaderSessionId), is(false));
+        assertThat(leaderElection.hasLeadershipAsync(oldLeaderSessionId).get(), is(false));
 
         embeddedHaServices.getDispatcherLeaderService().grantLeadership();
         final UUID newLeaderSessionId = leaderContender.getLeaderSessionFuture().get();
 
-        assertThat(leaderElection.hasLeadership(newLeaderSessionId), is(true));
+        assertThat(leaderElection.hasLeadershipAsync(newLeaderSessionId).get(), is(true));
 
-        leaderElection.confirmLeadership(oldLeaderSessionId, ADDRESS);
-        leaderElection.confirmLeadership(newLeaderSessionId, ADDRESS);
+        leaderElection.confirmLeadershipAsync(oldLeaderSessionId, ADDRESS).get();
+        leaderElection.confirmLeadershipAsync(newLeaderSessionId, ADDRESS).get();
 
-        assertThat(leaderElection.hasLeadership(newLeaderSessionId), is(true));
+        assertThat(leaderElection.hasLeadershipAsync(newLeaderSessionId).get(), is(true));
 
         leaderContender.tryRethrowException();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.leaderelection;
 
-import org.apache.flink.core.testutils.FlinkAssertions;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerExtension;
@@ -34,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -218,7 +219,7 @@ class DefaultLeaderElectionServiceTest {
             closeThread.join();
             grantThread.join();
 
-            FlinkAssertions.assertThatFuture(driverCloseTriggered).eventuallySucceeds();
+            assertThatFuture(driverCloseTriggered).eventuallySucceeds();
         }
     }
 
@@ -702,7 +703,7 @@ class DefaultLeaderElectionServiceTest {
     }
 
     @Test
-    void testHasLeadershipWithLeadershipButNoGrantEventProcessed() throws Exception {
+    void testHasLeadershipAsyncWithLeadershipButNoGrantEventProcessed() throws Exception {
         new Context() {
             {
                 runTestWithManuallyTriggeredEvents(
@@ -712,14 +713,20 @@ class DefaultLeaderElectionServiceTest {
 
                             applyToBothContenderContexts(
                                     ctx -> {
-                                        assertThat(
-                                                        leaderElectionService.hasLeadership(
-                                                                ctx.componentId, expectedSessionID))
-                                                .isFalse();
-                                        assertThat(
-                                                        leaderElectionService.hasLeadership(
-                                                                ctx.componentId, UUID.randomUUID()))
-                                                .isFalse();
+                                        final CompletableFuture<Boolean> validSessionFuture =
+                                                leaderElectionService.hasLeadershipAsync(
+                                                        ctx.componentId, expectedSessionID);
+                                        final CompletableFuture<Boolean> invalidSessionFuture =
+                                                leaderElectionService.hasLeadershipAsync(
+                                                        ctx.componentId, UUID.randomUUID());
+                                        executorService.triggerAll();
+
+                                        assertThatFuture(validSessionFuture)
+                                                .eventuallySucceeds()
+                                                .isEqualTo(true);
+                                        assertThatFuture(invalidSessionFuture)
+                                                .eventuallySucceeds()
+                                                .isEqualTo(false);
                                     });
                         });
             }
@@ -727,7 +734,7 @@ class DefaultLeaderElectionServiceTest {
     }
 
     @Test
-    void testHasLeadershipWithLeadershipAndGrantEventProcessed() throws Exception {
+    void testHasLeadershipAsyncWithLeadershipAndGrantEventProcessed() throws Exception {
         new Context() {
             {
                 runTestWithManuallyTriggeredEvents(
@@ -745,14 +752,20 @@ class DefaultLeaderElectionServiceTest {
                                         assertThat(ctx.contender.getLeaderSessionID())
                                                 .isEqualTo(expectedSessionID);
 
-                                        assertThat(
-                                                        leaderElectionService.hasLeadership(
-                                                                ctx.componentId, expectedSessionID))
-                                                .isTrue();
-                                        assertThat(
-                                                        leaderElectionService.hasLeadership(
-                                                                ctx.componentId, UUID.randomUUID()))
-                                                .isFalse();
+                                        final CompletableFuture<Boolean> validSessionFuture =
+                                                leaderElectionService.hasLeadershipAsync(
+                                                        ctx.componentId, expectedSessionID);
+                                        final CompletableFuture<Boolean> invalidSessionFuture =
+                                                leaderElectionService.hasLeadershipAsync(
+                                                        ctx.componentId, UUID.randomUUID());
+                                        executorService.triggerAll();
+
+                                        assertThatFuture(validSessionFuture)
+                                                .eventuallySucceeds()
+                                                .isEqualTo(true);
+                                        assertThatFuture(invalidSessionFuture)
+                                                .eventuallySucceeds()
+                                                .isEqualTo(false);
                                     });
                         });
             }
@@ -760,7 +773,7 @@ class DefaultLeaderElectionServiceTest {
     }
 
     @Test
-    void testHasLeadershipWithLeadershipLostButNoRevokeEventProcessed() throws Exception {
+    void testHasLeadershipAsyncWithLeadershipLostButNoRevokeEventProcessed() throws Exception {
         new Context() {
             {
                 runTestWithManuallyTriggeredEvents(
@@ -773,20 +786,27 @@ class DefaultLeaderElectionServiceTest {
 
                             applyToBothContenderContexts(
                                     ctx -> {
-                                        assertThat(
-                                                        leaderElectionService.hasLeadership(
-                                                                ctx.componentId, expectedSessionID))
+                                        final CompletableFuture<Boolean> validSessionFuture =
+                                                leaderElectionService.hasLeadershipAsync(
+                                                        ctx.componentId, expectedSessionID);
+                                        final CompletableFuture<Boolean> invalidSessionFuture =
+                                                leaderElectionService.hasLeadershipAsync(
+                                                        ctx.componentId, UUID.randomUUID());
+
+                                        executorService.triggerAll();
+
+                                        assertThatFuture(validSessionFuture)
+                                                .eventuallySucceeds()
                                                 .as(
                                                         "No operation should be handled anymore after the HA backend "
                                                                 + "indicated leadership loss even if the onRevokeLeadership wasn't "
                                                                 + "processed, yet, because some other process could have picked up "
                                                                 + "the leadership in the meantime already based on the HA "
                                                                 + "backend's decision.")
-                                                .isFalse();
-                                        assertThat(
-                                                        leaderElectionService.hasLeadership(
-                                                                ctx.componentId, UUID.randomUUID()))
-                                                .isFalse();
+                                                .isEqualTo(false);
+                                        assertThatFuture(invalidSessionFuture)
+                                                .eventuallySucceeds()
+                                                .isEqualTo(false);
                                     });
                         });
             }
@@ -794,7 +814,7 @@ class DefaultLeaderElectionServiceTest {
     }
 
     @Test
-    void testHasLeadershipWithLeadershipLostAndRevokeEventProcessed() throws Exception {
+    void testHasLeadershipAsyncWithLeadershipLostAndRevokeEventProcessed() throws Exception {
         new Context() {
             {
                 runTestWithSynchronousEventHandling(
@@ -805,14 +825,16 @@ class DefaultLeaderElectionServiceTest {
 
                             applyToBothContenderContexts(
                                     ctx -> {
-                                        assertThat(
-                                                        leaderElectionService.hasLeadership(
+                                        assertThatFuture(
+                                                        leaderElectionService.hasLeadershipAsync(
                                                                 ctx.componentId, expectedSessionID))
-                                                .isFalse();
-                                        assertThat(
-                                                        leaderElectionService.hasLeadership(
+                                                .eventuallySucceeds()
+                                                .isEqualTo(false);
+                                        assertThatFuture(
+                                                        leaderElectionService.hasLeadershipAsync(
                                                                 ctx.componentId, UUID.randomUUID()))
-                                                .isFalse();
+                                                .eventuallySucceeds()
+                                                .isEqualTo(false);
                                     });
                         });
             }
@@ -820,7 +842,7 @@ class DefaultLeaderElectionServiceTest {
     }
 
     @Test
-    void testHasLeadershipAfterLeaderElectionClose() throws Exception {
+    void testHasLeadershipAsyncAfterLeaderElectionClose() throws Exception {
         new Context() {
             {
                 runTestWithSynchronousEventHandling(
@@ -832,10 +854,11 @@ class DefaultLeaderElectionServiceTest {
                                     ctx -> {
                                         ctx.leaderElection.close();
 
-                                        assertThat(
-                                                        leaderElectionService.hasLeadership(
+                                        assertThatFuture(
+                                                        leaderElectionService.hasLeadershipAsync(
                                                                 ctx.componentId, expectedSessionID))
-                                                .isFalse();
+                                                .eventuallySucceeds()
+                                                .isEqualTo(false);
                                     });
                         });
             }
@@ -1038,7 +1061,7 @@ class DefaultLeaderElectionServiceTest {
                                                 .hasValue(expectedLeaderInformation);
 
                                         // Old confirm call should be ignored.
-                                        ctx.leaderElection.confirmLeadership(
+                                        ctx.leaderElection.confirmLeadershipAsync(
                                                 UUID.randomUUID(), ctx.address);
                                         assertThat(
                                                         leaderElectionService.getLeaderSessionID(
@@ -1069,7 +1092,7 @@ class DefaultLeaderElectionServiceTest {
                             applyToBothContenderContexts(
                                     ctx -> {
                                         // Old confirm call should be ignored.
-                                        ctx.leaderElection.confirmLeadership(
+                                        ctx.leaderElection.confirmLeadershipAsync(
                                                 currentLeaderSessionId, ctx.address);
 
                                         assertThat(
@@ -1244,6 +1267,73 @@ class DefaultLeaderElectionServiceTest {
 
         leaderElection.close();
         testInstance.close();
+    }
+
+    /**
+     * This test is used to verify FLINK-36451 where we observed concurrent nested locks being
+     * acquired from the {@link LeaderContender} and from the {@link DefaultLeaderElectionService}.
+     */
+    @Test
+    void testNestedDeadlockInLeadershipConfirmation() throws Exception {
+        final AtomicReference<LeaderInformationRegister> leaderInformationStorage =
+                new AtomicReference<>(LeaderInformationRegister.empty());
+        try (final DefaultLeaderElectionService testInstance =
+                new DefaultLeaderElectionService(
+                        TestingLeaderElectionDriver.newBuilder(
+                                        new AtomicBoolean(false),
+                                        leaderInformationStorage,
+                                        new AtomicBoolean(false))
+                                ::build)) {
+            final String componentId = "test-component";
+            final LeaderElection leaderElection = testInstance.createLeaderElection(componentId);
+
+            // we need the lock to be acquired once for the leadership grant and once for the
+            // revocation
+            final CountDownLatch contenderLockAcquireLatch = new CountDownLatch(2);
+            final OneShotLatch grantReceivedLatch = new OneShotLatch();
+
+            final AtomicBoolean contenderLeadership = new AtomicBoolean(false);
+            final TestingGenericLeaderContender leaderContender =
+                    TestingGenericLeaderContender.newBuilder()
+                            .setPreLockAcquireAction(contenderLockAcquireLatch::countDown)
+                            .setGrantLeadershipConsumer(
+                                    ignoredSessionId -> {
+                                        contenderLeadership.set(true);
+                                        grantReceivedLatch.trigger();
+                                    })
+                            .setRevokeLeadershipRunnable(() -> contenderLeadership.set(false))
+                            .build();
+
+            leaderElection.startLeaderElection(leaderContender);
+
+            final UUID leaderSessionId = UUID.randomUUID();
+            testInstance.onGrantLeadership(leaderSessionId);
+            grantReceivedLatch.await();
+
+            final CompletableFuture<Void> revocationFuture;
+            final CompletableFuture<Void> confirmLeadershipFuture;
+            synchronized (leaderContender.getLock()) {
+                revocationFuture = CompletableFuture.runAsync(testInstance::onRevokeLeadership);
+                contenderLockAcquireLatch.await();
+                confirmLeadershipFuture =
+                        leaderElection.confirmLeadershipAsync(leaderSessionId, "random-address");
+            }
+
+            assertThatFuture(revocationFuture).eventuallySucceeds();
+            assertThatFuture(confirmLeadershipFuture).eventuallySucceeds();
+
+            assertThat(contenderLeadership).isFalse();
+            assertThat(leaderInformationStorage.get().forComponentId(componentId).isPresent())
+                    .as(
+                            "The LeaderInformation is empty because the leadership confirmation succeeded the "
+                                    + "leadership revocation which resulted in no leader information being written out to "
+                                    + "the HA backend.")
+                    .isFalse();
+
+            // not closing the LeaderElection instance would leave the DefaultLeaderElectionService
+            // in an inconsistent state causing an error when closing the service
+            leaderElection.close();
+        }
     }
 
     private static String createRandomComponentId() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionTest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.assertThatFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class StandaloneLeaderElectionTest {
@@ -79,26 +80,34 @@ class StandaloneLeaderElectionTest {
     }
 
     @Test
-    void testHasLeadershipWithContender() throws Exception {
+    void testHasLeadershipAsyncWithContender() throws Exception {
         final TestingGenericLeaderContender contender =
                 TestingGenericLeaderContender.newBuilder().build();
         try (final LeaderElection testInstance = new StandaloneLeaderElection(SESSION_ID)) {
             testInstance.startLeaderElection(contender);
 
-            assertThat(testInstance.hasLeadership(SESSION_ID)).isTrue();
+            assertThatFuture(testInstance.hasLeadershipAsync(SESSION_ID))
+                    .eventuallySucceeds()
+                    .isEqualTo(true);
 
             final UUID differentSessionID = UUID.randomUUID();
-            assertThat(testInstance.hasLeadership(differentSessionID)).isFalse();
+            assertThatFuture(testInstance.hasLeadershipAsync(differentSessionID))
+                    .eventuallySucceeds()
+                    .isEqualTo(false);
         }
     }
 
     @Test
-    void testHasLeadershipWithoutContender() throws Exception {
+    void testHasLeadershipAsyncWithoutContender() throws Exception {
         try (final LeaderElection testInstance = new StandaloneLeaderElection(SESSION_ID)) {
-            assertThat(testInstance.hasLeadership(SESSION_ID)).isFalse();
+            assertThatFuture(testInstance.hasLeadershipAsync(SESSION_ID))
+                    .eventuallySucceeds()
+                    .isEqualTo(false);
 
             final UUID differentSessionID = UUID.randomUUID();
-            assertThat(testInstance.hasLeadership(differentSessionID)).isFalse();
+            assertThatFuture(testInstance.hasLeadershipAsync(differentSessionID))
+                    .eventuallySucceeds()
+                    .isEqualTo(false);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingContender.java
@@ -50,9 +50,12 @@ public class TestingContender extends TestingLeaderBase implements LeaderContend
 
         this.leaderSessionID = leaderSessionID;
 
-        leaderElection.confirmLeadership(leaderSessionID, address);
-
-        leaderEventQueue.offer(LeaderInformation.known(leaderSessionID, address));
+        leaderElection
+                .confirmLeadershipAsync(leaderSessionID, address)
+                .thenRun(
+                        () ->
+                                leaderEventQueue.offer(
+                                        LeaderInformation.known(leaderSessionID, address)));
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderContender.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingGenericLeaderContender.java
@@ -29,21 +29,30 @@ public class TestingGenericLeaderContender implements LeaderContender {
 
     private final Object lock = new Object();
 
+    private final Runnable preLockAcquireAction;
+
     private final Consumer<UUID> grantLeadershipConsumer;
     private final Runnable revokeLeadershipRunnable;
     private final Consumer<Exception> handleErrorConsumer;
 
     private TestingGenericLeaderContender(
+            Runnable preLockAcquireAction,
             Consumer<UUID> grantLeadershipConsumer,
             Runnable revokeLeadershipRunnable,
             Consumer<Exception> handleErrorConsumer) {
+        this.preLockAcquireAction = preLockAcquireAction;
         this.grantLeadershipConsumer = grantLeadershipConsumer;
         this.revokeLeadershipRunnable = revokeLeadershipRunnable;
         this.handleErrorConsumer = handleErrorConsumer;
     }
 
+    public Object getLock() {
+        return lock;
+    }
+
     @Override
     public void grantLeadership(UUID leaderSessionID) {
+        preLockAcquireAction.run();
         synchronized (lock) {
             grantLeadershipConsumer.accept(leaderSessionID);
         }
@@ -51,6 +60,7 @@ public class TestingGenericLeaderContender implements LeaderContender {
 
     @Override
     public void revokeLeadership() {
+        preLockAcquireAction.run();
         synchronized (lock) {
             revokeLeadershipRunnable.run();
         }
@@ -58,6 +68,7 @@ public class TestingGenericLeaderContender implements LeaderContender {
 
     @Override
     public void handleError(Exception exception) {
+        preLockAcquireAction.run();
         synchronized (lock) {
             handleErrorConsumer.accept(exception);
         }
@@ -69,6 +80,7 @@ public class TestingGenericLeaderContender implements LeaderContender {
 
     /** {@code Builder} for creating {@code TestingGenericLeaderContender} instances. */
     public static class Builder {
+        private Runnable preLockAcquireAction = () -> {};
         private Consumer<UUID> grantLeadershipConsumer = ignoredSessionID -> {};
         private Runnable revokeLeadershipRunnable = () -> {};
         private Consumer<Exception> handleErrorConsumer =
@@ -93,9 +105,17 @@ public class TestingGenericLeaderContender implements LeaderContender {
             return this;
         }
 
+        public Builder setPreLockAcquireAction(Runnable preLockAcquireAction) {
+            this.preLockAcquireAction = preLockAcquireAction;
+            return this;
+        }
+
         public TestingGenericLeaderContender build() {
             return new TestingGenericLeaderContender(
-                    grantLeadershipConsumer, revokeLeadershipRunnable, handleErrorConsumer);
+                    preLockAcquireAction,
+                    grantLeadershipConsumer,
+                    revokeLeadershipRunnable,
+                    handleErrorConsumer);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElection.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElection.java
@@ -66,7 +66,9 @@ public class TestingLeaderElection implements LeaderElection {
 
     @Override
     public synchronized void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
-        if (confirmationFuture != null && !confirmationFuture.isDone()) {
+        if (leaderSessionID.equals(this.issuedLeaderSessionId)
+                && confirmationFuture != null
+                && !confirmationFuture.isDone()) {
             confirmationFuture.complete(LeaderInformation.known(leaderSessionID, leaderAddress));
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElection.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElection.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.leaderelection;
 
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.concurrent.FutureUtils;
 
 import javax.annotation.Nullable;
 
@@ -65,17 +66,21 @@ public class TestingLeaderElection implements LeaderElection {
     }
 
     @Override
-    public synchronized void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
+    public synchronized CompletableFuture<Void> confirmLeadershipAsync(
+            UUID leaderSessionID, String leaderAddress) {
         if (leaderSessionID.equals(this.issuedLeaderSessionId)
                 && confirmationFuture != null
                 && !confirmationFuture.isDone()) {
             confirmationFuture.complete(LeaderInformation.known(leaderSessionID, leaderAddress));
         }
+
+        return FutureUtils.completedVoidFuture();
     }
 
     @Override
-    public synchronized boolean hasLeadership(UUID leaderSessionId) {
-        return hasLeadership() && leaderSessionId.equals(issuedLeaderSessionId);
+    public synchronized CompletableFuture<Boolean> hasLeadershipAsync(UUID leaderSessionId) {
+        return CompletableFuture.completedFuture(
+                hasLeadership() && leaderSessionId.equals(issuedLeaderSessionId));
     }
 
     private boolean hasLeadership() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/util/DocumentingDispatcherRestEndpoint.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.rest.handler.legacy.metrics.VoidMetricFetcher;
 import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ConfigurationException;
+import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandler;
 
@@ -93,11 +94,14 @@ public class DocumentingDispatcherRestEndpoint extends DispatcherRestEndpoint
         public void startLeaderElection(LeaderContender contender) {}
 
         @Override
-        public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {}
+        public CompletableFuture<Void> confirmLeadershipAsync(
+                UUID leaderSessionID, String leaderAddress) {
+            return FutureUtils.completedVoidFuture();
+        }
 
         @Override
-        public boolean hasLeadership(UUID leaderSessionId) {
-            return false;
+        public CompletableFuture<Boolean> hasLeadershipAsync(UUID leaderSessionId) {
+            return CompletableFuture.completedFuture(false);
         }
 
         @Override


### PR DESCRIPTION
This is the 1.19 backport of parent PR https://github.com/apache/flink/pull/25679