### PR TITLE
[hotfix] Remove requiremenet for java 8 in docs

### DIFF
--- a/docs/content.zh/docs/dev/configuration/gradle.md
+++ b/docs/content.zh/docs/dev/configuration/gradle.md
@@ -29,7 +29,7 @@ under the License.
 ## 要求
 
 - Gradle 7.x 
-- Java 8 (deprecated) 或 Java 11
+- Java 11
 
 ## 将项目导入 IDE
 

--- a/docs/content.zh/docs/dev/configuration/maven.md
+++ b/docs/content.zh/docs/dev/configuration/maven.md
@@ -29,7 +29,7 @@ under the License.
 ## 要求
 
 - Maven 3.8.6
-- Java 8 (deprecated) or Java 11
+- Java 11
 
 ## 将项目导入 IDE
 

--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -35,7 +35,7 @@ under the License.
 
 首先需要准备源码。可以[从发布版本下载源码]({{< downloads >}}) 或者[从 Git 库克隆 Flink 源码]({{< github_repo >}})。
 
-还需要准备 **Maven 3.8.6** 和 **JDK** (Java开发套件)。Flink 依赖 **Java 8 (deprecated) 或 Java 11** 来进行构建。
+还需要准备 **Maven 3.8.6** 和 **JDK** (Java开发套件)。Flink 依赖 **Java 11** 来进行构建。
 
 输入以下命令从 Git 克隆代码
 

--- a/docs/content/docs/dev/configuration/maven.md
+++ b/docs/content/docs/dev/configuration/maven.md
@@ -31,7 +31,7 @@ publish, and deploy projects. You can use it to manage the entire lifecycle of y
 ## Requirements
 
 - Maven 3.8.6
-- Java 8 (deprecated) or Java 11
+- Java 11
 
 ## Importing the project into your IDE
 

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -33,7 +33,7 @@ This page covers how to build Flink {{< version >}} from sources.
 
 In order to build Flink you need the source code. Either [download the source of a release]({{< downloads >}}) or [clone the git repository]({{< github_repo >}}).
 
-In addition you need **Maven 3.8.6** and a **JDK** (Java Development Kit). Flink requires **Java 8 (deprecated) or Java 11** to build.
+In addition you need **Maven 3.8.6** and a **JDK** (Java Development Kit). Flink requires **Java 11** to build.
 
 To clone from git, enter:
 


### PR DESCRIPTION


## What is the purpose of the change
This is a follow up for the commit under https://github.com/apache/flink/pull/25775


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
