### PR TITLE
[FLINK-36876] Support external eventLoopGroup for RestClient

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -250,7 +250,7 @@ public class RestClusterClient<T> implements ClusterClient<T> {
             T clusterId,
             WaitStrategy waitStrategy,
             ClientHighAvailabilityServicesFactory clientHAServicesFactory,
-            EventLoopGroup group)
+            @Nullable EventLoopGroup group)
             throws Exception {
         this.configuration = checkNotNull(configuration);
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -133,6 +133,7 @@ import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.util.function.CheckedSupplier;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ConnectTimeoutException;
+import org.apache.flink.shaded.netty4.io.netty.channel.EventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import org.slf4j.Logger;
@@ -215,7 +216,16 @@ public class RestClusterClient<T> implements ClusterClient<T> {
     public RestClusterClient(
             Configuration config, T clusterId, ClientHighAvailabilityServicesFactory factory)
             throws Exception {
-        this(config, null, clusterId, new ExponentialWaitStrategy(10L, 2000L), factory);
+        this(config, null, clusterId, new ExponentialWaitStrategy(10L, 2000L), factory, null);
+    }
+
+    public RestClusterClient(
+            Configuration config,
+            T clusterId,
+            ClientHighAvailabilityServicesFactory factory,
+            EventLoopGroup group)
+            throws Exception {
+        this(config, null, clusterId, new ExponentialWaitStrategy(10L, 2000L), factory, group);
     }
 
     @VisibleForTesting
@@ -230,7 +240,8 @@ public class RestClusterClient<T> implements ClusterClient<T> {
                 restClient,
                 clusterId,
                 waitStrategy,
-                DefaultClientHighAvailabilityServicesFactory.INSTANCE);
+                DefaultClientHighAvailabilityServicesFactory.INSTANCE,
+                null);
     }
 
     private RestClusterClient(
@@ -238,7 +249,8 @@ public class RestClusterClient<T> implements ClusterClient<T> {
             @Nullable RestClient restClient,
             T clusterId,
             WaitStrategy waitStrategy,
-            ClientHighAvailabilityServicesFactory clientHAServicesFactory)
+            ClientHighAvailabilityServicesFactory clientHAServicesFactory,
+            EventLoopGroup group)
             throws Exception {
         this.configuration = checkNotNull(configuration);
 
@@ -258,7 +270,8 @@ public class RestClusterClient<T> implements ClusterClient<T> {
         if (restClient != null) {
             this.restClient = restClient;
         } else {
-            this.restClient = RestClient.forUrl(configuration, executorService, jobmanagerUrl);
+            this.restClient =
+                    RestClient.forUrl(configuration, executorService, jobmanagerUrl, group);
         }
 
         this.waitStrategy = checkNotNull(waitStrategy);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -90,6 +90,8 @@ import org.apache.flink.shaded.netty4.io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -197,7 +199,7 @@ public class RestClient implements AutoCloseableAsync {
             String host,
             int port,
             SelectStrategyFactory selectStrategyFactory,
-            EventLoopGroup group)
+            @Nullable EventLoopGroup group)
             throws ConfigurationException {
         Preconditions.checkNotNull(configuration);
         this.executor = Preconditions.checkNotNull(executor);
@@ -291,6 +293,9 @@ public class RestClient implements AutoCloseableAsync {
                             selectStrategyFactory);
             useInternalEventLoopGroup = true;
         } else {
+            Preconditions.checkArgument(
+                    !group.isShuttingDown() && !group.isShutdown(),
+                    "provided eventLoopGroup is shut/shutting down");
             useInternalEventLoopGroup = false;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -144,7 +144,7 @@ public class RestClient implements AutoCloseableAsync {
             ConcurrentHashMap.newKeySet();
 
     private final List<OutboundChannelHandlerFactory> outboundChannelHandlerFactories;
-    private final Boolean useInternalEventLoopGroup;
+    private final boolean useInternalEventLoopGroup;
 
     /**
      * Creates a new RestClient for the provided root URL. If the protocol of the URL is "https",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/RestClient.java
@@ -59,6 +59,7 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInitializer;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelOption;
 import org.apache.flink.shaded.netty4.io.netty.channel.DefaultSelectStrategyFactory;
+import org.apache.flink.shaded.netty4.io.netty.channel.EventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.SelectStrategyFactory;
 import org.apache.flink.shaded.netty4.io.netty.channel.SimpleChannelInboundHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
@@ -143,6 +144,7 @@ public class RestClient implements AutoCloseableAsync {
             ConcurrentHashMap.newKeySet();
 
     private final List<OutboundChannelHandlerFactory> outboundChannelHandlerFactories;
+    private final Boolean useInternalEventLoopGroup;
 
     /**
      * Creates a new RestClient for the provided root URL. If the protocol of the URL is "https",
@@ -150,23 +152,34 @@ public class RestClient implements AutoCloseableAsync {
      */
     public static RestClient forUrl(Configuration configuration, Executor executor, URL rootUrl)
             throws ConfigurationException {
+        return forUrl(configuration, executor, rootUrl, null);
+    }
+
+    public static RestClient forUrl(
+            Configuration configuration, Executor executor, URL rootUrl, EventLoopGroup group)
+            throws ConfigurationException {
         Preconditions.checkNotNull(configuration);
         Preconditions.checkNotNull(rootUrl);
         if ("https".equals(rootUrl.getProtocol())) {
             configuration = configuration.clone();
             configuration.set(SSL_REST_ENABLED, true);
         }
-        return new RestClient(configuration, executor, rootUrl.getHost(), rootUrl.getPort());
+        return new RestClient(configuration, executor, rootUrl.getHost(), rootUrl.getPort(), group);
     }
 
     public RestClient(Configuration configuration, Executor executor)
             throws ConfigurationException {
-        this(configuration, executor, null, -1);
+        this(configuration, executor, null, -1, null);
     }
 
-    public RestClient(Configuration configuration, Executor executor, String host, int port)
+    public RestClient(
+            Configuration configuration,
+            Executor executor,
+            String host,
+            int port,
+            EventLoopGroup group)
             throws ConfigurationException {
-        this(configuration, executor, host, port, DefaultSelectStrategyFactory.INSTANCE);
+        this(configuration, executor, host, port, DefaultSelectStrategyFactory.INSTANCE, group);
     }
 
     @VisibleForTesting
@@ -175,7 +188,7 @@ public class RestClient implements AutoCloseableAsync {
             Executor executor,
             SelectStrategyFactory selectStrategyFactory)
             throws ConfigurationException {
-        this(configuration, executor, null, -1, selectStrategyFactory);
+        this(configuration, executor, null, -1, selectStrategyFactory, null);
     }
 
     private RestClient(
@@ -183,7 +196,8 @@ public class RestClient implements AutoCloseableAsync {
             Executor executor,
             String host,
             int port,
-            SelectStrategyFactory selectStrategyFactory)
+            SelectStrategyFactory selectStrategyFactory,
+            EventLoopGroup group)
             throws ConfigurationException {
         Preconditions.checkNotNull(configuration);
         this.executor = Preconditions.checkNotNull(executor);
@@ -264,15 +278,21 @@ public class RestClient implements AutoCloseableAsync {
                     }
                 };
 
-        // No NioEventLoopGroup constructor available that allows passing nThreads, threadFactory,
-        // and selectStrategyFactory without also passing a SelectorProvider, so mimicking its
-        // default value seen in other constructors
-        NioEventLoopGroup group =
-                new NioEventLoopGroup(
-                        1,
-                        new ExecutorThreadFactory("flink-rest-client-netty"),
-                        SelectorProvider.provider(),
-                        selectStrategyFactory);
+        if (group == null) {
+            // No NioEventLoopGroup constructor available that allows passing nThreads,
+            // threadFactory,
+            // and selectStrategyFactory without also passing a SelectorProvider, so mimicking its
+            // default value seen in other constructors
+            group =
+                    new NioEventLoopGroup(
+                            1,
+                            new ExecutorThreadFactory("flink-rest-client-netty"),
+                            SelectorProvider.provider(),
+                            selectStrategyFactory);
+            useInternalEventLoopGroup = true;
+        } else {
+            useInternalEventLoopGroup = false;
+        }
 
         bootstrap = new Bootstrap();
         bootstrap
@@ -317,7 +337,7 @@ public class RestClient implements AutoCloseableAsync {
             LOG.debug("Shutting down rest endpoint.");
 
             if (bootstrap != null) {
-                if (bootstrap.config().group() != null) {
+                if (bootstrap.config().group() != null && useInternalEventLoopGroup) {
                     bootstrap
                             .config()
                             .group()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestClientTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.rest.versioning.RuntimeRestAPIVersion;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.NetUtils;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.function.CheckedSupplier;
 
@@ -38,8 +39,10 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 import org.apache.flink.shaded.netty4.io.netty.channel.ConnectTimeoutException;
 import org.apache.flink.shaded.netty4.io.netty.channel.DefaultSelectStrategyFactory;
+import org.apache.flink.shaded.netty4.io.netty.channel.EventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.channel.SelectStrategy;
 import org.apache.flink.shaded.netty4.io.netty.channel.SelectStrategyFactory;
+import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -113,6 +116,20 @@ class RestClientTest {
                     .extracting(Throwable::getCause, as(InstanceOfAssertFactories.THROWABLE))
                     .hasMessageContaining(unroutableIp);
         }
+    }
+
+    @Test
+    void testExternalEventGroup() throws Exception {
+        EventLoopGroup externalGroup =
+                new NioEventLoopGroup(
+                        1, new ExecutorThreadFactory("flink-rest-client-netty-external"));
+
+        final RestClient restClient =
+                new RestClient(
+                        new Configuration(), Executors.directExecutor(), null, -1, externalGroup);
+        restClient.closeAsync();
+
+        assertThat(externalGroup.isShuttingDown() || externalGroup.isShutdown()).isFalse();
     }
 
     @Test


### PR DESCRIPTION

## What is the purpose of the change

Support external eventLoopGroup for RestClient


## Brief change log


  - *Support pass an external eventLoopGroup in the constructor of RestClient*
  - *Close only for internal eventLoopGroup, not for external*

## Verifying this change

The change is tested by RestClientTest.testExternalEventGroup

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
