### PR TITLE
[FLINK-36881][table] Introduce GroupTableAggFunction in GroupTableAggregate with Async State API

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
@@ -124,6 +124,7 @@ class TableAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(
     testHarness.open()
     val expectedOutput = new ConcurrentLinkedQueue[Object]()
 
+
     // set TtlTimeProvider with 1
     testHarness.setStateTtlProcessingTime(1)
 


### PR DESCRIPTION
## What is the purpose of the change

Introduce GroupTableAggFunction in GroupTableAggregate with async state api.

## Brief change log

  - *Introduce GroupTableAggFunction in GroupTableAggregate with async state api.*
  - *Add ITs and HarnessTests*


## Verifying this change

Existent tests and new added tests can verify this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)