### PR TITLE
[FLINK-36896][table] Table API trim expression incorrectly translated to SQL

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ExpressionSerializationTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ExpressionSerializationTest.java
@@ -179,9 +179,6 @@ public class ExpressionSerializationTest {
                 TestSpec.forExpr($("f0").trimTrailing("ABC"))
                         .withField("f0", DataTypes.STRING())
                         .expectStr("TRIM(TRAILING 'ABC' FROM `f0`)"),
-                TestSpec.forExpr($("f0").concat("f0"))
-                        .withField("f0", DataTypes.STRING())
-                        .expectStr("CONCAT(`f0`, 3)"),
                 TestSpec.forExpr($("f0").overlay("ABC", 2))
                         .withField("f0", DataTypes.STRING())
                         .expectStr("OVERLAY(`f0` PLACING 'ABC' FROM 2)"),

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ExpressionSerializationTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ExpressionSerializationTest.java
@@ -172,13 +172,16 @@ public class ExpressionSerializationTest {
                         .expectStr("POSITION(`f0` IN 'ABC')"),
                 TestSpec.forExpr($("f0").trim("ABC"))
                         .withField("f0", DataTypes.STRING())
-                        .expectStr("TRIM BOTH 'ABC' FROM `f0`"),
+                        .expectStr("TRIM(BOTH 'ABC' FROM `f0`)"),
                 TestSpec.forExpr($("f0").trimLeading("ABC"))
                         .withField("f0", DataTypes.STRING())
-                        .expectStr("TRIM LEADING 'ABC' FROM `f0`"),
+                        .expectStr("TRIM(LEADING 'ABC' FROM `f0`)"),
                 TestSpec.forExpr($("f0").trimTrailing("ABC"))
                         .withField("f0", DataTypes.STRING())
-                        .expectStr("TRIM TRAILING 'ABC' FROM `f0`"),
+                        .expectStr("TRIM(TRAILING 'ABC' FROM `f0`)"),
+                TestSpec.forExpr($("f0").concat("f0"))
+                        .withField("f0", DataTypes.STRING())
+                        .expectStr("CONCAT(`f0`, 3)"),
                 TestSpec.forExpr($("f0").overlay("ABC", 2))
                         .withField("f0", DataTypes.STRING())
                         .expectStr("OVERLAY(`f0` PLACING 'ABC' FROM 2)"),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/SqlCallSyntax.java
@@ -233,13 +233,13 @@ public interface SqlCallSyntax {
 
                 // leading & trailing is translated to BOTH
                 if (trimLeading && trimTrailing) {
-                    format = "TRIM BOTH %s FROM %s";
+                    format = "TRIM(BOTH %s FROM %s)";
                 } else if (trimLeading) {
-                    format = "TRIM LEADING %s FROM %s";
+                    format = "TRIM(LEADING %s FROM %s)";
                 } else if (trimTrailing) {
-                    format = "TRIM TRAILING %s FROM %s";
+                    format = "TRIM(TRAILING %s FROM %s)";
                 } else {
-                    format = "TRIM %s FROM %s";
+                    format = "TRIM(%s FROM %s)";
                 }
 
                 return String.format(


### PR DESCRIPTION

## What is the purpose of the change

While translation of `trim()` to SQL parenthesis are missed

## Brief change log

`SqlCallSyntax`

## Verifying this change
`ExpressionSerializationTest.java`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
