### PR TITLE
[BP-1.20][FLINK-35887][core] Fix NPE in TypeExtractor where getSuperclass from an interface returns null

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -2224,7 +2224,9 @@ public class TypeExtractor {
      */
     @PublicEvolving
     public static boolean isRecord(Class<?> clazz) {
-        return clazz.getSuperclass().getName().equals("java.lang.Record")
+        Class<?> superclass = clazz.getSuperclass();
+        return superclass != null
+                && superclass.getName().equals("java.lang.Record")
                 && (clazz.getModifiers() & Modifier.FINAL) != 0;
     }
 

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/types/PojoTestUtilsTest.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/types/PojoTestUtilsTest.java
@@ -17,9 +17,17 @@
 
 package org.apache.flink.types;
 
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -39,6 +47,12 @@ class PojoTestUtilsTest {
     @Test
     void testPojoAcceptedIfKryoRequired() {
         PojoTestUtils.assertSerializedAsPojo(PojoRequiringKryo.class);
+    }
+
+    @Test
+    void testPojoTypeInfoOnInterface() {
+        // reported in FLINK-35887
+        PojoTestUtils.assertSerializedAsPojo(Foo.class);
     }
 
     @Test
@@ -63,5 +77,15 @@ class PojoTestUtilsTest {
 
     public static class PojoRequiringKryo {
         public List<Integer> x;
+    }
+
+    @TypeInfo(FooFactory.class)
+    public interface Foo {}
+
+    public static class FooFactory extends TypeInfoFactory<Foo> {
+        @Override
+        public TypeInformation<Foo> createTypeInfo(Type type, Map<String, TypeInformation<?>> map) {
+            return Types.POJO(Foo.class, new HashMap<>());
+        }
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

Fix NPE reported in [FLINK-35887](https://issues.apache.org/jira/browse/FLINK-35887).

## Brief change log

Add null checking for the result of getSuperclass on an interface.

## Verifying this change

`PojoTestUtilsTest#testPojoTypeInfoOnInterface `

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ()
