### PR TITLE
[FLINK-36706] Refactor TypeInferenceExtractor for PTFs

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/ArgumentTrait.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/annotation/ArgumentTrait.java
@@ -40,7 +40,7 @@ public enum ArgumentTrait {
      *
      * <p>It's the default if no {@link ArgumentHint} is provided.
      */
-    SCALAR(StaticArgumentTrait.SCALAR),
+    SCALAR(true, StaticArgumentTrait.SCALAR),
 
     /**
      * An argument that accepts a table "as row" (i.e. with row semantics). This trait only applies
@@ -56,7 +56,7 @@ public enum ArgumentTrait {
      * can be processed independently. The framework is free in how to distribute rows across
      * virtual processors and each virtual processor has access only to the currently processed row.
      */
-    TABLE_AS_ROW(StaticArgumentTrait.TABLE_AS_ROW),
+    TABLE_AS_ROW(true, StaticArgumentTrait.TABLE_AS_ROW),
 
     /**
      * An argument that accepts a table "as set" (i.e. with set semantics). This trait only applies
@@ -77,20 +77,26 @@ public enum ArgumentTrait {
      * <p>It is also possible not to provide a key ({@link #OPTIONAL_PARTITION_BY}), in which case
      * only one virtual processor handles the entire table, thereby losing scalability benefits.
      */
-    TABLE_AS_SET(StaticArgumentTrait.TABLE_AS_SET),
+    TABLE_AS_SET(true, StaticArgumentTrait.TABLE_AS_SET),
 
     /**
      * Defines that a PARTITION BY clause is optional for {@link #TABLE_AS_SET}. By default, it is
      * mandatory for improving the parallel execution by distributing the table by key.
      */
-    OPTIONAL_PARTITION_BY(StaticArgumentTrait.OPTIONAL_PARTITION_BY, TABLE_AS_SET);
+    OPTIONAL_PARTITION_BY(false, StaticArgumentTrait.OPTIONAL_PARTITION_BY, TABLE_AS_SET);
 
+    private final boolean isRoot;
     private final StaticArgumentTrait staticTrait;
     private final Set<ArgumentTrait> requirements;
 
-    ArgumentTrait(StaticArgumentTrait staticTrait, ArgumentTrait... requirements) {
+    ArgumentTrait(boolean isRoot, StaticArgumentTrait staticTrait, ArgumentTrait... requirements) {
+        this.isRoot = isRoot;
         this.staticTrait = staticTrait;
         this.requirements = Arrays.stream(requirements).collect(Collectors.toSet());
+    }
+
+    public boolean isRoot() {
+        return isRoot;
     }
 
     public Set<ArgumentTrait> getRequirements() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/ProcessTableFunction.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.annotation.ArgumentTrait;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.types.extraction.TypeInferenceExtractor;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.util.Collector;
 
@@ -225,8 +226,9 @@ public abstract class ProcessTableFunction<T> extends UserDefinedFunction {
     }
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public TypeInference getTypeInference(DataTypeFactory typeFactory) {
-        throw new UnsupportedOperationException("Type inference is not implemented yet.");
+        return TypeInferenceExtractor.forProcessTableFunction(typeFactory, (Class) getClass());
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
@@ -92,6 +92,8 @@ public final class UserDefinedFunctionHelper {
 
     public static final String ASYNC_TABLE_EVAL = "eval";
 
+    public static final String PROCESS_TABLE_EVAL = "eval";
+
     /**
      * Tries to infer the TypeInformation of an AggregateFunction's accumulator type.
      *
@@ -320,9 +322,12 @@ public final class UserDefinedFunctionHelper {
                 methods.stream()
                         .anyMatch(
                                 method ->
-                                        ExtractionUtils.isInvokable(method, argumentClasses)
+                                        ExtractionUtils.isInvokable(false, method, argumentClasses)
                                                 && ExtractionUtils.isAssignable(
-                                                        outputClass, method.getReturnType(), true));
+                                                        outputClass,
+                                                        method.getReturnType(),
+                                                        true,
+                                                        false));
         if (!isMatching) {
             throw new ValidationException(
                     String.format(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/UserDefinedFunctionHelper.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
 import org.apache.flink.table.functions.python.utils.PythonFunctionUtils;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.extraction.ExtractionUtils;
+import org.apache.flink.table.types.extraction.ExtractionUtils.Autoboxing;
 import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -322,12 +323,13 @@ public final class UserDefinedFunctionHelper {
                 methods.stream()
                         .anyMatch(
                                 method ->
-                                        ExtractionUtils.isInvokable(false, method, argumentClasses)
+                                        // Strict autoboxing is disabled for backwards compatibility
+                                        ExtractionUtils.isInvokable(
+                                                        Autoboxing.JVM, method, argumentClasses)
                                                 && ExtractionUtils.isAssignable(
                                                         outputClass,
                                                         method.getReturnType(),
-                                                        true,
-                                                        false));
+                                                        Autoboxing.JVM));
         if (!isMatching) {
             throw new ValidationException(
                     String.format(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/BaseMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/BaseMappingExtractor.java
@@ -113,6 +113,10 @@ abstract class BaseMappingExtractor {
 
     /**
      * Extraction that uses the method parameters for producing a {@link FunctionSignatureTemplate}.
+     *
+     * @param offset excludes the first n method parameters as arguments. This is necessary for
+     *     aggregating functions which don't require a {@link StateHint}. Accumulators are mandatory
+     *     and are kind of an implicit {@link StateHint}.
      */
     static SignatureExtraction createArgumentsFromParametersExtraction(
             int offset, @Nullable Class<?> contextClass) {
@@ -141,6 +145,10 @@ abstract class BaseMappingExtractor {
 
     /**
      * Extraction that uses the method parameters for producing a {@link FunctionSignatureTemplate}.
+     *
+     * @param offset excludes the first n method parameters as arguments. This is necessary for
+     *     aggregating functions which don't require a {@link StateHint}. Accumulators are mandatory
+     *     and are kind of an implicit {@link StateHint}.
      */
     static SignatureExtraction createArgumentsFromParametersExtraction(int offset) {
         return createArgumentsFromParametersExtraction(offset, null);
@@ -158,7 +166,7 @@ abstract class BaseMappingExtractor {
      * Extraction that uses a generic type variable for producing a {@link FunctionStateTemplate}.
      * Or method parameters with {@link StateHint} for state entries as a fallback.
      */
-    static ResultExtraction createStateFromGenericInClassOrParameters(
+    static ResultExtraction createStateFromGenericInClassOrParametersExtraction(
             Class<? extends UserDefinedFunction> baseClass, int genericPos) {
         return (extractor, method) -> {
             final List<StateParameter> stateParameters = extractStateParameters(method);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/BaseMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/BaseMappingExtractor.java
@@ -21,13 +21,21 @@ package org.apache.flink.table.types.extraction;
 import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.ArgumentTrait;
 import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.StateHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.procedures.Procedure;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionOutputTemplate;
+import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionStateTemplate;
+import org.apache.flink.table.types.inference.StaticArgumentTrait;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.lang3.ArrayUtils;
 
 import javax.annotation.Nullable;
 
@@ -36,6 +44,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,26 +74,109 @@ abstract class BaseMappingExtractor {
 
     protected final DataTypeFactory typeFactory;
 
-    private final String methodName;
+    protected final String methodName;
 
     private final SignatureExtraction signatureExtraction;
 
     protected final ResultExtraction outputExtraction;
 
-    protected final MethodVerification verification;
+    protected final MethodVerification outputVerification;
 
     public BaseMappingExtractor(
             DataTypeFactory typeFactory,
             String methodName,
             SignatureExtraction signatureExtraction,
             ResultExtraction outputExtraction,
-            MethodVerification verification) {
+            MethodVerification outputVerification) {
         this.typeFactory = typeFactory;
         this.methodName = methodName;
         this.signatureExtraction = signatureExtraction;
         this.outputExtraction = outputExtraction;
-        this.verification = verification;
+        this.outputVerification = outputVerification;
     }
+
+    Map<FunctionSignatureTemplate, FunctionOutputTemplate> extractOutputMapping() {
+        try {
+            return extractResultMappings(
+                    outputExtraction, FunctionTemplate::getOutputTemplate, outputVerification);
+        } catch (Throwable t) {
+            throw extractionError(t, "Error in extracting a signature to output mapping.");
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Extraction strategies
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Extraction that uses the method parameters for producing a {@link FunctionSignatureTemplate}.
+     */
+    static SignatureExtraction createArgumentsFromParametersExtraction(
+            int offset, @Nullable Class<?> contextClass) {
+        return (extractor, method) -> {
+            final List<ArgumentParameter> args =
+                    extractArgumentParameters(method, offset, contextClass);
+
+            final EnumSet<StaticArgumentTrait>[] argumentTraits = extractArgumentTraits(args);
+
+            final List<FunctionArgumentTemplate> argumentTemplates =
+                    extractArgumentTemplates(
+                            extractor.typeFactory, extractor.getFunctionClass(), args);
+
+            final String[] argumentNames = extractArgumentNames(method, args);
+
+            final boolean[] argumentOptionals = extractArgumentOptionals(args);
+
+            return FunctionSignatureTemplate.of(
+                    argumentTemplates,
+                    method.isVarArgs(),
+                    argumentTraits,
+                    argumentNames,
+                    argumentOptionals);
+        };
+    }
+
+    /**
+     * Extraction that uses the method parameters for producing a {@link FunctionSignatureTemplate}.
+     */
+    static SignatureExtraction createArgumentsFromParametersExtraction(int offset) {
+        return createArgumentsFromParametersExtraction(offset, null);
+    }
+
+    /** Extraction that uses the method parameters with {@link StateHint} for state entries. */
+    static ResultExtraction createStateFromParametersExtraction() {
+        return (extractor, method) -> {
+            final List<StateParameter> stateParameters = extractStateParameters(method);
+            return createStateTemplateFromParameters(extractor, method, stateParameters);
+        };
+    }
+
+    /**
+     * Extraction that uses a generic type variable for producing a {@link FunctionStateTemplate}.
+     * Or method parameters with {@link StateHint} for state entries as a fallback.
+     */
+    static ResultExtraction createStateFromGenericInClassOrParameters(
+            Class<? extends UserDefinedFunction> baseClass, int genericPos) {
+        return (extractor, method) -> {
+            final List<StateParameter> stateParameters = extractStateParameters(method);
+            if (stateParameters.isEmpty()) {
+                final DataType dataType =
+                        DataTypeExtractor.extractFromGeneric(
+                                extractor.typeFactory,
+                                baseClass,
+                                genericPos,
+                                extractor.getFunctionClass());
+                final LinkedHashMap<String, DataType> state = new LinkedHashMap<>();
+                state.put("acc", dataType);
+                return FunctionResultTemplate.ofState(state);
+            }
+            return createStateTemplateFromParameters(extractor, method, stateParameters);
+        };
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Methods for subclasses
+    // --------------------------------------------------------------------------------------------
 
     protected abstract Set<FunctionTemplate> extractGlobalFunctionTemplates();
 
@@ -96,27 +188,35 @@ abstract class BaseMappingExtractor {
 
     protected abstract String getHintType();
 
-    Map<FunctionSignatureTemplate, FunctionResultTemplate> extractOutputMapping() {
-        try {
-            return extractResultMappings(
-                    outputExtraction, FunctionTemplate::getOutputTemplate, verification);
-        } catch (Throwable t) {
-            throw extractionError(t, "Error in extracting a signature to output mapping.");
-        }
+    protected static Class<?>[] assembleParameters(List<Class<?>> state, List<Class<?>> arguments) {
+        return Stream.concat(state.stream(), arguments.stream()).toArray(Class[]::new);
+    }
+
+    protected static ValidationException createMethodNotFoundError(
+            String methodName,
+            Class<?>[] parameters,
+            @Nullable Class<?> returnType,
+            String pattern) {
+        return extractionError(
+                "Considering all hints, the method should comply with the signature:\n%s%s",
+                createMethodSignatureString(methodName, parameters, returnType),
+                pattern.isEmpty() ? "" : "\nPattern: " + pattern);
     }
 
     /**
-     * Extracts mappings from signature to result (either accumulator or output) for the entire
-     * function. Verifies if the extracted inference matches with the implementation.
+     * Extracts mappings from signature to result (either state or output) for the entire function.
+     * Verifies if the extracted inference matches with the implementation.
      *
      * <p>For example, from {@code (INT, BOOLEAN, ANY) -> INT}. It does this by going through all
      * implementation methods and collecting all "per-method" mappings. The function mapping is the
      * union of all "per-method" mappings.
      */
-    protected Map<FunctionSignatureTemplate, FunctionResultTemplate> extractResultMappings(
-            ResultExtraction resultExtraction,
-            Function<FunctionTemplate, FunctionResultTemplate> accessor,
-            MethodVerification verification) {
+    @SuppressWarnings("unchecked")
+    protected <T extends FunctionResultTemplate>
+            Map<FunctionSignatureTemplate, T> extractResultMappings(
+                    ResultExtraction resultExtraction,
+                    Function<FunctionTemplate, FunctionResultTemplate> accessor,
+                    @Nullable MethodVerification verification) {
         final Set<FunctionTemplate> global = extractGlobalFunctionTemplates();
         final Set<FunctionResultTemplate> globalResultOnly =
                 findResultOnlyTemplates(global, accessor);
@@ -125,7 +225,7 @@ abstract class BaseMappingExtractor {
         final Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappings =
                 new LinkedHashMap<>();
         final List<Method> methods = collectMethods(methodName);
-        if (methods.size() == 0) {
+        if (methods.isEmpty()) {
             throw extractionError(
                     "Could not find a publicly accessible method named '%s'.", methodName);
         }
@@ -145,9 +245,6 @@ abstract class BaseMappingExtractor {
                 // check if the method can be called
                 verifyMappingForMethod(correctMethod, collectedMappingsPerMethod, verification);
 
-                // check if we declare optional on a primitive type parameter
-                verifyOptionalOnPrimitiveParameter(correctMethod, collectedMappingsPerMethod);
-
                 // check if method strategies conflict with function strategies
                 collectedMappingsPerMethod.forEach(
                         (signature, result) -> putMapping(collectedMappings, signature, result));
@@ -158,48 +255,55 @@ abstract class BaseMappingExtractor {
                         method.toString());
             }
         }
-        return collectedMappings;
+        return (Map<FunctionSignatureTemplate, T>) collectedMappings;
     }
 
-    /**
-     * Special case for Scala which generates two methods when using var-args (a {@code Seq < String
-     * >} and {@code String...}). This method searches for the Java-like variant.
-     */
-    static Method correctVarArgMethod(Method method) {
-        final int paramCount = method.getParameterCount();
-        final Class<?>[] paramClasses = method.getParameterTypes();
-        if (paramCount > 0
-                && paramClasses[paramCount - 1].getName().equals("scala.collection.Seq")) {
-            final Type[] paramTypes = method.getGenericParameterTypes();
-            final ParameterizedType seqType = (ParameterizedType) paramTypes[paramCount - 1];
-            final Type varArgType = seqType.getActualTypeArguments()[0];
-            return ExtractionUtils.collectMethods(method.getDeclaringClass(), method.getName())
-                    .stream()
-                    .filter(Method::isVarArgs)
-                    .filter(candidate -> candidate.getParameterCount() == paramCount)
-                    .filter(
-                            candidate -> {
-                                final Type[] candidateParamTypes =
-                                        candidate.getGenericParameterTypes();
-                                for (int i = 0; i < paramCount - 1; i++) {
-                                    if (candidateParamTypes[i] != paramTypes[i]) {
-                                        return false;
-                                    }
-                                }
-                                final Class<?> candidateVarArgType =
-                                        candidate.getParameterTypes()[paramCount - 1];
-                                return candidateVarArgType.isArray()
-                                        &&
-                                        // check for Object is needed in case of Scala primitives
-                                        // (e.g. Int)
-                                        (varArgType == Object.class
-                                                || candidateVarArgType.getComponentType()
-                                                        == varArgType);
-                            })
-                    .findAny()
-                    .orElse(method);
+    protected static void checkNoState(@Nullable List<Class<?>> state) {
+        if (state != null && !state.isEmpty()) {
+            throw extractionError("State is not supported for this kind of function.");
         }
-        return method;
+    }
+
+    protected static void checkSingleState(@Nullable List<Class<?>> state) {
+        if (state == null || state.size() != 1) {
+            throw extractionError(
+                    "Aggregating functions need exactly one state entry for the accumulator.");
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Helper methods
+    // --------------------------------------------------------------------------------------------
+
+    private static FunctionStateTemplate createStateTemplateFromParameters(
+            BaseMappingExtractor extractor, Method method, List<StateParameter> stateParameters) {
+        final String[] argumentNames = extractStateNames(method, stateParameters);
+        if (argumentNames == null) {
+            throw extractionError("Unable to extract names for all state entries.");
+        }
+
+        final List<DataType> dataTypes =
+                stateParameters.stream()
+                        .map(
+                                s ->
+                                        DataTypeExtractor.extractFromMethodParameter(
+                                                extractor.typeFactory,
+                                                extractor.getFunctionClass(),
+                                                s.method,
+                                                s.pos))
+                        .collect(Collectors.toList());
+
+        final LinkedHashMap<String, DataType> state =
+                IntStream.range(0, dataTypes.size())
+                        .mapToObj(i -> Map.entry(argumentNames[i], dataTypes.get(i)))
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        Map.Entry::getValue,
+                                        (o, n) -> o,
+                                        LinkedHashMap::new));
+
+        return FunctionResultTemplate.ofState(state);
     }
 
     /**
@@ -247,9 +351,47 @@ abstract class BaseMappingExtractor {
         return collectedMappingsPerMethod;
     }
 
-    // --------------------------------------------------------------------------------------------
-    // Helper methods (ordered by invocation order)
-    // --------------------------------------------------------------------------------------------
+    /**
+     * Special case for Scala which generates two methods when using var-args (a {@code Seq < String
+     * >} and {@code String...}). This method searches for the Java-like variant.
+     */
+    private static Method correctVarArgMethod(Method method) {
+        final int paramCount = method.getParameterCount();
+        final Class<?>[] paramClasses = method.getParameterTypes();
+        if (paramCount > 0
+                && paramClasses[paramCount - 1].getName().equals("scala.collection.Seq")) {
+            final Type[] paramTypes = method.getGenericParameterTypes();
+            final ParameterizedType seqType = (ParameterizedType) paramTypes[paramCount - 1];
+            final Type varArgType = seqType.getActualTypeArguments()[0];
+            return ExtractionUtils.collectMethods(method.getDeclaringClass(), method.getName())
+                    .stream()
+                    .filter(Method::isVarArgs)
+                    .filter(candidate -> candidate.getParameterCount() == paramCount)
+                    .filter(
+                            candidate -> {
+                                final Type[] candidateParamTypes =
+                                        candidate.getGenericParameterTypes();
+                                for (int i = 0; i < paramCount - 1; i++) {
+                                    if (candidateParamTypes[i] != paramTypes[i]) {
+                                        return false;
+                                    }
+                                }
+                                final Class<?> candidateVarArgType =
+                                        candidate.getParameterTypes()[paramCount - 1];
+                                return candidateVarArgType.isArray()
+                                        &&
+                                        // check for Object is needed in case of Scala primitives
+                                        // (e.g. Int)
+                                        (varArgType == Object.class
+                                                || candidateVarArgType.getComponentType()
+                                                        == varArgType);
+                            })
+                    .findAny()
+                    .orElse(method);
+        }
+        return method;
+    }
+
     /** Explicit mappings with complete signature to result declaration. */
     private void putExplicitMappings(
             Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappings,
@@ -322,166 +464,259 @@ abstract class BaseMappingExtractor {
     private void verifyMappingForMethod(
             Method method,
             Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappingsPerMethod,
-            MethodVerification verification) {
+            @Nullable MethodVerification verification) {
+        if (verification == null) {
+            return;
+        }
         collectedMappingsPerMethod.forEach(
-                (signature, result) ->
-                        verification.verify(method, signature.toClass(), result.toClass()));
-    }
-
-    private void verifyOptionalOnPrimitiveParameter(
-            Method method,
-            Map<FunctionSignatureTemplate, FunctionResultTemplate> collectedMappingsPerMethod) {
-        collectedMappingsPerMethod
-                .keySet()
-                .forEach(
-                        signature -> {
-                            Boolean[] argumentOptional = signature.argumentOptionals;
-                            // Here we restrict that the argument must contain optional parameters
-                            // in order to obtain the FunctionSignatureTemplate of the method for
-                            // verification. Therefore, the extract method will only be called once.
-                            // If no function hint is set, this verify will not be executed.
-                            if (argumentOptional != null
-                                    && Arrays.stream(argumentOptional)
-                                            .anyMatch(Boolean::booleanValue)) {
-                                FunctionSignatureTemplate functionResultTemplate =
-                                        signatureExtraction.extract(this, method);
-                                for (int i = 0; i < argumentOptional.length; i++) {
-                                    DataType dataType =
-                                            functionResultTemplate.argumentTemplates.get(i)
-                                                    .dataType;
-                                    if (dataType != null
-                                            && argumentOptional[i]
-                                            && dataType.getConversionClass() != null
-                                            && dataType.getConversionClass().isPrimitive()) {
-                                        throw extractionError(
-                                                "Argument at position %d is optional but a primitive type doesn't accept null value.",
-                                                i);
-                                    }
-                                }
-                            }
-                        });
+                (signature, result) -> {
+                    if (result instanceof FunctionStateTemplate) {
+                        final FunctionStateTemplate stateTemplate = (FunctionStateTemplate) result;
+                        verification.verify(
+                                method, stateTemplate.toClassList(), signature.toClassList(), null);
+                    } else if (result instanceof FunctionOutputTemplate) {
+                        final FunctionOutputTemplate outputTemplate =
+                                (FunctionOutputTemplate) result;
+                        verification.verify(
+                                method,
+                                List.of(),
+                                signature.toClassList(),
+                                outputTemplate.toClass());
+                    }
+                });
     }
 
     // --------------------------------------------------------------------------------------------
-    // Context sensitive extraction and verification logic
+    // Parameters extraction (i.e. state and arguments)
     // --------------------------------------------------------------------------------------------
 
-    /**
-     * Extraction that uses the method parameters for producing a {@link FunctionSignatureTemplate}.
-     */
-    static SignatureExtraction createParameterSignatureExtraction(int offset) {
-        return (extractor, method) -> {
-            final List<FunctionArgumentTemplate> parameterTypes =
-                    extractArgumentTemplates(
-                            extractor.typeFactory, extractor.getFunctionClass(), method, offset);
+    /** Method parameter that qualifies as a function argument (i.e. not a context or state). */
+    private static class ArgumentParameter {
+        final Parameter parameter;
+        final Method method;
+        // Pos in the method, not necessarily in the extracted function
+        final int pos;
 
-            final String[] argumentNames = extractArgumentNames(method, offset);
-
-            final Boolean[] argumentOptionals = extractArgumentOptionals(method, offset);
-
-            return FunctionSignatureTemplate.of(
-                    parameterTypes, method.isVarArgs(), argumentNames, argumentOptionals);
-        };
+        private ArgumentParameter(Parameter parameter, Method method, int pos) {
+            this.parameter = parameter;
+            this.method = method;
+            this.pos = pos;
+        }
     }
 
-    private static List<FunctionArgumentTemplate> extractArgumentTemplates(
-            DataTypeFactory typeFactory, Class<?> extractedClass, Method method, int offset) {
-        return IntStream.range(offset, method.getParameterCount())
+    /** Method parameter that qualifies as a function state (i.e. not a context or argument). */
+    private static class StateParameter {
+        final Parameter parameter;
+        final Method method;
+        // Pos in the method, not necessarily in the extracted function
+        final int pos;
+
+        private StateParameter(Parameter parameter, Method method, int pos) {
+            this.parameter = parameter;
+            this.method = method;
+            this.pos = pos;
+        }
+    }
+
+    private static List<ArgumentParameter> extractArgumentParameters(
+            Method method, int offset, @Nullable Class<?> contextClass) {
+        final Parameter[] parameters = method.getParameters();
+        return IntStream.range(0, parameters.length)
                 .mapToObj(
-                        i ->
-                                // check for input group before start extracting a data type
-                                tryExtractInputGroupArgument(method, i)
-                                        .orElseGet(
-                                                () ->
-                                                        extractDataTypeArgument(
-                                                                typeFactory,
-                                                                extractedClass,
-                                                                method,
-                                                                i)))
+                        pos -> {
+                            final Parameter parameter = parameters[pos];
+                            return new ArgumentParameter(parameter, method, pos);
+                        })
+                .skip(offset)
+                .filter(arg -> contextClass == null || arg.parameter.getType() != contextClass)
+                .filter(arg -> arg.parameter.getAnnotation(StateHint.class) == null)
                 .collect(Collectors.toList());
     }
 
-    static Optional<FunctionArgumentTemplate> tryExtractInputGroupArgument(
-            Method method, int paramPos) {
-        final Parameter parameter = method.getParameters()[paramPos];
-        final DataTypeHint hint = parameter.getAnnotation(DataTypeHint.class);
-        final ArgumentHint argumentHint = parameter.getAnnotation(ArgumentHint.class);
-        if (hint != null && argumentHint != null) {
+    private static List<StateParameter> extractStateParameters(Method method) {
+        final Parameter[] parameters = method.getParameters();
+        return IntStream.range(0, parameters.length)
+                .mapToObj(
+                        pos -> {
+                            final Parameter parameter = parameters[pos];
+                            return new StateParameter(parameter, method, pos);
+                        })
+                .filter(arg -> arg.parameter.getAnnotation(StateHint.class) != null)
+                .collect(Collectors.toList());
+    }
+
+    private static List<FunctionArgumentTemplate> extractArgumentTemplates(
+            DataTypeFactory typeFactory, Class<?> extractedClass, List<ArgumentParameter> args) {
+        return args.stream()
+                .map(
+                        arg ->
+                                // check for input group before start extracting a data type
+                                tryExtractInputGroupArgument(arg)
+                                        .orElseGet(
+                                                () ->
+                                                        extractArgumentByKind(
+                                                                typeFactory, extractedClass, arg)))
+                .collect(Collectors.toList());
+    }
+
+    private static Optional<FunctionArgumentTemplate> tryExtractInputGroupArgument(
+            ArgumentParameter arg) {
+        final DataTypeHint dataTypehint = arg.parameter.getAnnotation(DataTypeHint.class);
+        final ArgumentHint argumentHint = arg.parameter.getAnnotation(ArgumentHint.class);
+        if (dataTypehint != null && argumentHint != null) {
             throw extractionError(
-                    "Argument and dataType hints cannot be declared in the same parameter at position %d.",
-                    paramPos);
+                    "Argument and data type hints cannot be declared at the same time at position %d.",
+                    arg.pos);
         }
         if (argumentHint != null) {
             final DataTypeTemplate template = DataTypeTemplate.fromAnnotation(argumentHint, null);
             if (template.inputGroup != null) {
-                return Optional.of(FunctionArgumentTemplate.of(template.inputGroup));
+                return Optional.of(FunctionArgumentTemplate.ofInputGroup(template.inputGroup));
             }
-        } else if (hint != null) {
-            final DataTypeTemplate template = DataTypeTemplate.fromAnnotation(hint, null);
+        } else if (dataTypehint != null) {
+            final DataTypeTemplate template = DataTypeTemplate.fromAnnotation(dataTypehint, null);
             if (template.inputGroup != null) {
-                return Optional.of(FunctionArgumentTemplate.of(template.inputGroup));
+                return Optional.of(FunctionArgumentTemplate.ofInputGroup(template.inputGroup));
             }
         }
         return Optional.empty();
     }
 
-    private static FunctionArgumentTemplate extractDataTypeArgument(
-            DataTypeFactory typeFactory, Class<?> extractedClass, Method method, int paramPos) {
+    private static FunctionArgumentTemplate extractArgumentByKind(
+            DataTypeFactory typeFactory, Class<?> extractedClass, ArgumentParameter arg) {
+        final Parameter parameter = arg.parameter;
+        final ArgumentHint argumentHint = parameter.getAnnotation(ArgumentHint.class);
+        final int pos = arg.pos;
+        final Set<ArgumentTrait> rootTrait =
+                Optional.ofNullable(argumentHint)
+                        .map(
+                                hint ->
+                                        Arrays.stream(hint.value())
+                                                .filter(ArgumentTrait::isRoot)
+                                                .collect(Collectors.toSet()))
+                        .orElse(Set.of(ArgumentTrait.SCALAR));
+        if (rootTrait.size() != 1) {
+            throw extractionError(
+                    "Incorrect argument kind at position %d. Argument kind must be one of: %s",
+                    pos,
+                    Arrays.stream(ArgumentTrait.values())
+                            .filter(ArgumentTrait::isRoot)
+                            .collect(Collectors.toList()));
+        }
+
+        if (rootTrait.contains(ArgumentTrait.SCALAR)) {
+            return extractScalarArgument(typeFactory, extractedClass, arg);
+        } else if (rootTrait.contains(ArgumentTrait.TABLE_AS_ROW)
+                || rootTrait.contains(ArgumentTrait.TABLE_AS_SET)) {
+            return extractTableArgument(typeFactory, argumentHint, extractedClass, arg);
+        } else {
+            throw extractionError("Unknown argument kind.");
+        }
+    }
+
+    private static FunctionArgumentTemplate extractTableArgument(
+            DataTypeFactory typeFactory,
+            ArgumentHint argumentHint,
+            Class<?> extractedClass,
+            ArgumentParameter arg) {
+        try {
+            final DataType type =
+                    DataTypeExtractor.extractFromMethodParameter(
+                            typeFactory, extractedClass, arg.method, arg.pos);
+            return FunctionArgumentTemplate.ofDataType(type);
+        } catch (Throwable t) {
+            final Class<?> paramClass = arg.parameter.getType();
+            final Class<?> argClass = argumentHint.type().bridgedTo();
+            if (argClass == Row.class || argClass == RowData.class) {
+                return FunctionArgumentTemplate.ofTable(argClass);
+            }
+            if (paramClass == Row.class || paramClass == RowData.class) {
+                return FunctionArgumentTemplate.ofTable(paramClass);
+            }
+            // Just a regular error for a typed argument
+            throw t;
+        }
+    }
+
+    private static FunctionArgumentTemplate extractScalarArgument(
+            DataTypeFactory typeFactory, Class<?> extractedClass, ArgumentParameter arg) {
         final DataType type =
                 DataTypeExtractor.extractFromMethodParameter(
-                        typeFactory, extractedClass, method, paramPos);
+                        typeFactory, extractedClass, arg.method, arg.pos);
         // unwrap data type in case of varargs
-        if (method.isVarArgs() && paramPos == method.getParameterCount() - 1) {
+        if (arg.parameter.isVarArgs()) {
             // for ARRAY
             if (type instanceof CollectionDataType) {
-                return FunctionArgumentTemplate.of(
+                return FunctionArgumentTemplate.ofDataType(
                         ((CollectionDataType) type).getElementDataType());
             }
             // special case for varargs that have been misinterpreted as BYTES
             else if (type.equals(DataTypes.BYTES())) {
-                return FunctionArgumentTemplate.of(
+                return FunctionArgumentTemplate.ofDataType(
                         DataTypes.TINYINT().notNull().bridgedTo(byte.class));
             }
         }
-        return FunctionArgumentTemplate.of(type);
+        return FunctionArgumentTemplate.ofDataType(type);
     }
 
-    static @Nullable String[] extractArgumentNames(Method method, int offset) {
+    @SuppressWarnings("unchecked")
+    private static EnumSet<StaticArgumentTrait>[] extractArgumentTraits(
+            List<ArgumentParameter> args) {
+        return args.stream()
+                .map(
+                        arg -> {
+                            final ArgumentHint argumentHint =
+                                    arg.parameter.getAnnotation(ArgumentHint.class);
+                            if (argumentHint == null) {
+                                return EnumSet.of(StaticArgumentTrait.SCALAR);
+                            }
+                            final List<StaticArgumentTrait> traits =
+                                    Arrays.stream(argumentHint.value())
+                                            .map(ArgumentTrait::toStaticTrait)
+                                            .collect(Collectors.toList());
+                            return EnumSet.copyOf(traits);
+                        })
+                .toArray(EnumSet[]::new);
+    }
+
+    private static @Nullable String[] extractArgumentNames(
+            Method method, List<ArgumentParameter> args) {
         final List<String> methodParameterNames =
                 ExtractionUtils.extractMethodParameterNames(method);
         if (methodParameterNames != null) {
-            return methodParameterNames
-                    .subList(offset, methodParameterNames.size())
-                    .toArray(new String[0]);
+            return args.stream()
+                    .map(arg -> methodParameterNames.get(arg.pos))
+                    .toArray(String[]::new);
         } else {
             return null;
         }
     }
 
-    static Boolean[] extractArgumentOptionals(Method method, int offset) {
-        return Arrays.stream(method.getParameters())
-                .skip(offset)
-                .map(parameter -> parameter.getAnnotation(ArgumentHint.class))
-                .map(
-                        h -> {
-                            if (h == null) {
-                                return false;
-                            }
-                            final ArgumentTrait[] traits = h.value();
-                            if (traits.length != 1 || traits[0] != ArgumentTrait.SCALAR) {
-                                throw extractionError(
-                                        "Only scalar arguments are supported so far.");
-                            }
-                            return h.isOptional();
-                        })
-                .toArray(Boolean[]::new);
+    private static @Nullable String[] extractStateNames(Method method, List<StateParameter> state) {
+        final List<String> methodParameterNames =
+                ExtractionUtils.extractMethodParameterNames(method);
+        if (methodParameterNames != null) {
+            return state.stream()
+                    .map(arg -> methodParameterNames.get(arg.pos))
+                    .toArray(String[]::new);
+        } else {
+            return null;
+        }
     }
 
-    protected static ValidationException createMethodNotFoundError(
-            String methodName, Class<?>[] parameters, @Nullable Class<?> returnType) {
-        return extractionError(
-                "Considering all hints, the method should comply with the signature:\n%s",
-                createMethodSignatureString(methodName, parameters, returnType));
+    private static boolean[] extractArgumentOptionals(List<ArgumentParameter> args) {
+        final Boolean[] argumentOptionals =
+                args.stream()
+                        .map(arg -> arg.parameter.getAnnotation(ArgumentHint.class))
+                        .map(
+                                hint -> {
+                                    if (hint == null) {
+                                        return false;
+                                    }
+                                    return hint.isOptional();
+                                })
+                        .toArray(Boolean[]::new);
+        return ArrayUtils.toPrimitive(argumentOptionals);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -489,18 +724,22 @@ abstract class BaseMappingExtractor {
     // --------------------------------------------------------------------------------------------
 
     /** Extracts a {@link FunctionSignatureTemplate} from a method. */
-    protected interface SignatureExtraction {
+    interface SignatureExtraction {
         FunctionSignatureTemplate extract(BaseMappingExtractor extractor, Method method);
     }
 
     /** Extracts a {@link FunctionResultTemplate} from a class or method. */
-    protected interface ResultExtraction {
+    interface ResultExtraction {
         @Nullable
         FunctionResultTemplate extract(BaseMappingExtractor extractor, Method method);
     }
 
     /** Verifies the signature of a method. */
     protected interface MethodVerification {
-        void verify(Method method, List<Class<?>> arguments, Class<?> result);
+        void verify(
+                Method method,
+                List<Class<?>> state,
+                List<Class<?>> arguments,
+                @Nullable Class<?> result);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.typeutils.AvroUtils;
 import org.apache.flink.table.annotation.ArgumentHint;
 import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.StateHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.dataview.DataView;
 import org.apache.flink.table.api.dataview.ListView;
@@ -144,8 +145,11 @@ public final class DataTypeExtractor {
         final Parameter parameter = method.getParameters()[paramPos];
         final DataTypeHint hint = parameter.getAnnotation(DataTypeHint.class);
         final ArgumentHint argumentHint = parameter.getAnnotation(ArgumentHint.class);
+        final StateHint stateHint = parameter.getAnnotation(StateHint.class);
         final DataTypeTemplate template;
-        if (argumentHint != null) {
+        if (stateHint != null) {
+            template = DataTypeTemplate.fromAnnotation(typeFactory, stateHint.type());
+        } else if (argumentHint != null) {
             template = DataTypeTemplate.fromAnnotation(typeFactory, argumentHint.type());
         } else if (hint != null) {
             template = DataTypeTemplate.fromAnnotation(typeFactory, hint);
@@ -206,9 +210,9 @@ public final class DataTypeExtractor {
      * Extracts a data type from a method return type by considering surrounding classes and method
      * annotation.
      */
-    public static DataType extractFromMethodOutput(
+    public static DataType extractFromMethodReturnType(
             DataTypeFactory typeFactory, Class<?> baseClass, Method method) {
-        return extractFromMethodOutput(
+        return extractFromMethodReturnType(
                 typeFactory, baseClass, method, method.getGenericReturnType());
     }
 
@@ -216,7 +220,7 @@ public final class DataTypeExtractor {
      * Extracts a data type from a method return type with specifying the method's type explicitly
      * by considering surrounding classes and method annotation.
      */
-    public static DataType extractFromMethodOutput(
+    public static DataType extractFromMethodReturnType(
             DataTypeFactory typeFactory, Class<?> baseClass, Method method, Type methodReturnType) {
         final DataTypeHint hint = method.getAnnotation(DataTypeHint.class);
         final DataTypeTemplate template;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
@@ -922,6 +922,7 @@ public final class ExtractionUtils {
     // --------------------------------------------------------------------------------------------
 
     /** Checks the relation between primitive and boxed types. */
+    @Internal
     public enum Autoboxing {
         /**
          * int.class cannot be passed into f(Integer.class). Integer.class cannot be passed into

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionArgumentTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionArgumentTemplate.java
@@ -37,21 +37,29 @@ import static org.apache.flink.table.types.extraction.ExtractionUtils.extraction
 @Internal
 final class FunctionArgumentTemplate {
 
-    final @Nullable DataType dataType;
+    private final @Nullable DataType dataType;
+    private final @Nullable InputGroup inputGroup;
+    private final @Nullable Class<?> conversionClass;
 
-    final @Nullable InputGroup inputGroup;
-
-    private FunctionArgumentTemplate(@Nullable DataType dataType, @Nullable InputGroup inputGroup) {
+    private FunctionArgumentTemplate(
+            @Nullable DataType dataType,
+            @Nullable InputGroup inputGroup,
+            @Nullable Class<?> conversionClass) {
         this.dataType = dataType;
         this.inputGroup = inputGroup;
+        this.conversionClass = conversionClass;
     }
 
-    static FunctionArgumentTemplate of(DataType dataType) {
-        return new FunctionArgumentTemplate(dataType, null);
+    static FunctionArgumentTemplate ofDataType(DataType dataType) {
+        return new FunctionArgumentTemplate(dataType, null, null);
     }
 
-    static FunctionArgumentTemplate of(InputGroup inputGroup) {
-        return new FunctionArgumentTemplate(null, inputGroup);
+    static FunctionArgumentTemplate ofInputGroup(InputGroup inputGroup) {
+        return new FunctionArgumentTemplate(null, inputGroup, null);
+    }
+
+    static FunctionArgumentTemplate ofTable(Class<?> conversionClass) {
+        return new FunctionArgumentTemplate(null, null, conversionClass);
     }
 
     ArgumentTypeStrategy toArgumentTypeStrategy() {
@@ -68,9 +76,16 @@ final class FunctionArgumentTemplate {
         }
     }
 
+    public @Nullable DataType toDataType() {
+        return dataType;
+    }
+
     Class<?> toConversionClass() {
         if (dataType != null) {
             return dataType.getConversionClass();
+        }
+        if (conversionClass != null) {
+            return conversionClass;
         }
         assert inputGroup != null;
         switch (inputGroup) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionMappingExtractor.java
@@ -24,6 +24,8 @@ import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionOutputTemplate;
+import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionStateTemplate;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -31,12 +33,13 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.types.extraction.ExtractionUtils.collectAnnotationsOfClass;
@@ -59,27 +62,209 @@ final class FunctionMappingExtractor extends BaseMappingExtractor {
 
     private final Class<? extends UserDefinedFunction> function;
 
-    private final @Nullable ResultExtraction accumulatorExtraction;
+    private final @Nullable ResultExtraction stateExtraction;
+    private final @Nullable MethodVerification stateVerification;
 
     FunctionMappingExtractor(
             DataTypeFactory typeFactory,
             Class<? extends UserDefinedFunction> function,
             String methodName,
             SignatureExtraction signatureExtraction,
-            @Nullable ResultExtraction accumulatorExtraction,
+            @Nullable ResultExtraction stateExtraction,
+            @Nullable MethodVerification stateVerification,
             ResultExtraction outputExtraction,
-            MethodVerification verification) {
-        super(typeFactory, methodName, signatureExtraction, outputExtraction, verification);
+            @Nullable MethodVerification outputVerification) {
+        super(typeFactory, methodName, signatureExtraction, outputExtraction, outputVerification);
         this.function = function;
-        this.accumulatorExtraction = accumulatorExtraction;
+        this.stateExtraction = stateExtraction;
+        this.stateVerification = stateVerification;
     }
+
+    Map<FunctionSignatureTemplate, FunctionStateTemplate> extractStateMapping() {
+        Preconditions.checkState(supportsState());
+        try {
+            return extractResultMappings(
+                    stateExtraction, FunctionTemplate::getStateTemplate, stateVerification);
+        } catch (Throwable t) {
+            throw extractionError(t, "Error in extracting a signature to state mapping.");
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Extraction strategies
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Extraction that uses the method return type for producing a {@link FunctionOutputTemplate}.
+     */
+    static ResultExtraction createOutputFromReturnTypeInMethod() {
+        return (extractor, method) -> {
+            final DataType dataType =
+                    DataTypeExtractor.extractFromMethodReturnType(
+                            extractor.typeFactory, extractor.getFunctionClass(), method);
+            return FunctionResultTemplate.ofOutput(dataType);
+        };
+    }
+
+    /**
+     * Extraction that uses a generic type variable for producing a {@link FunctionResultTemplate}.
+     *
+     * <p>If enabled, a {@link DataTypeHint} from method or class has higher priority.
+     */
+    static ResultExtraction createOutputFromGenericInClass(
+            Class<? extends UserDefinedFunction> baseClass,
+            int genericPos,
+            boolean allowDataTypeHint) {
+        return (extractor, method) -> {
+            if (allowDataTypeHint) {
+                Optional<FunctionResultTemplate> hints = extractHints(extractor, method);
+                if (hints.isPresent()) {
+                    return hints.get();
+                }
+            }
+            final DataType dataType =
+                    DataTypeExtractor.extractFromGeneric(
+                            extractor.typeFactory,
+                            baseClass,
+                            genericPos,
+                            extractor.getFunctionClass());
+            return FunctionResultTemplate.ofOutput(dataType);
+        };
+    }
+
+    /**
+     * Extraction that uses a generic type variable of a method parameter for producing a {@link
+     * FunctionResultTemplate}.
+     *
+     * <p>If enabled, a {@link DataTypeHint} from method or class has higher priority.
+     */
+    static ResultExtraction createOutputFromGenericInMethod(
+            int paramPos, int genericPos, boolean allowDataTypeHint) {
+        return (extractor, method) -> {
+            if (allowDataTypeHint) {
+                Optional<FunctionResultTemplate> hints = extractHints(extractor, method);
+                if (hints.isPresent()) {
+                    return hints.get();
+                }
+            }
+            final DataType dataType =
+                    DataTypeExtractor.extractFromGenericMethodParameter(
+                            extractor.typeFactory,
+                            extractor.getFunctionClass(),
+                            method,
+                            paramPos,
+                            genericPos);
+            return FunctionResultTemplate.ofOutput(dataType);
+        };
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Verification strategies
+    // --------------------------------------------------------------------------------------------
+
+    /** Verification that checks a method by parameters (arguments only) and return type. */
+    static MethodVerification createParameterAndReturnTypeVerification() {
+        return (method, state, arguments, result) -> {
+            checkNoState(state);
+            final Class<?>[] parameters = assembleParameters(state, arguments);
+            final Class<?> returnType = method.getReturnType();
+            // TODO enable strict autoboxing
+            final boolean isValid =
+                    isInvokable(false, method, parameters)
+                            && isAssignable(result, returnType, true, false);
+            if (!isValid) {
+                throw createMethodNotFoundError(method.getName(), parameters, result, "");
+            }
+        };
+    }
+
+    /** Verification that checks a method by parameters (arguments only or with accumulator). */
+    static MethodVerification createParameterVerification(boolean requireAccumulator) {
+        return (method, state, arguments, result) -> {
+            if (requireAccumulator) {
+                checkSingleState(state);
+            } else {
+                checkNoState(state);
+            }
+            final Class<?>[] parameters = assembleParameters(state, arguments);
+            // TODO enable strict autoboxing
+            if (!isInvokable(false, method, parameters)) {
+                throw createMethodNotFoundError(
+                        method.getName(),
+                        parameters,
+                        null,
+                        requireAccumulator ? "(<accumulator> [, <argument>]*)" : "");
+            }
+        };
+    }
+
+    /**
+     * Verification that checks a method by parameters (arguments only) with mandatory {@link
+     * CompletableFuture}.
+     */
+    static MethodVerification createParameterAndCompletableFutureVerification(Class<?> baseClass) {
+        return (method, state, arguments, result) -> {
+            checkNoState(state);
+            final Class<?>[] parameters = assembleParameters(state, arguments);
+            final Class<?>[] parametersWithFuture =
+                    Stream.concat(Stream.of(CompletableFuture.class), Arrays.stream(parameters))
+                            .toArray(Class<?>[]::new);
+
+            Type genericType = method.getGenericParameterTypes()[0];
+            genericType = resolveVariableWithClassContext(baseClass, genericType);
+            if (!(genericType instanceof ParameterizedType)) {
+                throw extractionError(
+                        "The method '%s' needs generic parameters for the CompletableFuture at position %d.",
+                        method.getName(), 0);
+            }
+            final Type returnType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+            Class<?> returnClazz = getClassFromType(returnType);
+            // TODO enable strict autoboxing
+            if (!(isInvokable(false, method, parametersWithFuture)
+                    && isAssignable(result, returnClazz, true, false))) {
+                throw createMethodNotFoundError(
+                        method.getName(),
+                        parametersWithFuture,
+                        null,
+                        "(<completable future> [, <argument>]*)");
+            }
+        };
+    }
+
+    /**
+     * Verification that checks a method by parameters (state and arguments) with optional context.
+     */
+    static MethodVerification createParameterAndOptionalContextVerification(
+            Class<?> context, boolean allowState) {
+        return (method, state, arguments, result) -> {
+            if (!allowState) {
+                checkNoState(state);
+            }
+            final Class<?>[] parameters = assembleParameters(state, arguments);
+            final Class<?>[] parametersWithContext =
+                    Stream.concat(Stream.of(context), Arrays.stream(parameters))
+                            .toArray(Class<?>[]::new);
+            if (!isInvokable(true, method, parameters)
+                    && !isInvokable(true, method, parametersWithContext)) {
+                throw createMethodNotFoundError(
+                        method.getName(),
+                        parameters,
+                        null,
+                        allowState ? "(<context>? [, <state>]* [, <argument>]*)" : "");
+            }
+        };
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Methods from super class
+    // --------------------------------------------------------------------------------------------
 
     Class<? extends UserDefinedFunction> getFunction() {
         return function;
     }
 
-    boolean hasAccumulator() {
-        return accumulatorExtraction != null;
+    boolean supportsState() {
+        return stateExtraction != null;
     }
 
     @Override
@@ -107,87 +292,9 @@ final class FunctionMappingExtractor extends BaseMappingExtractor {
         return "Function";
     }
 
-    Map<FunctionSignatureTemplate, FunctionResultTemplate> extractAccumulatorMapping() {
-        Preconditions.checkState(hasAccumulator());
-        try {
-            return extractResultMappings(
-                    accumulatorExtraction,
-                    FunctionTemplate::getAccumulatorTemplate,
-                    (method, signature, result) -> {
-                        // put the result into the signature for accumulators
-                        final List<Class<?>> arguments =
-                                Stream.concat(Stream.of(result), signature.stream())
-                                        .collect(Collectors.toList());
-                        verification.verify(method, arguments, null);
-                    });
-        } catch (Throwable t) {
-            throw extractionError(t, "Error in extracting a signature to accumulator mapping.");
-        }
-    }
-
-    /**
-     * Extraction that uses the method return type for producing a {@link FunctionResultTemplate}.
-     */
-    static ResultExtraction createReturnTypeResultExtraction() {
-        return (extractor, method) -> {
-            final DataType dataType =
-                    DataTypeExtractor.extractFromMethodOutput(
-                            extractor.typeFactory, extractor.getFunctionClass(), method);
-            return FunctionResultTemplate.of(dataType);
-        };
-    }
-
-    /**
-     * Extraction that uses a generic type variable for producing a {@link FunctionResultTemplate}.
-     *
-     * <p>If enabled, a {@link DataTypeHint} from method or class has higher priority.
-     */
-    static ResultExtraction createGenericResultExtraction(
-            Class<? extends UserDefinedFunction> baseClass,
-            int genericPos,
-            boolean allowDataTypeHint) {
-        return (extractor, method) -> {
-            if (allowDataTypeHint) {
-                Optional<FunctionResultTemplate> hints = extractHints(extractor, method);
-                if (hints.isPresent()) {
-                    return hints.get();
-                }
-            }
-            final DataType dataType =
-                    DataTypeExtractor.extractFromGeneric(
-                            extractor.typeFactory,
-                            baseClass,
-                            genericPos,
-                            extractor.getFunctionClass());
-            return FunctionResultTemplate.of(dataType);
-        };
-    }
-
-    /**
-     * Extraction that uses a generic type variable of a method parameter for producing a {@link
-     * FunctionResultTemplate}.
-     *
-     * <p>If enabled, a {@link DataTypeHint} from method or class has higher priority.
-     */
-    static ResultExtraction createGenericResultExtractionFromMethod(
-            int paramPos, int genericPos, boolean allowDataTypeHint) {
-        return (extractor, method) -> {
-            if (allowDataTypeHint) {
-                Optional<FunctionResultTemplate> hints = extractHints(extractor, method);
-                if (hints.isPresent()) {
-                    return hints.get();
-                }
-            }
-            final DataType dataType =
-                    DataTypeExtractor.extractFromGenericMethodParameter(
-                            extractor.typeFactory,
-                            extractor.getFunctionClass(),
-                            method,
-                            paramPos,
-                            genericPos);
-            return FunctionResultTemplate.of(dataType);
-        };
-    }
+    // --------------------------------------------------------------------------------------------
+    // Helper methods
+    // --------------------------------------------------------------------------------------------
 
     /** Uses hints to extract functional template. */
     private static Optional<FunctionResultTemplate> extractHints(
@@ -203,83 +310,10 @@ final class FunctionMappingExtractor extends BaseMappingExtractor {
         }
         if (dataTypeHints.size() == 1) {
             return Optional.ofNullable(
-                    FunctionTemplate.createResultTemplate(
+                    FunctionTemplate.createOutputTemplate(
                             extractor.typeFactory, dataTypeHints.iterator().next()));
         }
         // otherwise continue with regular extraction
         return Optional.empty();
-    }
-
-    /** Verification that checks a method by parameters and return type. */
-    static MethodVerification createParameterAndReturnTypeVerification() {
-        return (method, signature, result) -> {
-            final Class<?>[] parameters = signature.toArray(new Class[0]);
-            final Class<?> returnType = method.getReturnType();
-            final boolean isValid =
-                    isInvokable(method, parameters) && isAssignable(result, returnType, true);
-            if (!isValid) {
-                throw createMethodNotFoundError(method.getName(), parameters, result);
-            }
-        };
-    }
-
-    /** Verification that checks a method by parameters including an accumulator. */
-    static MethodVerification createParameterWithAccumulatorVerification() {
-        return (method, signature, result) -> {
-            if (result != null) {
-                // ignore the accumulator in the first argument
-                createParameterWithArgumentVerification(null).verify(method, signature, result);
-            } else {
-                // check the signature only
-                createParameterVerification().verify(method, signature, null);
-            }
-        };
-    }
-
-    /** Verification that checks a method by parameters including an additional first parameter. */
-    static MethodVerification createParameterWithArgumentVerification(
-            @Nullable Class<?> argumentClass) {
-        return (method, signature, result) -> {
-            final Class<?>[] parameters =
-                    Stream.concat(Stream.of(argumentClass), signature.stream())
-                            .toArray(Class<?>[]::new);
-            if (!isInvokable(method, parameters)) {
-                throw createMethodNotFoundError(method.getName(), parameters, null);
-            }
-        };
-    }
-
-    /** Verification that checks a method by parameters including an additional first parameter. */
-    static MethodVerification createGenericParameterWithArgumentAndReturnTypeVerification(
-            Class<?> baseClass, Class<?> argumentClass, int paramPos, int genericPos) {
-        return (method, signature, result) -> {
-            final Class<?>[] parameters =
-                    Stream.concat(Stream.of(argumentClass), signature.stream())
-                            .toArray(Class<?>[]::new);
-
-            Type genericType = method.getGenericParameterTypes()[paramPos];
-            genericType = resolveVariableWithClassContext(baseClass, genericType);
-            if (!(genericType instanceof ParameterizedType)) {
-                throw extractionError(
-                        "The method '%s' needs generic parameters for the %d arg.",
-                        method.getName(), paramPos);
-            }
-            Type returnType =
-                    ((ParameterizedType) genericType).getActualTypeArguments()[genericPos];
-            Class<?> returnClazz = getClassFromType(returnType);
-            if (!(isInvokable(method, parameters) && isAssignable(result, returnClazz, true))) {
-                throw createMethodNotFoundError(method.getName(), parameters, null);
-            }
-        };
-    }
-
-    /** Verification that checks a method by parameters. */
-    static MethodVerification createParameterVerification() {
-        return (method, signature, result) -> {
-            final Class<?>[] parameters = signature.toArray(new Class[0]);
-            if (!isInvokable(method, parameters)) {
-                throw createMethodNotFoundError(method.getName(), parameters, null);
-            }
-        };
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionResultTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionResultTemplate.java
@@ -20,47 +20,130 @@ package org.apache.flink.table.types.extraction;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.StateTypeStrategy;
+import org.apache.flink.table.types.inference.StateTypeStrategyWrapper;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
-/** Template of a function intermediate result (i.e. accumulator) or final result (i.e. output). */
+import static org.apache.flink.table.types.extraction.ExtractionUtils.extractionError;
+
+/** Template of a function intermediate result (i.e. state) or final result (i.e. output). */
 @Internal
-final class FunctionResultTemplate {
+interface FunctionResultTemplate {
 
-    final DataType dataType;
-
-    private FunctionResultTemplate(DataType dataType) {
-        this.dataType = dataType;
+    static FunctionOutputTemplate ofOutput(DataType dataType) {
+        return new FunctionOutputTemplate(dataType);
     }
 
-    static FunctionResultTemplate of(DataType dataType) {
-        return new FunctionResultTemplate(dataType);
+    static FunctionStateTemplate ofState(LinkedHashMap<String, DataType> state) {
+        return new FunctionStateTemplate(state);
     }
 
-    TypeStrategy toTypeStrategy() {
-        return TypeStrategies.explicit(dataType);
-    }
+    @Internal
+    class FunctionOutputTemplate implements FunctionResultTemplate {
 
-    Class<?> toClass() {
-        return dataType.getConversionClass();
-    }
+        private final DataType dataType;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
+        private FunctionOutputTemplate(DataType dataType) {
+            this.dataType = dataType;
         }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
+
+        TypeStrategy toTypeStrategy() {
+            return TypeStrategies.explicit(dataType);
         }
-        FunctionResultTemplate that = (FunctionResultTemplate) o;
-        return dataType.equals(that.dataType);
+
+        Class<?> toClass() {
+            return dataType.getConversionClass();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final FunctionOutputTemplate template = (FunctionOutputTemplate) o;
+            return Objects.equals(dataType, template.dataType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(dataType);
+        }
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(dataType);
+    @Internal
+    class FunctionStateTemplate implements FunctionResultTemplate {
+
+        private final LinkedHashMap<String, DataType> state;
+
+        private FunctionStateTemplate(LinkedHashMap<String, DataType> state) {
+            this.state = state;
+        }
+
+        List<Class<?>> toClassList() {
+            return state.values().stream()
+                    .map(DataType::getConversionClass)
+                    .collect(Collectors.toList());
+        }
+
+        LinkedHashMap<String, StateTypeStrategy> toStateTypeStrategies() {
+            return state.entrySet().stream()
+                    .collect(
+                            Collectors.toMap(
+                                    Map.Entry::getKey,
+                                    e -> createStateTypeStrategy(e.getValue()),
+                                    (o, n) -> o,
+                                    LinkedHashMap::new));
+        }
+
+        String toAccumulatorStateName() {
+            checkSingleStateEntry();
+            return state.keySet().iterator().next();
+        }
+
+        TypeStrategy toAccumulatorTypeStrategy() {
+            checkSingleStateEntry();
+            return createTypeStrategy(state.values().iterator().next());
+        }
+
+        private void checkSingleStateEntry() {
+            if (state.size() != 1) {
+                throw extractionError("Aggregating functions support only one state entry.");
+            }
+        }
+
+        private static StateTypeStrategy createStateTypeStrategy(DataType dataType) {
+            return StateTypeStrategyWrapper.of(TypeStrategies.explicit(dataType));
+        }
+
+        private static TypeStrategy createTypeStrategy(DataType dataType) {
+            return TypeStrategies.explicit(dataType);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final FunctionStateTemplate that = (FunctionStateTemplate) o;
+            return Objects.equals(state, that.state);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(state);
+        }
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionTemplate.java
@@ -24,15 +24,27 @@ import org.apache.flink.table.annotation.ArgumentTrait;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.annotation.ProcedureHint;
+import org.apache.flink.table.annotation.StateHint;
 import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionOutputTemplate;
+import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionStateTemplate;
+import org.apache.flink.table.types.inference.StaticArgumentTrait;
+import org.apache.flink.types.Row;
 
 import javax.annotation.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.apache.flink.table.types.extraction.ExtractionUtils.extractionError;
 
@@ -47,16 +59,16 @@ final class FunctionTemplate {
 
     private final @Nullable FunctionSignatureTemplate signatureTemplate;
 
-    private final @Nullable FunctionResultTemplate accumulatorTemplate;
+    private final @Nullable FunctionStateTemplate stateTemplate;
 
-    private final @Nullable FunctionResultTemplate outputTemplate;
+    private final @Nullable FunctionOutputTemplate outputTemplate;
 
     private FunctionTemplate(
             @Nullable FunctionSignatureTemplate signatureTemplate,
-            @Nullable FunctionResultTemplate accumulatorTemplate,
-            @Nullable FunctionResultTemplate outputTemplate) {
+            @Nullable FunctionStateTemplate stateTemplate,
+            @Nullable FunctionOutputTemplate outputTemplate) {
         this.signatureTemplate = signatureTemplate;
-        this.accumulatorTemplate = accumulatorTemplate;
+        this.stateTemplate = stateTemplate;
         this.outputTemplate = outputTemplate;
     }
 
@@ -64,10 +76,8 @@ final class FunctionTemplate {
      * Creates an instance using the given {@link FunctionHint}. It resolves explicitly defined data
      * types.
      */
+    @SuppressWarnings("deprecation")
     static FunctionTemplate fromAnnotation(DataTypeFactory typeFactory, FunctionHint hint) {
-        if (hint.state().length > 0) {
-            throw extractionError("State hints are not supported yet.");
-        }
         return new FunctionTemplate(
                 createSignatureTemplate(
                         typeFactory,
@@ -76,14 +86,18 @@ final class FunctionTemplate {
                         defaultAsNull(hint, FunctionHint::argument),
                         defaultAsNull(hint, FunctionHint::arguments),
                         hint.isVarArgs()),
-                createResultTemplate(typeFactory, defaultAsNull(hint, FunctionHint::accumulator)),
-                createResultTemplate(typeFactory, defaultAsNull(hint, FunctionHint::output)));
+                createStateTemplate(
+                        typeFactory,
+                        defaultAsNull(hint, FunctionHint::accumulator),
+                        defaultAsNull(hint, FunctionHint::state)),
+                createOutputTemplate(typeFactory, defaultAsNull(hint, FunctionHint::output)));
     }
 
     /**
      * Creates an instance using the given {@link ProcedureHint}. It resolves explicitly defined
      * data types.
      */
+    @SuppressWarnings("deprecation")
     static FunctionTemplate fromAnnotation(DataTypeFactory typeFactory, ProcedureHint hint) {
         return new FunctionTemplate(
                 createSignatureTemplate(
@@ -93,12 +107,12 @@ final class FunctionTemplate {
                         defaultAsNull(hint, ProcedureHint::argument),
                         defaultAsNull(hint, ProcedureHint::arguments),
                         hint.isVarArgs()),
-                null,
-                createResultTemplate(typeFactory, defaultAsNull(hint, ProcedureHint::output)));
+                createStateTemplate(typeFactory, null, null),
+                createOutputTemplate(typeFactory, defaultAsNull(hint, ProcedureHint::output)));
     }
 
     /** Creates an instance of {@link FunctionResultTemplate} from a {@link DataTypeHint}. */
-    static @Nullable FunctionResultTemplate createResultTemplate(
+    static @Nullable FunctionOutputTemplate createOutputTemplate(
             DataTypeFactory typeFactory, @Nullable DataTypeHint hint) {
         if (hint == null) {
             return null;
@@ -110,10 +124,39 @@ final class FunctionTemplate {
             throw extractionError(t, "Error in data type hint annotation.");
         }
         if (template.dataType != null) {
-            return FunctionResultTemplate.of(template.dataType);
+            return FunctionResultTemplate.ofOutput(template.dataType);
         }
         throw extractionError(
                 "Data type hint does not specify a data type for use as function result.");
+    }
+
+    /** Creates a {@link FunctionStateTemplate}s from {@link StateHint}s or accumulator. */
+    static @Nullable FunctionStateTemplate createStateTemplate(
+            DataTypeFactory typeFactory,
+            @Nullable DataTypeHint accumulatorHint,
+            @Nullable StateHint[] stateHints) {
+        if (accumulatorHint == null && stateHints == null) {
+            return null;
+        }
+        if (accumulatorHint != null && stateHints != null) {
+            throw extractionError(
+                    "State hints and accumulator cannot be declared in the same function hint. "
+                            + "Use either one or the other.");
+        }
+        final LinkedHashMap<String, DataType> state = new LinkedHashMap<>();
+        if (accumulatorHint != null) {
+            state.put("acc", createStateDataType(typeFactory, accumulatorHint, "accumulator"));
+            return FunctionResultTemplate.ofState(state);
+        }
+        IntStream.range(0, stateHints.length)
+                .forEach(
+                        pos -> {
+                            final StateHint hint = stateHints[pos];
+                            state.put(
+                                    hint.name(),
+                                    createStateDataType(typeFactory, hint.type(), "state entry"));
+                        });
+        return FunctionResultTemplate.ofState(state);
     }
 
     @Nullable
@@ -122,8 +165,8 @@ final class FunctionTemplate {
     }
 
     @Nullable
-    FunctionResultTemplate getAccumulatorTemplate() {
-        return accumulatorTemplate;
+    FunctionResultTemplate getStateTemplate() {
+        return stateTemplate;
     }
 
     @Nullable
@@ -141,13 +184,13 @@ final class FunctionTemplate {
         }
         FunctionTemplate template = (FunctionTemplate) o;
         return Objects.equals(signatureTemplate, template.signatureTemplate)
-                && Objects.equals(accumulatorTemplate, template.accumulatorTemplate)
+                && Objects.equals(stateTemplate, template.stateTemplate)
                 && Objects.equals(outputTemplate, template.outputTemplate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(signatureTemplate, accumulatorTemplate, outputTemplate);
+        return Objects.hash(signatureTemplate, stateTemplate, outputTemplate);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -185,6 +228,7 @@ final class FunctionTemplate {
         return actualValue;
     }
 
+    @SuppressWarnings("unchecked")
     private static @Nullable FunctionSignatureTemplate createSignatureTemplate(
             DataTypeFactory typeFactory,
             @Nullable DataTypeHint[] inputs,
@@ -204,79 +248,150 @@ final class FunctionTemplate {
             argumentHints = pluralArgumentHints;
         }
 
-        String[] argumentHintNames;
-        DataTypeHint[] argumentHintTypes;
-
         // Deal with #arguments() and #input()
         if (argumentHints != null && inputs != null) {
             throw extractionError(
-                    "Argument and input hints cannot be declared in the same function hint.");
+                    "Argument and input hints cannot be declared in the same function hint. "
+                            + "Use either one or the other.");
         }
-
-        Boolean[] argumentOptionals;
+        final DataTypeHint[] argumentHintTypes;
+        final boolean[] argumentOptionals;
+        final ArgumentTrait[][] argumentTraits;
+        String[] argumentHintNames;
         if (argumentHints != null) {
-            final boolean allScalar =
-                    Arrays.stream(argumentHints)
-                            .allMatch(
-                                    h -> {
-                                        final ArgumentTrait[] traits = h.value();
-                                        return traits.length == 1
-                                                && traits[0] == ArgumentTrait.SCALAR;
-                                    });
-            if (!allScalar) {
-                throw extractionError("Only scalar arguments are supported so far.");
-            }
-
-            argumentHintNames = new String[argumentHints.length];
             argumentHintTypes = new DataTypeHint[argumentHints.length];
-            argumentOptionals = new Boolean[argumentHints.length];
-            boolean allArgumentNameNotSet = true;
+            argumentOptionals = new boolean[argumentHints.length];
+            argumentTraits = new ArgumentTrait[argumentHints.length][];
+            argumentHintNames = new String[argumentHints.length];
+            boolean allArgumentNamesNotSet = true;
             for (int i = 0; i < argumentHints.length; i++) {
-                ArgumentHint argumentHint = argumentHints[i];
+                final ArgumentHint argumentHint = argumentHints[i];
                 argumentHintNames[i] = defaultAsNull(argumentHint, ArgumentHint::name);
                 argumentHintTypes[i] = defaultAsNull(argumentHint, ArgumentHint::type);
                 argumentOptionals[i] = argumentHint.isOptional();
-                if (argumentHintTypes[i] == null) {
-                    throw extractionError("The type of the argument at position %d is not set.", i);
-                }
+                argumentTraits[i] = argumentHint.value();
                 if (argumentHintNames[i] != null) {
-                    allArgumentNameNotSet = false;
-                } else if (!allArgumentNameNotSet) {
+                    allArgumentNamesNotSet = false;
+                } else if (!allArgumentNamesNotSet) {
                     throw extractionError(
-                            "The argument name in function hint must be either fully set or not set at all.");
+                            "Argument names in function hint must be either fully set or not set at all.");
                 }
             }
-            if (allArgumentNameNotSet) {
+            if (allArgumentNamesNotSet) {
                 argumentHintNames = null;
             }
-        } else {
-            if (inputs == null) {
-                return null;
-            }
+        } else if (inputs != null) {
             argumentHintTypes = inputs;
             argumentHintNames = argumentNames;
-            argumentOptionals = new Boolean[inputs.length];
-            Arrays.fill(argumentOptionals, false);
+            argumentOptionals = new boolean[inputs.length];
+            argumentTraits = new ArgumentTrait[inputs.length][];
+            Arrays.fill(argumentTraits, new ArgumentTrait[] {ArgumentTrait.SCALAR});
+        } else {
+            return null;
         }
 
+        final List<FunctionArgumentTemplate> argumentTemplates =
+                IntStream.range(0, argumentHintTypes.length)
+                        .mapToObj(
+                                i ->
+                                        createArgumentTemplate(
+                                                typeFactory,
+                                                i,
+                                                argumentHintTypes[i],
+                                                argumentTraits[i]))
+                        .collect(Collectors.toList());
+
         return FunctionSignatureTemplate.of(
-                Arrays.stream(argumentHintTypes)
-                        .map(dataTypeHint -> createArgumentTemplate(typeFactory, dataTypeHint))
-                        .collect(Collectors.toList()),
+                argumentTemplates,
                 isVarArg,
+                Arrays.stream(argumentTraits)
+                        .map(
+                                t -> {
+                                    final List<StaticArgumentTrait> traits =
+                                            Arrays.stream(t)
+                                                    .map(ArgumentTrait::toStaticTrait)
+                                                    .collect(Collectors.toList());
+                                    return EnumSet.copyOf(traits);
+                                })
+                        .toArray(EnumSet[]::new),
                 argumentHintNames,
                 argumentOptionals);
     }
 
     private static FunctionArgumentTemplate createArgumentTemplate(
-            DataTypeFactory typeFactory, DataTypeHint hint) {
-        final DataTypeTemplate template = DataTypeTemplate.fromAnnotation(typeFactory, hint);
+            DataTypeFactory typeFactory,
+            int pos,
+            @Nullable DataTypeHint hint,
+            ArgumentTrait[] argumentTraits) {
+        final Set<ArgumentTrait> rootTrait =
+                Arrays.stream(argumentTraits)
+                        .filter(ArgumentTrait::isRoot)
+                        .collect(Collectors.toSet());
+        if (rootTrait.size() != 1) {
+            throw extractionError(
+                    "Incorrect argument kind at position %d. Argument kind must be one of: %s",
+                    pos,
+                    Arrays.stream(ArgumentTrait.values())
+                            .filter(ArgumentTrait::isRoot)
+                            .collect(Collectors.toList()));
+        }
+
+        if (rootTrait.contains(ArgumentTrait.SCALAR)) {
+            if (hint != null) {
+                final DataTypeTemplate template;
+                try {
+                    template = DataTypeTemplate.fromAnnotation(typeFactory, hint);
+                } catch (Throwable t) {
+                    throw extractionError(
+                            t,
+                            "Error in data type hint annotation for argument at position %s.",
+                            pos);
+                }
+                if (template.dataType != null) {
+                    return FunctionArgumentTemplate.ofDataType(template.dataType);
+                } else if (template.inputGroup != null) {
+                    return FunctionArgumentTemplate.ofInputGroup(template.inputGroup);
+                }
+            }
+            throw extractionError("Data type missing for scalar argument at position %s.", pos);
+        } else if (rootTrait.contains(ArgumentTrait.TABLE_AS_ROW)
+                || rootTrait.contains(ArgumentTrait.TABLE_AS_SET)) {
+            try {
+                final DataTypeTemplate template =
+                        DataTypeTemplate.fromAnnotation(typeFactory, hint);
+                if (template.dataType != null) {
+                    return FunctionArgumentTemplate.ofDataType(template.dataType);
+                } else if (template.inputGroup != null) {
+                    throw extractionError(
+                            "Input groups are not supported for table argument at position %s.",
+                            pos);
+                }
+                return FunctionArgumentTemplate.ofTable(Row.class);
+            } catch (Throwable t) {
+                final Class<?> argClass = hint == null ? Row.class : hint.bridgedTo();
+                if (argClass == Row.class || argClass == RowData.class) {
+                    return FunctionArgumentTemplate.ofTable(argClass);
+                }
+                // Just a regular error for a typed argument
+                throw t;
+            }
+        } else {
+            throw extractionError("Unknown argument kind.");
+        }
+    }
+
+    private static DataType createStateDataType(
+            DataTypeFactory typeFactory, DataTypeHint dataTypeHint, String description) {
+        final DataTypeTemplate template;
+        try {
+            template = DataTypeTemplate.fromAnnotation(typeFactory, dataTypeHint);
+        } catch (Throwable t) {
+            throw extractionError(t, "Error in data type hint annotation.");
+        }
         if (template.dataType != null) {
-            return FunctionArgumentTemplate.of(template.dataType);
-        } else if (template.inputGroup != null) {
-            return FunctionArgumentTemplate.of(template.inputGroup);
+            return template.dataType;
         }
         throw extractionError(
-                "Data type hint does neither specify a data type nor input group for use as function argument.");
+                "Data type hint does not specify a data type for use as %s.", description);
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ProcedureMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ProcedureMappingExtractor.java
@@ -87,21 +87,25 @@ final class ProcedureMappingExtractor extends BaseMappingExtractor {
     static MethodVerification createParameterWithOptionalContextAndArrayReturnTypeVerification() {
         return (method, state, arguments, result) -> {
             checkNoState(state);
-            final Class<?>[] parameters = assembleParameters(state, arguments);
+            checkScalarArgumentsOnly(arguments);
+            final Class<?>[] parameters = assembleParameters(null, arguments);
             // ignore the ProcedureContext in the first argument
             final Class<?>[] parametersWithContext =
                     Stream.concat(Stream.of((Class<?>) null), Arrays.stream(parameters))
                             .toArray(Class<?>[]::new);
+            assert result != null;
+            final Class<?> resultClass = result.toClass();
             final Class<?> returnType = method.getReturnType();
             final boolean isValid =
                     isInvokable(true, method, parametersWithContext)
                             && returnType.isArray()
-                            && isAssignable(result, returnType.getComponentType(), true, false);
+                            && isAssignable(
+                                    resultClass, returnType.getComponentType(), true, false);
             if (!isValid) {
                 throw createMethodNotFoundError(
                         method.getName(),
                         parametersWithContext,
-                        Array.newInstance(result, 0).getClass(),
+                        Array.newInstance(resultClass, 0).getClass(),
                         "(<context> [, <argument>]*)");
             }
         };

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ProcedureMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ProcedureMappingExtractor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.procedures.Procedure;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.ExtractionUtils.Autoboxing;
 import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionOutputTemplate;
 
 import java.lang.reflect.Array;
@@ -96,11 +97,14 @@ final class ProcedureMappingExtractor extends BaseMappingExtractor {
             assert result != null;
             final Class<?> resultClass = result.toClass();
             final Class<?> returnType = method.getReturnType();
+            // Parameters should be validated using strict autoboxing.
+            // For return types, we can be more flexible as the procedure should know what it
+            // declared.
             final boolean isValid =
-                    isInvokable(true, method, parametersWithContext)
+                    isInvokable(Autoboxing.STRICT, method, parametersWithContext)
                             && returnType.isArray()
                             && isAssignable(
-                                    resultClass, returnType.getComponentType(), true, false);
+                                    resultClass, returnType.getComponentType(), Autoboxing.JVM);
             if (!isValid) {
                 throw createMethodNotFoundError(
                         method.getName(),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ProcedureMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ProcedureMappingExtractor.java
@@ -22,9 +22,11 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.procedures.Procedure;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionOutputTemplate;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -49,11 +51,65 @@ final class ProcedureMappingExtractor extends BaseMappingExtractor {
             Class<? extends Procedure> procedure,
             String methodName,
             SignatureExtraction signatureExtraction,
-            ResultExtraction outputExtraction,
+            ResultExtraction resultExtraction,
             MethodVerification verification) {
-        super(typeFactory, methodName, signatureExtraction, outputExtraction, verification);
+        super(typeFactory, methodName, signatureExtraction, resultExtraction, verification);
         this.procedure = procedure;
     }
+
+    // --------------------------------------------------------------------------------------------
+    // Extraction strategy
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Extraction that uses the method return type for producing a {@link FunctionOutputTemplate}.
+     */
+    static ResultExtraction createOutputFromArrayReturnTypeInMethod() {
+        return (extractor, method) -> {
+            final DataType dataType =
+                    DataTypeExtractor.extractFromMethodReturnType(
+                            extractor.typeFactory,
+                            extractor.getFunctionClass(),
+                            method,
+                            method.getReturnType().getComponentType());
+            return FunctionResultTemplate.ofOutput(dataType);
+        };
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Verification strategy
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Verification that checks a method by parameters (arguments only) with mandatory context and
+     * array return type.
+     */
+    static MethodVerification createParameterWithOptionalContextAndArrayReturnTypeVerification() {
+        return (method, state, arguments, result) -> {
+            checkNoState(state);
+            final Class<?>[] parameters = assembleParameters(state, arguments);
+            // ignore the ProcedureContext in the first argument
+            final Class<?>[] parametersWithContext =
+                    Stream.concat(Stream.of((Class<?>) null), Arrays.stream(parameters))
+                            .toArray(Class<?>[]::new);
+            final Class<?> returnType = method.getReturnType();
+            final boolean isValid =
+                    isInvokable(true, method, parametersWithContext)
+                            && returnType.isArray()
+                            && isAssignable(result, returnType.getComponentType(), true, false);
+            if (!isValid) {
+                throw createMethodNotFoundError(
+                        method.getName(),
+                        parametersWithContext,
+                        Array.newInstance(result, 0).getClass(),
+                        "(<context> [, <argument>]*)");
+            }
+        };
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Methods from super class
+    // --------------------------------------------------------------------------------------------
 
     @Override
     protected Set<FunctionTemplate> extractGlobalFunctionTemplates() {
@@ -78,38 +134,5 @@ final class ProcedureMappingExtractor extends BaseMappingExtractor {
     @Override
     protected String getHintType() {
         return "Procedure";
-    }
-
-    /**
-     * Extraction that uses the method return type for producing a {@link FunctionResultTemplate}.
-     */
-    static ResultExtraction createReturnTypeResultExtraction() {
-        return (extractor, method) -> {
-            final DataType dataType =
-                    DataTypeExtractor.extractFromMethodOutput(
-                            extractor.typeFactory,
-                            extractor.getFunctionClass(),
-                            method,
-                            method.getReturnType().getComponentType());
-            return FunctionResultTemplate.of(dataType);
-        };
-    }
-
-    static MethodVerification createParameterAndReturnTypeVerification() {
-        return ((method, signature, result) -> {
-            // ignore the ProcedureContext in the first argument
-            final Class<?>[] parameters =
-                    Stream.concat(Stream.of((Class<?>) null), signature.stream())
-                            .toArray(Class<?>[]::new);
-            final Class<?> returnType = method.getReturnType();
-            final boolean isValid =
-                    isInvokable(method, parameters)
-                            && returnType.isArray()
-                            && isAssignable(result, returnType.getComponentType(), true);
-            if (!isValid) {
-                throw createMethodNotFoundError(
-                        method.getName(), parameters, Array.newInstance(result, 0).getClass());
-            }
-        });
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.AsyncScalarFunction;
 import org.apache.flink.table.functions.AsyncTableFunction;
+import org.apache.flink.table.functions.ProcessTableFunction;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
@@ -32,33 +33,38 @@ import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.procedures.Procedure;
 import org.apache.flink.table.procedures.ProcedureDefinition;
-import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionOutputTemplate;
+import org.apache.flink.table.types.extraction.FunctionResultTemplate.FunctionStateTemplate;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.StateTypeStrategy;
+import org.apache.flink.table.types.inference.StateTypeStrategyWrapper;
+import org.apache.flink.table.types.inference.StaticArgument;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
 
 import javax.annotation.Nullable;
 
-import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.types.extraction.BaseMappingExtractor.createArgumentsFromParametersExtraction;
+import static org.apache.flink.table.types.extraction.BaseMappingExtractor.createStateFromParametersExtraction;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.extractionError;
-import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createGenericParameterWithArgumentAndReturnTypeVerification;
-import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createGenericResultExtraction;
-import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createGenericResultExtractionFromMethod;
+import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createOutputFromGenericInClass;
+import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createOutputFromGenericInMethod;
+import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createOutputFromReturnTypeInMethod;
+import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterAndCompletableFutureVerification;
+import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterAndOptionalContextVerification;
 import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterAndReturnTypeVerification;
-import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterSignatureExtraction;
 import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterVerification;
-import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterWithAccumulatorVerification;
-import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterWithArgumentVerification;
-import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createReturnTypeResultExtraction;
+import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createStateFromGenericInClassOrParameters;
+import static org.apache.flink.table.types.extraction.ProcedureMappingExtractor.createOutputFromArrayReturnTypeInMethod;
+import static org.apache.flink.table.types.extraction.ProcedureMappingExtractor.createParameterWithOptionalContextAndArrayReturnTypeVerification;
 
 /**
  * Reflection-based utility for extracting a {@link TypeInference} from a supported subclass of
@@ -81,11 +87,12 @@ public final class TypeInferenceExtractor {
                         typeFactory,
                         function,
                         UserDefinedFunctionHelper.SCALAR_EVAL,
-                        createParameterSignatureExtraction(0),
+                        createArgumentsFromParametersExtraction(0),
                         null,
-                        createReturnTypeResultExtraction(),
+                        null,
+                        createOutputFromReturnTypeInMethod(),
                         createParameterAndReturnTypeVerification());
-        return extractTypeInference(mappingExtractor);
+        return extractTypeInference(mappingExtractor, false);
     }
 
     /** Extracts a type inference from a {@link AsyncScalarFunction}. */
@@ -96,12 +103,12 @@ public final class TypeInferenceExtractor {
                         typeFactory,
                         function,
                         UserDefinedFunctionHelper.ASYNC_SCALAR_EVAL,
-                        createParameterSignatureExtraction(1),
+                        createArgumentsFromParametersExtraction(1),
                         null,
-                        createGenericResultExtractionFromMethod(0, 0, true),
-                        createGenericParameterWithArgumentAndReturnTypeVerification(
-                                function, CompletableFuture.class, 0, 0));
-        return extractTypeInference(mappingExtractor);
+                        null,
+                        createOutputFromGenericInMethod(0, 0, true),
+                        createParameterAndCompletableFutureVerification(function));
+        return extractTypeInference(mappingExtractor, false);
     }
 
     /** Extracts a type inference from a {@link AggregateFunction}. */
@@ -112,11 +119,12 @@ public final class TypeInferenceExtractor {
                         typeFactory,
                         function,
                         UserDefinedFunctionHelper.AGGREGATE_ACCUMULATE,
-                        createParameterSignatureExtraction(1),
-                        createGenericResultExtraction(AggregateFunction.class, 1, false),
-                        createGenericResultExtraction(AggregateFunction.class, 0, true),
-                        createParameterWithAccumulatorVerification());
-        return extractTypeInference(mappingExtractor);
+                        createArgumentsFromParametersExtraction(1),
+                        createStateFromGenericInClassOrParameters(AggregateFunction.class, 1),
+                        createParameterVerification(true),
+                        createOutputFromGenericInClass(AggregateFunction.class, 0, true),
+                        null);
+        return extractTypeInference(mappingExtractor, false);
     }
 
     /** Extracts a type inference from a {@link TableFunction}. */
@@ -127,11 +135,12 @@ public final class TypeInferenceExtractor {
                         typeFactory,
                         function,
                         UserDefinedFunctionHelper.TABLE_EVAL,
-                        createParameterSignatureExtraction(0),
+                        createArgumentsFromParametersExtraction(0),
                         null,
-                        createGenericResultExtraction(TableFunction.class, 0, true),
-                        createParameterVerification());
-        return extractTypeInference(mappingExtractor);
+                        null,
+                        createOutputFromGenericInClass(TableFunction.class, 0, true),
+                        createParameterVerification(false));
+        return extractTypeInference(mappingExtractor, false);
     }
 
     /** Extracts a type inference from a {@link TableAggregateFunction}. */
@@ -142,11 +151,12 @@ public final class TypeInferenceExtractor {
                         typeFactory,
                         function,
                         UserDefinedFunctionHelper.TABLE_AGGREGATE_ACCUMULATE,
-                        createParameterSignatureExtraction(1),
-                        createGenericResultExtraction(TableAggregateFunction.class, 1, false),
-                        createGenericResultExtraction(TableAggregateFunction.class, 0, true),
-                        createParameterWithAccumulatorVerification());
-        return extractTypeInference(mappingExtractor);
+                        createArgumentsFromParametersExtraction(1),
+                        createStateFromGenericInClassOrParameters(TableAggregateFunction.class, 1),
+                        createParameterVerification(true),
+                        createOutputFromGenericInClass(TableAggregateFunction.class, 0, true),
+                        null);
+        return extractTypeInference(mappingExtractor, false);
     }
 
     /** Extracts a type inference from a {@link AsyncTableFunction}. */
@@ -157,11 +167,30 @@ public final class TypeInferenceExtractor {
                         typeFactory,
                         function,
                         UserDefinedFunctionHelper.ASYNC_TABLE_EVAL,
-                        createParameterSignatureExtraction(1),
+                        createArgumentsFromParametersExtraction(1),
                         null,
-                        createGenericResultExtraction(AsyncTableFunction.class, 0, true),
-                        createParameterWithArgumentVerification(CompletableFuture.class));
-        return extractTypeInference(mappingExtractor);
+                        null,
+                        createOutputFromGenericInClass(AsyncTableFunction.class, 0, true),
+                        createParameterAndCompletableFutureVerification(function));
+        return extractTypeInference(mappingExtractor, false);
+    }
+
+    /** Extracts a type inference from a {@link ProcessTableFunction}. */
+    public static TypeInference forProcessTableFunction(
+            DataTypeFactory typeFactory, Class<? extends ProcessTableFunction<?>> function) {
+        final FunctionMappingExtractor mappingExtractor =
+                new FunctionMappingExtractor(
+                        typeFactory,
+                        function,
+                        UserDefinedFunctionHelper.PROCESS_TABLE_EVAL,
+                        createArgumentsFromParametersExtraction(
+                                0, ProcessTableFunction.Context.class),
+                        createStateFromParametersExtraction(),
+                        createParameterAndOptionalContextVerification(
+                                ProcessTableFunction.Context.class, true),
+                        createOutputFromGenericInClass(ProcessTableFunction.class, 0, true),
+                        null);
+        return extractTypeInference(mappingExtractor, true);
     }
 
     /** Extracts a type in inference from a {@link Procedure}. */
@@ -172,15 +201,16 @@ public final class TypeInferenceExtractor {
                         typeFactory,
                         procedure,
                         ProcedureDefinition.PROCEDURE_CALL,
-                        ProcedureMappingExtractor.createParameterSignatureExtraction(1),
-                        ProcedureMappingExtractor.createReturnTypeResultExtraction(),
-                        ProcedureMappingExtractor.createParameterAndReturnTypeVerification());
+                        createArgumentsFromParametersExtraction(1),
+                        createOutputFromArrayReturnTypeInMethod(),
+                        createParameterWithOptionalContextAndArrayReturnTypeVerification());
         return extractTypeInference(mappingExtractor);
     }
 
-    private static TypeInference extractTypeInference(FunctionMappingExtractor mappingExtractor) {
+    private static TypeInference extractTypeInference(
+            FunctionMappingExtractor mappingExtractor, boolean requiresStaticSignature) {
         try {
-            return extractTypeInferenceOrError(mappingExtractor);
+            return extractTypeInferenceOrError(mappingExtractor, requiresStaticSignature);
         } catch (Throwable t) {
             throw extractionError(
                     t,
@@ -192,7 +222,9 @@ public final class TypeInferenceExtractor {
 
     private static TypeInference extractTypeInference(ProcedureMappingExtractor mappingExtractor) {
         try {
-            return extractTypeInferenceOrError(mappingExtractor);
+            final Map<FunctionSignatureTemplate, FunctionOutputTemplate> outputMapping =
+                    mappingExtractor.extractOutputMapping();
+            return buildInference(null, outputMapping, false);
         } catch (Throwable t) {
             throw extractionError(
                     t,
@@ -203,123 +235,123 @@ public final class TypeInferenceExtractor {
     }
 
     private static TypeInference extractTypeInferenceOrError(
-            FunctionMappingExtractor mappingExtractor) {
-        final Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping =
+            FunctionMappingExtractor mappingExtractor, boolean requiresStaticSignature) {
+        final Map<FunctionSignatureTemplate, FunctionOutputTemplate> outputMapping =
                 mappingExtractor.extractOutputMapping();
 
-        if (!mappingExtractor.hasAccumulator()) {
-            return buildInference(null, outputMapping);
+        if (!mappingExtractor.supportsState()) {
+            return buildInference(null, outputMapping, requiresStaticSignature);
         }
 
-        final Map<FunctionSignatureTemplate, FunctionResultTemplate> accumulatorMapping =
-                mappingExtractor.extractAccumulatorMapping();
-        return buildInference(accumulatorMapping, outputMapping);
-    }
+        final Map<FunctionSignatureTemplate, FunctionStateTemplate> stateMapping =
+                mappingExtractor.extractStateMapping();
 
-    private static TypeInference extractTypeInferenceOrError(
-            ProcedureMappingExtractor mappingExtractor) {
-        final Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping =
-                mappingExtractor.extractOutputMapping();
-        return buildInference(null, outputMapping);
+        return buildInference(stateMapping, outputMapping, requiresStaticSignature);
     }
 
     private static TypeInference buildInference(
-            @Nullable Map<FunctionSignatureTemplate, FunctionResultTemplate> accumulatorMapping,
-            Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping) {
+            @Nullable Map<FunctionSignatureTemplate, FunctionStateTemplate> stateMapping,
+            Map<FunctionSignatureTemplate, FunctionOutputTemplate> outputMapping,
+            boolean requiresStaticSignature) {
         final TypeInference.Builder builder = TypeInference.newBuilder();
 
-        configureNamedArguments(builder, outputMapping);
-        configureOptionalArguments(builder, outputMapping);
-        configureTypedArguments(builder, outputMapping);
-
-        builder.inputTypeStrategy(translateInputTypeStrategy(outputMapping));
-
-        if (accumulatorMapping != null) {
-            // verify that accumulator and output are derived from the same input strategy
-            if (!accumulatorMapping.keySet().equals(outputMapping.keySet())) {
+        if (!configureStaticArguments(builder, outputMapping)) {
+            if (requiresStaticSignature) {
                 throw extractionError(
-                        "Mismatch between accumulator signature and output signature. "
-                                + "Both intermediate and output results must be derived from the same input strategy.");
+                        "Process table functions require a non-overloaded, non-vararg, and static signature.");
             }
-            builder.accumulatorTypeStrategy(translateResultTypeStrategy(accumulatorMapping));
+            builder.inputTypeStrategy(translateInputTypeStrategy(outputMapping));
         }
 
-        builder.outputTypeStrategy(translateResultTypeStrategy(outputMapping));
+        if (stateMapping != null) {
+            // verify that state and output are derived from the same signatures
+            if (!stateMapping.keySet().equals(outputMapping.keySet())) {
+                throw extractionError(
+                        "Mismatch between state signature and output signature. "
+                                + "Both intermediate and output results must be derived from the same input strategy.");
+            }
+            builder.stateTypeStrategies(translateStateTypeStrategies(stateMapping));
+        }
+
+        builder.outputTypeStrategy(translateOutputTypeStrategy(outputMapping));
+
         return builder.build();
     }
 
-    private static void configureNamedArguments(
+    private static boolean configureStaticArguments(
             TypeInference.Builder builder,
-            Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping) {
+            Map<FunctionSignatureTemplate, FunctionOutputTemplate> outputMapping) {
         final Set<FunctionSignatureTemplate> signatures = outputMapping.keySet();
-        if (signatures.stream().anyMatch(s -> s.isVarArgs || s.argumentNames == null)) {
-            return;
+        if (signatures.size() != 1) {
+            // Function is overloaded
+            return false;
         }
-        final List<List<String>> argumentNames =
-                signatures.stream()
-                        .map(
-                                s -> {
-                                    assert s.argumentNames != null;
-                                    return Arrays.asList(s.argumentNames);
-                                })
-                        .collect(Collectors.toList());
-        if (argumentNames.size() != 1) {
-            return;
+        final List<StaticArgument> arguments = signatures.iterator().next().toStaticArguments();
+        if (arguments == null) {
+            // Function is var arg or non-static (e.g. uses input groups instead of typed arguments)
+            return false;
         }
-        builder.namedArguments(argumentNames.iterator().next());
+        builder.staticArguments(arguments);
+        return true;
     }
 
-    private static void configureOptionalArguments(
-            TypeInference.Builder builder,
-            Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping) {
-        final Set<FunctionSignatureTemplate> signatures = outputMapping.keySet();
-        if (signatures.stream().anyMatch(s -> s.isVarArgs || s.argumentNames == null)) {
-            return;
-        }
-        final List<List<Boolean>> argumentOptional =
-                signatures.stream()
-                        .filter(s -> s.argumentOptionals != null)
-                        .map(s -> Arrays.asList(s.argumentOptionals))
-                        .collect(Collectors.toList());
-        if (argumentOptional.size() != 1 || argumentOptional.size() != signatures.size()) {
-            return;
-        }
-        builder.optionalArguments(argumentOptional.get(0));
+    private static InputTypeStrategy translateInputTypeStrategy(
+            Map<FunctionSignatureTemplate, FunctionOutputTemplate> outputMapping) {
+        return outputMapping.keySet().stream()
+                .map(FunctionSignatureTemplate::toInputTypeStrategy)
+                .reduce(InputTypeStrategies::or)
+                .orElse(InputTypeStrategies.sequence());
     }
 
-    private static void configureTypedArguments(
-            TypeInference.Builder builder,
-            Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping) {
-        if (outputMapping.size() != 1) {
-            return;
+    private static LinkedHashMap<String, StateTypeStrategy> translateStateTypeStrategies(
+            Map<FunctionSignatureTemplate, FunctionStateTemplate> stateMapping) {
+        // Simple signatures don't require a mapping, default for process table functions
+        if (stateMapping.size() == 1) {
+            final FunctionStateTemplate template =
+                    stateMapping.entrySet().iterator().next().getValue();
+            return template.toStateTypeStrategies();
         }
-        final FunctionSignatureTemplate signature = outputMapping.keySet().iterator().next();
-        final List<DataType> dataTypes =
-                signature.argumentTemplates.stream()
-                        .map(a -> a.dataType)
-                        .collect(Collectors.toList());
-        if (!signature.isVarArgs && dataTypes.stream().allMatch(Objects::nonNull)) {
-            builder.typedArguments(dataTypes);
-        }
-    }
-
-    private static TypeStrategy translateResultTypeStrategy(
-            Map<FunctionSignatureTemplate, FunctionResultTemplate> resultMapping) {
+        // For overloaded signatures to accumulators in aggregating functions
         final Map<InputTypeStrategy, TypeStrategy> mappings =
-                resultMapping.entrySet().stream()
+                stateMapping.entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        e -> e.getKey().toInputTypeStrategy(),
+                                        e -> e.getValue().toAccumulatorTypeStrategy()));
+        final StateTypeStrategy accumulatorStrategy =
+                StateTypeStrategyWrapper.of(TypeStrategies.mapping(mappings));
+        final Set<String> stateNames =
+                stateMapping.values().stream()
+                        .map(FunctionStateTemplate::toAccumulatorStateName)
+                        .collect(Collectors.toSet());
+        if (stateMapping.size() > 1 && stateNames.size() > 1) {
+            throw extractionError(
+                    "Overloaded aggregating functions must use the same name for state entries. "
+                            + "Found: %s",
+                    stateNames);
+        }
+        final String stateName = stateNames.iterator().next();
+        final LinkedHashMap<String, StateTypeStrategy> stateTypeStrategies = new LinkedHashMap<>();
+        stateTypeStrategies.put(stateName, accumulatorStrategy);
+        return stateTypeStrategies;
+    }
+
+    private static TypeStrategy translateOutputTypeStrategy(
+            Map<FunctionSignatureTemplate, FunctionOutputTemplate> outputMapping) {
+        // Simple signatures don't require a mapping
+        if (outputMapping.size() == 1) {
+            final FunctionOutputTemplate template =
+                    outputMapping.entrySet().iterator().next().getValue();
+            return template.toTypeStrategy();
+        }
+        // For overloaded signatures
+        final Map<InputTypeStrategy, TypeStrategy> mappings =
+                outputMapping.entrySet().stream()
                         .collect(
                                 Collectors.toMap(
                                         e -> e.getKey().toInputTypeStrategy(),
                                         e -> e.getValue().toTypeStrategy(),
                                         (t1, t2) -> t2));
         return TypeStrategies.mapping(mappings);
-    }
-
-    private static InputTypeStrategy translateInputTypeStrategy(
-            Map<FunctionSignatureTemplate, FunctionResultTemplate> outputMapping) {
-        return outputMapping.keySet().stream()
-                .map(FunctionSignatureTemplate::toInputTypeStrategy)
-                .reduce(InputTypeStrategies::or)
-                .orElse(InputTypeStrategies.sequence());
     }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
@@ -62,7 +62,7 @@ import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.c
 import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterAndOptionalContextVerification;
 import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterAndReturnTypeVerification;
 import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createParameterVerification;
-import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createStateFromGenericInClassOrParameters;
+import static org.apache.flink.table.types.extraction.FunctionMappingExtractor.createStateFromGenericInClassOrParametersExtraction;
 import static org.apache.flink.table.types.extraction.ProcedureMappingExtractor.createOutputFromArrayReturnTypeInMethod;
 import static org.apache.flink.table.types.extraction.ProcedureMappingExtractor.createParameterWithOptionalContextAndArrayReturnTypeVerification;
 
@@ -120,7 +120,8 @@ public final class TypeInferenceExtractor {
                         function,
                         UserDefinedFunctionHelper.AGGREGATE_ACCUMULATE,
                         createArgumentsFromParametersExtraction(1),
-                        createStateFromGenericInClassOrParameters(AggregateFunction.class, 1),
+                        createStateFromGenericInClassOrParametersExtraction(
+                                AggregateFunction.class, 1),
                         createParameterVerification(true),
                         createOutputFromGenericInClass(AggregateFunction.class, 0, true),
                         null);
@@ -152,7 +153,8 @@ public final class TypeInferenceExtractor {
                         function,
                         UserDefinedFunctionHelper.TABLE_AGGREGATE_ACCUMULATE,
                         createArgumentsFromParametersExtraction(1),
-                        createStateFromGenericInClassOrParameters(TableAggregateFunction.class, 1),
+                        createStateFromGenericInClassOrParametersExtraction(
+                                TableAggregateFunction.class, 1),
                         createParameterVerification(true),
                         createOutputFromGenericInClass(TableAggregateFunction.class, 0, true),
                         null);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgumentTrait.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/StaticArgumentTrait.java
@@ -19,10 +19,8 @@
 package org.apache.flink.table.types.inference;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.api.ValidationException;
 
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -47,21 +45,7 @@ public enum StaticArgumentTrait {
         this.requirements = Arrays.stream(requirements).collect(Collectors.toSet());
     }
 
-    public static void checkIntegrity(EnumSet<StaticArgumentTrait> traits) {
-        if (traits.stream().filter(t -> t.requirements.isEmpty()).count() != 1) {
-            throw new ValidationException(
-                    "Invalid argument traits. An argument must be declared as either scalar, table, or model.");
-        }
-        traits.forEach(
-                trait ->
-                        trait.requirements.forEach(
-                                requirement -> {
-                                    if (!traits.contains(requirement)) {
-                                        throw new ValidationException(
-                                                String.format(
-                                                        "Invalid argument traits. Trait %s requires %s.",
-                                                        trait, requirement));
-                                    }
-                                }));
+    public Set<StaticArgumentTrait> getRequirements() {
+        return requirements;
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
@@ -579,7 +579,8 @@ class DataTypeExtractorTest {
             final Method method = clazz.getMethods()[0];
             return new TestSpec(
                     description,
-                    (lookup) -> DataTypeExtractor.extractFromMethodOutput(lookup, clazz, method));
+                    (lookup) ->
+                            DataTypeExtractor.extractFromMethodReturnType(lookup, clazz, method));
         }
 
         static TestSpec forMethodOutput(Class<?> clazz) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/ExtractionUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/ExtractionUtilsTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.types.extraction;
 
+import org.apache.flink.table.types.extraction.ExtractionUtils.Autoboxing;
+
 import org.apache.flink.shaded.guava32.com.google.common.collect.ImmutableList;
 
 import org.junit.jupiter.api.Test;
@@ -36,14 +38,17 @@ public class ExtractionUtilsTest {
 
     @Test
     void testAutoboxing() {
-        assertThat(ExtractionUtils.isAssignable(int.class, Integer.class, true, true)).isTrue();
+        assertThat(ExtractionUtils.isAssignable(int.class, Integer.class, Autoboxing.STRICT))
+                .isTrue();
 
         // In strict autoboxing this is not allowed
-        assertThat(ExtractionUtils.isAssignable(Integer.class, int.class, true, true)).isFalse();
+        assertThat(ExtractionUtils.isAssignable(Integer.class, int.class, Autoboxing.STRICT))
+                .isFalse();
 
-        assertThat(ExtractionUtils.isAssignable(Integer.class, int.class, true, false)).isTrue();
+        assertThat(ExtractionUtils.isAssignable(Integer.class, int.class, Autoboxing.JVM)).isTrue();
 
-        assertThat(ExtractionUtils.isAssignable(Integer.class, Number.class, true, true)).isTrue();
+        assertThat(ExtractionUtils.isAssignable(Integer.class, Number.class, Autoboxing.STRICT))
+                .isTrue();
     }
 
     @Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/ExtractionUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/ExtractionUtilsTest.java
@@ -35,6 +35,18 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class ExtractionUtilsTest {
 
     @Test
+    void testAutoboxing() {
+        assertThat(ExtractionUtils.isAssignable(int.class, Integer.class, true, true)).isTrue();
+
+        // In strict autoboxing this is not allowed
+        assertThat(ExtractionUtils.isAssignable(Integer.class, int.class, true, true)).isFalse();
+
+        assertThat(ExtractionUtils.isAssignable(Integer.class, int.class, true, false)).isTrue();
+
+        assertThat(ExtractionUtils.isAssignable(Integer.class, Number.class, true, true)).isTrue();
+    }
+
+    @Test
     void testResolveParameters() {
         List<Method> methods = ExtractionUtils.collectMethods(LongClass.class, "method");
         Method method = methods.get(0);

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -305,6 +305,12 @@ class TypeInferenceExtractorTest {
                                 TypeStrategies.explicit(
                                         DataTypes.DOUBLE().notNull().bridgedTo(double.class))),
                 // ---
+                // non-scalar args
+                TestSpec.forScalarFunction(TableArgScalarFunction.class)
+                        .expectErrorMessage(
+                                "Only scalar arguments are supported at this location. "
+                                        + "But argument 't' declared the following traits: [TABLE_AS_ROW]"),
+                // ---
                 // different accumulator depending on input
                 TestSpec.forAggregateFunction(InputDependentAccumulatorFunction.class)
                         .expectAccumulator(
@@ -2400,5 +2406,11 @@ class TypeInferenceExtractorTest {
         public void eval(int i) {}
 
         public void eval(String i) {}
+    }
+
+    private static class TableArgScalarFunction extends ScalarFunction {
+        public int eval(@ArgumentHint(ArgumentTrait.TABLE_AS_ROW) Row t) {
+            return 0;
+        }
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.AsyncScalarFunction;
+import org.apache.flink.table.functions.ProcessTableFunction;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
@@ -39,6 +40,10 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.InputTypeStrategies;
 import org.apache.flink.table.types.inference.InputTypeStrategy;
+import org.apache.flink.table.types.inference.StateTypeStrategy;
+import org.apache.flink.table.types.inference.StateTypeStrategyWrapper;
+import org.apache.flink.table.types.inference.StaticArgument;
+import org.apache.flink.table.types.inference.StaticArgumentTrait;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
@@ -50,7 +55,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,70 +82,68 @@ class TypeInferenceExtractorTest {
         return Stream.of(
                 // function hint defines everything
                 TestSpec.forScalarFunction(FullFunctionHint.class)
-                        .expectNamedArguments("i", "s")
-                        .expectTypedArguments(DataTypes.INT(), DataTypes.STRING())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i", "s"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.INT()),
-                                            InputTypeStrategies.explicit(DataTypes.STRING())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.BOOLEAN())),
-
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectStaticArgument(StaticArgument.scalar("s", DataTypes.STRING(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.BOOLEAN())),
+                // ---
                 // function hint defines everything with overloading
                 TestSpec.forScalarFunction(FullFunctionHints.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.BIGINT())),
-
+                // ---
                 // global output hint with local input overloading
                 TestSpec.forScalarFunction(GlobalOutputFunctionHint.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.STRING())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.STRING()))),
                                 TypeStrategies.explicit(DataTypes.INT())),
-
+                // ---
                 // unsupported output overloading
                 TestSpec.forScalarFunction(InvalidSingleOutputFunctionHint.class)
                         .expectErrorMessage(
                                 "Function hints that lead to ambiguous results are not allowed."),
-
+                // ---
                 // global and local overloading
                 TestSpec.forScalarFunction(SplitFullFunctionHints.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.BIGINT())),
-
+                // ---
                 // global and local overloading with unsupported output overloading
                 TestSpec.forScalarFunction(InvalidFullOutputFunctionHint.class)
                         .expectErrorMessage(
                                 "Function hints with same input definition but different result types are not allowed."),
-
+                // ---
                 // ignore argument names during overloading
                 TestSpec.forScalarFunction(InvalidFullOutputFunctionWithArgNamesHint.class)
                         .expectErrorMessage(
                                 "Function hints with same input definition but different result types are not allowed."),
-
+                // ---
                 // invalid data type hint
                 TestSpec.forScalarFunction(IncompleteFunctionHint.class)
-                        .expectErrorMessage(
-                                "Data type hint does neither specify a data type nor input group for use as function argument."),
-
+                        .expectErrorMessage("Data type missing for scalar argument at position 1."),
+                // ---
                 // varargs and ANY input group
                 TestSpec.forScalarFunction(ComplexFunctionHint.class)
                         .expectOutputMapping(
@@ -149,66 +155,46 @@ class TypeInferenceExtractorTest {
                                             InputTypeStrategies.ANY
                                         }),
                                 TypeStrategies.explicit(DataTypes.BOOLEAN())),
-
+                // ---
                 // global input hints and local output hints
                 TestSpec.forScalarFunction(GlobalInputFunctionHints.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.INT())),
-
+                // ---
                 // no arguments
                 TestSpec.forScalarFunction(ZeroArgFunction.class)
-                        .expectNamedArguments()
-                        .expectTypedArguments()
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[0], new ArgumentTypeStrategy[0]),
-                                TypeStrategies.explicit(DataTypes.INT())),
-
+                        .expectEmptyStaticArguments()
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // no arguments async
                 TestSpec.forAsyncScalarFunction(ZeroArgFunctionAsync.class)
-                        .expectNamedArguments()
-                        .expectTypedArguments()
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[0], new ArgumentTypeStrategy[0]),
-                                TypeStrategies.explicit(DataTypes.INT())),
-
+                        .expectEmptyStaticArguments()
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // test primitive arguments extraction
                 TestSpec.forScalarFunction(MixedArgFunction.class)
-                        .expectNamedArguments("i", "d")
-                        .expectTypedArguments(
-                                DataTypes.INT().notNull().bridgedTo(int.class), DataTypes.DOUBLE())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i", "d"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(
-                                                    DataTypes.INT().notNull().bridgedTo(int.class)),
-                                            InputTypeStrategies.explicit(DataTypes.DOUBLE())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.INT())),
-
+                        .expectStaticArgument(
+                                StaticArgument.scalar(
+                                        "i", DataTypes.INT().notNull().bridgedTo(int.class), false))
+                        .expectStaticArgument(StaticArgument.scalar("d", DataTypes.DOUBLE(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // test primitive arguments extraction async
                 TestSpec.forAsyncScalarFunction(MixedArgFunctionAsync.class)
-                        .expectNamedArguments("i", "d")
-                        .expectTypedArguments(
-                                DataTypes.INT().notNull().bridgedTo(int.class), DataTypes.DOUBLE())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i", "d"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(
-                                                    DataTypes.INT().notNull().bridgedTo(int.class)),
-                                            InputTypeStrategies.explicit(DataTypes.DOUBLE())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.INT())),
-
+                        .expectStaticArgument(
+                                StaticArgument.scalar(
+                                        "i", DataTypes.INT().notNull().bridgedTo(int.class), false))
+                        .expectStaticArgument(StaticArgument.scalar("d", DataTypes.DOUBLE(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // test overloaded arguments extraction
                 TestSpec.forScalarFunction(OverloadedFunction.class)
                         .expectOutputMapping(
@@ -228,7 +214,7 @@ class TypeInferenceExtractorTest {
                                         }),
                                 TypeStrategies.explicit(
                                         DataTypes.BIGINT().notNull().bridgedTo(long.class))),
-
+                // ---
                 // test overloaded arguments extraction async
                 TestSpec.forAsyncScalarFunction(OverloadedFunctionAsync.class)
                         .expectOutputMapping(
@@ -247,7 +233,7 @@ class TypeInferenceExtractorTest {
                                             InputTypeStrategies.explicit(DataTypes.STRING())
                                         }),
                                 TypeStrategies.explicit(DataTypes.BIGINT())),
-
+                // ---
                 // test varying arguments extraction
                 TestSpec.forScalarFunction(VarArgFunction.class)
                         .expectOutputMapping(
@@ -260,7 +246,7 @@ class TypeInferenceExtractorTest {
                                                     DataTypes.INT().notNull().bridgedTo(int.class))
                                         }),
                                 TypeStrategies.explicit(DataTypes.STRING())),
-
+                // ---
                 // test varying arguments extraction async
                 TestSpec.forAsyncScalarFunction(VarArgFunctionAsync.class)
                         .expectOutputMapping(
@@ -273,7 +259,7 @@ class TypeInferenceExtractorTest {
                                                     DataTypes.INT().notNull().bridgedTo(int.class))
                                         }),
                                 TypeStrategies.explicit(DataTypes.STRING())),
-
+                // ---
                 // test varying arguments extraction with byte
                 TestSpec.forScalarFunction(VarArgWithByteFunction.class)
                         .expectOutputMapping(
@@ -286,7 +272,7 @@ class TypeInferenceExtractorTest {
                                                             .bridgedTo(byte.class))
                                         }),
                                 TypeStrategies.explicit(DataTypes.STRING())),
-
+                // ---
                 // test varying arguments extraction with byte async
                 TestSpec.forAsyncScalarFunction(VarArgWithByteFunctionAsync.class)
                         .expectOutputMapping(
@@ -299,140 +285,126 @@ class TypeInferenceExtractorTest {
                                                             .bridgedTo(byte.class))
                                         }),
                                 TypeStrategies.explicit(DataTypes.STRING())),
-
+                // ---
                 // output hint with input extraction
                 TestSpec.forScalarFunction(ExtractWithOutputHintFunction.class)
-                        .expectNamedArguments("i")
-                        .expectTypedArguments(DataTypes.INT())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.INT())),
-
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // output hint with input extraction
                 TestSpec.forAsyncScalarFunction(ExtractWithOutputHintFunctionAsync.class)
-                        .expectNamedArguments("i")
-                        .expectTypedArguments(DataTypes.INT())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.INT())),
-
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // output extraction with input hints
                 TestSpec.forScalarFunction(ExtractWithInputHintFunction.class)
-                        .expectNamedArguments("i", "b")
-                        .expectTypedArguments(DataTypes.INT(), DataTypes.BOOLEAN())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i", "b"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.INT()),
-                                            InputTypeStrategies.explicit(DataTypes.BOOLEAN())
-                                        }),
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectStaticArgument(
+                                StaticArgument.scalar("b", DataTypes.BOOLEAN(), false))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.DOUBLE().notNull().bridgedTo(double.class))),
-
+                // ---
                 // different accumulator depending on input
                 TestSpec.forAggregateFunction(InputDependentAccumulatorFunction.class)
-                        .expectAccumulatorMapping(
-                                InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
-                                TypeStrategies.explicit(
-                                        DataTypes.ROW(DataTypes.FIELD("f", DataTypes.BIGINT()))))
-                        .expectAccumulatorMapping(
-                                InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.STRING())),
-                                TypeStrategies.explicit(
-                                        DataTypes.ROW(DataTypes.FIELD("f", DataTypes.STRING()))))
+                        .expectAccumulator(
+                                TypeStrategies.mapping(
+                                        Map.of(
+                                                InputTypeStrategies.sequence(
+                                                        List.of("arg0"),
+                                                        List.of(
+                                                                InputTypeStrategies.explicit(
+                                                                        DataTypes.BIGINT()))),
+                                                TypeStrategies.explicit(
+                                                        DataTypes.ROW(
+                                                                DataTypes.FIELD(
+                                                                        "f", DataTypes.BIGINT()))),
+                                                InputTypeStrategies.sequence(
+                                                        List.of("arg0"),
+                                                        List.of(
+                                                                InputTypeStrategies.explicit(
+                                                                        DataTypes.STRING()))),
+                                                TypeStrategies.explicit(
+                                                        DataTypes.ROW(
+                                                                DataTypes.FIELD(
+                                                                        "f",
+                                                                        DataTypes.STRING()))))))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.STRING()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.STRING())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.STRING()))),
                                 TypeStrategies.explicit(DataTypes.STRING())),
-
+                // ---
                 // input, accumulator, and output are spread across the function
                 TestSpec.forAggregateFunction(AggregateFunctionWithManyAnnotations.class)
-                        .expectNamedArguments("r")
-                        .expectTypedArguments(
-                                DataTypes.ROW(
-                                        DataTypes.FIELD("i", DataTypes.INT()),
-                                        DataTypes.FIELD("b", DataTypes.BOOLEAN())))
-                        .expectAccumulatorMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"r"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(
-                                                    DataTypes.ROW(
-                                                            DataTypes.FIELD("i", DataTypes.INT()),
-                                                            DataTypes.FIELD(
-                                                                    "b", DataTypes.BOOLEAN())))
-                                        }),
+                        .expectStaticArgument(
+                                StaticArgument.scalar(
+                                        "r",
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("i", DataTypes.INT()),
+                                                DataTypes.FIELD("b", DataTypes.BOOLEAN())),
+                                        false))
+                        .expectAccumulator(
                                 TypeStrategies.explicit(
                                         DataTypes.ROW(DataTypes.FIELD("b", DataTypes.BOOLEAN()))))
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"r"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(
-                                                    DataTypes.ROW(
-                                                            DataTypes.FIELD("i", DataTypes.INT()),
-                                                            DataTypes.FIELD(
-                                                                    "b", DataTypes.BOOLEAN())))
-                                        }),
-                                TypeStrategies.explicit(DataTypes.STRING())),
-
+                        .expectOutput(TypeStrategies.explicit(DataTypes.STRING())),
+                // ---
+                // accumulator with state hint
+                TestSpec.forAggregateFunction(StateHintAggregateFunction.class)
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectState("myAcc", TypeStrategies.explicit(MyState.TYPE))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
+                // accumulator with state hint in function hint
+                TestSpec.forAggregateFunction(StateHintInFunctionHintAggregateFunction.class)
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectState("myAcc", TypeStrategies.explicit(MyState.TYPE))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // test for table functions
                 TestSpec.forTableFunction(OutputHintTableFunction.class)
-                        .expectNamedArguments("i")
-                        .expectTypedArguments(DataTypes.INT().notNull().bridgedTo(int.class))
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(
-                                                    DataTypes.INT().notNull().bridgedTo(int.class))
-                                        }),
+                        .expectStaticArgument(
+                                StaticArgument.scalar(
+                                        "i", DataTypes.INT().notNull().bridgedTo(int.class), false))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.ROW(
                                                 DataTypes.FIELD("i", DataTypes.INT()),
                                                 DataTypes.FIELD("b", DataTypes.BOOLEAN())))),
-
+                // ---
                 // mismatch between hints and implementation regarding return type
                 TestSpec.forScalarFunction(InvalidMethodScalarFunction.class)
                         .expectErrorMessage(
                                 "Considering all hints, the method should comply with the signature:\n"
                                         + "java.lang.String eval(int[])"),
-
+                // ---
                 // mismatch between hints and implementation regarding return type
                 TestSpec.forAsyncScalarFunction(InvalidMethodScalarFunctionAsync.class)
                         .expectErrorMessage(
                                 "Considering all hints, the method should comply with the signature:\n"
                                         + "eval(java.util.concurrent.CompletableFuture, int[])"),
-
+                // ---
                 // mismatch between hints and implementation regarding accumulator
                 TestSpec.forAggregateFunction(InvalidMethodAggregateFunction.class)
                         .expectErrorMessage(
                                 "Considering all hints, the method should comply with the signature:\n"
-                                        + "accumulate(java.lang.Integer, int, boolean)"),
-
+                                        + "accumulate(java.lang.Integer, int, boolean)\n"
+                                        + "Pattern: (<accumulator> [, <argument>]*)"),
+                // ---
                 // no implementation
                 TestSpec.forTableFunction(MissingMethodTableFunction.class)
                         .expectErrorMessage(
                                 "Could not find a publicly accessible method named 'eval'."),
-
+                // ---
                 // named arguments with overloaded function
                 // expected no named argument for overloaded function
                 TestSpec.forScalarFunction(NamedArgumentsScalarFunction.class),
-
+                // ---
                 // scalar function that takes any input
                 TestSpec.forScalarFunction(InputGroupScalarFunction.class)
                         .expectOutputMapping(
@@ -440,7 +412,7 @@ class TypeInferenceExtractorTest {
                                         new String[] {"o"},
                                         new ArgumentTypeStrategy[] {InputTypeStrategies.ANY}),
                                 TypeStrategies.explicit(DataTypes.STRING())),
-
+                // ---
                 // scalar function that takes any input as vararg
                 TestSpec.forScalarFunction(VarArgInputGroupScalarFunction.class)
                         .expectOutputMapping(
@@ -448,6 +420,7 @@ class TypeInferenceExtractorTest {
                                         new String[] {"o"},
                                         new ArgumentTypeStrategy[] {InputTypeStrategies.ANY}),
                                 TypeStrategies.explicit(DataTypes.STRING())),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with implicit overloading order",
                                 OrderedScalarFunction.class)
@@ -465,160 +438,158 @@ class TypeInferenceExtractorTest {
                                             InputTypeStrategies.explicit(DataTypes.BIGINT())
                                         }),
                                 TypeStrategies.explicit(DataTypes.BIGINT())),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with explicit overloading order by class annotations",
                                 OrderedScalarFunction2.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.BIGINT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with explicit overloading order by method annotations",
                                 OrderedScalarFunction3.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.BIGINT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 TestSpec.forTableFunction(
                                 "A data type hint on the class is used instead of a function output hint",
                                 DataTypeHintOnTableFunctionClass.class)
-                        .expectNamedArguments()
-                        .expectTypedArguments()
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {}, new ArgumentTypeStrategy[] {}),
+                        .expectEmptyStaticArguments()
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.ROW(DataTypes.FIELD("i", DataTypes.INT())))),
+                // ---
                 TestSpec.forTableFunction(
                                 "A data type hint on the method is used instead of a function output hint",
                                 DataTypeHintOnTableFunctionMethod.class)
-                        .expectNamedArguments("i")
-                        .expectTypedArguments(DataTypes.INT())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.ROW(DataTypes.FIELD("i", DataTypes.INT())))),
+                // ---
                 TestSpec.forTableFunction(
                                 "Invalid data type hint on top of method and class",
                                 InvalidDataTypeHintOnTableFunction.class)
                         .expectErrorMessage(
                                 "More than one data type hint found for output of function. "
                                         + "Please use a function hint instead."),
+                // ---
                 TestSpec.forScalarFunction(
                                 "A data type hint on the method is used for enriching (not a function output hint)",
                                 DataTypeHintOnScalarFunction.class)
-                        .expectNamedArguments()
-                        .expectTypedArguments()
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {}, new ArgumentTypeStrategy[] {}),
+                        .expectEmptyStaticArguments()
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.ROW(DataTypes.FIELD("i", DataTypes.INT()))
                                                 .bridgedTo(RowData.class))),
+                // ---
                 TestSpec.forAsyncScalarFunction(
                                 "A data type hint on the method is used for enriching (not a function output hint)",
                                 DataTypeHintOnScalarFunctionAsync.class)
-                        .expectNamedArguments()
-                        .expectTypedArguments()
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {}, new ArgumentTypeStrategy[] {}),
+                        .expectEmptyStaticArguments()
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.ROW(DataTypes.FIELD("i", DataTypes.INT()))
                                                 .bridgedTo(RowData.class))),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with arguments hints",
                                 ArgumentHintScalarFunction.class)
-                        .expectNamedArguments("f1", "f2")
-                        .expectTypedArguments(DataTypes.STRING(), DataTypes.INT())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"f1", "f2"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.STRING()),
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.STRING())),
+                        .expectStaticArgument(
+                                StaticArgument.scalar("f1", DataTypes.STRING(), false))
+                        .expectStaticArgument(StaticArgument.scalar("f2", DataTypes.INT(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.STRING())),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with arguments hints missing type",
                                 ArgumentHintMissingTypeScalarFunction.class)
-                        .expectErrorMessage("The type of the argument at position 0 is not set."),
+                        .expectErrorMessage("Data type missing for scalar argument at position 0."),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with arguments hints all missing name",
                                 ArgumentHintMissingNameScalarFunction.class)
-                        .expectNamedArguments("arg0", "arg1")
-                        .expectTypedArguments(DataTypes.STRING(), DataTypes.INT()),
+                        .expectStaticArgument(
+                                StaticArgument.scalar("arg0", DataTypes.STRING(), false))
+                        .expectStaticArgument(StaticArgument.scalar("arg1", DataTypes.INT(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.STRING())),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with arguments hints all missing partial name",
                                 ArgumentHintMissingPartialNameScalarFunction.class)
                         .expectErrorMessage(
-                                "The argument name in function hint must be either fully set or not set at all."),
+                                "Argument names in function hint must be either fully set or not set at all."),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with arguments hints name conflict",
                                 ArgumentHintNameConflictScalarFunction.class)
                         .expectErrorMessage(
                                 "Argument name conflict, there are at least two argument names that are the same."),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with arguments hints on method parameter",
                                 ArgumentHintOnParameterScalarFunction.class)
-                        .expectNamedArguments("in1", "in2")
-                        .expectTypedArguments(DataTypes.STRING(), DataTypes.INT())
-                        .expectOptionalArguments(false, false)
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"in1", "in2"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.STRING()),
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.STRING())),
+                        .expectStaticArgument(
+                                StaticArgument.scalar("in1", DataTypes.STRING(), false))
+                        .expectStaticArgument(StaticArgument.scalar("in2", DataTypes.INT(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.STRING())),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with arguments hints and inputs hints both defined",
                                 ArgumentsAndInputsScalarFunction.class)
                         .expectErrorMessage(
                                 "Argument and input hints cannot be declared in the same function hint."),
+                // ---
                 TestSpec.forScalarFunction(
-                                "Scalar function with argument hint and dataType hint declared in the same parameter",
+                                "Scalar function with argument hint and data type hint declared in the same parameter",
                                 ArgumentsHintAndDataTypeHintScalarFunction.class)
                         .expectErrorMessage(
-                                "Argument and dataType hints cannot be declared in the same parameter at position 0."),
+                                "Argument and data type hints cannot be declared at the same time at position 0."),
+                // ---
                 TestSpec.forScalarFunction(
                                 "An invalid scalar function that declare FunctionHint for both class and method in the same class.",
                                 InvalidFunctionHintOnClassAndMethod.class)
                         .expectErrorMessage(
                                 "Argument and input hints cannot be declared in the same function hint."),
+                // ---
                 TestSpec.forScalarFunction(
                                 "A valid scalar class that declare FunctionHint for both class and method in the same class.",
                                 ValidFunctionHintOnClassAndMethod.class)
-                        .expectNamedArguments("f1", "f2")
-                        .expectTypedArguments(DataTypes.STRING(), DataTypes.INT())
-                        .expectOptionalArguments(true, true),
+                        .expectStaticArgument(StaticArgument.scalar("f1", DataTypes.STRING(), true))
+                        .expectStaticArgument(StaticArgument.scalar("f2", DataTypes.INT(), true)),
+                // ---
                 TestSpec.forScalarFunction(
                                 "The FunctionHint of the function conflicts with the method.",
                                 ScalarFunctionWithFunctionHintConflictMethod.class)
                         .expectErrorMessage(
                                 "Considering all hints, the method should comply with the signature"),
+                // ---
                 // For function with overloaded function, argument name will be empty
                 TestSpec.forScalarFunction(
                         "Scalar function with overloaded functions and arguments hint declared.",
                         ArgumentsHintScalarFunctionWithOverloadedFunction.class),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with argument type not null but optional.",
                                 ArgumentHintNotNullTypeWithOptionalsScalarFunction.class)
                         .expectErrorMessage(
                                 "Argument at position 0 is optional but its type doesn't accept null value."),
+                // ---
                 TestSpec.forScalarFunction(
                                 "Scalar function with arguments hint and variable length args",
                                 ArgumentHintVariableLengthScalarFunction.class)
@@ -630,58 +601,181 @@ class TypeInferenceExtractorTest {
                                             InputTypeStrategies.explicit(DataTypes.INT())
                                         }),
                                 TypeStrategies.explicit(DataTypes.STRING())),
-                TestSpec.forScalarFunction(FunctionHintTableArgScalarFunction.class)
-                        .expectErrorMessage("Only scalar arguments are supported so far."),
-                TestSpec.forScalarFunction(ArgumentHintTableArgScalarFunction.class)
-                        .expectErrorMessage("Only scalar arguments are supported so far."),
-                TestSpec.forScalarFunction(StateHintScalarFunction.class)
-                        .expectErrorMessage("State hints are not supported yet."));
+                // ---
+                TestSpec.forProcessTableFunction(StatelessProcessTableFunction.class)
+                        .expectStaticArgument(
+                                StaticArgument.scalar(
+                                        "i", DataTypes.INT().notNull().bridgedTo(int.class), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
+                TestSpec.forProcessTableFunction(StateProcessTableFunction.class)
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectState("s", TypeStrategies.explicit(MyState.TYPE))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
+                TestSpec.forProcessTableFunction(NamedStateProcessTableFunction.class)
+                        .expectStaticArgument(
+                                StaticArgument.scalar("myArg", DataTypes.INT(), false))
+                        .expectState("myState", TypeStrategies.explicit(MyState.TYPE))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
+                TestSpec.forProcessTableFunction(MultiStateProcessTableFunction.class)
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectState("s1", TypeStrategies.explicit(MyFirstState.TYPE))
+                        .expectState("s2", TypeStrategies.explicit(MySecondState.TYPE))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
+                TestSpec.forProcessTableFunction(UntypedTableArgProcessTableFunction.class)
+                        .expectStaticArgument(
+                                StaticArgument.table(
+                                        "t",
+                                        Row.class,
+                                        false,
+                                        EnumSet.of(StaticArgumentTrait.TABLE_AS_ROW)))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
+                TestSpec.forProcessTableFunction(TypedTableArgProcessTableFunction.class)
+                        .expectStaticArgument(
+                                StaticArgument.table(
+                                        "t",
+                                        TypedTableArgProcessTableFunction.Customer.TYPE,
+                                        false,
+                                        EnumSet.of(StaticArgumentTrait.TABLE_AS_ROW)))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
+                TestSpec.forProcessTableFunction(ComplexProcessTableFunction.class)
+                        .expectStaticArgument(
+                                StaticArgument.table(
+                                        "setTable",
+                                        RowData.class,
+                                        false,
+                                        EnumSet.of(
+                                                StaticArgumentTrait.TABLE_AS_SET,
+                                                StaticArgumentTrait.OPTIONAL_PARTITION_BY)))
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectStaticArgument(
+                                StaticArgument.table(
+                                        "rowTable",
+                                        Row.class,
+                                        true,
+                                        EnumSet.of(StaticArgumentTrait.TABLE_AS_ROW)))
+                        .expectStaticArgument(StaticArgument.scalar("s", DataTypes.STRING(), true))
+                        .expectState("s1", TypeStrategies.explicit(MyFirstState.TYPE))
+                        .expectState(
+                                "other",
+                                TypeStrategies.explicit(
+                                        DataTypes.ROW(DataTypes.FIELD("f", DataTypes.FLOAT()))))
+                        .expectOutput(
+                                TypeStrategies.explicit(
+                                        DataTypes.ROW(DataTypes.FIELD("b", DataTypes.BOOLEAN())))),
+                // ---
+                TestSpec.forProcessTableFunction(ComplexProcessTableFunctionWithFunctionHint.class)
+                        .expectStaticArgument(
+                                StaticArgument.table(
+                                        "setTable",
+                                        RowData.class,
+                                        false,
+                                        EnumSet.of(
+                                                StaticArgumentTrait.TABLE_AS_SET,
+                                                StaticArgumentTrait.OPTIONAL_PARTITION_BY)))
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectStaticArgument(
+                                StaticArgument.table(
+                                        "rowTable",
+                                        Row.class,
+                                        true,
+                                        EnumSet.of(StaticArgumentTrait.TABLE_AS_ROW)))
+                        .expectStaticArgument(StaticArgument.scalar("s", DataTypes.STRING(), true))
+                        .expectState("s1", TypeStrategies.explicit(MyFirstState.TYPE))
+                        .expectState(
+                                "other",
+                                TypeStrategies.explicit(
+                                        DataTypes.ROW(DataTypes.FIELD("f", DataTypes.FLOAT()))))
+                        .expectOutput(
+                                TypeStrategies.explicit(
+                                        DataTypes.ROW(DataTypes.FIELD("b", DataTypes.BOOLEAN())))),
+                // ---
+                TestSpec.forProcessTableFunction(WrongStateOrderProcessTableFunction.class)
+                        .expectErrorMessage(
+                                "Considering all hints, the method should comply with the signature:\n"
+                                        + "eval(org.apache.flink.table.types.extraction.TypeInferenceExtractorTest.MyFirstState, int)\n"
+                                        + "Pattern: (<context>? [, <state>]* [, <argument>]*)"),
+                // ---
+                TestSpec.forProcessTableFunction(MissingStateTypeProcessTableFunction.class)
+                        .expectErrorMessage(
+                                "Could not extract a data type from 'class java.lang.Object' in parameter 0 of method 'eval'"),
+                // ---
+                TestSpec.forProcessTableFunction(EnrichedExtractionStateProcessTableFunction.class)
+                        .expectState("d", TypeStrategies.explicit(DataTypes.DECIMAL(3, 2)))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
+                TestSpec.forProcessTableFunction(WrongTypedTableProcessTableFunction.class)
+                        .expectErrorMessage(
+                                "Invalid data type 'INT' for table argument 'i'. "
+                                        + "Typed table arguments must use a composite type (i.e. row or structured type)."),
+                // ---
+                TestSpec.forProcessTableFunction(WrongArgumentTraitsProcessTableFunction.class)
+                        .expectErrorMessage(
+                                "Invalid argument traits for argument 'r'. "
+                                        + "Trait OPTIONAL_PARTITION_BY requires TABLE_AS_SET."),
+                // ---
+                TestSpec.forProcessTableFunction(
+                                MixingStaticAndInputGroupProcessTableFunction.class)
+                        .expectErrorMessage(
+                                "Process table functions require a non-overloaded, non-vararg, and static signature."),
+                // ---
+                TestSpec.forProcessTableFunction(MultiEvalProcessTableFunction.class)
+                        .expectErrorMessage(
+                                "Process table functions require a non-overloaded, non-vararg, and static signature."));
     }
 
     private static Stream<TestSpec> procedureSpecs() {
         return Stream.of(
                 // procedure hint defines everything
                 TestSpec.forProcedure(FullProcedureHint.class)
-                        .expectNamedArguments("i", "s")
-                        .expectTypedArguments(DataTypes.INT(), DataTypes.STRING())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i", "s"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.INT()),
-                                            InputTypeStrategies.explicit(DataTypes.STRING())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.BOOLEAN())),
-                // procedure hint defines everything
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectStaticArgument(StaticArgument.scalar("s", DataTypes.STRING(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.BOOLEAN())),
+                // ---
+                // procedure hints define everything
                 TestSpec.forProcedure(FullProcedureHints.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.BIGINT())),
+                // ---
                 // global output hint with local input overloading
                 TestSpec.forProcedure(GlobalOutputProcedureHint.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.STRING())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.STRING()))),
                                 TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // global and local overloading
                 TestSpec.forProcedure(SplitFullProcedureHints.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.BIGINT())),
+                // ---
                 // varargs and ANY input group
                 TestSpec.forProcedure(ComplexProcedureHint.class)
                         .expectOutputMapping(
@@ -693,38 +787,33 @@ class TypeInferenceExtractorTest {
                                             InputTypeStrategies.ANY
                                         }),
                                 TypeStrategies.explicit(DataTypes.BOOLEAN())),
+                // ---
                 // global input hints and local output hints
                 TestSpec.forProcedure(GlobalInputProcedureHints.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // no arguments
                 TestSpec.forProcedure(ZeroArgProcedure.class)
-                        .expectNamedArguments()
-                        .expectTypedArguments()
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[0], new ArgumentTypeStrategy[0]),
-                                TypeStrategies.explicit(DataTypes.INT())),
+                        .expectEmptyStaticArguments()
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // test primitive arguments extraction
                 TestSpec.forProcedure(MixedArgProcedure.class)
-                        .expectNamedArguments("i", "d")
-                        .expectTypedArguments(
-                                DataTypes.INT().notNull().bridgedTo(int.class), DataTypes.DOUBLE())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i", "d"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(
-                                                    DataTypes.INT().notNull().bridgedTo(int.class)),
-                                            InputTypeStrategies.explicit(DataTypes.DOUBLE())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.INT())),
+                        .expectStaticArgument(
+                                StaticArgument.scalar(
+                                        "i", DataTypes.INT().notNull().bridgedTo(int.class), false))
+                        .expectStaticArgument(StaticArgument.scalar("d", DataTypes.DOUBLE(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // test overloaded arguments extraction
                 TestSpec.forProcedure(OverloadedProcedure.class)
                         .expectOutputMapping(
@@ -744,6 +833,7 @@ class TypeInferenceExtractorTest {
                                         }),
                                 TypeStrategies.explicit(
                                         DataTypes.BIGINT().notNull().bridgedTo(long.class))),
+                // ---
                 // test varying arguments extraction
                 TestSpec.forProcedure(VarArgProcedure.class)
                         .expectOutputMapping(
@@ -756,6 +846,7 @@ class TypeInferenceExtractorTest {
                                                     DataTypes.INT().notNull().bridgedTo(int.class))
                                         }),
                                 TypeStrategies.explicit(DataTypes.STRING())),
+                // ---
                 // test varying arguments extraction with byte
                 TestSpec.forProcedure(VarArgWithByteProcedure.class)
                         .expectOutputMapping(
@@ -768,33 +859,25 @@ class TypeInferenceExtractorTest {
                                                             .bridgedTo(byte.class))
                                         }),
                                 TypeStrategies.explicit(DataTypes.STRING())),
+                // ---
                 // output hint with input extraction
                 TestSpec.forProcedure(ExtractWithOutputHintProcedure.class)
-                        .expectNamedArguments("i")
-                        .expectTypedArguments(DataTypes.INT())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
-                                TypeStrategies.explicit(DataTypes.INT())),
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectOutput(TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 // output extraction with input hints
                 TestSpec.forProcedure(ExtractWithInputHintProcedure.class)
-                        .expectNamedArguments("i", "b")
-                        .expectTypedArguments(DataTypes.INT(), DataTypes.BOOLEAN())
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"i", "b"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.INT()),
-                                            InputTypeStrategies.explicit(DataTypes.BOOLEAN())
-                                        }),
+                        .expectStaticArgument(StaticArgument.scalar("i", DataTypes.INT(), false))
+                        .expectStaticArgument(
+                                StaticArgument.scalar("b", DataTypes.BOOLEAN(), false))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.DOUBLE().notNull().bridgedTo(double.class))),
+                // ---
                 // named arguments with overloaded function
                 // expected no named argument for overloaded function
                 TestSpec.forProcedure(NamedArgumentsProcedure.class),
+                // ---
                 // procedure function that takes any input
                 TestSpec.forProcedure(InputGroupProcedure.class)
                         .expectOutputMapping(
@@ -802,6 +885,7 @@ class TypeInferenceExtractorTest {
                                         new String[] {"o"},
                                         new ArgumentTypeStrategy[] {InputTypeStrategies.ANY}),
                                 TypeStrategies.explicit(DataTypes.STRING())),
+                // ---
                 // procedure function that takes any input as vararg
                 TestSpec.forProcedure(VarArgInputGroupProcedure.class)
                         .expectOutputMapping(
@@ -809,6 +893,7 @@ class TypeInferenceExtractorTest {
                                         new String[] {"o"},
                                         new ArgumentTypeStrategy[] {InputTypeStrategies.ANY}),
                                 TypeStrategies.explicit(DataTypes.STRING())),
+                // ---
                 TestSpec.forProcedure(
                                 "Procedure with implicit overloading order", OrderedProcedure.class)
                         .expectOutputMapping(
@@ -825,203 +910,169 @@ class TypeInferenceExtractorTest {
                                             InputTypeStrategies.explicit(DataTypes.BIGINT())
                                         }),
                                 TypeStrategies.explicit(DataTypes.BIGINT())),
+                // ---
                 TestSpec.forProcedure(
                                 "Procedure with explicit overloading order by class annotations",
                                 OrderedProcedure2.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.BIGINT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 TestSpec.forProcedure(
                                 "Procedure with explicit overloading order by method annotations",
                                 OrderedProcedure3.class)
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.BIGINT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.BIGINT()))),
                                 TypeStrategies.explicit(DataTypes.BIGINT()))
                         .expectOutputMapping(
                                 InputTypeStrategies.sequence(
-                                        InputTypeStrategies.explicit(DataTypes.INT())),
+                                        List.of("arg0"),
+                                        List.of(InputTypeStrategies.explicit(DataTypes.INT()))),
                                 TypeStrategies.explicit(DataTypes.INT())),
+                // ---
                 TestSpec.forProcedure(
                                 "A data type hint on the method is used for enriching (not a function output hint)",
                                 DataTypeHintOnProcedure.class)
-                        .expectNamedArguments()
-                        .expectTypedArguments()
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {}, new ArgumentTypeStrategy[] {}),
+                        .expectEmptyStaticArguments()
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.ROW(DataTypes.FIELD("i", DataTypes.INT()))
                                                 .bridgedTo(RowData.class))),
+                // ---
                 // unsupported output overloading
                 TestSpec.forProcedure(InvalidSingleOutputProcedureHint.class)
                         .expectErrorMessage(
                                 "Procedure hints that lead to ambiguous results are not allowed."),
+                // ---
                 // global and local overloading with unsupported output overloading
                 TestSpec.forProcedure(InvalidFullOutputProcedureHint.class)
                         .expectErrorMessage(
                                 "Procedure hints with same input definition but different result types are not allowed."),
+                // ---
                 // ignore argument names during overloading
                 TestSpec.forProcedure(InvalidFullOutputProcedureWithArgNamesHint.class)
                         .expectErrorMessage(
                                 "Procedure hints with same input definition but different result types are not allowed."),
+                // ---
                 // invalid data type hint
                 TestSpec.forProcedure(IncompleteProcedureHint.class)
-                        .expectErrorMessage(
-                                "Data type hint does neither specify a data type nor input group for use as function argument."),
+                        .expectErrorMessage("Data type missing for scalar argument at position 1."),
+                // ---
                 // mismatch between hints and implementation regarding return type
                 TestSpec.forProcedure(InvalidMethodProcedure.class)
                         .expectErrorMessage(
                                 "Considering all hints, the method should comply with the signature:\n"
-                                        + "java.lang.String[] call(_, int[])"),
+                                        + "java.lang.String[] call(_, int[])\n"
+                                        + "Pattern: (<context> [, <argument>]*)"),
+                // ---
                 // no implementation
                 TestSpec.forProcedure(MissingMethodProcedure.class)
                         .expectErrorMessage(
                                 "Could not find a publicly accessible method named 'call'."),
+                // ---
                 TestSpec.forProcedure(
                                 "Named arguments procedure with argument hint on method",
                                 ArgumentHintOnMethodProcedure.class)
-                        .expectNamedArguments("f1", "f2")
-                        .expectTypedArguments(DataTypes.STRING(), DataTypes.INT())
-                        .expectOptionalArguments(true, true)
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"f1", "f2"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.STRING()),
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
+                        .expectStaticArgument(StaticArgument.scalar("f1", DataTypes.STRING(), true))
+                        .expectStaticArgument(StaticArgument.scalar("f2", DataTypes.INT(), true))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.INT().notNull().bridgedTo(int.class))),
+                // ---
                 TestSpec.forProcedure(
                                 "Named arguments procedure with argument hint on class",
                                 ArgumentHintOnClassProcedure.class)
-                        .expectNamedArguments("f1", "f2")
-                        .expectTypedArguments(DataTypes.STRING(), DataTypes.INT())
-                        .expectOptionalArguments(true, true)
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"f1", "f2"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.STRING()),
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
+                        .expectStaticArgument(StaticArgument.scalar("f1", DataTypes.STRING(), true))
+                        .expectStaticArgument(StaticArgument.scalar("f2", DataTypes.INT(), true))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.INT().notNull().bridgedTo(int.class))),
+                // ---
                 TestSpec.forProcedure(
                                 "Named arguments procedure with argument hint on parameter",
                                 ArgumentHintOnParameterProcedure.class)
-                        .expectNamedArguments("parameter_f1", "parameter_f2")
-                        .expectTypedArguments(
-                                DataTypes.STRING(), DataTypes.INT().bridgedTo(int.class))
-                        .expectOptionalArguments(true, false)
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"parameter_f1", "parameter_f2"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.STRING()),
-                                            InputTypeStrategies.explicit(
-                                                    DataTypes.INT().bridgedTo(int.class))
-                                        }),
+                        .expectStaticArgument(
+                                StaticArgument.scalar("parameter_f1", DataTypes.STRING(), true))
+                        .expectStaticArgument(
+                                StaticArgument.scalar(
+                                        "parameter_f2",
+                                        DataTypes.INT().bridgedTo(int.class),
+                                        false))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.INT().notNull().bridgedTo(int.class))),
+                // ---
                 TestSpec.forProcedure(
                                 "Named arguments procedure with argument hint on method and parameter",
                                 ArgumentHintOnMethodAndParameterProcedure.class)
-                        .expectNamedArguments("local_f1", "local_f2")
-                        .expectTypedArguments(DataTypes.STRING(), DataTypes.INT())
-                        .expectOptionalArguments(true, true)
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"local_f1", "local_f2"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.STRING()),
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
+                        .expectStaticArgument(
+                                StaticArgument.scalar("local_f1", DataTypes.STRING(), true))
+                        .expectStaticArgument(
+                                StaticArgument.scalar("local_f2", DataTypes.INT(), true))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.INT().notNull().bridgedTo(int.class))),
+                // ---
                 TestSpec.forProcedure(
                                 "Named arguments procedure with argument hint on class and method",
                                 ArgumentHintOnClassAndMethodProcedure.class)
-                        .expectNamedArguments("global_f1", "global_f2")
-                        .expectTypedArguments(DataTypes.STRING(), DataTypes.INT())
-                        .expectOptionalArguments(false, false)
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"global_f1", "global_f2"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.STRING()),
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
+                        .expectStaticArgument(
+                                StaticArgument.scalar("global_f1", DataTypes.STRING(), false))
+                        .expectStaticArgument(
+                                StaticArgument.scalar("global_f2", DataTypes.INT(), false))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.INT().notNull().bridgedTo(int.class))),
+                // ---
                 TestSpec.forProcedure(
                                 "Named arguments procedure with argument hint on class and method and parameter",
                                 ArgumentHintOnClassAndMethodAndParameterProcedure.class)
-                        .expectNamedArguments("global_f1", "global_f2")
-                        .expectTypedArguments(DataTypes.STRING(), DataTypes.INT())
-                        .expectOptionalArguments(false, false)
-                        .expectOutputMapping(
-                                InputTypeStrategies.sequence(
-                                        new String[] {"global_f1", "global_f2"},
-                                        new ArgumentTypeStrategy[] {
-                                            InputTypeStrategies.explicit(DataTypes.STRING()),
-                                            InputTypeStrategies.explicit(DataTypes.INT())
-                                        }),
+                        .expectStaticArgument(
+                                StaticArgument.scalar("global_f1", DataTypes.STRING(), false))
+                        .expectStaticArgument(
+                                StaticArgument.scalar("global_f2", DataTypes.INT(), false))
+                        .expectOutput(
                                 TypeStrategies.explicit(
                                         DataTypes.INT().notNull().bridgedTo(int.class))),
+                // ---
                 TestSpec.forProcedure(
                                 "Named arguments procedure with argument hint type not null but optional",
                                 ArgumentHintNotNullWithOptionalProcedure.class)
                         .expectErrorMessage(
                                 "Argument at position 1 is optional but its type doesn't accept null value."),
+                // ---
                 TestSpec.forProcedure(
                                 "Named arguments procedure with argument name conflict",
                                 ArgumentHintNameConflictProcedure.class)
                         .expectErrorMessage(
                                 "Argument name conflict, there are at least two argument names that are the same."),
+                // ---
                 TestSpec.forProcedure(
                                 "Named arguments procedure with optional type on primitive type",
                                 ArgumentHintOptionalOnPrimitiveParameterConflictProcedure.class)
                         .expectErrorMessage(
-                                "Argument at position 1 is optional but a primitive type doesn't accept null value."));
+                                "Considering all hints, the method should comply with the signature:\n"
+                                        + "int[] call(_, java.lang.String, java.lang.Integer)"));
     }
 
     @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("testData")
-    void testArgumentNames(TestSpec testSpec) {
-        if (testSpec.expectedArgumentNames != null) {
-            assertThat(testSpec.typeInferenceExtraction.get().getNamedArguments())
-                    .isEqualTo(Optional.of(testSpec.expectedArgumentNames));
-        } else if (testSpec.expectedErrorMessage == null) {
-            assertThat(testSpec.typeInferenceExtraction.get().getNamedArguments())
-                    .isEqualTo(Optional.empty());
-        }
-    }
-
-    @ParameterizedTest(name = "{index}: {0}")
-    @MethodSource("testData")
-    void testArgumentOptionals(TestSpec testSpec) {
-        if (testSpec.expectedArgumentOptionals != null) {
-            assertThat(testSpec.typeInferenceExtraction.get().getOptionalArguments())
-                    .isEqualTo(Optional.of(testSpec.expectedArgumentOptionals));
-        }
-    }
-
-    @ParameterizedTest(name = "{index}: {0}")
-    @MethodSource("testData")
-    void testArgumentTypes(TestSpec testSpec) {
-        if (testSpec.expectedArgumentTypes != null) {
-            assertThat(testSpec.typeInferenceExtraction.get().getTypedArguments())
-                    .isEqualTo(Optional.of(testSpec.expectedArgumentTypes));
-        } else if (testSpec.expectedErrorMessage == null) {
-            assertThat(testSpec.typeInferenceExtraction.get().getTypedArguments())
-                    .isEqualTo(Optional.empty());
+    void testStaticArguments(TestSpec testSpec) {
+        if (testSpec.expectedStaticArguments != null) {
+            final Optional<List<StaticArgument>> staticArguments =
+                    testSpec.typeInferenceExtraction.get().getStaticArguments();
+            assertThat(staticArguments).isPresent();
+            assertThat(staticArguments.get())
+                    .containsExactlyElementsOf(testSpec.expectedStaticArguments);
         }
     }
 
@@ -1039,16 +1090,14 @@ class TypeInferenceExtractorTest {
 
     @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("testData")
-    void testAccumulatorTypeStrategy(TestSpec testSpec) {
-        if (!testSpec.expectedAccumulatorStrategies.isEmpty()) {
-            assertThat(
-                            testSpec.typeInferenceExtraction
-                                    .get()
-                                    .getAccumulatorTypeStrategy()
-                                    .isPresent())
-                    .isEqualTo(true);
-            assertThat(testSpec.typeInferenceExtraction.get().getAccumulatorTypeStrategy().get())
-                    .isEqualTo(TypeStrategies.mapping(testSpec.expectedAccumulatorStrategies));
+    void testStateTypeStrategies(TestSpec testSpec) {
+        if (!testSpec.expectedStateStrategies.isEmpty()) {
+            assertThat(testSpec.typeInferenceExtraction.get().getStateTypeStrategies())
+                    .isNotEmpty();
+            assertThat(testSpec.typeInferenceExtraction.get().getStateTypeStrategies())
+                    .isEqualTo(testSpec.expectedStateStrategies);
+        } else if (testSpec.expectedErrorMessage == null) {
+            assertThat(testSpec.typeInferenceExtraction.get().getStateTypeStrategies()).isEmpty();
         }
     }
 
@@ -1056,8 +1105,13 @@ class TypeInferenceExtractorTest {
     @MethodSource("testData")
     void testOutputTypeStrategy(TestSpec testSpec) {
         if (!testSpec.expectedOutputStrategies.isEmpty()) {
-            assertThat(testSpec.typeInferenceExtraction.get().getOutputTypeStrategy())
-                    .isEqualTo(TypeStrategies.mapping(testSpec.expectedOutputStrategies));
+            if (testSpec.expectedOutputStrategies.size() == 1) {
+                assertThat(testSpec.typeInferenceExtraction.get().getOutputTypeStrategy())
+                        .isEqualTo(testSpec.expectedOutputStrategies.values().iterator().next());
+            } else {
+                assertThat(testSpec.typeInferenceExtraction.get().getOutputTypeStrategy())
+                        .isEqualTo(TypeStrategies.mapping(testSpec.expectedOutputStrategies));
+            }
         }
     }
 
@@ -1086,13 +1140,9 @@ class TypeInferenceExtractorTest {
 
         final Supplier<TypeInference> typeInferenceExtraction;
 
-        @Nullable List<String> expectedArgumentNames;
+        @Nullable List<StaticArgument> expectedStaticArguments;
 
-        @Nullable List<Boolean> expectedArgumentOptionals;
-
-        @Nullable List<DataType> expectedArgumentTypes;
-
-        Map<InputTypeStrategy, TypeStrategy> expectedAccumulatorStrategies;
+        LinkedHashMap<String, StateTypeStrategy> expectedStateStrategies;
 
         Map<InputTypeStrategy, TypeStrategy> expectedOutputStrategies;
 
@@ -1101,7 +1151,7 @@ class TypeInferenceExtractorTest {
         private TestSpec(String description, Supplier<TypeInference> typeInferenceExtraction) {
             this.description = description;
             this.typeInferenceExtraction = typeInferenceExtraction;
-            this.expectedAccumulatorStrategies = new LinkedHashMap<>();
+            this.expectedStateStrategies = new LinkedHashMap<>();
             this.expectedOutputStrategies = new LinkedHashMap<>();
         }
 
@@ -1161,6 +1211,14 @@ class TypeInferenceExtractorTest {
                                     new DataTypeFactoryMock(), function));
         }
 
+        static TestSpec forProcessTableFunction(Class<? extends ProcessTableFunction<?>> function) {
+            return new TestSpec(
+                    function.getSimpleName(),
+                    () ->
+                            TypeInferenceExtractor.forProcessTableFunction(
+                                    new DataTypeFactoryMock(), function));
+        }
+
         static TestSpec forProcedure(Class<? extends Procedure> procedure) {
             return forProcedure(null, procedure);
         }
@@ -1174,29 +1232,46 @@ class TypeInferenceExtractorTest {
                                     new DataTypeFactoryMock(), procedure));
         }
 
-        TestSpec expectNamedArguments(String... expectedArgumentNames) {
-            this.expectedArgumentNames = Arrays.asList(expectedArgumentNames);
+        TestSpec expectEmptyStaticArguments() {
+            this.expectedStaticArguments = new ArrayList<>();
             return this;
         }
 
-        TestSpec expectOptionalArguments(Boolean... expectedArgumentOptionals) {
-            this.expectedArgumentOptionals = Arrays.asList(expectedArgumentOptionals);
+        TestSpec expectStaticArgument(StaticArgument argument) {
+            if (this.expectedStaticArguments == null) {
+                this.expectedStaticArguments = new ArrayList<>();
+            }
+            this.expectedStaticArguments.add(argument);
             return this;
         }
 
-        TestSpec expectTypedArguments(DataType... expectedArgumentTypes) {
-            this.expectedArgumentTypes = Arrays.asList(expectedArgumentTypes);
+        TestSpec expectAccumulator(TypeStrategy typeStrategy) {
+            this.expectedStateStrategies.put("acc", StateTypeStrategyWrapper.of(typeStrategy));
             return this;
         }
 
-        TestSpec expectAccumulatorMapping(
-                InputTypeStrategy validator, TypeStrategy accumulatorStrategy) {
-            this.expectedAccumulatorStrategies.put(validator, accumulatorStrategy);
+        TestSpec expectState(String name, StateTypeStrategy stateTypeStrategy) {
+            this.expectedStateStrategies.put(name, stateTypeStrategy);
+            return this;
+        }
+
+        TestSpec expectState(String name, TypeStrategy typeStrategy) {
+            this.expectedStateStrategies.put(name, StateTypeStrategyWrapper.of(typeStrategy));
+            return this;
+        }
+
+        TestSpec expectState(LinkedHashMap<String, StateTypeStrategy> stateTypeStrategy) {
+            this.expectedStateStrategies.putAll(stateTypeStrategy);
             return this;
         }
 
         TestSpec expectOutputMapping(InputTypeStrategy validator, TypeStrategy outputStrategy) {
             this.expectedOutputStrategies.put(validator, outputStrategy);
+            return this;
+        }
+
+        TestSpec expectOutput(TypeStrategy outputStrategy) {
+            this.expectedOutputStrategies.put(InputTypeStrategies.WILDCARD, outputStrategy);
             return this;
         }
 
@@ -1408,6 +1483,39 @@ class TypeInferenceExtractorTest {
         @Override
         public Row createAccumulator() {
             return null;
+        }
+    }
+
+    private static class StateHintAggregateFunction extends AggregateFunction<Integer, MyState> {
+        public void accumulate(
+                @StateHint(name = "myAcc") MyState acc, @ArgumentHint(name = "i") Integer i) {}
+
+        @Override
+        public Integer getValue(MyState accumulator) {
+            return null;
+        }
+
+        @Override
+        public MyState createAccumulator() {
+            return new MyState();
+        }
+    }
+
+    @FunctionHint(
+            state = {@StateHint(name = "myAcc", type = @DataTypeHint(bridgedTo = MyState.class))},
+            arguments = {@ArgumentHint(name = "i", type = @DataTypeHint("INT"))})
+    private static class StateHintInFunctionHintAggregateFunction
+            extends AggregateFunction<Integer, Object> {
+        public void accumulate(Object acc, Integer i) {}
+
+        @Override
+        public Integer getValue(Object accumulator) {
+            return null;
+        }
+
+        @Override
+        public Object createAccumulator() {
+            return new Object();
         }
     }
 
@@ -2130,32 +2238,167 @@ class TypeInferenceExtractorTest {
         }
     }
 
+    private static class StatelessProcessTableFunction extends ProcessTableFunction<Integer> {
+        public void eval(int i) {}
+    }
+
+    public static class MyState {
+        static final DataType TYPE =
+                DataTypes.STRUCTURED(
+                        MyState.class,
+                        DataTypes.FIELD("d", DataTypes.DOUBLE().notNull().bridgedTo(double.class)));
+        public double d;
+    }
+
+    public static class MyFirstState {
+        static final DataType TYPE =
+                DataTypes.STRUCTURED(MyFirstState.class, DataTypes.FIELD("d", DataTypes.DOUBLE()));
+        public Double d;
+    }
+
+    public static class MySecondState {
+        static final DataType TYPE =
+                DataTypes.STRUCTURED(MySecondState.class, DataTypes.FIELD("i", DataTypes.INT()));
+        public Integer i;
+    }
+
+    private static class StateProcessTableFunction extends ProcessTableFunction<Integer> {
+        public void eval(@StateHint MyState s, Integer i) {}
+    }
+
+    private static class NamedStateProcessTableFunction extends ProcessTableFunction<Integer> {
+        public void eval(
+                @StateHint(name = "myState") MyState s, @ArgumentHint(name = "myArg") Integer i) {}
+    }
+
+    private static class MultiStateProcessTableFunction extends ProcessTableFunction<Integer> {
+        public void eval(@StateHint MyFirstState s1, @StateHint MySecondState s2, Integer i) {}
+    }
+
+    private static class UntypedTableArgProcessTableFunction extends ProcessTableFunction<Integer> {
+        public void eval(@ArgumentHint(ArgumentTrait.TABLE_AS_ROW) Row t) {}
+    }
+
+    private static class TypedTableArgProcessTableFunction extends ProcessTableFunction<Integer> {
+        public static class Customer {
+            static final DataType TYPE =
+                    DataTypes.STRUCTURED(
+                            Customer.class,
+                            DataTypes.FIELD("age", DataTypes.INT()),
+                            DataTypes.FIELD("name", DataTypes.STRING()));
+            public String name;
+            public Integer age;
+        }
+
+        public void eval(@ArgumentHint(ArgumentTrait.TABLE_AS_ROW) Customer t) {}
+    }
+
+    @DataTypeHint("ROW<b BOOLEAN>")
+    private static class ComplexProcessTableFunction extends ProcessTableFunction<Row> {
+        public void eval(
+                Context context,
+                @StateHint(name = "s1") MyFirstState s1,
+                @StateHint(name = "other", type = @DataTypeHint("ROW<f FLOAT>")) Row s2,
+                @ArgumentHint(
+                                value = {
+                                    ArgumentTrait.TABLE_AS_SET,
+                                    ArgumentTrait.OPTIONAL_PARTITION_BY
+                                },
+                                name = "setTable")
+                        RowData t1,
+                @ArgumentHint(name = "i") Integer i,
+                @ArgumentHint(
+                                value = {ArgumentTrait.TABLE_AS_ROW},
+                                name = "rowTable",
+                                isOptional = true)
+                        Row t2,
+                @ArgumentHint(isOptional = true, name = "s") String s) {}
+    }
+
     @FunctionHint(
+            state = {
+                @StateHint(name = "s1", type = @DataTypeHint(bridgedTo = MyFirstState.class)),
+                @StateHint(name = "other", type = @DataTypeHint("ROW<f FLOAT>"))
+            },
             arguments = {
                 @ArgumentHint(
-                        value = ArgumentTrait.TABLE_AS_ROW,
-                        type = @DataTypeHint("ROW<i INT>"))
-            })
-    private static class FunctionHintTableArgScalarFunction extends ScalarFunction {
-        public String eval(Row table) {
-            return "";
-        }
+                        name = "setTable",
+                        value = {ArgumentTrait.TABLE_AS_SET, ArgumentTrait.OPTIONAL_PARTITION_BY},
+                        type = @DataTypeHint(bridgedTo = RowData.class)),
+                @ArgumentHint(name = "i", type = @DataTypeHint("INT")),
+                @ArgumentHint(
+                        name = "rowTable",
+                        value = {ArgumentTrait.TABLE_AS_ROW},
+                        isOptional = true),
+                @ArgumentHint(name = "s", isOptional = true, type = @DataTypeHint("STRING"))
+            },
+            output = @DataTypeHint("ROW<b BOOLEAN>"))
+    private static class ComplexProcessTableFunctionWithFunctionHint
+            extends ProcessTableFunction<Row> {
+
+        public void eval(
+                Context context,
+                MyFirstState arg0,
+                Row arg1,
+                RowData arg2,
+                Integer arg3,
+                Row arg4,
+                String arg5) {}
     }
 
-    private static class ArgumentHintTableArgScalarFunction extends ScalarFunction {
-        public String eval(
+    private static class WrongStateOrderProcessTableFunction extends ProcessTableFunction<Integer> {
+
+        public void eval(int i, @StateHint MyFirstState state) {}
+    }
+
+    private static class MissingStateTypeProcessTableFunction
+            extends ProcessTableFunction<Integer> {
+
+        public void eval(@StateHint Object state) {}
+    }
+
+    private static class EnrichedExtractionStateProcessTableFunction
+            extends ProcessTableFunction<Integer> {
+
+        public void eval(
+                @StateHint(
+                                type =
+                                        @DataTypeHint(
+                                                defaultDecimalPrecision = 3,
+                                                defaultDecimalScale = 2))
+                        BigDecimal d) {}
+    }
+
+    private static class WrongTypedTableProcessTableFunction extends ProcessTableFunction<Integer> {
+        public void eval(@ArgumentHint(ArgumentTrait.TABLE_AS_SET) Integer i) {}
+    }
+
+    private static class WrongArgumentTraitsProcessTableFunction
+            extends ProcessTableFunction<Integer> {
+        public void eval(
+                @ArgumentHint({ArgumentTrait.TABLE_AS_ROW, ArgumentTrait.OPTIONAL_PARTITION_BY})
+                        Row r) {}
+    }
+
+    private static class MixingStaticAndInputGroupProcessTableFunction
+            extends ProcessTableFunction<Integer> {
+        public void eval(
+                @ArgumentHint(ArgumentTrait.TABLE_AS_ROW) Row r,
+                @DataTypeHint(inputGroup = InputGroup.ANY) Object o) {}
+    }
+
+    private static class InvalidInputGroupTableArgProcessTableFunction
+            extends ProcessTableFunction<Integer> {
+        public void eval(
                 @ArgumentHint(
                                 value = ArgumentTrait.TABLE_AS_ROW,
-                                type = @DataTypeHint("ROW<i INT>"))
-                        Row table) {
-            return "";
-        }
+                                type = @DataTypeHint(inputGroup = InputGroup.ANY))
+                        Row r) {}
     }
 
-    @FunctionHint(state = @StateHint(name = "state", type = @DataTypeHint("INT")))
-    private static class StateHintScalarFunction extends ScalarFunction {
-        public String eval() {
-            return "";
-        }
+    private static class MultiEvalProcessTableFunction extends ProcessTableFunction<Integer> {
+        public void eval(int i) {}
+
+        public void eval(String i) {}
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerCallProcedureOperation.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerCallProcedureOperation.java
@@ -48,6 +48,7 @@ import org.apache.flink.table.procedures.Procedure;
 import org.apache.flink.table.procedures.ProcedureDefinition;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.extraction.ExtractionUtils;
+import org.apache.flink.table.types.extraction.ExtractionUtils.Autoboxing;
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.table.utils.print.RowDataToStringConverter;
@@ -171,13 +172,14 @@ public class PlannerCallProcedureOperation implements CallProcedureOperation {
                 methods.stream()
                         .filter(
                                 method ->
-                                        ExtractionUtils.isInvokable(false, method, inputClz)
+                                        // Strict autoboxing is disabled for backwards compatibility
+                                        ExtractionUtils.isInvokable(
+                                                        Autoboxing.JVM, method, inputClz)
                                                 && method.getReturnType().isArray()
                                                 && isAssignable(
                                                         outputType.getConversionClass(),
                                                         method.getReturnType().getComponentType(),
-                                                        true,
-                                                        false))
+                                                        Autoboxing.JVM))
                         .collect(Collectors.toList());
         if (callMethods.isEmpty()) {
             throw new ValidationException(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerCallProcedureOperation.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/PlannerCallProcedureOperation.java
@@ -171,12 +171,13 @@ public class PlannerCallProcedureOperation implements CallProcedureOperation {
                 methods.stream()
                         .filter(
                                 method ->
-                                        ExtractionUtils.isInvokable(method, inputClz)
+                                        ExtractionUtils.isInvokable(false, method, inputClz)
                                                 && method.getReturnType().isArray()
                                                 && isAssignable(
                                                         outputType.getConversionClass(),
                                                         method.getReturnType().getComponentType(),
-                                                        true))
+                                                        true,
+                                                        false))
                         .collect(Collectors.toList());
         if (callMethods.isEmpty()) {
             throw new ValidationException(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToCallOperationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToCallOperationTest.java
@@ -212,7 +212,7 @@ public class SqlNodeToCallOperationTest extends SqlNodeToOperationConversionTest
                 input = {@DataTypeHint("STRING"), @DataTypeHint("STRING")},
                 output = @DataTypeHint("INT"),
                 argumentNames = {"c", "d"})
-        public int[] call(ProcedureContext context, String arg3, String arg4) {
+        public java.lang.Integer[] call(ProcedureContext context, String arg3, String arg4) {
             return null;
         }
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToCallOperationTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlNodeToCallOperationTest.java
@@ -212,7 +212,7 @@ public class SqlNodeToCallOperationTest extends SqlNodeToOperationConversionTest
                 input = {@DataTypeHint("STRING"), @DataTypeHint("STRING")},
                 output = @DataTypeHint("INT"),
                 argumentNames = {"c", "d"})
-        public java.lang.Integer[] call(ProcedureContext context, String arg3, String arg4) {
+        public int[] call(ProcedureContext context, String arg3, String arg4) {
             return null;
         }
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/ValuesITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/ValuesITCase.java
@@ -368,14 +368,14 @@ class ValuesITCase extends StreamingTestBase {
             })
     public static class CustomScalarFunction extends ScalarFunction {
         public String eval(
-                byte tinyint,
-                short smallInt,
-                int integer,
-                long bigint,
-                float floating,
-                double doublePrecision,
+                Byte tinyint,
+                Short smallInt,
+                Integer integer,
+                Long bigint,
+                Float floating,
+                Double doublePrecision,
                 BigDecimal decimal,
-                boolean bool,
+                Boolean bool,
                 LocalTime time,
                 LocalDate date,
                 //				Period dateTimeInteraval, TODO TIMESTAMP WITH TIMEZONE not supported yet

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.planner.expressions.utils
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.table.annotation.{DataTypeHint, FunctionHint}
+import org.apache.flink.table.annotation.DataTypeHint
 import org.apache.flink.table.functions.{AggregateFunction, FunctionContext, ScalarFunction, TableFunction}
 import org.apache.flink.table.legacy.api.Types
 import org.apache.flink.table.planner.JInt
@@ -105,10 +105,7 @@ class RichFunc1 extends ScalarFunction {
     }
   }
 
-  @FunctionHint(
-    input = Array(new DataTypeHint("INT")),
-    output = new DataTypeHint(value = "INT", bridgedTo = classOf[JInt]))
-  def eval(index: Int): Int = {
+  def eval(index: JInt): JInt = {
     index + added
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
@@ -265,7 +265,7 @@ class SortAggITCase extends AggregateITCaseBase("SortAggregate") {
     tEnv.getConfig.set(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, Int.box(1))
     env.setParallelism(1)
     checkResult(
-      "SELECT myPrimitiveArrayUdaf(a, b) FROM Table3",
+      "SELECT myPrimitiveArrayUdaf(IFNULL(a, 0), IFNULL(b, 0)) FROM Table3",
       Seq(row(Array(231, 91)))
     )
     checkResult(
@@ -273,7 +273,7 @@ class SortAggITCase extends AggregateITCaseBase("SortAggregate") {
       Seq(row(Array("HHHHILCCCCCCCCCCCCCCC", "iod?.r123456789012345")))
     )
     checkResult(
-      "SELECT myNestedLongArrayUdaf(a, b)[2] FROM Table3",
+      "SELECT myNestedLongArrayUdaf(IFNULL(a, 0), IFNULL(b, 0))[2] FROM Table3",
       Seq(row(Array(91, 231)))
     )
     checkResult(
@@ -285,11 +285,11 @@ class SortAggITCase extends AggregateITCaseBase("SortAggregate") {
   @Test
   def testMapUdaf(): Unit = {
     checkResult(
-      "SELECT myPrimitiveMapUdaf(a, b)[3] FROM Table3",
+      "SELECT myPrimitiveMapUdaf(IFNULL(a, 0), IFNULL(b, 0))[3] FROM Table3",
       Seq(row(15))
     )
     checkResult(
-      "SELECT myPrimitiveMapUdaf(a, b)[6] FROM Table3",
+      "SELECT myPrimitiveMapUdaf(IFNULL(a, 0), IFNULL(b, 0))[6] FROM Table3",
       Seq(row(111))
     )
     checkResult(
@@ -509,10 +509,7 @@ class MyPrimitiveArrayUdaf extends AggregateFunction[Array[Long], Array[Long]] {
 
   override def getValue(accumulator: Array[Long]): Array[Long] = accumulator
 
-  def accumulate(
-      accumulator: Array[Long],
-      @DataTypeHint("INT") a: Int,
-      @DataTypeHint("BIGINT") b: Long): Unit = {
+  def accumulate(accumulator: Array[Long], a: Int, b: Long): Unit = {
     accumulator(0) += a
     accumulator(1) += b
   }
@@ -536,10 +533,7 @@ class MyNestedLongArrayUdaf extends AggregateFunction[Array[Array[Long]], Array[
 
   override def getValue(accumulator: Array[Array[Long]]): Array[Array[Long]] = accumulator
 
-  def accumulate(
-      accumulator: Array[Array[Long]],
-      @DataTypeHint("INT") a: Int,
-      @DataTypeHint("BIGINT") b: Long): Unit = {
+  def accumulate(accumulator: Array[Array[Long]], a: Int, b: Long): Unit = {
     accumulator(0)(0) += a
     accumulator(0)(1) += b
     accumulator(1)(0) += b
@@ -562,39 +556,31 @@ class MyNestedStringArrayUdaf
   }
 }
 
-@FunctionHint(
-  input = Array(new DataTypeHint("INT"), new DataTypeHint("BIGINT")),
-  accumulator = new DataTypeHint("MAP<BIGINT, INT>"),
-  output = new DataTypeHint("MAP<BIGINT, INT>"))
 class MyPrimitiveMapUdaf
-  extends AggregateFunction[java.util.Map[Long, Int], java.util.Map[Long, Int]] {
+  extends AggregateFunction[java.util.Map[JLong, JInt], java.util.Map[JLong, JInt]] {
 
-  override def createAccumulator(): java.util.Map[Long, Int] =
-    new java.util.HashMap[Long, Int]()
+  override def createAccumulator(): java.util.Map[JLong, JInt] =
+    new java.util.HashMap[JLong, JInt]()
 
-  override def getValue(accumulator: java.util.Map[Long, Int]): java.util.Map[Long, Int] =
+  override def getValue(accumulator: java.util.Map[JLong, JInt]): java.util.Map[JLong, JInt] =
     accumulator
 
-  def accumulate(accumulator: java.util.Map[Long, Int], a: Int, b: Long): Unit = {
+  def accumulate(accumulator: java.util.Map[JLong, JInt], a: Int, b: Long): Unit = {
     accumulator.putIfAbsent(b, 0)
     accumulator.put(b, accumulator.get(b) + a)
   }
 }
 
-@FunctionHint(
-  input = Array(new DataTypeHint("INT"), new DataTypeHint("STRING")),
-  accumulator = new DataTypeHint("MAP<STRING, INT>"),
-  output = new DataTypeHint("MAP<STRING, INT>"))
 class MyObjectMapUdaf
-  extends AggregateFunction[java.util.Map[String, Int], java.util.Map[String, Int]] {
+  extends AggregateFunction[java.util.Map[String, JInt], java.util.Map[String, JInt]] {
 
-  override def createAccumulator(): java.util.Map[String, Int] =
-    new java.util.HashMap[String, Int]()
+  override def createAccumulator(): java.util.Map[String, JInt] =
+    new java.util.HashMap[String, JInt]()
 
-  override def getValue(accumulator: java.util.Map[String, Int]): java.util.Map[String, Int] =
+  override def getValue(accumulator: java.util.Map[String, JInt]): java.util.Map[String, JInt] =
     accumulator
 
-  def accumulate(accumulator: java.util.Map[String, Int], a: Int, c: String): Unit = {
+  def accumulate(accumulator: java.util.Map[String, JInt], a: JInt, c: String): Unit = {
     val key = c.substring(0, 2)
     accumulator.putIfAbsent(key, 0)
     accumulator.put(key, accumulator.get(key) + a)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
@@ -382,20 +382,15 @@ object UserDefinedFunctionTestUtils {
       TestAddWithOpen.aliveCounter.incrementAndGet()
     }
 
-    @FunctionHint(
-      input = Array(
-        new DataTypeHint(value = "BIGINT", bridgedTo = classOf[JLong]),
-        new DataTypeHint(value = "BIGINT", bridgedTo = classOf[JLong])),
-      output = new DataTypeHint(value = "BIGINT", bridgedTo = classOf[JLong]))
-    def eval(a: Long, b: Long): Long = {
+    def eval(a: JLong, b: JLong): JLong = {
       if (!isOpened) {
         throw new IllegalStateException("Open method is not called.")
       }
       a + b
     }
 
-    def eval(a: Long, b: Int): Long = {
-      eval(a, b.asInstanceOf[Long])
+    def eval(a: JLong, b: JInt): JLong = {
+      eval(a, b.toLong)
     }
 
     override def close(): Unit = {
@@ -411,13 +406,7 @@ object UserDefinedFunctionTestUtils {
 
   @SerialVersionUID(1L)
   object TestMod extends ScalarFunction {
-    @FunctionHint(
-      input = Array(
-        new DataTypeHint(value = "BIGINT", bridgedTo = classOf[JLong]),
-        new DataTypeHint(value = "INT", bridgedTo = classOf[JInt])
-      ),
-      output = new DataTypeHint(value = "BIGINT", bridgedTo = classOf[JLong]))
-    def eval(src: Long, mod: Int): Long = {
+    def eval(src: JLong, mod: JInt): JLong = {
       src % mod
     }
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/CountAggFunction.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/CountAggFunction.scala
@@ -42,7 +42,7 @@ class CountAggFunction extends AggregateFunction[JLong, CountAccumulator] {
     acc.f0 += 1L
   }
 
-  def retract(acc: CountAccumulator, @DataTypeHint("INT") value: Any): Unit = {
+  def retract(acc: CountAccumulator, value: Any): Unit = {
     if (value != null) {
       acc.f0 -= 1L
     }


### PR DESCRIPTION
## What is the purpose of the change

This refactors the TypeInferenceExtractor to support ProcessTableFunction as defined in FLIP-440.

The extractor tries its best to extract list of `StaticArgument` of both scalar and table kind. Table kind can be both typed (structured type) or untyped (Row). `@StateHint` allows defining state entries.

Some simple examples:
```
public class StateProcessTableFunction extends ProcessTableFunction<Integer> {
    public void eval(@StateHint MyState s, Integer i) {}
}

public class NamedStateProcessTableFunction extends ProcessTableFunction<Integer> {
    public void eval(
            @StateHint(name = "myState") MyState s, @ArgumentHint(name = "myArg") Integer i) {}
}

public class MultiStateProcessTableFunction extends ProcessTableFunction<Integer> {
    public void eval(@StateHint MyFirstState s1, @StateHint MySecondState s2, Integer i) {}
}

public class UntypedTableArgProcessTableFunction extends ProcessTableFunction<Integer> {
    public void eval(@ArgumentHint(ArgumentTrait.TABLE_AS_ROW) Row t) {}
}
```

More complex examples can be found in tests.

Several bugs were fixed on the way:
- disallowing nullable types to send data into non-null signatures due to incorrect autoboxing checks
- deriving an input strategy when a static signature is enough
- better error messages and helpful information for users to help specifying the correct parameter ordering

## Brief change log

- Refactor the `FunctionResultTemplate` into dedicated `FunctionStateTemplate` and `FunctionOutputTemplate`
- Unifying the accumulator and state entry logic
- Cleaning up code and find better comments/names for methods for improving code readability.

## Verifying this change

This change added tests and can be verified as follows: TypeInferenceExtractorTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
