### PR TITLE
[FLINK-36918][table] Introduce ProcTimeSortOperator in TemporalSort with Async State API

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/asyncprocessing/AsyncStateBaseTemporalSortOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/asyncprocessing/AsyncStateBaseTemporalSortOperator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.sort.asyncprocessing;
+
+import org.apache.flink.runtime.asyncprocessing.operators.AbstractAsyncStateStreamOperator;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.api.SimpleTimerService;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.operators.*;
+import org.apache.flink.table.data.RowData;
+
+/** Base class for stream temporal sort operator. */
+abstract class AsyncStateBaseTemporalSortOperator extends AbstractAsyncStateStreamOperator<RowData>
+        implements OneInputStreamOperator<RowData, RowData>, Triggerable<RowData, VoidNamespace> {
+
+    protected transient TimerService timerService;
+    protected transient TimestampedCollector<RowData> collector;
+
+    AsyncStateBaseTemporalSortOperator() {}
+
+    @Override
+    public boolean useSplittableTimers() {
+        return true;
+    }
+
+    @Override
+    public void open() throws Exception {
+        InternalTimerService<VoidNamespace> internalTimerService =
+                getInternalTimerService("user-timers", VoidNamespaceSerializer.INSTANCE, this);
+        timerService = new SimpleTimerService(internalTimerService);
+        collector = new TimestampedCollector<>(output);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/utils/ProcTimeSortHelper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sort/utils/ProcTimeSortHelper.java
@@ -1,0 +1,35 @@
+package org.apache.flink.table.runtime.operators.sort.utils;
+
+import org.apache.flink.streaming.api.operators.TimestampedCollector;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.RecordComparator;
+
+import java.util.List;
+
+public abstract class ProcTimeSortHelper {
+
+    private List<RowData> sortBuffer;
+    private RecordComparator comparator;
+    protected TimestampedCollector<RowData> collector;
+
+    public ProcTimeSortHelper(
+            List<RowData> sortBuffer,
+            RecordComparator comparator,
+            TimestampedCollector<RowData> collector) {
+        this.sortBuffer = sortBuffer;
+        this.comparator = comparator;
+        this.collector = collector;
+    }
+
+    public void emitData(Iterable<RowData> inputs) {
+        // sort the rows
+        sortBuffer.sort(comparator);
+
+        // Emit the rows in order
+        sortBuffer.forEach((RowData row) -> collector.collect(row));
+
+        clearDataState();
+    }
+
+    protected abstract void clearDataState();
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce ProcTimeSortOperator in TemporalSort with async state api.

## Brief change log

  - *Introduce ProcTimeSortOperator in TemporalSort with async state api.*
  - *Add ITs and ProcTimeSortOperatorTest*


## Verifying this change

Existent tests and new added tests can verify this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)