### PR TITLE
[FLINK-36919][table] Add missing dropTable/dropView methods to TableEnvironment

### DIFF
--- a/docs/content.zh/docs/dev/python/table/table_environment.md
+++ b/docs/content.zh/docs/dev/python/table/table_environment.md
@@ -134,7 +134,7 @@ TableEnvironment API
     </tr>
     <tr>
       <td>
-        <strong>drop_view(view_path)</strong>
+        <strong>drop_view(view_path, ignore_if_not_exists=True)</strong>
       </td>
       <td>
         Drops a view registered in the given path.
@@ -157,7 +157,7 @@ TableEnvironment API
     </tr>
     <tr>
       <td>
-        <strong>drop_table(table_path)</strong>
+        <strong>drop_table(table_path, ignore_if_not_exists=True)</strong>
       </td>
       <td>
         Drops a table registered under the given path.

--- a/docs/content.zh/docs/dev/python/table/table_environment.md
+++ b/docs/content.zh/docs/dev/python/table/table_environment.md
@@ -134,6 +134,17 @@ TableEnvironment API
     </tr>
     <tr>
       <td>
+        <strong>drop_view(view_path)</strong>
+      </td>
+      <td>
+        Drops a view registered in the given path.
+      </td>
+      <td class="text-center">
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_view" name="link">}}
+      </td>
+    </tr>
+    <tr>
+      <td>
         <strong>drop_temporary_table(table_path)</strong>
       </td>
       <td>
@@ -142,6 +153,17 @@ TableEnvironment API
       </td>
       <td class="text-center">
         {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_table" name="链接">}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>drop_table(table_path)</strong>
+      </td>
+      <td>
+        Drops a table registered under the given path.
+      </td>
+      <td class="text-center">
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_table" name="link">}}
       </td>
     </tr>
     <tr>

--- a/docs/content/docs/dev/python/table/table_environment.md
+++ b/docs/content/docs/dev/python/table/table_environment.md
@@ -145,6 +145,17 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
     </tr>
     <tr>
       <td>
+        <strong>drop_view(view_path, ignore_if_not_exists)</strong>
+      </td>
+      <td>
+        Drops a view registered in the given path.
+      </td>
+      <td class="text-center">
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_view" name="link">}}
+      </td>
+    </tr>
+    <tr>
+      <td>
         <strong>drop_temporary_table(table_path)</strong>
       </td>
       <td>
@@ -158,6 +169,17 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
     <tr>
       <td>
         <strong>drop_table(table_path)</strong>
+      </td>
+      <td>
+        Drops a table registered under the given path.
+      </td>
+      <td class="text-center">
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_table" name="link">}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>drop_table(table_path, ignore_if_not_exists)</strong>
       </td>
       <td>
         Drops a table registered under the given path.

--- a/docs/content/docs/dev/python/table/table_environment.md
+++ b/docs/content/docs/dev/python/table/table_environment.md
@@ -134,18 +134,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
     </tr>
     <tr>
       <td>
-        <strong>drop_view(view_path)</strong>
-      </td>
-      <td>
-        Drops a view registered in the given path.
-      </td>
-      <td class="text-center">
-        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_view" name="link">}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <strong>drop_view(view_path, ignore_if_not_exists)</strong>
+        <strong>drop_view(view_path, ignore_if_not_exists=True)</strong>
       </td>
       <td>
         Drops a view registered in the given path.
@@ -168,18 +157,7 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
     </tr>
     <tr>
       <td>
-        <strong>drop_table(table_path)</strong>
-      </td>
-      <td>
-        Drops a table registered under the given path.
-      </td>
-      <td class="text-center">
-        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_table" name="link">}}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <strong>drop_table(table_path, ignore_if_not_exists)</strong>
+        <strong>drop_table(table_path, ignore_if_not_exists=True)</strong>
       </td>
       <td>
         Drops a table registered under the given path.

--- a/docs/content/docs/dev/python/table/table_environment.md
+++ b/docs/content/docs/dev/python/table/table_environment.md
@@ -134,6 +134,17 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
     </tr>
     <tr>
       <td>
+        <strong>drop_view(view_path)</strong>
+      </td>
+      <td>
+        Drops a view registered in the given path.
+      </td>
+      <td class="text-center">
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_view" name="link">}}
+      </td>
+    </tr>
+    <tr>
+      <td>
         <strong>drop_temporary_table(table_path)</strong>
       </td>
       <td>
@@ -142,6 +153,17 @@ These APIs are used to create/remove Table API/SQL Tables and write queries:
       </td>
       <td class="text-center">
         {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_temporary_table" name="link">}}
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <strong>drop_table(table_path)</strong>
+      </td>
+      <td>
+        Drops a table registered under the given path.
+      </td>
+      <td class="text-center">
+        {{< pythondoc file="pyflink.table.html#pyflink.table.TableEnvironment.drop_table" name="link">}}
       </td>
     </tr>
     <tr>

--- a/flink-python/docs/reference/pyflink.table/table_environment.rst
+++ b/flink-python/docs/reference/pyflink.table/table_environment.rst
@@ -162,10 +162,12 @@ keyword, thus must be escaped) in a catalog named 'cat.1' and database named 'db
     TableEnvironment.create_temporary_table
     TableEnvironment.create_temporary_view
     TableEnvironment.drop_function
+    TableEnvironment.drop_table
     TableEnvironment.drop_temporary_function
     TableEnvironment.drop_temporary_system_function
     TableEnvironment.drop_temporary_table
     TableEnvironment.drop_temporary_view
+    TableEnvironment.drop_view
     TableEnvironment.execute_sql
     TableEnvironment.explain_sql
     TableEnvironment.from_descriptor

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -657,6 +657,20 @@ class TableEnvironment(object):
         """
         return self._j_tenv.dropTemporaryTable(table_path)
 
+    def drop_table(self, table_path: str) -> bool:
+        """
+        Drops a table registered in the given path.
+
+        If a permanent table with a given path exists, it will be used
+        from now on for any queries that reference this path.
+
+        :param table_path: The path of the registered table.
+        :return: True if a table existed in the given path and was removed.
+
+        .. versionadded:: 2.0.0
+        """
+        return self._j_tenv.dropTable(table_path)
+
     def drop_temporary_view(self, view_path: str) -> bool:
         """
         Drops a temporary view registered in the given path.
@@ -664,11 +678,28 @@ class TableEnvironment(object):
         If a permanent table or view with a given path exists, it will be used
         from now on for any queries that reference this path.
 
+        :param view_path: The path of the registered temporary view.
         :return: True if a view existed in the given path and was removed.
 
         .. versionadded:: 1.10.0
         """
         return self._j_tenv.dropTemporaryView(view_path)
+
+    def dropView(self, view_path: str) -> bool:
+        """
+
+        Drops a view registered in the given path.
+
+        Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
+        it will be inaccessible in the current session. To make the permanent object available again
+        one can drop the corresponding temporary object.
+
+        :param view_path: The path of the registered temporary view.
+        :return: True if a view existed in the given path and was removed
+
+        .. versionadded:: 2.0.0
+        """
+        return self._j_tenv.dropView(view_path)
 
     def explain_sql(self, stmt: str, *extra_details: ExplainDetail) -> str:
         """

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -661,8 +661,11 @@ class TableEnvironment(object):
         """
         Drops a table registered in the given path.
 
-        If a permanent table with a given path exists, it will be used
-        from now on for any queries that reference this path.
+        Temporary objects can shadow permanent ones.
+        If a permanent object in a given path exists,
+        it will be inaccessible in the current session.
+        To make the permanent object available again
+        one can drop the corresponding temporary object.
 
         :param table_path: The path of the registered table.
         :return: True if a table existed in the given path and was removed.
@@ -690,8 +693,10 @@ class TableEnvironment(object):
 
         Drops a view registered in the given path.
 
-        Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
-        it will be inaccessible in the current session. To make the permanent object available again
+        Temporary objects can shadow permanent ones.
+        If a permanent object in a given path exists,
+        it will be inaccessible in the current session.
+        To make the permanent object available again
         one can drop the corresponding temporary object.
 
         :param view_path: The path of the registered temporary view.

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -688,9 +688,8 @@ class TableEnvironment(object):
         """
         return self._j_tenv.dropTemporaryView(view_path)
 
-    def dropView(self, view_path: str) -> bool:
+    def drop_view(self, view_path: str) -> bool:
         """
-
         Drops a view registered in the given path.
 
         Temporary objects can shadow permanent ones.

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -662,7 +662,7 @@ class TableEnvironment(object):
         Drops a table registered in the given path.
 
         Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
-        make sure to drop the temporary object first using :func:`drop_temporary_view`.
+        make sure to drop the temporary object first using :func:`drop_temporary_table`.
         This method can only drop permanent objects.
 
         :param table_path: The path of the registered table.
@@ -691,7 +691,7 @@ class TableEnvironment(object):
         Drops a view registered in the given path.
 
         Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
-        make sure to drop the temporary object first using :func:`drop_temporary_table`.
+        make sure to drop the temporary object first using :func:`drop_temporary_view`.
         This method can only drop permanent objects.
 
         :param view_path: The path of the registered view.

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -666,6 +666,7 @@ class TableEnvironment(object):
         This method can only drop permanent objects.
 
         :param table_path: The path of the registered table.
+        :param ignore_if_not_exists: Ignore if table not exists.
         :return: True if a table existed in the given path and was removed.
 
         .. versionadded:: 2.0.0
@@ -695,6 +696,7 @@ class TableEnvironment(object):
         This method can only drop permanent objects.
 
         :param view_path: The path of the registered view.
+        :param ignore_if_not_exists: Ignore if view not exists.
         :return: True if a view existed in the given path and was removed
 
         .. versionadded:: 2.0.0

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -657,7 +657,7 @@ class TableEnvironment(object):
         """
         return self._j_tenv.dropTemporaryTable(table_path)
 
-    def drop_table(self, table_path: str) -> bool:
+    def drop_table(self, table_path: str, ignore_if_not_exists: Optional[bool] = True) -> bool:
         """
         Drops a table registered in the given path.
 
@@ -670,7 +670,7 @@ class TableEnvironment(object):
 
         .. versionadded:: 2.0.0
         """
-        return self._j_tenv.dropTable(table_path)
+        return self._j_tenv.dropTable(table_path, ignore_if_not_exists)
 
     def drop_temporary_view(self, view_path: str) -> bool:
         """
@@ -686,7 +686,7 @@ class TableEnvironment(object):
         """
         return self._j_tenv.dropTemporaryView(view_path)
 
-    def drop_view(self, view_path: str) -> bool:
+    def drop_view(self, view_path: str, ignore_if_not_exists: Optional[bool] = True) -> bool:
         """
         Drops a view registered in the given path.
 
@@ -699,7 +699,7 @@ class TableEnvironment(object):
 
         .. versionadded:: 2.0.0
         """
-        return self._j_tenv.dropView(view_path)
+        return self._j_tenv.dropView(view_path, ignore_if_not_exists)
 
     def explain_sql(self, stmt: str, *extra_details: ExplainDetail) -> str:
         """

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -699,7 +699,7 @@ class TableEnvironment(object):
         To make the permanent object available again
         one can drop the corresponding temporary object.
 
-        :param view_path: The path of the registered temporary view.
+        :param view_path: The path of the registered view.
         :return: True if a view existed in the given path and was removed
 
         .. versionadded:: 2.0.0

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -661,12 +661,12 @@ class TableEnvironment(object):
         """
         Drops a table registered in the given path.
 
-        Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
+        This method can only drop permanent objects. Temporary objects can shadow permanent ones.
+        If a temporary object exists in a given path,
         make sure to drop the temporary object first using :func:`drop_temporary_table`.
-        This method can only drop permanent objects.
 
         :param table_path: The path of the registered table.
-        :param ignore_if_not_exists: Ignore if table not exists.
+        :param ignore_if_not_exists: Ignore if table does not exist.
         :return: True if a table existed in the given path and was removed.
 
         .. versionadded:: 2.0.0
@@ -691,12 +691,12 @@ class TableEnvironment(object):
         """
         Drops a view registered in the given path.
 
-        Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
+        This method can only drop permanent objects. Temporary objects can shadow permanent ones.
+        If a temporary object exists in a given path,
         make sure to drop the temporary object first using :func:`drop_temporary_view`.
-        This method can only drop permanent objects.
 
         :param view_path: The path of the registered view.
-        :param ignore_if_not_exists: Ignore if view not exists.
+        :param ignore_if_not_exists: Ignore if view does not exist.
         :return: True if a view existed in the given path and was removed
 
         .. versionadded:: 2.0.0

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -661,11 +661,9 @@ class TableEnvironment(object):
         """
         Drops a table registered in the given path.
 
-        Temporary objects can shadow permanent ones.
-        If a permanent object in a given path exists,
-        it will be inaccessible in the current session.
-        To make the permanent object available again
-        one can drop the corresponding temporary object.
+        Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
+        make sure to drop the temporary object first using :func:`drop_temporary_view`.
+        This method can only drop permanent objects.
 
         :param table_path: The path of the registered table.
         :return: True if a table existed in the given path and was removed.
@@ -692,11 +690,9 @@ class TableEnvironment(object):
         """
         Drops a view registered in the given path.
 
-        Temporary objects can shadow permanent ones.
-        If a permanent object in a given path exists,
-        it will be inaccessible in the current session.
-        To make the permanent object available again
-        one can drop the corresponding temporary object.
+        Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
+        make sure to drop the temporary object first using :func:`drop_temporary_table`.
+        This method can only drop permanent objects.
 
         :param view_path: The path of the registered view.
         :return: True if a view existed in the given path and was removed

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1042,6 +1042,17 @@ public interface TableEnvironment {
     boolean dropTable(String path);
 
     /**
+     * Drops a table registered in the given path.
+     *
+     * <p>Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
+     * make sure to drop the temporary object first using {@link #dropTemporaryTable}. This method
+     * can only drop permanent objects.
+     *
+     * @return true if a table existed in the given path and was removed
+     */
+    boolean dropTable(String path, boolean ignoreIfNotExists);
+
+    /**
      * Drops a temporary view registered in the given path.
      *
      * <p>If a permanent table or view with a given path exists, it will be used from now on for any
@@ -1061,6 +1072,17 @@ public interface TableEnvironment {
      * @return true if a view existed in the given path and was removed
      */
     boolean dropView(String path);
+
+    /**
+     * Drops a view registered in the given path.
+     *
+     * <p>Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
+     * make sure to drop the temporary object first using {@link #dropTemporaryView}. This method
+     * can only drop permanent objects.
+     *
+     * @return true if a view existed in the given path and was removed
+     */
+    boolean dropView(String path, boolean ignoreIfNotExists);
 
     /**
      * Returns the AST of the specified statement and the execution plan to compute the result of

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1031,6 +1031,13 @@ public interface TableEnvironment {
     boolean dropTemporaryTable(String path);
 
     /**
+     * Drops a table in a given fully qualified path.
+     *
+     * @return true if a table existed in the given path and was removed
+     */
+    boolean dropTable(String path);
+
+    /**
      * Drops a temporary view registered in the given path.
      *
      * <p>If a permanent table or view with a given path exists, it will be used from now on for any
@@ -1039,6 +1046,13 @@ public interface TableEnvironment {
      * @return true if a view existed in the given path and was removed
      */
     boolean dropTemporaryView(String path);
+
+    /**
+     * Drops a table in a given fully qualified path.
+     *
+     * @return true if a view existed in the given path and was removed
+     */
+    boolean dropView(String path);
 
     /**
      * Returns the AST of the specified statement and the execution plan to compute the result of

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1081,7 +1081,7 @@ public interface TableEnvironment {
      * If a temporary object exists in a given path, make sure to drop the temporary object first
      * using {@link #dropTemporaryView}.
      *
-     * <p>Compared to SQL, this method will not throw an error if the table does not exist. Use
+     * <p>Compared to SQL, this method will not throw an error if the view does not exist. Use
      * {@link #dropView(java.lang.String, boolean)} to change the default behavior.
      *
      * @param path The given path under which the view will be dropped. See also the {@link

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1031,7 +1031,11 @@ public interface TableEnvironment {
     boolean dropTemporaryTable(String path);
 
     /**
-     * Drops a table in a given fully qualified path.
+     * Drops a table registered in the given path.
+     *
+     * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
+     * it will be inaccessible in the current session. To make the permanent object available again
+     * one can drop the corresponding temporary object.
      *
      * @return true if a table existed in the given path and was removed
      */
@@ -1048,7 +1052,11 @@ public interface TableEnvironment {
     boolean dropTemporaryView(String path);
 
     /**
-     * Drops a view in a given fully qualified path.
+     * Drops a view registered in the given path.
+     *
+     * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
+     * it will be inaccessible in the current session. To make the permanent object available again
+     * one can drop the corresponding temporary object.
      *
      * @return true if a view existed in the given path and was removed
      */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1044,7 +1044,8 @@ public interface TableEnvironment {
      *
      * @param path The given path under which the table will be dropped. See also the {@link
      *     TableEnvironment} class description for the format of the path.
-     * @return true if a table existed in the given path and was removed
+     * @return true if table existed in the given path and was dropped, false if table didn't exist
+     *     in the given path.
      */
     boolean dropTable(String path);
 
@@ -1057,9 +1058,10 @@ public interface TableEnvironment {
      *
      * @param path The given path under which the given table will be dropped. See also the {@link
      *     TableEnvironment} class description for the format of the path.
-     * @param ignoreIfNotExists whether to ignore if table does not exist.
-     * @return true if a table existed in the given path and was removed, throws {@link
-     *     ValidationException} if the table does not exist and ignoreIfNotExists is false
+     * @param ignoreIfNotExists If false exception will be thrown if the view to drop does not
+     *     exist.
+     * @return true if table existed in the given path and was dropped, false if table didn't exist
+     *     in the given path.
      */
     boolean dropTable(String path, boolean ignoreIfNotExists);
 
@@ -1087,7 +1089,8 @@ public interface TableEnvironment {
      *
      * @param path The given path under which the view will be dropped. See also the {@link
      *     TableEnvironment} class description for the format of the path.
-     * @return true if a view existed in the given path and was removed
+     * @return true if view existed in the given path and was dropped, false if view didn't exist in
+     *     the given path.
      */
     boolean dropView(String path);
 
@@ -1100,9 +1103,10 @@ public interface TableEnvironment {
      *
      * @param path The given path under which the view will be dropped. See also the {@link
      *     TableEnvironment} class description for the format of the path.
-     * @param ignoreIfNotExists whether to ignore if view does not exist.
-     * @return true if a view existed in the given path and was removed, throws {@link
-     *     ValidationException} if the view does not exist and ignoreIfNotExists is false
+     * @param ignoreIfNotExists If false exception will be thrown if the view to drop does not
+     *     exist.
+     * @return true if view existed in the given path and was dropped, false if view didn't exist in
+     *     the given path and ignoreIfNotExists was true.
      */
     boolean dropView(String path, boolean ignoreIfNotExists);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1057,6 +1057,7 @@ public interface TableEnvironment {
      *
      * @param path The given path under which the given table will be dropped. See also the {@link
      *     TableEnvironment} class description for the format of the path.
+     * @param ignoreIfNotExists whether to ignore if table does not exist.
      * @return true if a table existed in the given path and was removed. Throws {@link
      *     ValidationException} if the table does not exist and ignoreIfNotExists is false
      */
@@ -1099,7 +1100,7 @@ public interface TableEnvironment {
      *
      * @param path The given path under which the view will be dropped. See also the {@link
      *     TableEnvironment} class description for the format of the path.
-     * @param ignoreIfNotExists whether to ignore if view not exists.
+     * @param ignoreIfNotExists whether to ignore if view does not exist.
      * @return true if a view existed in the given path and was removed, throws {@link
      *     ValidationException} if the view does not exist and ignoreIfNotExists is false
      */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1033,9 +1033,9 @@ public interface TableEnvironment {
     /**
      * Drops a table registered in the given path.
      *
-     * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
-     * it will be inaccessible in the current session. To make the permanent object available again
-     * one can drop the corresponding temporary object.
+     * <p>Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
+     * make sure to drop the temporary object first using {@link #dropTemporaryTable}. This method
+     * can only drop permanent objects.
      *
      * @return true if a table existed in the given path and was removed
      */
@@ -1054,9 +1054,9 @@ public interface TableEnvironment {
     /**
      * Drops a view registered in the given path.
      *
-     * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
-     * it will be inaccessible in the current session. To make the permanent object available again
-     * one can drop the corresponding temporary object.
+     * <p>Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
+     * make sure to drop the temporary object first using {@link #dropTemporaryView}. This method
+     * can only drop permanent objects.
      *
      * @return true if a view existed in the given path and was removed
      */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1048,7 +1048,7 @@ public interface TableEnvironment {
     boolean dropTemporaryView(String path);
 
     /**
-     * Drops a table in a given fully qualified path.
+     * Drops a view in a given fully qualified path.
      *
      * @return true if a view existed in the given path and was removed
      */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1026,6 +1026,8 @@ public interface TableEnvironment {
      * <p>If a permanent table with a given path exists, it will be used from now on for any queries
      * that reference this path.
      *
+     * @param path The given path under which the temporary table will be dropped. See also the
+     *     {@link TableEnvironment} class description for the format of the path.
      * @return true if a table existed in the given path and was removed
      */
     boolean dropTemporaryTable(String path);
@@ -1033,13 +1035,15 @@ public interface TableEnvironment {
     /**
      * Drops a table registered in the given path.
      *
-     * <p>Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
-     * make sure to drop the temporary object first using {@link #dropTemporaryTable}. This method
-     * can only drop permanent objects.
+     * <p>This method can only drop permanent objects. Temporary objects can shadow permanent ones.
+     * If a temporary object exists in a given path, make sure to drop the temporary object first
+     * using {@link #dropTemporaryTable}.
      *
      * <p>Compared to SQL, this method will not throw an error if the table does not exist. Use
      * {@link #dropTable(java.lang.String, boolean)} to change the default behavior.
      *
+     * @param path The given path under which the table will be dropped. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
      * @return true if a table existed in the given path and was removed
      */
     boolean dropTable(String path);
@@ -1047,12 +1051,14 @@ public interface TableEnvironment {
     /**
      * Drops a table registered in the given path.
      *
-     * <p>Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
-     * make sure to drop the temporary object first using {@link #dropTemporaryTable}. This method
-     * can only drop permanent objects.
+     * <p>This method can only drop permanent objects. Temporary objects can shadow permanent ones.
+     * If a temporary object exists in a given path, make sure to drop the temporary object first
+     * using {@link #dropTemporaryTable}.
      *
+     * @param path The given path under which the given table will be dropped. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
      * @return true if a table existed in the given path and was removed. Throws {@link
-     *     ValidationException} if table not exists and ignoreIfNotExists is false
+     *     ValidationException} if the table does not exist and ignoreIfNotExists is false
      */
     boolean dropTable(String path, boolean ignoreIfNotExists);
 
@@ -1062,6 +1068,8 @@ public interface TableEnvironment {
      * <p>If a permanent table or view with a given path exists, it will be used from now on for any
      * queries that reference this path.
      *
+     * @param path The given path under which the temporary view will be dropped. See also the
+     *     {@link TableEnvironment} class description for the format of the path.
      * @return true if a view existed in the given path and was removed
      */
     boolean dropTemporaryView(String path);
@@ -1069,13 +1077,15 @@ public interface TableEnvironment {
     /**
      * Drops a view registered in the given path.
      *
-     * <p>Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
-     * make sure to drop the temporary object first using {@link #dropTemporaryView}. This method
-     * can only drop permanent objects.
+     * <p>This method can only drop permanent objects. Temporary objects can shadow permanent ones.
+     * If a temporary object exists in a given path, make sure to drop the temporary object first
+     * using {@link #dropTemporaryView}.
      *
-     * <p>* Compared to SQL, this method will not throw an error if the table does not exist. Use
+     * <p>Compared to SQL, this method will not throw an error if the table does not exist. Use
      * {@link #dropView(java.lang.String, boolean)} to change the default behavior.
      *
+     * @param path The given path under which the view will be dropped. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
      * @return true if a view existed in the given path and was removed
      */
     boolean dropView(String path);
@@ -1083,12 +1093,15 @@ public interface TableEnvironment {
     /**
      * Drops a view registered in the given path.
      *
-     * <p>Temporary objects can shadow permanent ones. If a temporary object exists in a given path,
-     * make sure to drop the temporary object first using {@link #dropTemporaryView}. This method
-     * can only drop permanent objects.
+     * <p>This method can only drop permanent objects. Temporary objects can shadow permanent ones.
+     * If a temporary object exists in a given path, make sure to drop the temporary object first
+     * using {@link #dropTemporaryView}.
      *
-     * @return true if a view existed in the given path and was removed Throws {@link
-     *     ValidationException} if view not exists and ignoreIfNotExists is false
+     * @param path The given path under which the view will be dropped. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
+     * @param ignoreIfNotExists whether to ignore if view not exists.
+     * @return true if a view existed in the given path and was removed, throws {@link
+     *     ValidationException} if the view does not exist and ignoreIfNotExists is false
      */
     boolean dropView(String path, boolean ignoreIfNotExists);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1037,6 +1037,9 @@ public interface TableEnvironment {
      * make sure to drop the temporary object first using {@link #dropTemporaryTable}. This method
      * can only drop permanent objects.
      *
+     * <p>Compared to SQL, this method will not throw an error if the table does not exist. Use
+     * {@link #dropTable(java.lang.String, boolean)} to change the default behavior.
+     *
      * @return true if a table existed in the given path and was removed
      */
     boolean dropTable(String path);
@@ -1048,7 +1051,8 @@ public interface TableEnvironment {
      * make sure to drop the temporary object first using {@link #dropTemporaryTable}. This method
      * can only drop permanent objects.
      *
-     * @return true if a table existed in the given path and was removed
+     * @return true if a table existed in the given path and was removed. Throws {@link
+     *     ValidationException} if table not exists and ignoreIfNotExists is false
      */
     boolean dropTable(String path, boolean ignoreIfNotExists);
 
@@ -1069,6 +1073,9 @@ public interface TableEnvironment {
      * make sure to drop the temporary object first using {@link #dropTemporaryView}. This method
      * can only drop permanent objects.
      *
+     * <p>* Compared to SQL, this method will not throw an error if the table does not exist. Use
+     * {@link #dropView(java.lang.String, boolean)} to change the default behavior.
+     *
      * @return true if a view existed in the given path and was removed
      */
     boolean dropView(String path);
@@ -1080,7 +1087,8 @@ public interface TableEnvironment {
      * make sure to drop the temporary object first using {@link #dropTemporaryView}. This method
      * can only drop permanent objects.
      *
-     * @return true if a view existed in the given path and was removed
+     * @return true if a view existed in the given path and was removed Throws {@link
+     *     ValidationException} if view not exists and ignoreIfNotExists is false
      */
     boolean dropView(String path, boolean ignoreIfNotExists);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1058,7 +1058,7 @@ public interface TableEnvironment {
      * @param path The given path under which the given table will be dropped. See also the {@link
      *     TableEnvironment} class description for the format of the path.
      * @param ignoreIfNotExists whether to ignore if table does not exist.
-     * @return true if a table existed in the given path and was removed. Throws {@link
+     * @return true if a table existed in the given path and was removed, throws {@link
      *     ValidationException} if the table does not exist and ignoreIfNotExists is false
      */
     boolean dropTable(String path, boolean ignoreIfNotExists);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -651,6 +651,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     @Override
     public boolean dropTable(String path) {
+        return dropTable(path, true);
+    }
+
+    @Override
+    public boolean dropTable(String path, boolean ignoreIfNotExists) {
         UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
         return catalogManager.dropTable(identifier, true);
@@ -670,9 +675,14 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     @Override
     public boolean dropView(String path) {
+        return dropView(path, true);
+    }
+
+    @Override
+    public boolean dropView(String path, boolean ignoreIfNotExists) {
         UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-        return catalogManager.dropView(identifier, true);
+        return catalogManager.dropView(identifier, ignoreIfNotExists);
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -650,11 +650,35 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     }
 
     @Override
+    public boolean dropTable(String path) {
+        UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
+        ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+        try {
+            catalogManager.dropTable(identifier, false);
+            return true;
+        } catch (ValidationException e) {
+            return false;
+        }
+    }
+
+    @Override
     public boolean dropTemporaryView(String path) {
         UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
         try {
             catalogManager.dropTemporaryView(identifier, false);
+            return true;
+        } catch (ValidationException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean dropView(String path) {
+        UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
+        ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+        try {
+            catalogManager.dropView(identifier, false);
             return true;
         } catch (ValidationException e) {
             return false;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -653,12 +653,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     public boolean dropTable(String path) {
         UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-        try {
-            catalogManager.dropTable(identifier, false);
-            return true;
-        } catch (ValidationException e) {
-            return false;
-        }
+        return catalogManager.dropTable(identifier, true);
     }
 
     @Override
@@ -677,12 +672,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     public boolean dropView(String path) {
         UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-        try {
-            catalogManager.dropView(identifier, false);
-            return true;
-        } catch (ValidationException e) {
-            return false;
-        }
+        return catalogManager.dropView(identifier, true);
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -658,7 +658,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     public boolean dropTable(String path, boolean ignoreIfNotExists) {
         UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-        return catalogManager.dropTable(identifier, true);
+        return catalogManager.dropTable(identifier, ignoreIfNotExists);
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1274,6 +1274,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      * @param objectIdentifier The fully qualified path of the table to drop.
      * @param ignoreIfNotExists If false exception will be thrown if the table to drop does not
      *     exist.
+     * @return true if table was dropped, it will return false if table was not found and ignore if
+     *     exists flag is true.
      */
     public boolean dropTable(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
         return dropTableInternal(objectIdentifier, ignoreIfNotExists, true, false);
@@ -1285,6 +1287,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      * @param objectIdentifier The fully qualified path of the materialized table to drop.
      * @param ignoreIfNotExists If false exception will be thrown if the table to drop does not
      *     exist.
+     * @return true if materialized table was dropped, it will return false if materialized table
+     *     was not found and ignore if exists flag is true.
      */
     public boolean dropMaterializedTable(
             ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
@@ -1297,6 +1301,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      * @param objectIdentifier The fully qualified path of the view to drop.
      * @param ignoreIfNotExists If false exception will be thrown if the view to drop does not
      *     exist.
+     * @return true if view was dropped, it will return false if view was not found and ignore if
+     *     exists flag is true.
      */
     public boolean dropView(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
         return dropTableInternal(objectIdentifier, ignoreIfNotExists, false, false);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1313,19 +1313,19 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
     private boolean dropTableInternal(
             ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists, TableKind kind) {
         final Predicate<CatalogBaseTable> filter;
-        final String tableOrView;
+        final String kindStr;
         switch (kind) {
             case VIEW:
                 filter = table -> table instanceof CatalogView;
-                tableOrView = "View";
+                kindStr = "View";
                 break;
             case TABLE:
                 filter = table -> table instanceof CatalogTable;
-                tableOrView = "Table";
+                kindStr = "Table";
                 break;
             case MATERIALIZED_TABLE:
                 filter = table -> table instanceof CatalogMaterializedTable;
-                tableOrView = "Materialized Table";
+                kindStr = "Materialized Table";
                 break;
             default:
                 throw new ValidationException("Not supported table kind: " + kind);
@@ -1333,12 +1333,12 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
 
         // Same name temporary table or view exists.
         if (filter.test(temporaryTables.get(objectIdentifier))) {
-            final String lowerTableOrView = tableOrView.toLowerCase(Locale.ROOT);
+            final String lowerKindStr = kindStr.toLowerCase(Locale.ROOT);
             throw new ValidationException(
                     String.format(
                             "Temporary %s with identifier '%s' exists. "
                                     + "Drop it first before removing the permanent %s.",
-                            lowerTableOrView, objectIdentifier, lowerTableOrView));
+                            lowerKindStr, objectIdentifier, lowerKindStr));
         }
         final Optional<CatalogBaseTable> resultOpt = getUnresolvedTable(objectIdentifier);
         if (resultOpt.isPresent() && filter.test(resultOpt.get())) {
@@ -1373,7 +1373,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
             throw new ValidationException(
                     String.format(
                             "%s with identifier '%s' does not exist.",
-                            tableOrView, objectIdentifier.asSummaryString()));
+                            kindStr, objectIdentifier.asSummaryString()));
         }
         return false;
     }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1274,8 +1274,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      * @param objectIdentifier The fully qualified path of the table to drop.
      * @param ignoreIfNotExists If false exception will be thrown if the table to drop does not
      *     exist.
-     * @return true if table was dropped, it will return false if table was not found and ignore if
-     *     exists flag is true.
+     * @return true if table existed in the given path and was dropped, false if table didn't exist
+     *     in the given path and ignoreIfNotExists was true.
      */
     public boolean dropTable(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
         return dropTableInternal(objectIdentifier, ignoreIfNotExists, true, false);
@@ -1287,8 +1287,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      * @param objectIdentifier The fully qualified path of the materialized table to drop.
      * @param ignoreIfNotExists If false exception will be thrown if the table to drop does not
      *     exist.
-     * @return true if materialized table was dropped, it will return false if materialized table
-     *     was not found and ignore if exists flag is true.
+     * @return true if materialized table existed in the given path and was dropped, false if
+     *     materialized table didn't exist in the given path and ignoreIfNotExists was true.
      */
     public boolean dropMaterializedTable(
             ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
@@ -1301,8 +1301,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      * @param objectIdentifier The fully qualified path of the view to drop.
      * @param ignoreIfNotExists If false exception will be thrown if the view to drop does not
      *     exist.
-     * @return true if view was dropped, it will return false if view was not found and ignore if
-     *     exists flag is true.
+     * @return true if view existed in the given path and was dropped, false if view didn't exist in
+     *     the given path and ignoreIfNotExists was true.
      */
     public boolean dropView(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
         return dropTableInternal(objectIdentifier, ignoreIfNotExists, false, false);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -1275,8 +1275,8 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      * @param ignoreIfNotExists If false exception will be thrown if the table to drop does not
      *     exist.
      */
-    public void dropTable(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
-        dropTableInternal(objectIdentifier, ignoreIfNotExists, true, false);
+    public boolean dropTable(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
+        return dropTableInternal(objectIdentifier, ignoreIfNotExists, true, false);
     }
 
     /**
@@ -1286,9 +1286,9 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      * @param ignoreIfNotExists If false exception will be thrown if the table to drop does not
      *     exist.
      */
-    public void dropMaterializedTable(
+    public boolean dropMaterializedTable(
             ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
-        dropTableInternal(objectIdentifier, ignoreIfNotExists, true, true);
+        return dropTableInternal(objectIdentifier, ignoreIfNotExists, true, true);
     }
 
     /**
@@ -1298,11 +1298,11 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
      * @param ignoreIfNotExists If false exception will be thrown if the view to drop does not
      *     exist.
      */
-    public void dropView(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
-        dropTableInternal(objectIdentifier, ignoreIfNotExists, false, false);
+    public boolean dropView(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
+        return dropTableInternal(objectIdentifier, ignoreIfNotExists, false, false);
     }
 
-    private void dropTableInternal(
+    private boolean dropTableInternal(
             ObjectIdentifier objectIdentifier,
             boolean ignoreIfNotExists,
             boolean isDropTable,
@@ -1350,6 +1350,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                     objectIdentifier,
                     ignoreIfNotExists,
                     "DropTable");
+            return true;
         } else if (!ignoreIfNotExists) {
             String tableOrView =
                     isDropTable ? isDropMaterializedTable ? "Materialized Table" : "Table" : "View";
@@ -1358,6 +1359,7 @@ public final class CatalogManager implements CatalogRegistry, AutoCloseable {
                             "%s with identifier '%s' does not exist.",
                             tableOrView, objectIdentifier.asSummaryString()));
         }
+        return false;
     }
 
     /**

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -2809,16 +2809,8 @@ class TableEnvironmentTest {
   }
 
   private def createViewsForDropTests(): Unit = {
+    createTableForTests()
     val viewDdls = Array[String](
-      """
-        |CREATE TABLE T1(
-        |  a int,
-        |  b varchar,
-        |  c int
-        |) with (
-        |  'connector' = 'COLLECTION'
-        |)
-      """.stripMargin,
       """
         |CREATE VIEW T2(d, e, f) AS SELECT a, b, c FROM T1
       """.stripMargin,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.{Configuration, CoreOptions, ExecutionOpti
 import org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches
 import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment, StreamExecutionEnvironment}
 import org.apache.flink.table.api.bridge.scala._
-import org.apache.flink.table.api.internal.{TableEnvironmentInternal, TableImpl}
+import org.apache.flink.table.api.internal.TableEnvironmentInternal
 import org.apache.flink.table.catalog._
 import org.apache.flink.table.factories.{TableFactoryUtil, TableSourceFactoryContextImpl}
 import org.apache.flink.table.functions.TestGenericUDF
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue, 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.{MethodSource, ValueSource}
+import org.junit.jupiter.params.provider.ValueSource
 
 import java.io.File
 import java.nio.file.Path
@@ -1889,6 +1889,11 @@ class TableEnvironmentTest {
 
     assertFalse(tableEnv.dropTable("default_catalog.default_database.T2"))
     assert(tableEnv.listTables().sameElements(Array[String]("T1")))
+
+    assertThatThrownBy(() => tableEnv.dropTable("default_catalog.default_database.T2", false))
+      .hasMessageContaining(
+        "Table with identifier 'default_catalog.default_database.T2' does not exist.")
+      .isInstanceOf[ValidationException]
 
     assertFalse(tableEnv.dropTable("default_catalog.default_database.T2"))
     assertFalse(tableEnv.dropTable("invalid.default_database.T2"))


### PR DESCRIPTION
## What is the purpose of the change

FLIP-489 [1] adds missing dropTable/dropView methods to TableEnvironment
[1] https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=332499781

## Verifying this change

TableEnvironmentImpl.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( JavaDocs)
