### PR TITLE
[FLINK-36928][Runtime] Split the action of Epoch into two parts (trigger & final)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/EpochManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/EpochManager.java
@@ -68,12 +68,23 @@ public class EpochManager {
     /** Current active epoch, only one active epoch at the same time. */
     Epoch activeEpoch;
 
+    /**
+     * The epoch that is possibly in finishing status, the following new records should share this
+     * epoch.
+     */
+    @Nullable Epoch finishingEpoch;
+
+    /** The flag that prevent the recursive call of {@link #tryFinishInQueue()}. */
+    boolean recursiveFlag;
+
     public EpochManager(AsyncExecutionController<?> aec) {
         this.epochNum = 0;
         this.outputQueue = new LinkedList<>();
         this.asyncExecutionController = aec;
         // init an empty epoch, the epoch action will be updated when non-record is received.
         this.activeEpoch = new Epoch(epochNum++);
+        this.finishingEpoch = null;
+        this.recursiveFlag = false;
     }
 
     /**
@@ -83,23 +94,42 @@ public class EpochManager {
      * @return the current open epoch.
      */
     public Epoch onRecord() {
-        activeEpoch.ongoingRecordCount++;
-        return activeEpoch;
+        if (finishingEpoch != null) {
+            finishingEpoch.ongoingRecordCount++;
+            return finishingEpoch;
+        } else {
+            activeEpoch.ongoingRecordCount++;
+            return activeEpoch;
+        }
+    }
+
+    /**
+     * Add a record to a specified epoch.
+     *
+     * @param epoch the specified epoch.
+     * @return the specified epoch itself.
+     */
+    public Epoch onEpoch(Epoch epoch) {
+        epoch.ongoingRecordCount++;
+        return epoch;
     }
 
     /**
      * Add a non-record to the current epoch, close current epoch and open a new epoch. Must be
      * invoked within task thread.
      *
-     * @param action the action associated with this non-record.
+     * @param triggerAction the action associated with this non-record.
      * @param parallelMode the parallel mode for this epoch.
      */
-    public void onNonRecord(Runnable action, ParallelMode parallelMode) {
+    public void onNonRecord(
+            @Nullable Runnable triggerAction,
+            @Nullable Runnable finalAction,
+            ParallelMode parallelMode) {
         LOG.trace(
                 "on NonRecord, old epoch: {}, outputQueue size: {}",
                 activeEpoch,
                 outputQueue.size());
-        switchActiveEpoch(action);
+        switchActiveEpoch(triggerAction, finalAction);
         if (parallelMode == ParallelMode.SERIAL_BETWEEN_EPOCH) {
             asyncExecutionController.drainInflightRecords(0);
         }
@@ -118,19 +148,34 @@ public class EpochManager {
     }
 
     private void tryFinishInQueue() {
+        // We don't permit recursive call of this method.
+        if (recursiveFlag) {
+            return;
+        }
+        recursiveFlag = true;
         // If one epoch has been closed before and all records in
         // this epoch have finished, the epoch will be removed from the output queue.
-        while (!outputQueue.isEmpty() && outputQueue.peek().tryFinish()) {
-            LOG.trace(
-                    "Finish epoch: {}, outputQueue size: {}",
-                    outputQueue.peek(),
-                    outputQueue.size());
-            outputQueue.pop();
+        while (!outputQueue.isEmpty()) {
+            Epoch epoch = outputQueue.peek();
+            // The epoch is set for inheritance during possible trigger action.
+            finishingEpoch = epoch;
+            try {
+                if (epoch.tryFinish()) {
+                    outputQueue.pop();
+                } else {
+                    break;
+                }
+            } finally {
+                // Clear the override
+                finishingEpoch = null;
+            }
         }
+        recursiveFlag = false;
     }
 
-    private void switchActiveEpoch(Runnable action) {
-        activeEpoch.close(action);
+    private void switchActiveEpoch(
+            @Nullable Runnable triggerAction, @Nullable Runnable finalAction) {
+        activeEpoch.close(triggerAction, finalAction);
         outputQueue.offer(activeEpoch);
         this.activeEpoch = new Epoch(epochNum++);
         tryFinishInQueue();
@@ -151,7 +196,15 @@ public class EpochManager {
         /**
          * One epoch can only be finished when it meets the following three conditions. 1. The
          * records of this epoch have finished execution. 2. The epoch is closed. 3. The epoch is in
-         * the front of outputQueue.
+         * the front of outputQueue. When the status transit from {@link #CLOSED} to {@link
+         * #FINISHING}, a trigger action will go.
+         */
+        FINISHING,
+
+        /**
+         * After the action is triggered, there might be more async process bind to this epoch.
+         * After all these process finished, a final action will go and the epoch will fall into
+         * {@link #FINISHED} status.
          */
         FINISHED
     }
@@ -167,8 +220,14 @@ public class EpochManager {
         /** The number of records that are still ongoing in this epoch. */
         int ongoingRecordCount;
 
-        /** The action associated with non-record of this epoch(e.g. advance watermark). */
-        @Nullable Runnable action;
+        /** The action associated with non-record of this epoch(e.g. triggering timer). */
+        @Nullable Runnable triggerAction;
+
+        /**
+         * The action when we finish this epoch and the triggerAction as well as any async
+         * processing.
+         */
+        @Nullable Runnable finalAction;
 
         EpochStatus status;
 
@@ -176,34 +235,58 @@ public class EpochManager {
             this.id = id;
             this.ongoingRecordCount = 0;
             this.status = EpochStatus.OPEN;
-            this.action = null;
+            this.triggerAction = null;
+            this.finalAction = null;
         }
 
         /**
-         * Try to finish this epoch.
+         * Try to finish this epoch. This is the core logic of triggering actions. The state machine
+         * and timeline are as follows:
+         *
+         * <pre>
+         * Action:     close()       triggerAction       wait             finalAction
+         * Statue:  OPEN ----- CLOSED ----------FINISHING -------- FINISHED -----------
+         * </pre>
          *
          * @return whether this epoch has been normally finished.
          */
         boolean tryFinish() {
-            if (this.status == EpochStatus.FINISHED) {
-                // This epoch has been finished for some reason, but it is not finished here.
-                // Preventing recursive call of #tryFinishInQueue().
-                return false;
-            }
-            if (ongoingRecordCount == 0 && this.status == EpochStatus.CLOSED) {
-                this.status = EpochStatus.FINISHED;
-                if (action != null) {
-                    action.run();
+            if (ongoingRecordCount == 0) {
+                if (status == EpochStatus.CLOSED) {
+                    // CLOSED -> FINISHING
+                    transition(EpochStatus.FINISHING);
+                    if (triggerAction != null) {
+                        // trigger action will use {@link overrideEpoch}.
+                        triggerAction.run();
+                    }
                 }
-                return true;
+                // After the triggerAction run, if there is no new async process, the
+                // ongoingRecordCount remains 0, then the status should transit to FINISHED.
+                // Otherwise, we will reach here when ongoingRecordCount reaches 0 again.
+                if (ongoingRecordCount == 0 && status == EpochStatus.FINISHING) {
+                    // FINISHING -> FINISHED
+                    transition(EpochStatus.FINISHED);
+                    if (finalAction != null) {
+                        finalAction.run();
+                    }
+                }
+                return status == EpochStatus.FINISHED;
             }
             return false;
         }
 
-        /** Close this epoch. */
-        void close(Runnable action) {
-            this.action = action;
-            this.status = EpochStatus.CLOSED;
+        void transition(EpochStatus newStatus) {
+            if (status != newStatus) {
+                LOG.trace("Epoch {} transit from {} to {}", this, status, newStatus);
+                status = newStatus;
+            }
+        }
+
+        /** Close this epoch with defined triggerAction and finalAction. */
+        void close(@Nullable Runnable triggerAction, @Nullable Runnable finalAction) {
+            this.triggerAction = triggerAction;
+            this.finalAction = finalAction;
+            transition(EpochStatus.CLOSED);
         }
 
         public String toString() {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -31,7 +31,6 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 
 import java.io.Serializable;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * An entity keeping all the time-related services.
@@ -85,7 +84,7 @@ public interface InternalTimeServiceManager<K> {
      * Advances the Watermark of all managed {@link InternalTimerService timer services},
      * potentially firing event time timers.
      */
-    CompletableFuture<Void> advanceWatermark(Watermark watermark) throws Exception;
+    void advanceWatermark(Watermark watermark) throws Exception;
 
     /**
      * Try to {@link #advanceWatermark(Watermark)}, but if {@link ShouldStopAdvancingFn} returns

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManagerImpl.java
@@ -44,7 +44,6 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -239,14 +238,10 @@ public class InternalTimeServiceManagerImpl<K> implements InternalTimeServiceMan
     }
 
     @Override
-    public CompletableFuture<Void> advanceWatermark(Watermark watermark) throws Exception {
-        CompletableFuture<?>[] futures = new CompletableFuture[timerServices.size()];
-        int index = 0;
+    public void advanceWatermark(Watermark watermark) throws Exception {
         for (InternalTimerServiceImpl<?, ?> service : timerServices.values()) {
-            futures[index] = service.advanceWatermark(watermark.getTimestamp());
-            index++;
+            service.advanceWatermark(watermark.getTimestamp());
         }
-        return CompletableFuture.allOf(futures);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -307,7 +306,7 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N> {
         }
     }
 
-    public CompletableFuture<Void> advanceWatermark(long time) throws Exception {
+    public void advanceWatermark(long time) throws Exception {
         Preconditions.checkState(
                 tryAdvanceWatermark(
                         time,
@@ -315,7 +314,6 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N> {
                             // Never stop advancing.
                             return false;
                         }));
-        return CompletableFuture.completedFuture(null);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
@@ -37,7 +37,6 @@ import org.apache.flink.util.WrappingRuntimeException;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -87,11 +86,10 @@ public class BatchExecutionInternalTimeServiceManager<K>
     }
 
     @Override
-    public CompletableFuture<Void> advanceWatermark(Watermark watermark) {
+    public void advanceWatermark(Watermark watermark) {
         if (watermark.getTimestamp() == Long.MAX_VALUE) {
             keySelected(null);
         }
-        return CompletableFuture.completedFuture(null);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -691,7 +691,7 @@ class AsyncExecutionControllerTest {
 
         assertThat(epoch1).isEqualTo(epoch2);
         assertThat(epoch1.ongoingRecordCount).isEqualTo(2);
-        aec.processNonRecord(() -> output.incrementAndGet());
+        aec.processNonRecord(null, () -> output.incrementAndGet());
 
         assertThat(output.get()).isEqualTo(3);
         // SERIAL_BETWEEN_EPOCH mode would drain in-flight records on non-record arriving.
@@ -724,7 +724,7 @@ class AsyncExecutionControllerTest {
         userCode.run();
 
         aec.epochManager.onNonRecord(
-                () -> output.incrementAndGet(), ParallelMode.PARALLEL_BETWEEN_EPOCH);
+                null, () -> output.incrementAndGet(), ParallelMode.PARALLEL_BETWEEN_EPOCH);
         assertThat(epoch1.ongoingRecordCount).isEqualTo(1);
 
         String record2 = "key2-r2";
@@ -736,7 +736,7 @@ class AsyncExecutionControllerTest {
         assertThat(epoch1.ongoingRecordCount).isEqualTo(1);
         assertThat(epoch2.ongoingRecordCount).isEqualTo(1);
         aec.epochManager.onNonRecord(
-                () -> output.incrementAndGet(), ParallelMode.PARALLEL_BETWEEN_EPOCH);
+                null, () -> output.incrementAndGet(), ParallelMode.PARALLEL_BETWEEN_EPOCH);
         assertThat(epoch1.ongoingRecordCount).isEqualTo(1);
         assertThat(epoch2.ongoingRecordCount).isEqualTo(1);
         assertThat(output.get()).isEqualTo(0);
@@ -751,7 +751,7 @@ class AsyncExecutionControllerTest {
         assertThat(epoch2.ongoingRecordCount).isEqualTo(1);
         assertThat(epoch3.ongoingRecordCount).isEqualTo(1);
         aec.epochManager.onNonRecord(
-                () -> output.incrementAndGet(), ParallelMode.SERIAL_BETWEEN_EPOCH);
+                null, () -> output.incrementAndGet(), ParallelMode.SERIAL_BETWEEN_EPOCH);
         assertThat(epoch1.ongoingRecordCount).isEqualTo(0);
         assertThat(epoch2.ongoingRecordCount).isEqualTo(0);
         assertThat(epoch3.ongoingRecordCount).isEqualTo(0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/EpochManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/EpochManagerTest.java
@@ -39,7 +39,7 @@ class EpochManagerTest {
         assertThat(epoch1.ongoingRecordCount).isEqualTo(2);
         AtomicInteger output = new AtomicInteger(0);
         epochManager.onNonRecord(
-                () -> output.incrementAndGet(), ParallelMode.PARALLEL_BETWEEN_EPOCH);
+                null, () -> output.incrementAndGet(), ParallelMode.PARALLEL_BETWEEN_EPOCH);
         // record3 is in a new epoch
         Epoch epoch3 = epochManager.onRecord();
         assertThat(epoch3).isNotEqualTo(epoch1);
@@ -60,6 +60,7 @@ class EpochManagerTest {
 
         // Test if in the action there is a record processing. Should not be any error.
         epochManager.onNonRecord(
+                null,
                 () -> {
                     output.incrementAndGet();
                     Epoch epoch4 = epochManager.onRecord();
@@ -67,5 +68,28 @@ class EpochManagerTest {
                 },
                 ParallelMode.PARALLEL_BETWEEN_EPOCH);
         assertThat(output.get()).isEqualTo(2);
+    }
+
+    @Test
+    void testTwoAction() {
+        EpochManager epochManager = new EpochManager(null);
+        Epoch epoch1 = epochManager.onRecord();
+        Epoch epoch2 = epochManager.onRecord();
+        assertThat(epoch1).isEqualTo(epoch2);
+        assertThat(epoch1.ongoingRecordCount).isEqualTo(2);
+        AtomicInteger output = new AtomicInteger(0);
+        epochManager.onNonRecord(
+                () -> epochManager.onEpoch(epoch1),
+                () -> output.incrementAndGet(),
+                ParallelMode.PARALLEL_BETWEEN_EPOCH);
+        assertThat(epoch1.status).isEqualTo(EpochStatus.CLOSED);
+        assertThat(output.get()).isEqualTo(0);
+        epochManager.completeOneRecord(epoch1);
+        epochManager.completeOneRecord(epoch2);
+        assertThat(epoch1.status).isEqualTo(EpochStatus.FINISHING);
+        assertThat(output.get()).isEqualTo(0);
+        epochManager.completeOneRecord(epoch1);
+        assertThat(epoch1.status).isEqualTo(EpochStatus.FINISHED);
+        assertThat(output.get()).isEqualTo(1);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
@@ -39,9 +39,6 @@ import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link InternalTimerServiceAsyncImpl}. */
@@ -187,11 +184,8 @@ class InternalTimerServiceAsyncImplTest {
         service.registerEventTimeTimer("event-timer-2", 2L);
         service.registerEventTimeTimer("event-timer-3", 3L);
         assertThat(testTriggerable.eventTriggerCount).isEqualTo(1);
-        CompletableFuture<Void> future = service.advanceWatermark(3L);
-        AtomicBoolean done = new AtomicBoolean(false);
+        service.advanceWatermark(3L);
         assertThat(asyncExecutionController.getInFlightRecordNum()).isEqualTo(0);
-        future.thenAccept((v) -> done.set(true)).get();
-        assertThat(done.get()).isTrue();
         assertThat(testTriggerable.eventTriggerCount).isEqualTo(3);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/MailboxWatermarkProcessorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/MailboxWatermarkProcessorTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -108,7 +107,7 @@ class MailboxWatermarkProcessorTest {
         }
 
         @Override
-        public CompletableFuture<Void> advanceWatermark(Watermark watermark) throws Exception {
+        public void advanceWatermark(Watermark watermark) throws Exception {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
## What is the purpose of the change

We have introduced the `EpochManager` to handle the watermark during async state processing. The inputs are divided into several epochs where a action is attached and triggered after all the inputs finished their async processing. However, the action itself may trigger more async procedures which blocks some synchronous action. Thus this PR introduces two types of action, one is for triggered right after all the inputs finished, while another is for being triggered after all the async processing including the ones from the action finished.

This is a complete solution & abstraction of watermark handling. I'll revert some change from FLINK-36875, removing the unnecessary use of `CompletableFuture`.

## Brief change log

 - Remove `CompletableFuture` in signatures of `advanceWatermark`.
 - Introduce `triggerAction` and `finalAction` for each `Epoch`
 - Proper handle the state machine of `Epoch`
 - Support inheritance of `Epoch` for `asyncProcessWithKey`, meaning that the context during `asyncProcessWithKey` will share the same `epoch` from invoker's context.

## Verifying this change

This change added two tests `AbstractAsyncStateStreamOperatorTest#testWatermark` and `EpochManagerTest#testTwoAction`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
