### PR TITLE
[FLINK-36934][network] Enrich numSubpartitions to TierMasterAgent#addPartitionAndGetShuffleDescriptor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredInternalShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/shuffle/TieredInternalShuffleMaster.java
@@ -81,9 +81,9 @@ public class TieredInternalShuffleMaster {
     }
 
     public List<TierShuffleDescriptor> addPartitionAndGetShuffleDescriptor(
-            JobID jobID, ResultPartitionID resultPartitionID) {
+            JobID jobID, int numSubpartitions, ResultPartitionID resultPartitionID) {
         return tieredStorageMasterClient.addPartitionAndGetShuffleDescriptor(
-                jobID, resultPartitionID);
+                jobID, numSubpartitions, resultPartitionID);
     }
 
     public void releasePartition(ShuffleDescriptor shuffleDescriptor) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageMasterClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/storage/TieredStorageMasterClient.java
@@ -49,12 +49,12 @@ public class TieredStorageMasterClient {
     }
 
     public List<TierShuffleDescriptor> addPartitionAndGetShuffleDescriptor(
-            JobID jobID, ResultPartitionID resultPartitionID) {
+            JobID jobID, int numSubpartitions, ResultPartitionID resultPartitionID) {
         return tiers.stream()
                 .map(
                         tierMasterAgent ->
                                 tierMasterAgent.addPartitionAndGetShuffleDescriptor(
-                                        jobID, resultPartitionID))
+                                        jobID, numSubpartitions, resultPartitionID))
                 .collect(Collectors.toList());
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/NoOpMasterAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/NoOpMasterAgent.java
@@ -38,7 +38,7 @@ public class NoOpMasterAgent implements TierMasterAgent {
 
     @Override
     public TierShuffleDescriptor addPartitionAndGetShuffleDescriptor(
-            JobID jobID, ResultPartitionID resultPartitionID) {
+            JobID jobID, int numSubpartitions, ResultPartitionID resultPartitionID) {
         // noop
         return NoOpTierShuffleDescriptor.INSTANCE;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierMasterAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/TierMasterAgent.java
@@ -32,7 +32,7 @@ public interface TierMasterAgent {
 
     /** Add a new tiered storage partition and get the {@link TierShuffleDescriptor}. */
     TierShuffleDescriptor addPartitionAndGetShuffleDescriptor(
-            JobID jobID, ResultPartitionID resultPartitionID);
+            JobID jobID, int numSubpartitions, ResultPartitionID resultPartitionID);
 
     /**
      * Release a tiered storage partition.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteTierMasterAgent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteTierMasterAgent.java
@@ -56,7 +56,7 @@ public class RemoteTierMasterAgent implements TierMasterAgent {
 
     @Override
     public TierShuffleDescriptor addPartitionAndGetShuffleDescriptor(
-            JobID jobID, ResultPartitionID resultPartitionID) {
+            JobID jobID, int numSubpartitions, ResultPartitionID resultPartitionID) {
         TieredStoragePartitionId partitionId = convertId(resultPartitionID);
         resourceRegistry.registerResource(
                 partitionId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -108,7 +108,9 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
         if (tieredInternalShuffleMaster != null) {
             tierShuffleDescriptors =
                     tieredInternalShuffleMaster.addPartitionAndGetShuffleDescriptor(
-                            jobID, resultPartitionID);
+                            jobID,
+                            partitionDescriptor.getNumberOfSubpartitions(),
+                            resultPartitionID);
         }
 
         NettyShuffleDescriptor shuffleDeploymentDescriptor =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteTierMasterAgentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/tiered/tier/remote/RemoteTierMasterAgentTest.java
@@ -52,7 +52,7 @@ class RemoteTierMasterAgentTest {
         RemoteTierMasterAgent masterAgent =
                 new RemoteTierMasterAgent(tempFolder.getAbsolutePath(), resourceRegistry);
         TierShuffleDescriptor tierShuffleDescriptor =
-                masterAgent.addPartitionAndGetShuffleDescriptor(new JobID(), resultPartitionID);
+                masterAgent.addPartitionAndGetShuffleDescriptor(new JobID(), 1, resultPartitionID);
         assertThat(partitionFile.exists()).isTrue();
         masterAgent.releasePartition(tierShuffleDescriptor);
 


### PR DESCRIPTION
## What is the purpose of the change

*Tier master agent missing the number of subpartitions to record paritition metric in remote shuffle service.*


## Brief change log

  - *Expose `numSubpartitions` to `TierMasterAgent#addPartitionAndGetShuffleDescriptor`*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
