### PR TITLE
[hotfix][tests] Use scala's instanceOf in DataTypeExtractorScalaTest

### DIFF
--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/DataTypeExtractorScalaTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/types/extraction/DataTypeExtractorScalaTest.scala
@@ -37,8 +37,8 @@ class DataTypeExtractorScalaTest {
   def testScalaExtraction(testSpec: DataTypeExtractorTest.TestSpec): Unit = {
     if (testSpec.hasErrorMessage) {
       assertThatThrownBy(() => runExtraction(testSpec))
-        .isInstanceOf(classOf[ValidationException])
         .is(HamcrestCondition.matching(errorMatcher(testSpec)))
+        .isInstanceOf[ValidationException]
     } else {
       runExtraction(testSpec)
     }


### PR DESCRIPTION
## What is the purpose of the change
There is nothing wrong with current code if run it with maven

however scala's plugin of IntelliJIdea is not happy about it and constantly complaining if try to run scala tests from there (flink-table-planner module e.g `TableEnvironmentTest`)
Also if just open this class in IntelliJIdea it will highlight the error in this place

I tried to ask JetBrains to fix it however still not done (after about 2 years)
https://youtrack.jetbrains.com/issue/SCL-20679/Scala-plugin-becomes-broken-if-there-is-AssertJ-usage

## Brief change log
DataTypeExtractorScalaTest.scala

## Verifying this change
The change is in tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
