### PR TITLE
[FLINK-36608][table-runtime] Support dynamic StreamGraph optimization for AdaptiveBroadcastJoinOperator

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -10,7 +10,7 @@
     <tbody>
         <tr>
             <td><h5>table.optimizer.adaptive-broadcast-join.strategy</h5><br> <span class="label label-primary">Batch</span></td>
-            <td style="word-wrap: break-word;">none</td>
+            <td style="word-wrap: break-word;">auto</td>
             <td><p>Enum</p></td>
             <td>Flink will perform broadcast hash join optimization when the runtime statistics on one side of a join operator is less than the threshold `table.optimizer.join.broadcast-threshold`. The value of this configuration option decides when Flink should perform this optimization. AUTO means Flink will automatically choose the timing for optimization, RUNTIME_ONLY means broadcast hash join optimization is only performed at runtime, and NONE means the optimization is only carried out at compile time.<br /><br />Possible values:<ul><li>"auto": Flink will automatically choose the timing for optimization</li><li>"runtime_only": Broadcast hash join optimization is only performed at runtime.</li><li>"none": Broadcast hash join optimization is only carried out at compile time.</li></ul></td>
         </tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultAdaptiveExecutionHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultAdaptiveExecutionHandler.java
@@ -67,6 +67,8 @@ public class DefaultAdaptiveExecutionHandler implements AdaptiveExecutionHandler
 
         this.streamGraphOptimizer =
                 new StreamGraphOptimizer(streamGraph.getJobConfiguration(), userClassloader);
+        this.streamGraphOptimizer.initializeStrategies(
+                adaptiveGraphManager.getStreamGraphContext());
     }
 
     @Override
@@ -107,10 +109,11 @@ public class DefaultAdaptiveExecutionHandler implements AdaptiveExecutionHandler
                                                 return existing;
                                             }));
 
+            List<Integer> finishedStreamNodeIds =
+                    adaptiveGraphManager.getStreamNodeIdsByJobVertexId(vertexId);
             OperatorsFinished operatorsFinished =
-                    new OperatorsFinished(
-                            adaptiveGraphManager.getStreamNodeIdsByJobVertexId(vertexId),
-                            resultInfoMap);
+                    new OperatorsFinished(finishedStreamNodeIds, resultInfoMap);
+            adaptiveGraphManager.addFinishedStreamNodeIds(finishedStreamNodeIds);
 
             streamGraphOptimizer.onOperatorsFinished(
                     operatorsFinished, adaptiveGraphManager.getStreamGraphContext());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/StreamGraphOptimizationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/StreamGraphOptimizationStrategy.java
@@ -43,6 +43,14 @@ public interface StreamGraphOptimizationStrategy {
                                     + "implementing the StreamGraphOptimizationStrategy interface.");
 
     /**
+     * Initializes the StreamGraphOptimizationStrategy with the provided {@link StreamGraphContext}.
+     *
+     * @param context the StreamGraphContext with a read-only view of a StreamGraph, providing
+     *     methods to modify StreamEdges and StreamNodes within the StreamGraph.
+     */
+    default void initialize(StreamGraphContext context) {}
+
+    /**
      * Tries to optimize the StreamGraph using the provided {@link OperatorsFinished} and {@link
      * StreamGraphContext}. The method returns a boolean indicating whether the StreamGraph was
      * successfully optimized.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/StreamGraphOptimizer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/StreamGraphOptimizer.java
@@ -56,6 +56,10 @@ public class StreamGraphOptimizer {
         }
     }
 
+    public void initializeStrategies(StreamGraphContext context) {
+        checkNotNull(optimizationStrategies).forEach(strategy -> strategy.initialize(context));
+    }
+
     /**
      * Applies all loaded optimization strategies to the StreamGraph.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/AdaptiveGraphManager.java
@@ -135,6 +135,9 @@ public class AdaptiveGraphManager
     // Records the ID of the job vertex that has completed execution.
     private final Set<JobVertexID> finishedJobVertices;
 
+    // Records the ID of the stream nodes that has completed execution.
+    private final Set<Integer> finishedStreamNodeIds;
+
     private final AtomicBoolean hasHybridResultPartition;
 
     private final SlotSharingGroup defaultSlotSharingGroup;
@@ -171,6 +174,7 @@ public class AdaptiveGraphManager
         this.streamNodeIdsToJobVertexMap = new HashMap<>();
 
         this.finishedJobVertices = new HashSet<>();
+        this.finishedStreamNodeIds = new HashSet<>();
 
         this.streamGraphContext =
                 new DefaultStreamGraphContext(
@@ -179,6 +183,8 @@ public class AdaptiveGraphManager
                         frozenNodeToStartNodeMap,
                         intermediateOutputsCaches,
                         consumerEdgeIdToIntermediateDataSetMap,
+                        finishedStreamNodeIds,
+                        userClassloader,
                         this);
 
         this.jobGraph = createAndInitializeJobGraph(streamGraph, streamGraph.getJobID());
@@ -206,6 +212,10 @@ public class AdaptiveGraphManager
             streamNodes.add(streamGraph.getStreamNode(outEdge.getTargetId()));
         }
         return createJobVerticesAndUpdateGraph(streamNodes);
+    }
+
+    public void addFinishedStreamNodeIds(List<Integer> finishedStreamNodeIds) {
+        this.finishedStreamNodeIds.addAll(finishedStreamNodeIds);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/DefaultStreamGraphContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/DefaultStreamGraphContext.java
@@ -22,9 +22,13 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.forwardgroup.StreamNodeForwardGroup;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamEdge;
 import org.apache.flink.streaming.api.graph.util.ImmutableStreamGraph;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamNode;
 import org.apache.flink.streaming.api.graph.util.StreamEdgeUpdateRequestInfo;
+import org.apache.flink.streaming.api.graph.util.StreamNodeUpdateRequestInfo;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.runtime.partitioner.ForwardForConsecutiveHashPartitioner;
 import org.apache.flink.streaming.runtime.partitioner.ForwardForUnspecifiedPartitioner;
@@ -74,6 +78,7 @@ public class DefaultStreamGraphContext implements StreamGraphContext {
     private final Map<Integer, Map<StreamEdge, NonChainedOutput>> opIntermediateOutputsCaches;
 
     private final Map<String, IntermediateDataSet> consumerEdgeIdToIntermediateDataSetMap;
+    private final Set<Integer> finishedStreamNodeIds;
 
     @Nullable private final StreamGraphUpdateListener streamGraphUpdateListener;
 
@@ -83,13 +88,17 @@ public class DefaultStreamGraphContext implements StreamGraphContext {
             Map<Integer, StreamNodeForwardGroup> steamNodeIdToForwardGroupMap,
             Map<Integer, Integer> frozenNodeToStartNodeMap,
             Map<Integer, Map<StreamEdge, NonChainedOutput>> opIntermediateOutputsCaches,
-            Map<String, IntermediateDataSet> consumerEdgeIdToIntermediateDataSetMap) {
+            Map<String, IntermediateDataSet> consumerEdgeIdToIntermediateDataSetMap,
+            Set<Integer> finishedStreamNodeIds,
+            ClassLoader userClassloader) {
         this(
                 streamGraph,
                 steamNodeIdToForwardGroupMap,
                 frozenNodeToStartNodeMap,
                 opIntermediateOutputsCaches,
                 consumerEdgeIdToIntermediateDataSetMap,
+                finishedStreamNodeIds,
+                userClassloader,
                 null);
     }
 
@@ -99,14 +108,17 @@ public class DefaultStreamGraphContext implements StreamGraphContext {
             Map<Integer, Integer> frozenNodeToStartNodeMap,
             Map<Integer, Map<StreamEdge, NonChainedOutput>> opIntermediateOutputsCaches,
             Map<String, IntermediateDataSet> consumerEdgeIdToIntermediateDataSetMap,
+            Set<Integer> finishedStreamNodeIds,
+            ClassLoader userClassloader,
             @Nullable StreamGraphUpdateListener streamGraphUpdateListener) {
         this.streamGraph = checkNotNull(streamGraph);
         this.steamNodeIdToForwardGroupMap = checkNotNull(steamNodeIdToForwardGroupMap);
         this.frozenNodeToStartNodeMap = checkNotNull(frozenNodeToStartNodeMap);
         this.opIntermediateOutputsCaches = checkNotNull(opIntermediateOutputsCaches);
-        this.immutableStreamGraph = new ImmutableStreamGraph(this.streamGraph);
+        this.immutableStreamGraph = new ImmutableStreamGraph(this.streamGraph, userClassloader);
         this.consumerEdgeIdToIntermediateDataSetMap =
                 checkNotNull(consumerEdgeIdToIntermediateDataSetMap);
+        this.finishedStreamNodeIds = finishedStreamNodeIds;
         this.streamGraphUpdateListener = streamGraphUpdateListener;
     }
 
@@ -140,6 +152,9 @@ public class DefaultStreamGraphContext implements StreamGraphContext {
             if (newPartitioner != null) {
                 modifyOutputPartitioner(targetEdge, newPartitioner);
             }
+            if (requestInfo.getTypeNumber() != 0) {
+                targetEdge.setTypeNumber(requestInfo.getTypeNumber());
+            }
         }
 
         // Notify the listener that the StreamGraph has been updated.
@@ -150,32 +165,70 @@ public class DefaultStreamGraphContext implements StreamGraphContext {
         return true;
     }
 
+    @Override
+    public boolean modifyStreamNode(List<StreamNodeUpdateRequestInfo> requestInfos) {
+        for (StreamNodeUpdateRequestInfo requestInfo : requestInfos) {
+            StreamNode streamNode = streamGraph.getStreamNode(requestInfo.getNodeId());
+            if (requestInfo.getTypeSerializersIn() != null) {
+                if (requestInfo.getTypeSerializersIn().length
+                        != streamNode.getTypeSerializersIn().length) {
+                    LOG.info(
+                            "Modification for node {} is not allowed as the array size of typeSerializersIn is not matched.",
+                            requestInfo.getNodeId());
+                    return false;
+                }
+                streamNode.setSerializersIn(requestInfo.getTypeSerializersIn());
+            }
+        }
+
+        // Notify the listener that the StreamGraph has been updated.
+        if (streamGraphUpdateListener != null) {
+            streamGraphUpdateListener.onStreamGraphUpdated();
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean areAllUpstreamNodesFinished(ImmutableStreamNode streamNode) {
+        for (ImmutableStreamEdge streamEdge : streamNode.getInEdges()) {
+            if (!finishedStreamNodeIds.contains(streamEdge.getSourceId())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public IntermediateDataSetID getConsumedIntermediateDataSetId(String edgeId) {
+        return consumerEdgeIdToIntermediateDataSetMap.get(edgeId).getId();
+    }
+
     private boolean validateStreamEdgeUpdateRequest(StreamEdgeUpdateRequestInfo requestInfo) {
         Integer sourceNodeId = requestInfo.getSourceId();
         Integer targetNodeId = requestInfo.getTargetId();
 
         StreamEdge targetEdge = getStreamEdge(sourceNodeId, targetNodeId, requestInfo.getEdgeId());
 
-        if (targetEdge == null) {
-            return false;
-        }
-
-        // Modification is not allowed when the subscribing output is reused.
-        Map<StreamEdge, NonChainedOutput> opIntermediateOutputs =
-                opIntermediateOutputsCaches.get(sourceNodeId);
-        NonChainedOutput output =
-                opIntermediateOutputs != null ? opIntermediateOutputs.get(targetEdge) : null;
-        if (output != null) {
-            Set<StreamEdge> consumerStreamEdges =
-                    opIntermediateOutputs.entrySet().stream()
-                            .filter(entry -> entry.getValue().equals(output))
-                            .map(Map.Entry::getKey)
-                            .collect(Collectors.toSet());
-            if (consumerStreamEdges.size() != 1) {
-                LOG.info(
-                        "Skip modifying edge {} because the subscribing output is reused.",
-                        targetEdge);
-                return false;
+        // Modification to output partitioner is not allowed when the subscribing output is reused.
+        if (requestInfo.getOutputPartitioner() != null) {
+            Map<StreamEdge, NonChainedOutput> opIntermediateOutputs =
+                    opIntermediateOutputsCaches.get(sourceNodeId);
+            NonChainedOutput output =
+                    opIntermediateOutputs != null ? opIntermediateOutputs.get(targetEdge) : null;
+            if (output != null) {
+                Set<StreamEdge> consumerStreamEdges =
+                        opIntermediateOutputs.entrySet().stream()
+                                .filter(entry -> entry.getValue().equals(output))
+                                .map(Map.Entry::getKey)
+                                .collect(Collectors.toSet());
+                if (consumerStreamEdges.size() != 1) {
+                    LOG.info(
+                            "Skip modifying edge {} because the subscribing output is reused.",
+                            targetEdge);
+                    return false;
+                }
             }
         }
 
@@ -212,7 +265,7 @@ public class DefaultStreamGraphContext implements StreamGraphContext {
 
     private void modifyOutputPartitioner(
             StreamEdge targetEdge, StreamPartitioner<?> newPartitioner) {
-        if (newPartitioner == null || targetEdge == null) {
+        if (newPartitioner == null) {
             return;
         }
         StreamPartitioner<?> oldPartitioner = targetEdge.getPartitioner();
@@ -316,6 +369,10 @@ public class DefaultStreamGraphContext implements StreamGraphContext {
                 return edge;
             }
         }
-        return null;
+
+        throw new RuntimeException(
+                String.format(
+                        "Stream edge with id '%s' is not found whose source id is %d, target id is %d.",
+                        edgeId, sourceId, targetId));
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamEdge.java
@@ -55,7 +55,7 @@ public class StreamEdge implements Serializable {
     private final int uniqueId;
 
     /** The type number of the input for co-tasks. */
-    private final int typeNumber;
+    private int typeNumber;
 
     /** The side-output tag (if any) of this {@link StreamEdge}. */
     private final OutputTag outputTag;
@@ -191,6 +191,10 @@ public class StreamEdge implements Serializable {
 
     public void setSupportsUnalignedCheckpoints(boolean supportsUnalignedCheckpoints) {
         this.supportsUnalignedCheckpoints = supportsUnalignedCheckpoints;
+    }
+
+    public void setTypeNumber(int typeNumber) {
+        this.typeNumber = typeNumber;
     }
 
     public boolean supportsUnalignedCheckpoints() {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphContext.java
@@ -19,8 +19,11 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.streaming.api.graph.util.ImmutableStreamGraph;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamNode;
 import org.apache.flink.streaming.api.graph.util.StreamEdgeUpdateRequestInfo;
+import org.apache.flink.streaming.api.graph.util.StreamNodeUpdateRequestInfo;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 
 import javax.annotation.Nullable;
@@ -62,6 +65,30 @@ public interface StreamGraphContext {
      * @return true if all modifications were successful and applied atomically, false otherwise.
      */
     boolean modifyStreamEdge(List<StreamEdgeUpdateRequestInfo> requestInfos);
+
+    /**
+     * Modifies stream nodes within the StreamGraph.
+     *
+     * @param requestInfos the stream nodes to be modified.
+     * @return true if the modification was successful, false otherwise.
+     */
+    boolean modifyStreamNode(List<StreamNodeUpdateRequestInfo> requestInfos);
+
+    /**
+     * Check whether all upstream nodes of the stream node have finished executing.
+     *
+     * @param streamNode the stream node that needs to be determined.
+     * @return true if all upstream nodes are finished, false otherwise.
+     */
+    boolean areAllUpstreamNodesFinished(ImmutableStreamNode streamNode);
+
+    /**
+     * Retrieves the IntermediateDataSetID consumed by the specified edge.
+     *
+     * @param edgeId id of the edge
+     * @return the consumed IntermediateDataSetID
+     */
+    IntermediateDataSetID getConsumedIntermediateDataSetId(String edgeId);
 
     /** Interface for observers that monitor the status of a StreamGraph. */
     @Internal

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/ImmutableStreamGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/ImmutableStreamGraph.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.graph.util;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 
 import java.util.HashMap;
@@ -28,11 +29,13 @@ import java.util.Map;
 @Internal
 public class ImmutableStreamGraph {
     private final StreamGraph streamGraph;
+    private final ClassLoader userClassloader;
 
     private final Map<Integer, ImmutableStreamNode> immutableStreamNodes;
 
-    public ImmutableStreamGraph(StreamGraph streamGraph) {
+    public ImmutableStreamGraph(StreamGraph streamGraph, ClassLoader userClassloader) {
         this.streamGraph = streamGraph;
+        this.userClassloader = userClassloader;
         this.immutableStreamNodes = new HashMap<>();
     }
 
@@ -42,5 +45,13 @@ public class ImmutableStreamGraph {
         }
         return immutableStreamNodes.computeIfAbsent(
                 vertexId, id -> new ImmutableStreamNode(streamGraph.getStreamNode(id)));
+    }
+
+    public ReadableConfig getConfiguration() {
+        return streamGraph.getJobConfiguration();
+    }
+
+    public ClassLoader getUserClassLoader() {
+        return userClassloader;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/ImmutableStreamNode.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/ImmutableStreamNode.java
@@ -19,12 +19,18 @@
 package org.apache.flink.streaming.api.graph.util;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /** Helper class that provides read-only StreamNode. */
 @Internal
@@ -61,11 +67,21 @@ public class ImmutableStreamNode {
         return streamNode.getId();
     }
 
+    public @Nullable StreamOperatorFactory<?> getOperatorFactory() {
+        return streamNode.getOperatorFactory();
+    }
+
     public int getMaxParallelism() {
         return streamNode.getMaxParallelism();
     }
 
     public int getParallelism() {
         return streamNode.getParallelism();
+    }
+
+    public TypeSerializer<?>[] getTypeSerializersIn() {
+        return Arrays.stream(streamNode.getTypeSerializersIn())
+                .filter(Objects::nonNull)
+                .toArray(TypeSerializer<?>[]::new);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/StreamEdgeUpdateRequestInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/StreamEdgeUpdateRequestInfo.java
@@ -30,14 +30,25 @@ public class StreamEdgeUpdateRequestInfo {
 
     private StreamPartitioner<?> outputPartitioner;
 
+    // The type number for the input of co-tasks.
+    // For two or more inputs, typeNumber must be >= 1, and 0 means the request will not change the
+    // typeNumber.
+    private int typeNumber;
+
     public StreamEdgeUpdateRequestInfo(String edgeId, Integer sourceId, Integer targetId) {
         this.edgeId = edgeId;
         this.sourceId = sourceId;
         this.targetId = targetId;
     }
 
-    public StreamEdgeUpdateRequestInfo outputPartitioner(StreamPartitioner<?> outputPartitioner) {
+    public StreamEdgeUpdateRequestInfo withOutputPartitioner(
+            StreamPartitioner<?> outputPartitioner) {
         this.outputPartitioner = outputPartitioner;
+        return this;
+    }
+
+    public StreamEdgeUpdateRequestInfo withTypeNumber(int typeNumber) {
+        this.typeNumber = typeNumber;
         return this;
     }
 
@@ -55,5 +66,9 @@ public class StreamEdgeUpdateRequestInfo {
 
     public StreamPartitioner<?> getOutputPartitioner() {
         return outputPartitioner;
+    }
+
+    public int getTypeNumber() {
+        return typeNumber;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/StreamNodeUpdateRequestInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/util/StreamNodeUpdateRequestInfo.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph.util;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import javax.annotation.Nullable;
+
+/** Helper class carries the data required to updates a stream edge. */
+@Internal
+public class StreamNodeUpdateRequestInfo {
+    private final Integer nodeId;
+
+    // Null means it does not request to change the typeSerializersIn.
+    @Nullable private TypeSerializer<?>[] typeSerializersIn;
+
+    public StreamNodeUpdateRequestInfo(Integer nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public StreamNodeUpdateRequestInfo withTypeSerializersIn(
+            TypeSerializer<?>[] typeSerializersIn) {
+        this.typeSerializersIn = typeSerializersIn;
+        return this;
+    }
+
+    public Integer getNodeId() {
+        return nodeId;
+    }
+
+    @Nullable
+    public TypeSerializer<?>[] getTypeSerializersIn() {
+        return typeSerializersIn;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultAdaptiveExecutionHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultAdaptiveExecutionHandlerTest.java
@@ -277,7 +277,7 @@ class DefaultAdaptiveExecutionHandlerTest {
                                         outEdge.getEdgeId(),
                                         outEdge.getSourceId(),
                                         outEdge.getTargetId());
-                        requestInfo.outputPartitioner(new RebalancePartitioner<>());
+                        requestInfo.withOutputPartitioner(new RebalancePartitioner<>());
                         requestInfos.add(requestInfo);
                     }
                 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/StreamGraphOptimizerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/StreamGraphOptimizerTest.java
@@ -19,9 +19,12 @@
 package org.apache.flink.runtime.scheduler.adaptivebatch;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.streaming.api.graph.StreamGraphContext;
 import org.apache.flink.streaming.api.graph.util.ImmutableStreamGraph;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamNode;
 import org.apache.flink.streaming.api.graph.util.StreamEdgeUpdateRequestInfo;
+import org.apache.flink.streaming.api.graph.util.StreamNodeUpdateRequestInfo;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -76,6 +79,22 @@ class StreamGraphOptimizerTest {
                     public boolean modifyStreamEdge(
                             List<StreamEdgeUpdateRequestInfo> requestInfos) {
                         return false;
+                    }
+
+                    @Override
+                    public boolean modifyStreamNode(
+                            List<StreamNodeUpdateRequestInfo> requestInfos) {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean areAllUpstreamNodesFinished(ImmutableStreamNode streamNode) {
+                        return false;
+                    }
+
+                    @Override
+                    public IntermediateDataSetID getConsumedIntermediateDataSetId(String edgeId) {
+                        return null;
                     }
                 };
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/DefaultStreamGraphContextTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/DefaultStreamGraphContextTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -53,7 +54,9 @@ class DefaultStreamGraphContextTest {
                         forwardGroupsByEndpointNodeIdCache,
                         frozenNodeToStartNodeMap,
                         opIntermediateOutputsCaches,
-                        new HashMap<>());
+                        new HashMap<>(),
+                        new HashSet<>(),
+                        Thread.currentThread().getContextClassLoader());
 
         StreamNode sourceNode =
                 streamGraph.getStreamNode(streamGraph.getSourceIDs().iterator().next());
@@ -74,7 +77,7 @@ class DefaultStreamGraphContextTest {
                                 targetEdge.getEdgeId(),
                                 targetEdge.getSourceId(),
                                 targetEdge.getTargetId())
-                        .outputPartitioner(new ForwardForUnspecifiedPartitioner<>());
+                        .withOutputPartitioner(new ForwardForUnspecifiedPartitioner<>());
 
         assertThat(
                         streamGraphContext.modifyStreamEdge(
@@ -138,7 +141,9 @@ class DefaultStreamGraphContextTest {
                         forwardGroupsByEndpointNodeIdCache,
                         frozenNodeToStartNodeMap,
                         opIntermediateOutputsCaches,
-                        new HashMap<>());
+                        new HashMap<>(),
+                        new HashSet<>(),
+                        Thread.currentThread().getContextClassLoader());
 
         StreamNode sourceNode =
                 streamGraph.getStreamNode(streamGraph.getSourceIDs().iterator().next());
@@ -158,7 +163,7 @@ class DefaultStreamGraphContextTest {
                                 targetEdge.getEdgeId(),
                                 targetEdge.getSourceId(),
                                 targetEdge.getTargetId())
-                        .outputPartitioner(new ForwardForUnspecifiedPartitioner<>());
+                        .withOutputPartitioner(new ForwardForUnspecifiedPartitioner<>());
 
         // Modify rescale partitioner to forward partitioner.
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/util/ImmutableStreamGraphTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/util/ImmutableStreamGraphTest.java
@@ -36,7 +36,9 @@ class ImmutableStreamGraphTest {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.fromSequence(1L, 3L).map(value -> value).print().setParallelism(env.getParallelism());
         StreamGraph streamGraph = env.getStreamGraph();
-        ImmutableStreamGraph immutableStreamGraph = new ImmutableStreamGraph(streamGraph);
+        ImmutableStreamGraph immutableStreamGraph =
+                new ImmutableStreamGraph(
+                        streamGraph, Thread.currentThread().getContextClassLoader());
 
         for (StreamNode streamNode : streamGraph.getStreamNodes()) {
             isStreamNodeEquals(streamNode, immutableStreamGraph.getStreamNode(streamNode.getId()));

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -166,7 +166,7 @@ public class OptimizerConfigOptions {
             TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY =
                     key("table.optimizer.adaptive-broadcast-join.strategy")
                             .enumType(AdaptiveBroadcastJoinStrategy.class)
-                            .defaultValue(AdaptiveBroadcastJoinStrategy.NONE)
+                            .defaultValue(AdaptiveBroadcastJoinStrategy.AUTO)
                             .withDescription(
                                     "Flink will perform broadcast hash join optimization when the runtime "
                                             + "statistics on one side of a join operator is less than the "

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/adaptive/AdaptiveJoinOperatorGenerator.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/adaptive/AdaptiveJoinOperatorGenerator.java
@@ -155,4 +155,15 @@ public class AdaptiveJoinOperatorGenerator implements AdaptiveJoin {
         this.isBroadcastJoin = canBroadcast;
         this.leftIsBuild = leftIsBuild;
     }
+
+    @Override
+    public boolean shouldReorderInputs() {
+        // Sort merge join requires the left side to be read first if the broadcast threshold is not
+        // met.
+        if (!isBroadcastJoin && originalJoin == OperatorType.SortMergeJoin) {
+            return false;
+        }
+
+        return !leftIsBuild;
+    }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.delegation
 import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.ExecutionOptions
+import org.apache.flink.runtime.scheduler.adaptivebatch.StreamGraphOptimizationStrategy
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
@@ -34,6 +35,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodePlanDumper
 import org.apache.flink.table.planner.plan.optimize.{BatchCommonSubGraphBasedOptimizer, Optimizer}
 import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil
 import org.apache.flink.table.planner.utils.DummyStreamExecutionEnvironment
+import org.apache.flink.table.runtime.strategy.{AdaptiveBroadcastJoinOptimizationStrategy, PostProcessAdaptiveJoinStrategy}
 
 import org.apache.calcite.plan.{ConventionTraitDef, RelTrait, RelTraitDef}
 import org.apache.calcite.rel.RelCollationTraitDef
@@ -98,6 +100,22 @@ class BatchPlanner(
     }
     afterTranslation()
     transformations ++ planner.extraTransformations
+  }
+
+  override def afterTranslation(): Unit = {
+    super.afterTranslation()
+    val configuration = getTableConfig
+    val optimizationStrategies = new util.ArrayList[String]()
+    if (
+      configuration.get(OptimizerConfigOptions.TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY)
+        != OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.NONE
+    ) {
+      optimizationStrategies.add(classOf[AdaptiveBroadcastJoinOptimizationStrategy].getName)
+      optimizationStrategies.add(classOf[PostProcessAdaptiveJoinStrategy].getName)
+    }
+    configuration.set(
+      StreamGraphOptimizationStrategy.STREAM_GRAPH_OPTIMIZATION_STRATEGY,
+      optimizationStrategies)
   }
 
   override def explain(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/adaptive/AdaptiveBroadcastJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/adaptive/AdaptiveBroadcastJoinITCase.scala
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.runtime.batch.sql.adaptive
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{LONG_TYPE_INFO, STRING_TYPE_INFO}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase
+import org.apache.flink.types.Row
+
+import org.junit.jupiter.api.{BeforeEach, Test}
+
+import scala.collection.JavaConversions._
+import scala.util.Random
+
+/** IT cases for adaptive broadcast join. */
+class AdaptiveBroadcastJoinITCase extends BatchTestBase {
+
+  @BeforeEach
+  override def before(): Unit = {
+    super.before()
+
+    registerCollection(
+      "T",
+      AdaptiveBroadcastJoinITCase.dataT,
+      AdaptiveBroadcastJoinITCase.rowType,
+      "a, b, c, d",
+      AdaptiveBroadcastJoinITCase.nullables)
+    registerCollection(
+      "T1",
+      AdaptiveBroadcastJoinITCase.dataT1,
+      AdaptiveBroadcastJoinITCase.rowType,
+      "a1, b1, c1, d1",
+      AdaptiveBroadcastJoinITCase.nullables)
+    registerCollection(
+      "T2",
+      AdaptiveBroadcastJoinITCase.dataT2,
+      AdaptiveBroadcastJoinITCase.rowType,
+      "a2, b2, c2, d2",
+      AdaptiveBroadcastJoinITCase.nullables)
+    registerCollection(
+      "T3",
+      AdaptiveBroadcastJoinITCase.dataT3,
+      AdaptiveBroadcastJoinITCase.rowType,
+      "a3, b3, c3, d3",
+      AdaptiveBroadcastJoinITCase.nullables)
+  }
+
+  @Test
+  def testWithShuffleHashJoin(): Unit = {
+    tEnv.getConfig
+      .set(ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "NestedLoopJoin,SortMergeJoin")
+    testSimpleJoin()
+  }
+
+  @Test
+  def testWithShuffleMergeJoin(): Unit = {
+    tEnv.getConfig
+      .set(ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS, "NestedLoopJoin,ShuffleHashJoin")
+    testSimpleJoin()
+  }
+
+  @Test
+  def testWithBroadcastJoin(): Unit = {
+    tEnv.getConfig.set(
+      ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS,
+      "SortMergeJoin,NestedLoopJoin")
+    tEnv.getConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD,
+      Long.box(Long.MaxValue))
+    testSimpleJoin()
+  }
+
+  @Test
+  def testShuffleJoinWithForwardForConsecutiveHash(): Unit = {
+    tEnv.getConfig.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_MULTIPLE_INPUT_ENABLED,
+      Boolean.box(false))
+    val sql =
+      """
+        |WITH
+        |  r AS (SELECT * FROM T1, T2, T3 WHERE a1 = a2 and a1 = a3)
+        |SELECT sum(b1) FROM r group by a1
+        |""".stripMargin
+    checkResult(sql)
+  }
+
+  @Test
+  def testJoinWithUnionInput(): Unit = {
+    val sql =
+      """
+        |SELECT * FROM
+        |  (SELECT a FROM (SELECT a1 as a FROM T1) UNION ALL (SELECT a2 as a FROM T2)) Y
+        |  LEFT JOIN T ON T.a = Y.a
+        |""".stripMargin
+    checkResult(sql)
+  }
+
+  @Test
+  def testJoinWithMultipleInput(): Unit = {
+    val sql =
+      """
+        |SELECT * FROM
+        |  (SELECT a FROM T1 JOIN T ON a = a1) t1
+        |  INNER JOIN
+        |  (SELECT d2 FROM T JOIN T2 ON d2 = a) t2
+        |ON t1.a = t2.d2
+        |""".stripMargin
+    checkResult(sql)
+  }
+
+  def testSimpleJoin(): Unit = {
+    // inner join
+    val sql1 = "SELECT * FROM T1, T2 WHERE a1 = a2"
+    checkResult(sql1)
+
+    // left join
+    val sql2 = "SELECT * FROM T1 LEFT JOIN T2 on a1 = a2"
+    checkResult(sql2)
+
+    // right join
+    val sql3 = "SELECT * FROM T1 RIGHT JOIN T2 on a1 = a2"
+    checkResult(sql3)
+
+    // semi join
+    val sql4 = "SELECT * FROM T1 WHERE a1 IN (SELECT a2 FROM T2)"
+    checkResult(sql4)
+
+    // anti join
+    val sql5 = "SELECT * FROM T1 WHERE a1 NOT IN (SELECT a2 FROM T2 where a2 = a1)"
+    checkResult(sql5)
+  }
+
+  def checkResult(sql: String): Unit = {
+    tEnv.getConfig
+      .set(
+        OptimizerConfigOptions.TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY,
+        OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.NONE)
+    val expected = executeQuery(sql)
+    tEnv.getConfig
+      .set(
+        OptimizerConfigOptions.TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY,
+        OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.AUTO)
+    checkResult(sql, expected)
+    tEnv.getConfig
+      .set(
+        OptimizerConfigOptions.TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY,
+        OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.RUNTIME_ONLY)
+    checkResult(sql, expected)
+  }
+}
+
+object AdaptiveBroadcastJoinITCase {
+
+  def generateRandomData(): Seq[Row] = {
+    val data = new java.util.ArrayList[Row]()
+    val numRows = Random.nextInt(30)
+    lazy val strs = Seq("adaptive", "join", "itcase")
+    for (x <- 0 until numRows) {
+      data.add(
+        BatchTestBase.row(x.toLong, Random.nextLong(), strs(Random.nextInt(3)), Random.nextLong()))
+    }
+    data
+  }
+
+  lazy val rowType =
+    new RowTypeInfo(LONG_TYPE_INFO, LONG_TYPE_INFO, STRING_TYPE_INFO, LONG_TYPE_INFO)
+  lazy val nullables: Array[Boolean] = Array(true, true, true, true)
+
+  lazy val dataT: Seq[Row] = generateRandomData()
+  lazy val dataT1: Seq[Row] = generateRandomData()
+  lazy val dataT2: Seq[Row] = generateRandomData()
+  lazy val dataT3: Seq[Row] = generateRandomData()
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/join/JoinITCase.scala
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeutils.TypeComparator
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.api.java.typeutils.GenericTypeInfo
 import org.apache.flink.streaming.api.transformations.{LegacySinkTransformation, OneInputTransformation, TwoInputTransformation}
+import org.apache.flink.table.api.config.OptimizerConfigOptions
 import org.apache.flink.table.api.internal.{StatementSetImpl, TableEnvironmentInternal}
 import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.expressions.utils.FuncWithOpen
@@ -203,6 +204,9 @@ class JoinITCase extends BatchTestBase {
   @TestTemplate
   def testLongHashJoinGenerator(): Unit = {
     if (expectedJoinType == HashJoin) {
+      tEnv.getConfig.set(
+        OptimizerConfigOptions.TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY,
+        OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.NONE)
       val sink = (new CollectRowTableSink).configure(Array("c"), Array(Types.STRING))
       tEnv.asInstanceOf[TableEnvironmentInternal].registerTableSinkInternal("outputTable", sink)
       val stmtSet = tEnv.createStatementSet()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -33,7 +33,8 @@ import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment, Strea
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.bridge.java.{StreamTableEnvironment => JavaStreamTableEnv}
 import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment => ScalaStreamTableEnv}
-import org.apache.flink.table.api.config.ExecutionConfigOptions
+import org.apache.flink.table.api.config.{ExecutionConfigOptions, OptimizerConfigOptions}
+import org.apache.flink.table.api.config.OptimizerConfigOptions.AdaptiveBroadcastJoinStrategy.NONE
 import org.apache.flink.table.api.internal.{StatementSetImpl, TableEnvironmentImpl, TableEnvironmentInternal, TableImpl}
 import org.apache.flink.table.api.typeutils.CaseClassTypeInfo
 import org.apache.flink.table.catalog._
@@ -1200,6 +1201,9 @@ abstract class TableTestUtil(
   tableEnv.getConfig.set(
     BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED,
     Boolean.box(false))
+  tableEnv.getConfig.set(
+    OptimizerConfigOptions.TABLE_OPTIMIZER_ADAPTIVE_BROADCAST_JOIN_STRATEGY,
+    NONE)
 
   private val env: StreamExecutionEnvironment = getPlanner.getExecEnv
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/adaptive/AdaptiveJoin.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/adaptive/AdaptiveJoin.java
@@ -53,4 +53,12 @@ public interface AdaptiveJoin extends Serializable {
      * @param leftIsBuild whether the left input side is the build side.
      */
     void markAsBroadcastJoin(boolean canBeBroadcast, boolean leftIsBuild);
+
+    /**
+     * Check if the adaptive join node needs to adjust the read order of the input sides. For the
+     * hash join operator, it is necessary to ensure that the build side is read first.
+     *
+     * @return whether the inputs should be reordered.
+     */
+    boolean shouldReorderInputs();
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/adaptive/AdaptiveJoinOperatorFactory.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/adaptive/AdaptiveJoinOperatorFactory.java
@@ -79,6 +79,12 @@ public class AdaptiveJoinOperatorFactory<OUT> extends AbstractStreamOperatorFact
         adaptiveJoin.markAsBroadcastJoin(canBeBroadcast, leftIsBuild);
     }
 
+    @Override
+    public boolean shouldReorderInputs() {
+        checkAndLazyInitialize();
+        return adaptiveJoin.shouldReorderInputs();
+    }
+
     private void checkAndLazyInitialize() {
         if (this.adaptiveJoin == null) {
             lazyInitialize();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveBroadcastJoinOptimizationStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/AdaptiveBroadcastJoinOptimizationStrategy.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.strategy;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.scheduler.adaptivebatch.BlockingResultInfo;
+import org.apache.flink.runtime.scheduler.adaptivebatch.OperatorsFinished;
+import org.apache.flink.streaming.api.graph.StreamGraphContext;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamEdge;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamNode;
+import org.apache.flink.streaming.api.graph.util.StreamEdgeUpdateRequestInfo;
+import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
+import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.runtime.operators.join.adaptive.AdaptiveJoin;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** The stream graph optimization strategy of adaptive broadcast join. */
+public class AdaptiveBroadcastJoinOptimizationStrategy
+        extends BaseAdaptiveJoinOperatorOptimizationStrategy {
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AdaptiveBroadcastJoinOptimizationStrategy.class);
+
+    private Long broadcastThreshold;
+
+    private Map<Integer, Map<Integer, Long>> aggregatedInputBytesByTypeNumberAndNodeId;
+
+    @Override
+    public void initialize(StreamGraphContext context) {
+        ReadableConfig config = context.getStreamGraph().getConfiguration();
+        broadcastThreshold =
+                config.get(OptimizerConfigOptions.TABLE_OPTIMIZER_BROADCAST_JOIN_THRESHOLD);
+        aggregatedInputBytesByTypeNumberAndNodeId = new HashMap<>();
+    }
+
+    @Override
+    public boolean onOperatorsFinished(
+            OperatorsFinished operatorsFinished, StreamGraphContext context) {
+        visitDownstreamAdaptiveJoinNode(operatorsFinished, context);
+
+        return true;
+    }
+
+    @Override
+    protected void tryOptimizeAdaptiveJoin(
+            OperatorsFinished operatorsFinished,
+            StreamGraphContext context,
+            ImmutableStreamNode adaptiveJoinNode,
+            List<ImmutableStreamEdge> upstreamStreamEdges,
+            AdaptiveJoin adaptiveJoin) {
+        for (ImmutableStreamEdge upstreamEdge : upstreamStreamEdges) {
+            IntermediateDataSetID relatedDataSetId =
+                    context.getConsumedIntermediateDataSetId(upstreamEdge.getEdgeId());
+            long producedBytes =
+                    operatorsFinished.getResultInfoMap().get(upstreamEdge.getSourceId()).stream()
+                            .filter(
+                                    blockingResultInfo ->
+                                            relatedDataSetId.equals(
+                                                    blockingResultInfo.getResultId()))
+                            .mapToLong(BlockingResultInfo::getNumBytesProduced)
+                            .sum();
+            aggregatedInputBytesByTypeNumber(
+                    adaptiveJoinNode, upstreamEdge.getTypeNumber(), producedBytes);
+        }
+
+        // If all upstream nodes have finished, we attempt to optimize the AdaptiveJoin node.
+        if (context.areAllUpstreamNodesFinished(adaptiveJoinNode)) {
+            Long leftInputSize =
+                    aggregatedInputBytesByTypeNumberAndNodeId.get(adaptiveJoinNode.getId()).get(1);
+            checkState(
+                    leftInputSize != null,
+                    "Left input bytes of adaptive join [%s] is unknown, which is unexpected.",
+                    adaptiveJoinNode.getId());
+            Long rightInputSize =
+                    aggregatedInputBytesByTypeNumberAndNodeId.get(adaptiveJoinNode.getId()).get(2);
+            checkState(
+                    rightInputSize != null,
+                    "Right input bytes of adaptive join [%s] is unknown, which is unexpected.",
+                    adaptiveJoinNode.getId());
+
+            boolean leftSizeSmallerThanThreshold = leftInputSize <= broadcastThreshold;
+            boolean rightSizeSmallerThanThreshold = rightInputSize <= broadcastThreshold;
+            boolean leftSmallerThanRight = leftInputSize < rightInputSize;
+            FlinkJoinType joinType = adaptiveJoin.getJoinType();
+            boolean canBeBroadcast;
+            boolean leftIsBuild;
+            switch (joinType) {
+                case RIGHT:
+                    // For a right outer join, if the left side can be broadcast, then the left side
+                    // is
+                    // always the build side; otherwise, the smaller side is the build side.
+                    canBeBroadcast = leftSizeSmallerThanThreshold;
+                    leftIsBuild = true;
+                    break;
+                case INNER:
+                    canBeBroadcast = leftSizeSmallerThanThreshold || rightSizeSmallerThanThreshold;
+                    leftIsBuild = leftSmallerThanRight;
+                    break;
+                case LEFT:
+                case SEMI:
+                case ANTI:
+                    // For left outer / semi / anti join, if the right side can be broadcast, then
+                    // the
+                    // right side is always the build side; otherwise, the smaller side is the build
+                    // side.
+                    canBeBroadcast = rightSizeSmallerThanThreshold;
+                    leftIsBuild = false;
+                    break;
+                case FULL:
+                default:
+                    throw new RuntimeException(String.format("Unexpected join type %s.", joinType));
+            }
+
+            boolean isBroadcast = false;
+            if (canBeBroadcast) {
+                isBroadcast =
+                        tryModifyStreamEdgesForBroadcastJoin(
+                                adaptiveJoinNode.getInEdges(), context, leftIsBuild);
+
+                if (isBroadcast) {
+                    LOG.info(
+                            "The {} input data size of the join node [{}] is small enough, "
+                                    + "adaptively convert it to a broadcast hash join. Broadcast "
+                                    + "threshold bytes: {}, left input bytes: {}, right input bytes: {}.",
+                            leftIsBuild ? "left" : "right",
+                            adaptiveJoinNode.getId(),
+                            broadcastThreshold,
+                            leftInputSize,
+                            rightInputSize);
+                }
+            }
+            adaptiveJoin.markAsBroadcastJoin(
+                    isBroadcast, isBroadcast ? leftIsBuild : leftSmallerThanRight);
+
+            aggregatedInputBytesByTypeNumberAndNodeId.remove(adaptiveJoinNode.getId());
+        }
+    }
+
+    private void aggregatedInputBytesByTypeNumber(
+            ImmutableStreamNode adaptiveJoinNode, int typeNumber, long producedBytes) {
+        Integer streamNodeId = adaptiveJoinNode.getId();
+
+        aggregatedInputBytesByTypeNumberAndNodeId
+                .computeIfAbsent(streamNodeId, k -> new HashMap<>())
+                .merge(typeNumber, producedBytes, Long::sum);
+    }
+
+    private List<ImmutableStreamEdge> filterEdges(
+            List<ImmutableStreamEdge> inEdges, int typeNumber) {
+        return inEdges.stream()
+                .filter(e -> e.getTypeNumber() == typeNumber)
+                .collect(Collectors.toList());
+    }
+
+    private List<StreamEdgeUpdateRequestInfo> generateStreamEdgeUpdateRequestInfos(
+            List<ImmutableStreamEdge> modifiedEdges, StreamPartitioner<?> outputPartitioner) {
+        List<StreamEdgeUpdateRequestInfo> streamEdgeUpdateRequestInfos = new ArrayList<>();
+        for (ImmutableStreamEdge streamEdge : modifiedEdges) {
+            StreamEdgeUpdateRequestInfo streamEdgeUpdateRequestInfo =
+                    new StreamEdgeUpdateRequestInfo(
+                                    streamEdge.getEdgeId(),
+                                    streamEdge.getSourceId(),
+                                    streamEdge.getTargetId())
+                            .withOutputPartitioner(outputPartitioner);
+            streamEdgeUpdateRequestInfos.add(streamEdgeUpdateRequestInfo);
+        }
+
+        return streamEdgeUpdateRequestInfos;
+    }
+
+    private boolean tryModifyStreamEdgesForBroadcastJoin(
+            List<ImmutableStreamEdge> inEdges, StreamGraphContext context, boolean leftIsBuild) {
+        List<StreamEdgeUpdateRequestInfo> modifiedBuildSideEdges =
+                generateStreamEdgeUpdateRequestInfos(
+                        filterEdges(inEdges, leftIsBuild ? 1 : 2), new BroadcastPartitioner<>());
+        List<StreamEdgeUpdateRequestInfo> modifiedProbeSideEdges =
+                generateStreamEdgeUpdateRequestInfos(
+                        filterEdges(inEdges, leftIsBuild ? 2 : 1), new ForwardPartitioner<>());
+        modifiedBuildSideEdges.addAll(modifiedProbeSideEdges);
+
+        return context.modifyStreamEdge(modifiedBuildSideEdges);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/BaseAdaptiveJoinOperatorOptimizationStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/BaseAdaptiveJoinOperatorOptimizationStrategy.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.strategy;
+
+import org.apache.flink.runtime.scheduler.adaptivebatch.OperatorsFinished;
+import org.apache.flink.runtime.scheduler.adaptivebatch.StreamGraphOptimizationStrategy;
+import org.apache.flink.streaming.api.graph.StreamGraphContext;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamEdge;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamGraph;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamNode;
+import org.apache.flink.table.runtime.operators.join.adaptive.AdaptiveJoin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** The base stream graph optimization strategy class for adaptive join operator. */
+public abstract class BaseAdaptiveJoinOperatorOptimizationStrategy
+        implements StreamGraphOptimizationStrategy {
+
+    protected void visitDownstreamAdaptiveJoinNode(
+            OperatorsFinished operatorsFinished, StreamGraphContext context) {
+        ImmutableStreamGraph streamGraph = context.getStreamGraph();
+        List<Integer> finishedStreamNodeIds = operatorsFinished.getFinishedStreamNodeIds();
+        Map<ImmutableStreamNode, List<ImmutableStreamEdge>> joinNodesWithInEdges = new HashMap<>();
+        for (Integer finishedStreamNodeId : finishedStreamNodeIds) {
+            for (ImmutableStreamEdge streamEdge :
+                    streamGraph.getStreamNode(finishedStreamNodeId).getOutEdges()) {
+                ImmutableStreamNode downstreamNode =
+                        streamGraph.getStreamNode(streamEdge.getTargetId());
+                if (downstreamNode.getOperatorFactory() instanceof AdaptiveJoin) {
+                    joinNodesWithInEdges
+                            .computeIfAbsent(downstreamNode, k -> new ArrayList<>())
+                            .add(streamEdge);
+                }
+            }
+        }
+        for (ImmutableStreamNode joinNode : joinNodesWithInEdges.keySet()) {
+            tryOptimizeAdaptiveJoin(
+                    operatorsFinished,
+                    context,
+                    joinNode,
+                    joinNodesWithInEdges.get(joinNode),
+                    (AdaptiveJoin) joinNode.getOperatorFactory());
+        }
+    }
+
+    abstract void tryOptimizeAdaptiveJoin(
+            OperatorsFinished operatorsFinished,
+            StreamGraphContext context,
+            ImmutableStreamNode adaptiveJoinNode,
+            List<ImmutableStreamEdge> upstreamStreamEdges,
+            AdaptiveJoin adaptiveJoin);
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/PostProcessAdaptiveJoinStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/strategy/PostProcessAdaptiveJoinStrategy.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.strategy;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.runtime.scheduler.adaptivebatch.OperatorsFinished;
+import org.apache.flink.streaming.api.graph.StreamGraphContext;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamEdge;
+import org.apache.flink.streaming.api.graph.util.ImmutableStreamNode;
+import org.apache.flink.streaming.api.graph.util.StreamEdgeUpdateRequestInfo;
+import org.apache.flink.streaming.api.graph.util.StreamNodeUpdateRequestInfo;
+import org.apache.flink.table.runtime.operators.join.adaptive.AdaptiveJoin;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The post-processing phase of adaptive join optimization, which must be placed at the end of all
+ * adaptive join optimization strategies. This is necessary because certain operations, like
+ * 'reorder inputs', can influence how adaptive broadcast join or skewed join determine the left and
+ * right sides.
+ */
+public class PostProcessAdaptiveJoinStrategy extends BaseAdaptiveJoinOperatorOptimizationStrategy {
+
+    @Override
+    public boolean onOperatorsFinished(
+            OperatorsFinished operatorsFinished, StreamGraphContext context) {
+        visitDownstreamAdaptiveJoinNode(operatorsFinished, context);
+
+        return true;
+    }
+
+    @Override
+    protected void tryOptimizeAdaptiveJoin(
+            OperatorsFinished operatorsFinished,
+            StreamGraphContext context,
+            ImmutableStreamNode adaptiveJoinNode,
+            List<ImmutableStreamEdge> upstreamStreamEdges,
+            AdaptiveJoin adaptiveJoin) {
+        if (context.areAllUpstreamNodesFinished(adaptiveJoinNode)) {
+            // For hash join, reorder the join node inputs so the build side is read first.
+            if (adaptiveJoin.shouldReorderInputs()) {
+                if (!context.modifyStreamEdge(
+                                generateStreamEdgeUpdateRequestInfosForInputsReordered(
+                                        adaptiveJoinNode))
+                        || !context.modifyStreamNode(
+                                generateStreamNodeUpdateRequestInfosForInputsReordered(
+                                        adaptiveJoinNode))) {
+                    throw new RuntimeException(
+                            "Unexpected error occurs while reordering the inputs "
+                                    + "of the adaptive join node, potentially leading to data inaccuracies. "
+                                    + "Exceptions will be thrown.");
+                }
+            }
+
+            // Generate OperatorFactory for adaptive join operator after inputs are reordered.
+            ReadableConfig config = context.getStreamGraph().getConfiguration();
+            ClassLoader userClassLoader = context.getStreamGraph().getUserClassLoader();
+            adaptiveJoin.genOperatorFactory(userClassLoader, config);
+        }
+    }
+
+    private static List<StreamEdgeUpdateRequestInfo>
+            generateStreamEdgeUpdateRequestInfosForInputsReordered(
+                    ImmutableStreamNode adaptiveJoinNode) {
+        List<StreamEdgeUpdateRequestInfo> streamEdgeUpdateRequestInfos = new ArrayList<>();
+        for (ImmutableStreamEdge inEdge : adaptiveJoinNode.getInEdges()) {
+            StreamEdgeUpdateRequestInfo streamEdgeUpdateRequestInfo =
+                    new StreamEdgeUpdateRequestInfo(
+                            inEdge.getEdgeId(), inEdge.getSourceId(), inEdge.getTargetId());
+            streamEdgeUpdateRequestInfo.withTypeNumber(inEdge.getTypeNumber() == 1 ? 2 : 1);
+            streamEdgeUpdateRequestInfos.add(streamEdgeUpdateRequestInfo);
+        }
+        return streamEdgeUpdateRequestInfos;
+    }
+
+    private List<StreamNodeUpdateRequestInfo>
+            generateStreamNodeUpdateRequestInfosForInputsReordered(
+                    ImmutableStreamNode modifiedNode) {
+        List<StreamNodeUpdateRequestInfo> streamEdgeUpdateRequestInfos = new ArrayList<>();
+
+        TypeSerializer<?>[] typeSerializers = modifiedNode.getTypeSerializersIn();
+        Preconditions.checkState(
+                typeSerializers.length == 2,
+                String.format(
+                        "Adaptive join currently only supports two "
+                                + "inputs, but the join node [%s] has received %s inputs.",
+                        modifiedNode.getId(), typeSerializers.length));
+        TypeSerializer<?>[] swappedTypeSerializers = new TypeSerializer<?>[2];
+        swappedTypeSerializers[0] = typeSerializers[1];
+        swappedTypeSerializers[1] = typeSerializers[0];
+        StreamNodeUpdateRequestInfo requestInfo =
+                new StreamNodeUpdateRequestInfo(modifiedNode.getId())
+                        .withTypeSerializersIn(swappedTypeSerializers);
+        streamEdgeUpdateRequestInfos.add(requestInfo);
+
+        return streamEdgeUpdateRequestInfos;
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
@@ -358,10 +358,10 @@ class AdaptiveBatchSchedulerITCase {
                                     outEdge.getSourceId(),
                                     outEdge.getTargetId());
                     if (convertToBroadcastEdgeIds.contains(outEdge.getEdgeId())) {
-                        requestInfo.outputPartitioner(new BroadcastPartitioner<>());
+                        requestInfo.withOutputPartitioner(new BroadcastPartitioner<>());
                         requestInfos.add(requestInfo);
                     } else if (convertToRescaleEdgeIds.contains(outEdge.getEdgeId())) {
-                        requestInfo.outputPartitioner(new RescalePartitioner<>());
+                        requestInfo.withOutputPartitioner(new RescalePartitioner<>());
                         requestInfos.add(requestInfo);
                     }
                 }


### PR DESCRIPTION
## What is the purpose of the change

Since the adaptive join requires determining the actual join operator at runtime, we introduced the AdaptiveBatchSchedulerFactory to implement this functionality.


## Brief change log

  - *Introduce AdaptiveBatchSchedulerFactory to support dynamic generate join operator at runtime*
  - *Add IT case for adaptive broadcast join.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Verify end-to-end correctness through the IT case AdaptiveBroadcastJoinITCase.*
  - *Use TPC-DS to verify the effect of enabling adaptive broadcast join optimization.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? ( docs)
