### PR TITLE
[FLINK-36938] Provide hooks before and after the watermark processing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -327,16 +327,65 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
     //  Watermark handling
     // ------------------------------------------------------------------------
 
+    /**
+     * A hook that will be triggered when receiving a watermark. Some async state can safely go
+     * within this method. Return the watermark that should be normally processed.
+     *
+     * @param watermark the receiving watermark.
+     * @return the watermark that should be processed. Null if there is no need for following
+     *     processing.
+     */
+    public Watermark preProcessWatermark(Watermark watermark) throws Exception {
+        return watermark;
+    }
+
+    /**
+     * A hook that will be invoked after finishing advancing the watermark. It is not recommended to
+     * perform async state here. Only some synchronous logic is suggested.
+     *
+     * @param watermark the advanced watermark.
+     */
+    public void postProcessWatermark(Watermark watermark) throws Exception {}
+
+    /**
+     * Process a watermark when receiving it. Do not override this method since the async processing
+     * is difficult to write. Please override the hooks, see {@link #preProcessWatermark(Watermark)}
+     * and {@link #postProcessWatermark(Watermark)}. The basic logic of processWatermark with hooks
+     * in sync form would be:
+     *
+     * <pre>
+     *             Watermark watermark = preProcessWatermark(mark);
+     *             if (watermark != null) {
+     *                 super.processWatermark(watermark);
+     *                 postProcessWatermark(watermark);
+     *             }
+     * </pre>
+     */
     @Override
-    public void processWatermark(Watermark mark) throws Exception {
+    public final void processWatermark(Watermark mark) throws Exception {
         if (!isAsyncStateProcessingEnabled()) {
             // If async state processing is disabled, fallback to the super class.
-            super.processWatermark(mark);
+            Watermark watermark = preProcessWatermark(mark);
+            if (watermark != null) {
+                super.processWatermark(watermark);
+                postProcessWatermark(watermark);
+            }
             return;
         }
+        AtomicReference<Watermark> watermarkRef = new AtomicReference<>(null);
         asyncExecutionController.processNonRecord(
-                timeServiceManager == null ? null : () -> timeServiceManager.advanceWatermark(mark),
-                () -> output.emitWatermark(mark));
+                () -> {
+                    watermarkRef.set(preProcessWatermark(mark));
+                    if (timeServiceManager != null && watermarkRef.get() != null) {
+                        timeServiceManager.advanceWatermark(watermarkRef.get());
+                    }
+                },
+                () -> {
+                    if (watermarkRef.get() != null) {
+                        output.emitWatermark(watermarkRef.get());
+                        postProcessWatermark(watermarkRef.get());
+                    }
+                });
     }
 
     @Override
@@ -364,8 +413,10 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
                     wasIdle.set(combinedWatermark.isIdle());
                     // index is 0-based
                     if (combinedWatermark.updateStatus(index, watermarkStatus.isIdle())) {
-                        watermarkRef.set(new Watermark(combinedWatermark.getCombinedWatermark()));
-                        if (timeServiceManager != null) {
+                        watermarkRef.set(
+                                preProcessWatermark(
+                                        new Watermark(combinedWatermark.getCombinedWatermark())));
+                        if (timeServiceManager != null && watermarkRef.get() != null) {
                             timeServiceManager.advanceWatermark(watermarkRef.get());
                         }
                     }
@@ -373,6 +424,7 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
                 () -> {
                     if (watermarkRef.get() != null) {
                         output.emitWatermark(watermarkRef.get());
+                        postProcessWatermark(watermarkRef.get());
                     }
                     if (wasIdle.get() != combinedWatermark.isIdle()) {
                         output.emitWatermarkStatus(watermarkStatus);


### PR DESCRIPTION
## What is the purpose of the change

We have rewrite the `processWatermark` in abstract operators for async state processing. The sub-classes need a proper hook for doing something right before the watermark processing and right after the watermark emit.


## Brief change log

 - Add `preProcessWatermark` and `postProcessWatermark` in abstract operators for async state processing.

## Verifying this change

 - Added `testWatermarkHooks` in corresponding test classes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
