### PR TITLE
[FLINK-36944][DataStream/API] Introduce 'enableAsycState' in KeyedStream interfaces and implement reduce operator

### DIFF
--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -12,7 +12,7 @@
             <td><h5>state.backend.type</h5></td>
             <td style="word-wrap: break-word;">"hashmap"</td>
             <td>String</td>
-            <td>The state backend to be used to store state.<br />The implementation can be specified either via their shortcut  name, or via the class name of a <code class="highlighter-rouge">StateBackendFactory</code>. If a factory is specified it is instantiated via its zero argument constructor and its <code class="highlighter-rouge">StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)</code> method is called.<br />Recognized shortcut names are 'hashmap' and 'rocksdb'.</td>
+            <td>The state backend to be used to store state.<br />The implementation can be specified either via their shortcut  name, or via the class name of a <code class="highlighter-rouge">StateBackendFactory</code>. If a factory is specified it is instantiated via its zero argument constructor and its <code class="highlighter-rouge">StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)</code> method is called.<br />Recognized shortcut names are 'hashmap', 'rocksdb' and 'forst'.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/state_backend_configuration.html
+++ b/docs/layouts/shortcodes/generated/state_backend_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>state.backend.type</h5></td>
             <td style="word-wrap: break-word;">"hashmap"</td>
             <td>String</td>
-            <td>The state backend to be used to store state.<br />The implementation can be specified either via their shortcut  name, or via the class name of a <code class="highlighter-rouge">StateBackendFactory</code>. If a factory is specified it is instantiated via its zero argument constructor and its <code class="highlighter-rouge">StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)</code> method is called.<br />Recognized shortcut names are 'hashmap' and 'rocksdb'.</td>
+            <td>The state backend to be used to store state.<br />The implementation can be specified either via their shortcut  name, or via the class name of a <code class="highlighter-rouge">StateBackendFactory</code>. If a factory is specified it is instantiated via its zero argument constructor and its <code class="highlighter-rouge">StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)</code> method is called.<br />Recognized shortcut names are 'hashmap', 'rocksdb' and 'forst'.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
+++ b/flink-core/src/main/java/org/apache/flink/api/dag/Transformation.java
@@ -615,6 +615,15 @@ public abstract class Transformation<T> {
      */
     public abstract List<Transformation<?>> getInputs();
 
+    /** Enabling the async state for this transformation. */
+    public void enableAsyncState() {
+        // Subclass should override this method if they support async state processing.
+        throw new UnsupportedOperationException(
+                "The transformation does not support async state, "
+                        + "or you are enabling the async state without a keyed context "
+                        + "(not behind a keyBy()).");
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName()

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateBackendOptions.java
@@ -62,6 +62,7 @@ public class StateBackendOptions {
                                             TextElement.code(
                                                     "StateBackendFactory#createFromConfig(ReadableConfig, ClassLoader)"))
                                     .linebreak()
-                                    .text("Recognized shortcut names are 'hashmap' and 'rocksdb'.")
+                                    .text(
+                                            "Recognized shortcut names are 'hashmap', 'rocksdb' and 'forst'.")
                                     .build());
 }

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -92,6 +92,12 @@ under the License.
             <version>${project.version}</version>
         </dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-statebackend-forst</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- Dependencies for MatrixVectorMul. We exclude native libraries
 		because it is not available in all the operating systems and architectures. Moreover,
 		we also want to enable users to compile and run MatrixVectorMul in different runtime environments.-->

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/util/CLI.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/util/CLI.java
@@ -41,6 +41,7 @@ public class CLI extends ExecutionConfig.GlobalJobParameters {
     public static final String OUTPUT_KEY = "output";
     public static final String DISCOVERY_INTERVAL = "discovery-interval";
     public static final String EXECUTION_MODE = "execution-mode";
+    public static final String ASYNC_STATE = "async-state";
 
     public static CLI fromArgs(String[] args) throws Exception {
         MultipleParameterTool params = MultipleParameterTool.fromArgs(args);
@@ -72,7 +73,12 @@ public class CLI extends ExecutionConfig.GlobalJobParameters {
             executionMode = RuntimeExecutionMode.valueOf(params.get(EXECUTION_MODE).toUpperCase());
         }
 
-        return new CLI(inputs, output, watchInterval, executionMode, params);
+        boolean asyncState = false;
+        if (params.has(ASYNC_STATE)) {
+            asyncState = true;
+        }
+
+        return new CLI(inputs, output, watchInterval, executionMode, params, asyncState);
     }
 
     private final Path[] inputs;
@@ -80,18 +86,21 @@ public class CLI extends ExecutionConfig.GlobalJobParameters {
     private final Duration discoveryInterval;
     private final RuntimeExecutionMode executionMode;
     private final MultipleParameterTool params;
+    private final boolean asyncState;
 
     private CLI(
             Path[] inputs,
             Path output,
             Duration discoveryInterval,
             RuntimeExecutionMode executionMode,
-            MultipleParameterTool params) {
+            MultipleParameterTool params,
+            boolean asyncState) {
         this.inputs = inputs;
         this.output = output;
         this.discoveryInterval = discoveryInterval;
         this.executionMode = executionMode;
         this.params = params;
+        this.asyncState = asyncState;
     }
 
     public Optional<Path[]> getInputs() {
@@ -108,6 +117,10 @@ public class CLI extends ExecutionConfig.GlobalJobParameters {
 
     public RuntimeExecutionMode getExecutionMode() {
         return executionMode;
+    }
+
+    public boolean isAsyncState() {
+        return asyncState;
     }
 
     public OptionalInt getInt(String key) {
@@ -137,7 +150,8 @@ public class CLI extends ExecutionConfig.GlobalJobParameters {
         CLI cli = (CLI) o;
         return Arrays.equals(inputs, cli.inputs)
                 && Objects.equals(output, cli.output)
-                && Objects.equals(discoveryInterval, cli.discoveryInterval);
+                && Objects.equals(discoveryInterval, cli.discoveryInterval)
+                && asyncState == cli.asyncState;
     }
 
     @Override

--- a/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/StreamingExamplesITCase.java
+++ b/flink-examples/flink-examples-streaming/src/test/java/org/apache/flink/streaming/test/StreamingExamplesITCase.java
@@ -141,6 +141,25 @@ public class StreamingExamplesITCase extends AbstractTestBaseJUnit4 {
         compareResultsByLinesInMemory(WordCountData.COUNTS_AS_TUPLES, resultPath);
     }
 
+    @Test
+    public void testWordCountWithAsyncState() throws Exception {
+        final String textPath = createTempFile("text.txt", WordCountData.TEXT);
+        final String resultPath = getTempDirPath("result");
+
+        org.apache.flink.streaming.examples.wordcount.WordCount.main(
+                new String[] {
+                    "--input",
+                    textPath,
+                    "--output",
+                    resultPath,
+                    "--execution-mode",
+                    "streaming",
+                    "--async-state"
+                });
+
+        compareResultsByLinesInMemory(WordCountData.STREAMING_COUNTS_AS_TUPLES, resultPath);
+    }
+
     /**
      * This {@link WatermarkStrategy} assigns the current system time as the event-time timestamp.
      * In a real use case you should use proper timestamps and an appropriate {@link

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AggregatingStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/AggregatingStateDescriptor.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.state.v2;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 
 import javax.annotation.Nonnull;
 
@@ -69,6 +70,21 @@ public class AggregatingStateDescriptor<IN, ACC, OUT> extends StateDescriptor<AC
             @Nonnull TypeInformation<ACC> typeInfo,
             SerializerConfig serializerConfig) {
         super(stateId, typeInfo, serializerConfig);
+        this.aggregateFunction = checkNotNull(aggregateFunction);
+    }
+
+    /**
+     * Create a new {@code ReducingStateDescriptor} with the given stateId and the given type
+     * serializer.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param serializer The type serializer for accumulator.
+     */
+    public AggregatingStateDescriptor(
+            @Nonnull String stateId,
+            @Nonnull AggregateFunction<IN, ACC, OUT> aggregateFunction,
+            @Nonnull TypeSerializer<ACC> serializer) {
+        super(stateId, serializer);
         this.aggregateFunction = checkNotNull(aggregateFunction);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ListStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ListStateDescriptor.java
@@ -21,6 +21,9 @@ package org.apache.flink.runtime.state.v2;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.state.v2.ListState;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import javax.annotation.Nonnull;
 
 /**
  * {@link StateDescriptor} for {@link ListState}. This can be used to create partitioned list state
@@ -36,7 +39,7 @@ public class ListStateDescriptor<T> extends StateDescriptor<T> {
      * @param stateId The (unique) stateId for the state.
      * @param typeInfo The type of the values in the state.
      */
-    public ListStateDescriptor(String stateId, TypeInformation<T> typeInfo) {
+    public ListStateDescriptor(@Nonnull String stateId, @Nonnull TypeInformation<T> typeInfo) {
         super(stateId, typeInfo);
     }
 
@@ -49,8 +52,21 @@ public class ListStateDescriptor<T> extends StateDescriptor<T> {
      *     TypeSerializer}.
      */
     public ListStateDescriptor(
-            String stateId, TypeInformation<T> typeInfo, SerializerConfig serializerConfig) {
+            @Nonnull String stateId,
+            @Nonnull TypeInformation<T> typeInfo,
+            SerializerConfig serializerConfig) {
         super(stateId, typeInfo, serializerConfig);
+    }
+
+    /**
+     * Create a new {@code ListStateDescriptor} with the given stateId and the given type
+     * serializer.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param serializer The type serializer for the values in the state.
+     */
+    public ListStateDescriptor(@Nonnull String stateId, @Nonnull TypeSerializer<T> serializer) {
+        super(stateId, serializer);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/MapStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/MapStateDescriptor.java
@@ -34,8 +34,6 @@ import javax.annotation.Nonnull;
  * @param <UV> The type of the values that the map state can hold.
  */
 public class MapStateDescriptor<UK, UV> extends StateDescriptor<UV> {
-    /** The type of the user key in the state. */
-    @Nonnull private final TypeInformation<UK> userKeyTypeInfo;
 
     /** The serializer for the user key. */
     @Nonnull private final TypeSerializer<UK> userKeySerializer;
@@ -48,9 +46,9 @@ public class MapStateDescriptor<UK, UV> extends StateDescriptor<UV> {
      * @param userValueTypeInfo The type of the values in the state.
      */
     public MapStateDescriptor(
-            String stateId,
-            TypeInformation<UK> userKeyTypeInfo,
-            TypeInformation<UV> userValueTypeInfo) {
+            @Nonnull String stateId,
+            @Nonnull TypeInformation<UK> userKeyTypeInfo,
+            @Nonnull TypeInformation<UV> userValueTypeInfo) {
         this(stateId, userKeyTypeInfo, userValueTypeInfo, new SerializerConfigImpl());
     }
 
@@ -64,18 +62,27 @@ public class MapStateDescriptor<UK, UV> extends StateDescriptor<UV> {
      *     TypeSerializer}.
      */
     public MapStateDescriptor(
-            String stateId,
-            TypeInformation<UK> userKeyTypeInfo,
-            TypeInformation<UV> userValueTypeInfo,
+            @Nonnull String stateId,
+            @Nonnull TypeInformation<UK> userKeyTypeInfo,
+            @Nonnull TypeInformation<UV> userValueTypeInfo,
             SerializerConfig serializerConfig) {
         super(stateId, userValueTypeInfo, serializerConfig);
-        this.userKeyTypeInfo = userKeyTypeInfo;
         this.userKeySerializer = userKeyTypeInfo.createSerializer(serializerConfig);
     }
 
-    @Nonnull
-    public TypeInformation<UK> getUserKeyType() {
-        return userKeyTypeInfo;
+    /**
+     * Create a new {@code MapStateDescriptor} with the given stateId and the given type serializer.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param userKeySerializer The serializer for the user keys in the state.
+     * @param userValueSerializer The serializer for the user values in the state.
+     */
+    public MapStateDescriptor(
+            @Nonnull String stateId,
+            @Nonnull TypeSerializer<UK> userKeySerializer,
+            @Nonnull TypeSerializer<UV> userValueSerializer) {
+        super(stateId, userValueSerializer);
+        this.userKeySerializer = userKeySerializer;
     }
 
     @Nonnull

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ReducingStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ReducingStateDescriptor.java
@@ -21,6 +21,9 @@ package org.apache.flink.runtime.state.v2;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import javax.annotation.Nonnull;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -41,7 +44,9 @@ public class ReducingStateDescriptor<T> extends StateDescriptor<T> {
      * @param typeInfo The type of the values in the state.
      */
     public ReducingStateDescriptor(
-            String name, ReduceFunction<T> reduceFunction, TypeInformation<T> typeInfo) {
+            @Nonnull String name,
+            @Nonnull ReduceFunction<T> reduceFunction,
+            @Nonnull TypeInformation<T> typeInfo) {
         super(name, typeInfo);
         this.reduceFunction = checkNotNull(reduceFunction);
     }
@@ -54,11 +59,26 @@ public class ReducingStateDescriptor<T> extends StateDescriptor<T> {
      * @param typeInfo The type of the values in the state.
      */
     public ReducingStateDescriptor(
-            String name,
-            ReduceFunction<T> reduceFunction,
-            TypeInformation<T> typeInfo,
+            @Nonnull String name,
+            @Nonnull ReduceFunction<T> reduceFunction,
+            @Nonnull TypeInformation<T> typeInfo,
             SerializerConfig serializerConfig) {
         super(name, typeInfo, serializerConfig);
+        this.reduceFunction = checkNotNull(reduceFunction);
+    }
+
+    /**
+     * Create a new {@code ReducingStateDescriptor} with the given stateId and the given type
+     * serializer.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param serializer The type serializer for the values in the state.
+     */
+    public ReducingStateDescriptor(
+            @Nonnull String stateId,
+            @Nonnull ReduceFunction<T> reduceFunction,
+            @Nonnull TypeSerializer<T> serializer) {
+        super(stateId, serializer);
         this.reduceFunction = checkNotNull(reduceFunction);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/StateDescriptor.java
@@ -89,6 +89,17 @@ public abstract class StateDescriptor<T> implements Serializable {
         this.typeSerializer = typeInfo.createSerializer(serializerConfig);
     }
 
+    /**
+     * Create a new {@code StateDescriptor} with the given stateId and the given type serializer.
+     *
+     * @param stateId The stateId of the {@code StateDescriptor}.
+     * @param serializer The type serializer for the values in the state.
+     */
+    protected StateDescriptor(@Nonnull String stateId, TypeSerializer<T> serializer) {
+        this.stateId = checkNotNull(stateId, "stateId must not be null");
+        this.typeSerializer = checkNotNull(serializer, "type serializer must not be null");
+    }
+
     // ------------------------------------------------------------------------
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ValueStateDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ValueStateDescriptor.java
@@ -21,6 +21,9 @@ package org.apache.flink.runtime.state.v2;
 import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.state.v2.ValueState;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import javax.annotation.Nonnull;
 
 /**
  * {@link StateDescriptor} for {@link ValueState}. This can be used to create partitioned value
@@ -36,7 +39,7 @@ public class ValueStateDescriptor<T> extends StateDescriptor<T> {
      * @param stateId The (unique) stateId for the state.
      * @param typeInfo The type of the values in the state.
      */
-    public ValueStateDescriptor(String stateId, TypeInformation<T> typeInfo) {
+    public ValueStateDescriptor(@Nonnull String stateId, @Nonnull TypeInformation<T> typeInfo) {
         super(stateId, typeInfo);
     }
 
@@ -49,8 +52,21 @@ public class ValueStateDescriptor<T> extends StateDescriptor<T> {
      *     TypeSerializer}.
      */
     public ValueStateDescriptor(
-            String stateId, TypeInformation<T> typeInfo, SerializerConfig serializerConfig) {
+            @Nonnull String stateId,
+            @Nonnull TypeInformation<T> typeInfo,
+            SerializerConfig serializerConfig) {
         super(stateId, typeInfo, serializerConfig);
+    }
+
+    /**
+     * Create a new {@code ValueStateDescriptor} with the given stateId and the given type
+     * serializer.
+     *
+     * @param stateId The (unique) stateId for the state.
+     * @param serializer The type serializer for the values in the state.
+     */
+    public ValueStateDescriptor(@Nonnull String stateId, @Nonnull TypeSerializer<T> serializer) {
+        super(stateId, serializer);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/v2/ttl/TtlStateFactory.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.runtime.state.v2.ttl;
 
-import org.apache.flink.api.common.serialization.SerializerConfig;
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.state.v2.State;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeSerializer;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -162,10 +160,8 @@ public class TtlStateFactory<K, N, SV, TTLSV, S extends State, IS> {
                         ? (ValueStateDescriptor<TtlValue<SV>>) stateDesc
                         : new ValueStateDescriptor<>(
                                 stateDesc.getStateId(),
-                                new TtlTypeInformation<>(
-                                        new TtlSerializer<>(
-                                                LongSerializer.INSTANCE,
-                                                stateDesc.getSerializer())));
+                                new TtlSerializer<>(
+                                        LongSerializer.INSTANCE, stateDesc.getSerializer()));
         return (IS) new TtlValueState<>(createTtlStateContext(ttlDescriptor));
     }
 
@@ -177,10 +173,8 @@ public class TtlStateFactory<K, N, SV, TTLSV, S extends State, IS> {
                         ? (ListStateDescriptor<TtlValue<T>>) stateDesc
                         : new ListStateDescriptor<>(
                                 stateDesc.getStateId(),
-                                new TtlTypeInformation<>(
-                                        new TtlSerializer<>(
-                                                LongSerializer.INSTANCE,
-                                                listStateDesc.getSerializer())));
+                                new TtlSerializer<>(
+                                        LongSerializer.INSTANCE, listStateDesc.getSerializer()));
         return (IS) new TtlListState<>(createTtlStateContext(ttlDescriptor));
     }
 
@@ -192,11 +186,9 @@ public class TtlStateFactory<K, N, SV, TTLSV, S extends State, IS> {
                         ? (MapStateDescriptor<UK, TtlValue<UV>>) stateDesc
                         : new MapStateDescriptor<>(
                                 stateDesc.getStateId(),
-                                mapStateDesc.getUserKeyType(),
-                                new TtlTypeInformation<>(
-                                        new TtlSerializer<>(
-                                                LongSerializer.INSTANCE,
-                                                mapStateDesc.getSerializer())));
+                                mapStateDesc.getUserKeySerializer(),
+                                new TtlSerializer<>(
+                                        LongSerializer.INSTANCE, mapStateDesc.getSerializer()));
         return (IS) new TtlMapState<>(createTtlStateContext(ttlDescriptor));
     }
 
@@ -212,10 +204,8 @@ public class TtlStateFactory<K, N, SV, TTLSV, S extends State, IS> {
                                         reducingStateDesc.getReduceFunction(),
                                         ttlConfig,
                                         timeProvider),
-                                new TtlTypeInformation<>(
-                                        new TtlSerializer<>(
-                                                LongSerializer.INSTANCE,
-                                                stateDesc.getSerializer())));
+                                new TtlSerializer<>(
+                                        LongSerializer.INSTANCE, stateDesc.getSerializer()));
         return (IS) new TtlReducingState<>(createTtlStateContext(ttlDescriptor));
     }
 
@@ -232,10 +222,8 @@ public class TtlStateFactory<K, N, SV, TTLSV, S extends State, IS> {
                         : new AggregatingStateDescriptor<>(
                                 stateDesc.getStateId(),
                                 ttlAggregateFunction,
-                                new TtlTypeInformation<>(
-                                        new TtlSerializer<>(
-                                                LongSerializer.INSTANCE,
-                                                stateDesc.getSerializer())));
+                                new TtlSerializer<>(
+                                        LongSerializer.INSTANCE, stateDesc.getSerializer()));
         return (IS)
                 new TtlAggregatingState<>(
                         createTtlStateContext(ttlDescriptor), ttlAggregateFunction);
@@ -259,79 +247,6 @@ public class TtlStateFactory<K, N, SV, TTLSV, S extends State, IS> {
                 timeProvider,
                 (TypeSerializer<V>) stateDesc.getSerializer(),
                 () -> {});
-    }
-
-    public static class TtlTypeInformation<T> extends TypeInformation<TtlValue<T>> {
-
-        Class<?> typeClass;
-
-        TypeSerializer<TtlValue<T>> typeSerializer;
-
-        TtlTypeInformation(TypeSerializer<TtlValue<T>> typeSerializer) {
-            this.typeSerializer = typeSerializer;
-            typeClass = TtlValue.class;
-        }
-
-        @Override
-        public boolean isBasicType() {
-            return false;
-        }
-
-        @Override
-        public boolean isTupleType() {
-            return false;
-        }
-
-        @Override
-        public int getArity() {
-            return 2;
-        }
-
-        @Override
-        public int getTotalFields() {
-            return 2;
-        }
-
-        @Override
-        public Class<TtlValue<T>> getTypeClass() {
-            return (Class<TtlValue<T>>) typeClass;
-        }
-
-        @Override
-        public boolean isKeyType() {
-            return false;
-        }
-
-        @Override
-        public TypeSerializer<TtlValue<T>> createSerializer(SerializerConfig config) {
-            return typeSerializer;
-        }
-
-        @Override
-        public String toString() {
-            return "TtlTypeInformation{}";
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            return typeSerializer.equals(((TtlTypeInformation<T>) obj).typeSerializer);
-        }
-
-        @Override
-        public int hashCode() {
-            return typeSerializer.hashCode();
-        }
-
-        @Override
-        public boolean canEqual(Object obj) {
-            return obj instanceof TtlTypeInformation;
-        }
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/SingleOutputStreamOperator.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.functions.InvalidTypesException;
@@ -454,5 +455,19 @@ public class SingleOutputStreamOperator<T> extends DataStream<T> {
         }
 
         return new CachedDataStream<>(this.environment, this.transformation);
+    }
+
+    /**
+     * Enable the async state processing for following previous transformation. This also requires
+     * only State V2 APIs are used in the user function.
+     *
+     * @return the configured SingleOutputStreamOperator itself.
+     * @throws UnsupportedOperationException when the transformation does not support the async
+     *     state processing.
+     */
+    @Experimental
+    public SingleOutputStreamOperator<T> enableAsyncState() {
+        transformation.enableAsyncState();
+        return this;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/datastream/WindowedStream.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.datastream;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
@@ -849,6 +850,18 @@ public class WindowedStream<T, K, W extends Window> {
 
     private SingleOutputStreamOperator<T> aggregate(AggregationFunction<T> aggregator) {
         return reduce(aggregator);
+    }
+
+    /**
+     * Enable the async state processing for following keyed processing function. This also requires
+     * only State V2 APIs are used in the function.
+     *
+     * @return the configured WindowedStream itself.
+     */
+    @Experimental
+    public WindowedStream<T, K, W> enableAsyncState() {
+        input.enableAsyncState();
+        return this;
     }
 
     public StreamExecutionEnvironment getExecutionEnvironment() {

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduceAsyncStateOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamGroupedReduceAsyncStateOperator.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.state.v2.ValueState;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.asyncprocessing.operators.AbstractAsyncStateUdfStreamOperator;
+import org.apache.flink.runtime.state.v2.ValueStateDescriptor;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * A {@link StreamOperator} for executing a {@link ReduceFunction} on a {@link
+ * org.apache.flink.streaming.api.datastream.KeyedStream}.
+ */
+@Internal
+public class StreamGroupedReduceAsyncStateOperator<IN>
+        extends AbstractAsyncStateUdfStreamOperator<IN, ReduceFunction<IN>>
+        implements OneInputStreamOperator<IN, IN> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String STATE_NAME = "_op_state";
+
+    private transient ValueState<IN> values;
+
+    private final TypeSerializer<IN> serializer;
+
+    public StreamGroupedReduceAsyncStateOperator(
+            ReduceFunction<IN> reducer, TypeSerializer<IN> serializer) {
+        super(reducer);
+        this.serializer = serializer;
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        ValueStateDescriptor<IN> stateId = new ValueStateDescriptor<>(STATE_NAME, serializer);
+        values = getRuntimeContext().getValueState(stateId);
+    }
+
+    @Override
+    public void processElement(StreamRecord<IN> element) throws Exception {
+        IN value = element.getValue();
+        values.asyncValue()
+                .thenAccept(
+                        currentValue -> {
+                            if (currentValue != null) {
+                                IN reduced = userFunction.reduce(currentValue, value);
+                                values.asyncUpdate(reduced)
+                                        .thenAccept(e -> output.collect(element.replace(reduced)));
+                            } else {
+                                values.asyncUpdate(value)
+                                        .thenAccept(e -> output.collect(element.replace(value)));
+                            }
+                        });
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
@@ -44,6 +44,7 @@ public final class ReduceTransformation<IN, K> extends PhysicalTransformation<IN
     private final KeySelector<IN, K> keySelector;
     private final TypeInformation<K> keyTypeInfo;
     private ChainingStrategy chainingStrategy = ChainingStrategy.DEFAULT_CHAINING_STRATEGY;
+    private boolean isEnableAsyncState;
 
     public ReduceTransformation(
             String name,
@@ -99,5 +100,14 @@ public final class ReduceTransformation<IN, K> extends PhysicalTransformation<IN
     @Override
     public List<Transformation<?>> getInputs() {
         return Collections.singletonList(input);
+    }
+
+    @Override
+    public void enableAsyncState() {
+        isEnableAsyncState = true;
+    }
+
+    public boolean isEnableAsyncState() {
+        return isEnableAsyncState;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
@@ -44,7 +44,7 @@ public final class ReduceTransformation<IN, K> extends PhysicalTransformation<IN
     private final KeySelector<IN, K> keySelector;
     private final TypeInformation<K> keyTypeInfo;
     private ChainingStrategy chainingStrategy = ChainingStrategy.DEFAULT_CHAINING_STRATEGY;
-    private boolean isEnableAsyncState;
+    private boolean isEnableAsyncState = false;
 
     public ReduceTransformation(
             String name,

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamGroupedReduceAsyncStateOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/StreamGroupedReduceAsyncStateOperatorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.functions.ReduceFunction;
+import org.apache.flink.api.common.functions.RichReduceFunction;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.TestHarnessUtil;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedOneInputStreamOperatorTestHarness;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link StreamGroupedReduceAsyncStateOperator}. These test that:
+ *
+ * <ul>
+ *   <li>RichFunction methods are called correctly
+ *   <li>Timestamps of processed elements match the input timestamp
+ *   <li>Watermarks are correctly forwarded
+ * </ul>
+ */
+class StreamGroupedReduceAsyncStateOperatorTest {
+
+    @Test
+    void testGroupedReduce() throws Exception {
+
+        KeySelector<Integer, Integer> keySelector = new IntegerKeySelector();
+
+        StreamGroupedReduceAsyncStateOperator<Integer> operator =
+                new StreamGroupedReduceAsyncStateOperator<>(
+                        new MyReducer(), IntSerializer.INSTANCE);
+
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
+                        operator, keySelector, BasicTypeInfo.INT_TYPE_INFO)) {
+
+            long initialTime = 0L;
+            ConcurrentLinkedQueue<Object> expectedOutput = new ConcurrentLinkedQueue<>();
+
+            testHarness.open();
+
+            testHarness.processElement(new StreamRecord<>(1, initialTime + 1));
+            testHarness.processElement(new StreamRecord<>(1, initialTime + 2));
+            testHarness.processWatermark(new Watermark(initialTime + 2));
+            testHarness.processElement(new StreamRecord<>(2, initialTime + 3));
+            testHarness.processElement(new StreamRecord<>(2, initialTime + 4));
+            testHarness.processElement(new StreamRecord<>(3, initialTime + 5));
+
+            expectedOutput.add(new StreamRecord<>(1, initialTime + 1));
+            expectedOutput.add(new StreamRecord<>(2, initialTime + 2));
+            expectedOutput.add(new Watermark(initialTime + 2));
+            expectedOutput.add(new StreamRecord<>(2, initialTime + 3));
+            expectedOutput.add(new StreamRecord<>(4, initialTime + 4));
+            expectedOutput.add(new StreamRecord<>(3, initialTime + 5));
+
+            TestHarnessUtil.assertOutputEquals(
+                    "Output was not correct.", expectedOutput, testHarness.getOutput());
+        }
+    }
+
+    @Test
+    void testOpenClose() throws Exception {
+
+        KeySelector<Integer, Integer> keySelector = new IntegerKeySelector();
+
+        StreamGroupedReduceAsyncStateOperator<Integer> operator =
+                new StreamGroupedReduceAsyncStateOperator<>(
+                        new TestOpenCloseReduceFunction(), IntSerializer.INSTANCE);
+        AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Integer, Integer> testHarness =
+                AsyncKeyedOneInputStreamOperatorTestHarness.create(
+                        operator, keySelector, BasicTypeInfo.INT_TYPE_INFO);
+
+        long initialTime = 0L;
+
+        testHarness.open();
+
+        testHarness.processElement(new StreamRecord<>(1, initialTime));
+        testHarness.processElement(new StreamRecord<>(2, initialTime));
+
+        testHarness.close();
+
+        assertThat(TestOpenCloseReduceFunction.openCalled)
+                .as("RichFunction methods where not called.")
+                .isTrue();
+        assertThat(testHarness.getOutput()).as("Output contains no elements.").isNotEmpty();
+    }
+
+    // This must only be used in one test, otherwise the static fields will be changed
+    // by several tests concurrently
+    private static class TestOpenCloseReduceFunction extends RichReduceFunction<Integer> {
+        private static final long serialVersionUID = 1L;
+
+        public static boolean openCalled = false;
+        public static boolean closeCalled = false;
+
+        @Override
+        public void open(OpenContext openContext) throws Exception {
+            super.open(openContext);
+            assertThat(closeCalled).as("Close called before open.").isFalse();
+            openCalled = true;
+        }
+
+        @Override
+        public void close() throws Exception {
+            super.close();
+            assertThat(openCalled).as("Open was not called before close.").isTrue();
+            closeCalled = true;
+        }
+
+        @Override
+        public Integer reduce(Integer in1, Integer in2) throws Exception {
+            assertThat(openCalled).as("Open was not called before run.").isTrue();
+            return in1 + in2;
+        }
+    }
+
+    // Utilities
+
+    private static class MyReducer implements ReduceFunction<Integer> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Integer reduce(Integer value1, Integer value2) throws Exception {
+            return value1 + value2;
+        }
+    }
+
+    private static class IntegerKeySelector implements KeySelector<Integer, Integer> {
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Integer getKey(Integer value) throws Exception {
+            return value;
+        }
+    }
+
+    private static TypeInformation<Integer> typeInfo = BasicTypeInfo.INT_TYPE_INFO;
+}

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/util/asyncprocessing/AsyncKeyedOneInputStreamOperatorTestHarness.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/util/asyncprocessing/AsyncKeyedOneInputStreamOperatorTestHarness.java
@@ -65,6 +65,14 @@ public class AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
     public static <K, IN, OUT> AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT> create(
             OneInputStreamOperator<IN, OUT> operator,
             final KeySelector<IN, K> keySelector,
+            TypeInformation<K> keyType)
+            throws Exception {
+        return create(operator, keySelector, keyType, 1, 1, 0);
+    }
+
+    public static <K, IN, OUT> AsyncKeyedOneInputStreamOperatorTestHarness<K, IN, OUT> create(
+            OneInputStreamOperator<IN, OUT> operator,
+            final KeySelector<IN, K> keySelector,
             TypeInformation<K> keyType,
             int maxParallelism,
             int numSubtasks,

--- a/flink-tests/src/test/java/org/apache/flink/test/completeness/TypeInfoTestCoverageTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/completeness/TypeInfoTestCoverageTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 import org.apache.flink.formats.avro.typeutils.AvroTypeInfo;
 import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
-import org.apache.flink.runtime.state.v2.ttl.TtlStateFactory;
 import org.apache.flink.table.dataview.ListViewTypeInfo;
 import org.apache.flink.table.dataview.MapViewTypeInfo;
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
@@ -83,8 +82,7 @@ public class TypeInfoTestCoverageTest extends TestLogger {
                         BigDecimalTypeInfo.class.getName(),
                         DecimalDataTypeInfo.class.getName(),
                         GenericRecordAvroTypeInfo.class.getName(),
-                        AvroTypeInfo.class.getName(),
-                        TtlStateFactory.TtlTypeInformation.class.getName());
+                        AvroTypeInfo.class.getName());
 
         // check if a test exists for each type information
         for (Class<? extends TypeInformation> typeInfo : typeInfos) {


### PR DESCRIPTION
## What is the purpose of the change

As first part of FLIP-488, this PR introduces `enableAsycState` in KeyedStream and its related interface classes. Also it provides a basic implementation of async reduce operator.


## Brief change log

Please check each commit.
 - Introduce `enableAsyncState` API
 - Introduce serializer based state descriptor constructors
 - Implement async reduce operator
 - Introduce async state version of wordcount example


## Verifying this change

This PR adds a IT test on the wordcount example, which can be a IT test of new APIs and reduce operator.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
