### PR TITLE
[MINOR] Deprecated StreamSink and SinkOperator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/operators/StreamSink.java
@@ -25,6 +25,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 
 /** A {@link StreamOperator} for executing {@link SinkFunction SinkFunctions}. */
+@Deprecated
 @Internal
 public class StreamSink<IN> extends AbstractUdfStreamOperator<Object, SinkFunction<IN>>
         implements OneInputStreamOperator<IN, Object> {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkOperator.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.data.TimestampData;
  * A {@link StreamOperator} for executing {@link SinkFunction SinkFunctions}. This operator also
  * checks writing null values into NOT NULL columns.
  */
+@Deprecated
 public class SinkOperator extends AbstractUdfStreamOperator<Object, SinkFunction<RowData>>
         implements OneInputStreamOperator<RowData, Object> {
 


### PR DESCRIPTION
## What is the purpose of the change

This PR propose to deprecated `StreamSink` and `SinkOperator`.
I guess we can do this job if `SinkFunction` tagged with `Deprecated`.

## Brief change log

Add the annotation `Deprecated` for StreamSink and SinkOperator.

## Verifying this change

This change is a trivial rework cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
