### PR TITLE
[MINOR] Rename PunctuatedWatermarkStrategyWrapper with PunctuatedWatermarkAssignerWrapper

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacyTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacyTableSourceScan.java
@@ -40,7 +40,7 @@ import org.apache.flink.table.planner.sources.TableSourceUtil;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.table.runtime.operators.wmassigners.PeriodicWatermarkAssignerWrapper;
-import org.apache.flink.table.runtime.operators.wmassigners.PunctuatedWatermarkStrategyWrapper;
+import org.apache.flink.table.runtime.operators.wmassigners.PunctuatedWatermarkAssignerWrapper;
 import org.apache.flink.table.sources.wmstrategies.PeriodicWatermarkAssigner;
 import org.apache.flink.table.sources.wmstrategies.PunctuatedWatermarkAssigner;
 import org.apache.flink.table.sources.wmstrategies.WatermarkStrategy;
@@ -151,8 +151,8 @@ public class StreamExecLegacyTableSourceScan extends CommonExecLegacyTableSource
                                         return ingestedTable.assignTimestampsAndWatermarks(
                                                 watermarkGenerator);
                                     } else if (strategy instanceof PunctuatedWatermarkAssigner) {
-                                        PunctuatedWatermarkStrategyWrapper watermarkGenerator =
-                                                new PunctuatedWatermarkStrategyWrapper(
+                                        PunctuatedWatermarkAssignerWrapper watermarkGenerator =
+                                                new PunctuatedWatermarkAssignerWrapper(
                                                         (PunctuatedWatermarkAssigner) strategy,
                                                         rowtimeFieldIdx,
                                                         tableSource.getProducedDataType());

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/PunctuatedWatermarkAssignerWrapper.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/PunctuatedWatermarkAssignerWrapper.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 
 /** Generates periodic watermarks based on a {@link PunctuatedWatermarkAssigner}. */
 @Internal
-public class PunctuatedWatermarkStrategyWrapper
+public class PunctuatedWatermarkAssignerWrapper
         implements WatermarkStrategyWithPunctuatedWatermarks<RowData> {
     private static final long serialVersionUID = 1L;
     private final PunctuatedWatermarkAssigner assigner;
@@ -46,7 +46,7 @@ public class PunctuatedWatermarkStrategyWrapper
      * @param sourceType the type of source
      */
     @SuppressWarnings("unchecked")
-    public PunctuatedWatermarkStrategyWrapper(
+    public PunctuatedWatermarkAssignerWrapper(
             PunctuatedWatermarkAssigner assigner, int timeFieldIdx, DataType sourceType) {
         this.assigner = assigner;
         this.timeFieldIdx = timeFieldIdx;


### PR DESCRIPTION
## What is the purpose of the change

This PR propose to rename `PunctuatedWatermarkStrategyWrapper` with `PunctuatedWatermarkAssignerWrapper`.
Currently, `PeriodicWatermarkAssignerWrapper` wrappers `PeriodicWatermarkAssigner` and `PunctuatedWatermarkStrategyWrapper` wrappers `PunctuatedWatermarkAssigner`.
I think we should unify the naming specification.

## Brief change log

Rename PunctuatedWatermarkStrategyWrapper with PunctuatedWatermarkAssignerWrapper

## Verifying this change

This change is a trivial code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (JavaDocs)
