### PR TITLE
[FLINK-36949] Make getCurrentKey of async state operators return the ground truth

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionController.java
@@ -243,6 +243,10 @@ public class AsyncExecutionController<K> implements StateRequestHandler, Closeab
         }
     }
 
+    public RecordContext<K> getCurrentContext() {
+        return currentContext;
+    }
+
     /**
      * Dispose a context.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -305,7 +305,13 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
 
     @Override
     public Object getCurrentKey() {
-        return currentProcessingContext.getKey();
+        RecordContext currentContext = asyncExecutionController.getCurrentContext();
+        if (currentContext == null) {
+            throw new UnsupportedOperationException(
+                    "Have not set the current key yet, this may because the operator has not "
+                            + "started to run, or you are invoking this under a non-keyed context.");
+        }
+        return currentContext.getKey();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
@@ -154,7 +154,13 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
 
     @Override
     public Object getCurrentKey() {
-        return currentProcessingContext.getKey();
+        RecordContext currentContext = asyncExecutionController.getCurrentContext();
+        if (currentContext == null) {
+            throw new UnsupportedOperationException(
+                    "Have not set the current key yet, this may because the operator has not "
+                            + "started to run, or you are invoking this under a non-keyed context.");
+        }
+        return currentContext.getKey();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorTest.java
@@ -293,6 +293,7 @@ public class AbstractAsyncStateStreamOperatorTest {
                     testOperator.asyncProcessWithKey(
                             1L,
                             () -> {
+                                assertThat(testOperator.getCurrentKey()).isEqualTo(1L);
                                 testOperator.output(watermark.getTimestamp() + 1000L);
                             });
                     if (counter.incrementAndGet() % 2 == 0) {
@@ -484,6 +485,7 @@ public class AbstractAsyncStateStreamOperatorTest {
 
         @Override
         public void onEventTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+            assertThat(getCurrentKey()).isEqualTo(timer.getKey());
             output.collect(
                     new StreamRecord<>(
                             "EventTimer-" + timer.getKey() + "-" + timer.getTimestamp()));
@@ -491,6 +493,7 @@ public class AbstractAsyncStateStreamOperatorTest {
 
         @Override
         public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+            assertThat(getCurrentKey()).isEqualTo(timer.getKey());
             output.collect(
                     new StreamRecord<>(
                             "ProcessingTimer-" + timer.getKey() + "-" + timer.getTimestamp()));
@@ -601,12 +604,14 @@ public class AbstractAsyncStateStreamOperatorTest {
 
         @Override
         public void onEventTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+            assertThat(getCurrentKey()).isEqualTo(timer.getKey());
             output.collect(new StreamRecord<>(timer.getTimestamp()));
         }
 
         @Override
-        public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer)
-                throws Exception {}
+        public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+            assertThat(getCurrentKey()).isEqualTo(timer.getKey());
+        }
 
         @Override
         public void processElement1(StreamRecord<Long> element) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractAsyncStateStreamOperatorV2Test.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractAsyncStateStreamOperatorV2Test.java
@@ -290,6 +290,7 @@ class AbstractAsyncStateStreamOperatorV2Test {
                     operator.asyncProcessWithKey(
                             1L,
                             () -> {
+                                assertThat(operator.getCurrentKey()).isEqualTo(1L);
                                 operator.output(watermark.getTimestamp() + 1000L);
                             });
                     if (counter.incrementAndGet() % 2 == 0) {
@@ -620,6 +621,7 @@ class AbstractAsyncStateStreamOperatorV2Test {
 
         @Override
         public void onEventTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+            assertThat(getCurrentKey()).isEqualTo(timer.getKey());
             output.collect(
                     new StreamRecord<>(
                             "EventTimer-" + timer.getKey() + "-" + timer.getTimestamp()));
@@ -627,6 +629,7 @@ class AbstractAsyncStateStreamOperatorV2Test {
 
         @Override
         public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+            assertThat(getCurrentKey()).isEqualTo(timer.getKey());
             output.collect(
                     new StreamRecord<>(
                             "ProcessingTimer-" + timer.getKey() + "-" + timer.getTimestamp()));
@@ -842,12 +845,14 @@ class AbstractAsyncStateStreamOperatorV2Test {
 
         @Override
         public void onEventTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+            assertThat(getCurrentKey()).isEqualTo(timer.getKey());
             output.collect(new StreamRecord<>(timer.getTimestamp()));
         }
 
         @Override
-        public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer)
-                throws Exception {}
+        public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+            assertThat(getCurrentKey()).isEqualTo(timer.getKey());
+        }
 
         private Input<Long> createInput(int idx) {
             return new AbstractInput<Long, Long>(this, idx) {


### PR DESCRIPTION
## What is the purpose of the change

Currently, the abstract operators will cache the current context, and the `getCurrentKey()` will return the key of this context. However, this context may not be the context of current processing callback. It is for the convenience of releasing record reference counting. This PR fixes that in case some user logic may call `getCurrentKey()` by returning the ground truth of context in `AEC` directly.


## Brief change log

 - Change the `getCurrentKey` in both two abstract operators.


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
