### PR TITLE
[FLINK-36959][runtime] Fix the logic for computing readable buffer offsets and sizes when including empty buffers.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileReader.java
@@ -201,15 +201,13 @@ class PartitionedFileReader {
         long endPartitionOffset = indexEntryBuf.getLong();
         long endPartitionSize = indexEntryBuf.getLong();
 
-        if (startPartitionOffset != endPartitionOffset) {
+        if (startPartitionOffset != endPartitionOffset || startPartitionSize != endPartitionSize) {
             offsetAndSizesToRead.add(
                     Tuple2.of(
                             startPartitionOffset,
                             endPartitionOffset + endPartitionSize - startPartitionOffset));
         } else if (startPartitionSize != 0) {
-            checkArgument(
-                    startPartitionSize == endPartitionSize,
-                    "Offsets need to be either contiguous or all the same.");
+            // this branch is for broadcast subpartitions
             for (int i = startSubpartition; i <= endSubpartition; i++) {
                 offsetAndSizesToRead.add(Tuple2.of(startPartitionOffset, startPartitionSize));
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -180,7 +180,8 @@ public class SortMergeResultPartition extends ResultPartition {
             try {
                 // allocate at most 4M heap memory for caching of index entries
                 fileWriter =
-                        new PartitionedFileWriter(numSubpartitions, 4194304, resultFileBasePath);
+                        new PartitionedFileWriter(
+                                numSubpartitions, 4194304, resultFileBasePath, subpartitionOrder);
             } catch (Throwable throwable) {
                 throw new IOException("Failed to create file writer.", throwable);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartitionTestUtils.java
@@ -164,8 +164,13 @@ public enum PartitionTestUtils {
             }
         }
 
+        int[] writeOrder = new int[numSubpartitions];
+        for (int i = 0; i < numSubpartitions; i++) {
+            writeOrder[i] = i;
+        }
+
         PartitionedFileWriter fileWriter =
-                new PartitionedFileWriter(numSubpartitions, 1024, basePath);
+                new PartitionedFileWriter(numSubpartitions, 1024, basePath, writeOrder);
         fileWriter.startNewRegion(false);
         fileWriter.writeBuffers(buffers);
         return fileWriter.finish();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

[FLINK-36959][runtime] Fix the logic for computing readable buffer offsets and sizes when including empty buffers.


## Brief change log

[FLINK-36959][runtime] Fix the logic for computing readable buffer offsets and sizes when including empty buffers.

## Verifying this change
Added test testWriteAndReadWithEmptySubpartitionForMultipleSubpartitions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
