### PR TITLE
[FLINK-36120][Runtime] Internal APIs for declaring the record processing and variables

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/RecordContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/RecordContext.java
@@ -64,7 +64,7 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
     private Map<InternalPartitionedState<?>, Object> namespaces = null;
 
     /** User-defined variables. */
-    private final AtomicReferenceArray<Object> declaredVariables;
+    private final AtomicReferenceArray<Object> contextVariables;
 
     /**
      * The extra context info which is used to hold customized data defined by state backend. The
@@ -100,7 +100,7 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
         this.disposer = disposer;
         this.keyGroup = keyGroup;
         this.epoch = epoch;
-        this.declaredVariables = variables;
+        this.contextVariables = variables;
     }
 
     public Object getRecord() {
@@ -152,16 +152,16 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
     @SuppressWarnings("unchecked")
     public <T> T getVariable(int i) {
         checkVariableIndex(i);
-        return (T) declaredVariables.get(i);
+        return (T) contextVariables.get(i);
     }
 
     public <T> void setVariable(int i, T value) {
         checkVariableIndex(i);
-        declaredVariables.set(i, value);
+        contextVariables.set(i, value);
     }
 
     private void checkVariableIndex(int i) {
-        if (i >= declaredVariables.length()) {
+        if (i >= contextVariables.length()) {
             throw new UnsupportedOperationException(
                     "Variable index out of bounds. Maybe you are accessing "
                             + "a variable that have not been declared.");
@@ -169,7 +169,7 @@ public class RecordContext<K> extends ReferenceCounted<RecordContext.DisposerRun
     }
 
     AtomicReferenceArray<Object> getVariablesReference() {
-        return declaredVariables;
+        return contextVariables;
     }
 
     public void setExtra(Object extra) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationChain.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationChain.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.declare;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.core.state.StateFutureUtils;
+import org.apache.flink.util.function.FunctionWithException;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+/**
+ * A declaration chain allows to declare multiple async operations in a single chain.
+ *
+ * @param <IN> The type of the input elements.
+ */
+@Experimental
+public class DeclarationChain<IN> implements ThrowingConsumer<IN, Exception> {
+
+    private final DeclarationContext context;
+
+    private final Deque<Transformation<?, ?>> transformations;
+
+    private DeclarationStage<?> currentStage;
+
+    DeclarationChain(DeclarationContext context) {
+        this.context = context;
+        this.transformations = new LinkedList<>();
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void accept(IN in) throws Exception {
+        StateFuture future = StateFutureUtils.completedFuture(in);
+        for (Transformation trans : transformations) {
+            future = trans.apply(future);
+        }
+    }
+
+    public DeclarationStage<IN> firstStage() throws DeclarationException {
+        if (currentStage != null) {
+            throw new DeclarationException(
+                    "Diverged declaration. Please make sure you call firstStage() once.");
+        }
+        DeclarationStage<IN> declarationStage = new DeclarationStage<>();
+        currentStage = declarationStage;
+        return declarationStage;
+    }
+
+    Transformation<?, ?> getLastTransformation() {
+        return transformations.getLast();
+    }
+
+    /**
+     * A DeclarationStage is a single stage in a declaration chain. It allows a further chaining of
+     * operations.
+     *
+     * @param <T> The output of previous transformations. Will be the input type of further chained
+     *     operation.
+     */
+    public class DeclarationStage<T> {
+
+        private boolean afterThen = false;
+
+        private void preCheck() throws DeclarationException {
+            if (afterThen) {
+                throw new DeclarationException(
+                        "Double thenCompose called for single declaration block.");
+            }
+            if (currentStage != this) {
+                throw new DeclarationException(
+                        "Diverged declaration. Please make sure you are declaring on the last point.");
+            }
+            afterThen = true;
+        }
+
+        public <U> DeclarationStage<U> thenCompose(
+                FunctionWithException<T, StateFuture<U>, Exception> action)
+                throws DeclarationException {
+            preCheck();
+            DeclarationStage<U> next = new DeclarationStage<>();
+            ComposeTransformation<T, U> trans = new ComposeTransformation<>(action);
+            transformations.add(trans);
+            currentStage = next;
+            getLastTransformation().declare();
+            return next;
+        }
+
+        public DeclarationStage<Void> thenAccept(ThrowingConsumer<T, Exception> action)
+                throws DeclarationException {
+            preCheck();
+            DeclarationStage<Void> next = new DeclarationStage<>();
+            AcceptTransformation<T> trans = new AcceptTransformation<>(action);
+            transformations.add(trans);
+            currentStage = next;
+            getLastTransformation().declare();
+            return next;
+        }
+
+        public DeclarationStage<T> withName(String name) throws DeclarationException {
+            getLastTransformation().withName(name);
+            return this;
+        }
+
+        public DeclarationChain<IN> finish() throws DeclarationException {
+            preCheck();
+            getLastTransformation().declare();
+            return DeclarationChain.this;
+        }
+    }
+
+    @Internal
+    interface Transformation<FROM, TO> {
+        StateFuture<TO> apply(StateFuture<FROM> upstream) throws Exception;
+
+        void withName(String name) throws DeclarationException;
+
+        void declare() throws DeclarationException;
+    }
+
+    private abstract static class AbstractTransformation<FROM, TO>
+            implements Transformation<FROM, TO> {
+
+        String name = null;
+
+        @Override
+        public void withName(String newName) throws DeclarationException {
+            if (name != null) {
+                throw new DeclarationException("Double naming");
+            }
+            name = newName;
+            declare();
+        }
+    }
+
+    private class ComposeTransformation<FROM, TO> extends AbstractTransformation<FROM, TO> {
+
+        FunctionWithException<FROM, StateFuture<TO>, ? extends Exception> action;
+
+        NamedFunction<FROM, StateFuture<TO>> namedFunction;
+
+        ComposeTransformation(FunctionWithException<FROM, StateFuture<TO>, Exception> action) {
+            this.action = action;
+        }
+
+        @Override
+        public StateFuture<TO> apply(StateFuture<FROM> upstream) throws Exception {
+            return upstream.thenCompose(namedFunction);
+        }
+
+        @Override
+        public void declare() throws DeclarationException {
+            if (namedFunction == null) {
+                if (name == null) {
+                    namedFunction = context.declare(action);
+                } else {
+                    namedFunction = context.declare(name, action);
+                }
+            }
+        }
+    }
+
+    private class AcceptTransformation<FROM> extends AbstractTransformation<FROM, Void> {
+
+        ThrowingConsumer<FROM, Exception> action;
+
+        NamedConsumer<FROM> namedFunction;
+
+        AcceptTransformation(ThrowingConsumer<FROM, Exception> action) {
+            this.action = action;
+        }
+
+        @Override
+        public StateFuture<Void> apply(StateFuture<FROM> upstream) throws Exception {
+            return upstream.thenAccept(namedFunction);
+        }
+
+        @Override
+        public void declare() throws DeclarationException {
+            if (namedFunction == null) {
+                if (name == null) {
+                    namedFunction = context.declare(action);
+                } else {
+                    namedFunction = context.declare(name, action);
+                }
+            }
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationContext.java
@@ -93,4 +93,15 @@ public class DeclarationContext {
             throws DeclarationException {
         return manager.register(serializer, name, initialValue);
     }
+
+    /**
+     * Declaring a processing in chain-style. This method start a chain with an input type.
+     *
+     * @return the chain itself.
+     * @param <IN> the in type of the first block.
+     */
+    public <IN> DeclarationChain<IN>.DeclarationStage<IN> declareChain()
+            throws DeclarationException {
+        return new DeclarationChain<IN>(this).firstStage();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationContext.java
@@ -91,7 +91,19 @@ public class DeclarationContext {
     public <T> DeclaredVariable<T> declareVariable(
             TypeSerializer<T> serializer, String name, @Nullable Supplier<T> initialValue)
             throws DeclarationException {
-        return manager.register(serializer, name, initialValue);
+        return manager.registerVariable(serializer, name, initialValue);
+    }
+
+    /**
+     * Declare a variable that will keep value across callback with same context. This value cannot
+     * be serialized into checkpoint.
+     *
+     * @param initializer the initializer of variable. Can be null if no need to initialize.
+     * @param <T> The type of value.
+     */
+    public <T> ContextVariable<T> declareVariable(@Nullable Supplier<T> initializer)
+            throws DeclarationException {
+        return manager.registerVariable(initializer);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationContext.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.declare;
+
+import org.apache.flink.util.function.BiFunctionWithException;
+import org.apache.flink.util.function.FunctionWithException;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+/** A context to declare parts of process in user-defined function/operator. */
+public class DeclarationContext {
+
+    private final DeclarationManager manager;
+
+    public DeclarationContext(DeclarationManager manager) {
+        this.manager = manager;
+    }
+
+    // ------------- Declaring Callback part ----------------
+
+    /** Declare a callback with a name. */
+    public <T> NamedConsumer<T> declare(
+            String name, ThrowingConsumer<T, ? extends Exception> callback)
+            throws DeclarationException {
+        return manager.register(new NamedConsumer<>(name, callback));
+    }
+
+    /** Declare a callback with a name. */
+    public <T, V> NamedFunction<T, V> declare(
+            String name, FunctionWithException<T, V, ? extends Exception> callback)
+            throws DeclarationException {
+        return manager.register(new NamedFunction<>(name, callback));
+    }
+
+    /** Declare a callback with a name. */
+    public <T, U, V> NamedBiFunction<T, U, V> declare(
+            String name, BiFunctionWithException<T, U, V, ? extends Exception> callback)
+            throws DeclarationException {
+        return manager.register(new NamedBiFunction<>(name, callback));
+    }
+
+    /** Declare a callback with an automatically assigned name. */
+    public <T> NamedConsumer<T> declare(ThrowingConsumer<T, ? extends Exception> callback)
+            throws DeclarationException {
+        return declare(manager.nextAssignedName(), callback);
+    }
+
+    /** Declare a callback with an automatically assigned name. */
+    public <T, V> NamedFunction<T, V> declare(
+            FunctionWithException<T, V, ? extends Exception> callback) throws DeclarationException {
+        return declare(manager.nextAssignedName(), callback);
+    }
+
+    /** Declare a callback with an automatically assigned name. */
+    public <T, U, V> NamedBiFunction<T, U, V> declare(
+            BiFunctionWithException<T, U, V, ? extends Exception> callback)
+            throws DeclarationException {
+        return declare(manager.nextAssignedName(), callback);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationException.java
@@ -19,7 +19,7 @@
 package org.apache.flink.runtime.asyncprocessing.declare;
 
 /** Exception thrown when something wrong with declaration happens. */
-public class DeclarationException extends Exception {
+public class DeclarationException extends RuntimeException {
 
     public DeclarationException(String message) {
         super(message);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.declare;
+
+/** Exception thrown when something wrong with declaration happens. */
+public class DeclarationException extends Exception {
+
+    public DeclarationException(String message) {
+        super(message);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationManager.java
@@ -38,6 +38,8 @@ public class DeclarationManager {
 
     private int nextValidNameSequence = 0;
 
+    private int contextVariableCount = 0;
+
     public DeclarationManager() {
         this.knownCallbacks = new HashMap<>();
         this.knownVariables = new HashMap<>();
@@ -50,14 +52,19 @@ public class DeclarationManager {
         return knownCallback;
     }
 
-    <T> DeclaredVariable<T> register(
+    <T> ContextVariable<T> registerVariable(@Nullable Supplier<T> initializer)
+            throws DeclarationException {
+        return new ContextVariable<>(this, contextVariableCount++, initializer);
+    }
+
+    <T> DeclaredVariable<T> registerVariable(
             TypeSerializer<T> serializer, String name, @Nullable Supplier<T> initializer)
             throws DeclarationException {
         if (knownVariables.containsKey(name)) {
             throw new DeclarationException("Duplicated variable key " + name);
         }
         DeclaredVariable<T> variable =
-                new DeclaredVariable<>(this, knownVariables.size(), serializer, name, initializer);
+                new DeclaredVariable<>(this, contextVariableCount++, serializer, name, initializer);
         knownVariables.put(name, variable);
         return variable;
     }
@@ -81,7 +88,7 @@ public class DeclarationManager {
     }
 
     public int variableCount() {
-        return knownVariables.size();
+        return contextVariableCount;
     }
 
     String nextAssignedName(String prefix) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclarationManager.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.declare;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** The manager holds all the declaration information and manage the building procedure. */
+public class DeclarationManager {
+
+    private final Map<String, NamedCallback> knownCallbacks;
+
+    private int nextValidNameSequence = 0;
+
+    public DeclarationManager() {
+        this.knownCallbacks = new HashMap<>();
+    }
+
+    <T extends NamedCallback> T register(T knownCallback) throws DeclarationException {
+        if (knownCallbacks.put(knownCallback.getName(), knownCallback) != null) {
+            throw new DeclarationException("Duplicated key " + knownCallback.getName());
+        }
+        return knownCallback;
+    }
+
+    String nextAssignedName() {
+        String name;
+        do {
+            name = String.format("___%d___", nextValidNameSequence++);
+        } while (knownCallbacks.containsKey(name));
+        return name;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclaredVariable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/DeclaredVariable.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.declare;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import javax.annotation.Nullable;
+
+import java.util.function.Supplier;
+
+/** A variable declared in async state processing. The value could be persisted in checkpoint. */
+public class DeclaredVariable<T> {
+
+    final DeclarationManager manager;
+
+    final int ordinal;
+
+    final TypeSerializer<T> typeSerializer;
+
+    final String name;
+
+    @Nullable final Supplier<T> initializer;
+
+    DeclaredVariable(
+            DeclarationManager manager,
+            int ordinal,
+            TypeSerializer<T> typeSerializer,
+            String name,
+            @Nullable Supplier<T> initializer) {
+        this.manager = manager;
+        this.ordinal = ordinal;
+        this.typeSerializer = typeSerializer;
+        this.name = name;
+        this.initializer = initializer;
+    }
+
+    public T get() {
+        T t = manager.getVariableValue(ordinal);
+        if (t == null && initializer != null) {
+            t = initializer.get();
+            manager.setVariableValue(ordinal, t);
+        }
+        return t;
+    }
+
+    public void set(T newValue) {
+        manager.setVariableValue(ordinal, newValue);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/NamedBiFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/NamedBiFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.declare;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.util.function.BiFunctionWithException;
+
+import java.util.function.BiFunction;
+
+/** A named version of {@link BiFunction}. */
+@Experimental
+public class NamedBiFunction<T, U, V> extends NamedCallback
+        implements BiFunctionWithException<T, U, V, Exception> {
+
+    BiFunctionWithException<T, U, V, ? extends Exception> function;
+
+    public NamedBiFunction(
+            String name, BiFunctionWithException<T, U, V, ? extends Exception> function) {
+        super(name);
+        this.function = function;
+    }
+
+    @Override
+    public V apply(T t, U u) throws Exception {
+        return function.apply(t, u);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/NamedCallback.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/NamedCallback.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.declare;
+
+import org.apache.flink.annotation.Experimental;
+
+/** A named callback that can be identified and checkpoint. */
+@Experimental
+public abstract class NamedCallback {
+
+    private String name;
+
+    public NamedCallback(String name) {
+        this.name = name;
+    }
+
+    /** Get the name of this callback. */
+    public String getName() {
+        return name;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/NamedConsumer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/NamedConsumer.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.declare;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import java.util.function.Consumer;
+
+/** A named version of {@link Consumer}. */
+@Experimental
+public class NamedConsumer<T> extends NamedCallback implements ThrowingConsumer<T, Exception> {
+
+    ThrowingConsumer<? super T, ? extends Exception> consumer;
+
+    public NamedConsumer(String name, ThrowingConsumer<? super T, ? extends Exception> consumer) {
+        super(name);
+        this.consumer = consumer;
+    }
+
+    public void accept(T t) throws Exception {
+        consumer.accept(t);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/NamedFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/declare/NamedFunction.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.declare;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.util.function.FunctionWithException;
+
+import java.util.function.Function;
+
+/** A named version of {@link Function}. */
+@Experimental
+public class NamedFunction<T, R> extends NamedCallback
+        implements FunctionWithException<T, R, Exception> {
+
+    FunctionWithException<T, R, ? extends Exception> function;
+
+    public NamedFunction(String name, FunctionWithException<T, R, ? extends Exception> function) {
+        super(name);
+        this.function = function;
+    }
+
+    @Override
+    public R apply(T t) throws Exception {
+        return function.apply(t);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/functions/AbstractAsyncStatefulRichFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/functions/AbstractAsyncStatefulRichFunction.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationContext;
+
+/** The basic implementation of async state function. */
+@Internal
+public class AbstractAsyncStatefulRichFunction implements AsyncStatefulRichFunction {
+
+    private static final long serialVersionUID = 1L;
+
+    // --------------------------------------------------------------------------------------------
+    //  Runtime context access
+    // --------------------------------------------------------------------------------------------
+
+    private transient RuntimeContext runtimeContext;
+
+    @Override
+    public void setRuntimeContext(RuntimeContext t) {
+        this.runtimeContext = t;
+    }
+
+    @Override
+    public RuntimeContext getRuntimeContext() {
+        if (this.runtimeContext != null) {
+            return this.runtimeContext;
+        } else {
+            throw new IllegalStateException("The runtime context has not been initialized.");
+        }
+    }
+
+    // --------------------------------------------------------------------------------------------
+    //  Default life cycle methods
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public void open(DeclarationContext openContext) throws Exception {}
+
+    @Override
+    public void close() throws Exception {}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/functions/AsyncStatefulRichFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/functions/AsyncStatefulRichFunction.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.functions;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.Function;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationContext;
+
+/** The basic interface of async state function. */
+@Internal
+public interface AsyncStatefulRichFunction extends Function {
+
+    /**
+     * Initialization method for the function. It is called before the actual working methods (like
+     * <i>map</i> or <i>join</i>) and thus suitable for one time setup work. For functions that are
+     * part of an iteration, this method will be invoked at the beginning of each iteration
+     * superstep.
+     *
+     * <p>The openContext object passed to the function can be used for configuration and
+     * initialization. The openContext contains some necessary information that were configured on
+     * the function in the program composition.
+     *
+     * <pre>{@code
+     * public class MyFilter extends RichFilterFunction<String> {
+     *
+     *     private String searchString;
+     *
+     *     public void open(OpenContext openContext) {
+     *         // initialize the value of searchString
+     *     }
+     *
+     *     public boolean filter(String value) {
+     *         return value.equals(searchString);
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param openContext The context containing information about the context in which the function
+     *     is opened.
+     * @throws Exception Implementations may forward exceptions, which are caught by the runtime.
+     *     When the runtime catches an exception, it aborts the task and lets the fail-over logic
+     *     decide whether to retry the task execution.
+     */
+    void open(DeclarationContext openContext) throws Exception;
+
+    /**
+     * Tear-down method for the user code. It is called after the last call to the main working
+     * methods (e.g. <i>map</i> or <i>join</i>). For functions that are part of an iteration, this
+     * method will be invoked after each iteration superstep.
+     *
+     * <p>This method can be used for clean up work.
+     *
+     * @throws Exception Implementations may forward exceptions, which are caught by the runtime.
+     *     When the runtime catches an exception, it aborts the task and lets the fail-over logic
+     *     decide whether to retry the task execution.
+     */
+    void close() throws Exception;
+
+    // ------------------------------------------------------------------------
+    //  Runtime context
+    // ------------------------------------------------------------------------
+
+    /**
+     * Gets the context that contains information about the UDF's runtime, such as the parallelism
+     * of the function, the subtask index of the function, or the name of the task that executes the
+     * function.
+     *
+     * <p>The RuntimeContext also gives access to the {@link
+     * org.apache.flink.api.common.accumulators.Accumulator}s and the {@link
+     * org.apache.flink.api.common.cache.DistributedCache}.
+     *
+     * @return The UDF's runtime context.
+     */
+    RuntimeContext getRuntimeContext();
+
+    /**
+     * Sets the function's runtime context. Called by the framework when creating a parallel
+     * instance of the function.
+     *
+     * @param t The runtime context.
+     */
+    @Internal
+    void setRuntimeContext(RuntimeContext t);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.AsyncStateException;
 import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.v2.StateDescriptor;
@@ -81,6 +82,8 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
 
     private Environment environment;
 
+    protected DeclarationManager declarationManager;
+
     /** Initialize necessary state components for {@link AbstractStreamOperator}. */
     @Override
     public void initializeState(StreamTaskStateInitializer streamTaskStateManager)
@@ -97,6 +100,7 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
         final long asyncBufferTimeout =
                 environment.getExecutionConfig().getAsyncStateBufferTimeout();
 
+        this.declarationManager = new DeclarationManager();
         if (isAsyncStateProcessingEnabled()) {
             AsyncKeyedStateBackend asyncKeyedStateBackend =
                     stateHandler.getAsyncKeyedStateBackend();
@@ -189,6 +193,11 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
         // switch to original context
         asyncExecutionController.setCurrentContext(previousContext);
         currentProcessingContext = previousContext;
+    }
+
+    @Override
+    public final DeclarationManager getDeclarationManager() {
+        return declarationManager;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperator.java
@@ -110,6 +110,7 @@ public abstract class AbstractAsyncStateStreamOperator<OUT> extends AbstractStre
                                 mailboxExecutor,
                                 this::handleAsyncStateException,
                                 asyncKeyedStateBackend.createStateExecutor(),
+                                declarationManager,
                                 maxParallelism,
                                 asyncBufferSize,
                                 asyncBufferTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
@@ -106,6 +106,7 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
                                 environment.getMainMailboxExecutor(),
                                 this::handleAsyncStateException,
                                 asyncKeyedStateBackend.createStateExecutor(),
+                                declarationManager,
                                 maxParallelism,
                                 asyncBufferSize,
                                 asyncBufferTimeout,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AbstractAsyncStateStreamOperatorV2.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.AsyncStateException;
 import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.v2.StateDescriptor;
@@ -75,6 +76,8 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
 
     private RecordContext currentProcessingContext;
 
+    protected DeclarationManager declarationManager;
+
     public AbstractAsyncStateStreamOperatorV2(
             StreamOperatorParameters<OUT> parameters, int numberOfInputs) {
         super(parameters, numberOfInputs);
@@ -93,6 +96,7 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
         final long asyncBufferTimeout = getExecutionConfig().getAsyncStateBufferTimeout();
         int maxParallelism = getExecutionConfig().getMaxParallelism();
 
+        this.declarationManager = new DeclarationManager();
         if (isAsyncStateProcessingEnabled()) {
             AsyncKeyedStateBackend asyncKeyedStateBackend =
                     stateHandler.getAsyncKeyedStateBackend();
@@ -190,6 +194,11 @@ public abstract class AbstractAsyncStateStreamOperatorV2<OUT> extends AbstractSt
         // switch to original context
         asyncExecutionController.setCurrentContext(previousContext);
         currentProcessingContext = previousContext;
+    }
+
+    @Override
+    public final DeclarationManager getDeclarationManager() {
+        return declarationManager;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncKeyedProcessOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/AsyncKeyedProcessOperator.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclaredVariable;
+import org.apache.flink.runtime.asyncprocessing.streaming.api.AsyncKeyedProcessFunction;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.api.SimpleTimerService;
+import org.apache.flink.streaming.api.TimeDomain;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** A {@link StreamOperator} for executing {@link AsyncKeyedProcessFunction}. */
+@Internal
+public class AsyncKeyedProcessOperator<K, IN, OUT>
+        extends AbstractAsyncStateUdfStreamOperator<OUT, AsyncKeyedProcessFunction<K, IN, OUT>>
+        implements OneInputStreamOperator<IN, OUT>, Triggerable<K, VoidNamespace> {
+
+    private static final long serialVersionUID = 1L;
+
+    // Shared timestamp variable for collector, context and onTimerContext.
+    private transient DeclaredVariable<Long> sharedTimestamp;
+
+    private transient TimestampedCollectorWithDeclaredVariable<OUT> collector;
+
+    private transient ContextImpl context;
+
+    private transient OnTimerContextImpl onTimerContext;
+
+    private transient DeclarationContext declarationContext;
+
+    private transient ThrowingConsumer<IN, Exception> processor;
+    private transient ThrowingConsumer<Long, Exception> timerProcessor;
+
+    public AsyncKeyedProcessOperator(AsyncKeyedProcessFunction<K, IN, OUT> function) {
+        super(function);
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void open() throws Exception {
+        super.open();
+        declarationContext = new DeclarationContext(getDeclarationManager());
+        userFunction.open(declarationContext);
+        sharedTimestamp =
+                declarationContext.declareVariable(
+                        LongSerializer.INSTANCE,
+                        "_AsyncKeyedProcessOperator$sharedTimestamp",
+                        null);
+
+        collector = new TimestampedCollectorWithDeclaredVariable<>(output, sharedTimestamp);
+
+        InternalTimerService<VoidNamespace> internalTimerService =
+                getInternalTimerService("user-timers", VoidNamespaceSerializer.INSTANCE, this);
+
+        TimerService timerService = new SimpleTimerService(internalTimerService);
+
+        context = new ContextImpl(userFunction, timerService, sharedTimestamp);
+        onTimerContext =
+                new OnTimerContextImpl(
+                        userFunction, timerService, declarationContext, sharedTimestamp);
+
+        processor = userFunction.declareProcess(declarationContext, context, collector);
+        timerProcessor = userFunction.declareOnTimer(declarationContext, onTimerContext, collector);
+    }
+
+    @Override
+    public void onEventTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
+        collector.setAbsoluteTimestamp(timer.getTimestamp());
+        invokeUserFunction(TimeDomain.EVENT_TIME, timer);
+    }
+
+    @Override
+    public void onProcessingTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
+        collector.eraseTimestamp();
+        invokeUserFunction(TimeDomain.PROCESSING_TIME, timer);
+    }
+
+    @Override
+    public void processElement(StreamRecord<IN> element) throws Exception {
+        collector.setTimestamp(element);
+        processor.accept(element.getValue());
+    }
+
+    private void invokeUserFunction(TimeDomain timeDomain, InternalTimer<K, VoidNamespace> timer)
+            throws Exception {
+        onTimerContext.setTimeDomain(timeDomain);
+        sharedTimestamp.set(timer.getTimestamp());
+        timerProcessor.accept(timer.getTimestamp());
+    }
+
+    private class ContextImpl extends AsyncKeyedProcessFunction<K, IN, OUT>.Context {
+
+        private final TimerService timerService;
+
+        private final DeclaredVariable<Long> timestamp;
+
+        ContextImpl(
+                AsyncKeyedProcessFunction<K, IN, OUT> function,
+                TimerService timerService,
+                DeclaredVariable<Long> timestamp) {
+            function.super();
+            this.timerService = checkNotNull(timerService);
+            this.timestamp = timestamp;
+        }
+
+        @Override
+        public Long timestamp() {
+            return timestamp.get();
+        }
+
+        @Override
+        public TimerService timerService() {
+            return timerService;
+        }
+
+        @Override
+        public <X> void output(OutputTag<X> outputTag, X value) {
+            if (outputTag == null) {
+                throw new IllegalArgumentException("OutputTag must not be null.");
+            }
+
+            output.collect(outputTag, new StreamRecord<>(value, timestamp.get()));
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public K getCurrentKey() {
+            return (K) AsyncKeyedProcessOperator.this.getCurrentKey();
+        }
+    }
+
+    private class OnTimerContextImpl extends AsyncKeyedProcessFunction<K, IN, OUT>.OnTimerContext {
+
+        private final TimerService timerService;
+
+        private final DeclaredVariable<String> timeDomain;
+
+        private final DeclaredVariable<Long> timestamp;
+
+        OnTimerContextImpl(
+                AsyncKeyedProcessFunction<K, IN, OUT> function,
+                TimerService timerService,
+                DeclarationContext declarationContext,
+                DeclaredVariable<Long> timestamp) {
+            function.super();
+            this.timerService = checkNotNull(timerService);
+            this.timeDomain =
+                    declarationContext.declareVariable(
+                            StringSerializer.INSTANCE, "_OnTimerContextImpl$timeDomain", null);
+            this.timestamp = timestamp;
+        }
+
+        public void setTimeDomain(TimeDomain one) {
+            timeDomain.set(one.name());
+        }
+
+        @Override
+        public Long timestamp() {
+            checkState(timestamp.get() != null);
+            return timestamp.get();
+        }
+
+        @Override
+        public TimerService timerService() {
+            return timerService;
+        }
+
+        @Override
+        public <X> void output(OutputTag<X> outputTag, X value) {
+            if (outputTag == null) {
+                throw new IllegalArgumentException("OutputTag must not be null.");
+            }
+
+            output.collect(outputTag, new StreamRecord<>(value, timestamp()));
+        }
+
+        @Override
+        public TimeDomain timeDomain() {
+            checkState(timeDomain.get() != null);
+            return TimeDomain.valueOf(timeDomain.get());
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public K getCurrentKey() {
+            return (K) AsyncKeyedProcessOperator.this.getCurrentKey();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/TimestampedCollectorWithDeclaredVariable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/operators/TimestampedCollectorWithDeclaredVariable.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclaredVariable;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.RecordAttributes;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * Wrapper around an {@link Output} for user functions that expect a {@link Output}. This collector
+ * is mostly like the {@link org.apache.flink.streaming.api.operators.TimestampedCollector} but it
+ * keeps the timestamp in {@link DeclaredVariable} and give it to output finally. Most operators
+ * would set the timestamp of the incoming {@link StreamRecord} here.
+ *
+ * @param <T> The type of the elements that can be emitted.
+ */
+@Internal
+public final class TimestampedCollectorWithDeclaredVariable<T> implements Output<T> {
+
+    private final Output<StreamRecord<T>> output;
+
+    private final StreamRecord<T> reuse;
+
+    private final DeclaredVariable<Long> timestamp;
+
+    /**
+     * Creates a new {@link TimestampedCollectorWithDeclaredVariable} that wraps the given {@link
+     * Output}.
+     */
+    public TimestampedCollectorWithDeclaredVariable(
+            Output<StreamRecord<T>> output, DeclarationContext declarationContext) {
+        this(
+                output,
+                declarationContext.declareVariable(
+                        LongSerializer.INSTANCE, "_TCollector$timestamp", null));
+    }
+
+    /**
+     * Creates a new {@link TimestampedCollectorWithDeclaredVariable} that wraps the given {@link
+     * Output} and given {@link DeclaredVariable} that holds the timestamp.
+     */
+    public TimestampedCollectorWithDeclaredVariable(
+            Output<StreamRecord<T>> output, DeclaredVariable<Long> timestamp) {
+        this.output = output;
+        this.timestamp = timestamp;
+        this.reuse = new StreamRecord<>(null);
+    }
+
+    @Override
+    public void collect(T record) {
+        Long time = timestamp.get();
+        if (time == null) {
+            reuse.eraseTimestamp();
+        } else {
+            reuse.setTimestamp(time);
+        }
+        output.collect(reuse.replace(record));
+    }
+
+    public void setTimestamp(StreamRecord<?> timestampBase) {
+        if (timestampBase.hasTimestamp()) {
+            timestamp.set(timestampBase.getTimestamp());
+        } else {
+            timestamp.set(null);
+        }
+    }
+
+    public void setAbsoluteTimestamp(long time) {
+        timestamp.set(time);
+    }
+
+    public void eraseTimestamp() {
+        timestamp.set(null);
+    }
+
+    @Override
+    public void close() {
+        output.close();
+    }
+
+    @Override
+    public void emitWatermark(Watermark mark) {
+        output.emitWatermark(mark);
+    }
+
+    @Override
+    public void emitWatermarkStatus(WatermarkStatus watermarkStatus) {
+        output.emitWatermarkStatus(watermarkStatus);
+    }
+
+    @Override
+    public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> record) {
+        output.collect(outputTag, record);
+    }
+
+    @Override
+    public void emitLatencyMarker(LatencyMarker latencyMarker) {
+        output.emitLatencyMarker(latencyMarker);
+    }
+
+    @Override
+    public void emitRecordAttributes(RecordAttributes recordAttributes) {
+        output.emitRecordAttributes(recordAttributes);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/streaming/api/AsyncKeyedProcessFunction.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/asyncprocessing/streaming/api/AsyncKeyedProcessFunction.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.asyncprocessing.streaming.api;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationException;
+import org.apache.flink.runtime.asyncprocessing.functions.AbstractAsyncStatefulRichFunction;
+import org.apache.flink.streaming.api.TimeDomain;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+/**
+ * A keyed function that processes elements of a stream. This is the async state version.
+ *
+ * <p>For every element in the input stream the process {@link #declareProcess} declared is invoked.
+ * This can produce zero or more elements as output. Implementations can also query the time and set
+ * timers through the provided {@link Context}. For firing timers the process {@link
+ * #declareOnTimer} declared will be invoked. This can again produce zero or more elements as output
+ * and register further timers.
+ *
+ * <p><b>NOTE:</b> Access to keyed state and timers (which are also scoped to a key) is only
+ * available if the {@code AsyncKeyedProcessFunction} is applied on a {@code KeyedStream}.
+ *
+ * @param <K> Type of the key.
+ * @param <I> Type of the input elements.
+ * @param <O> Type of the output elements.
+ */
+@Internal
+public abstract class AsyncKeyedProcessFunction<K, I, O> extends AbstractAsyncStatefulRichFunction {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Process one element from the input stream.
+     *
+     * <p>This function can output zero or more elements using the {@link Collector} parameter and
+     * also update internal state or set timers using the {@link Context} parameter.
+     *
+     * @param context the context that provides useful methods to define named callbacks.
+     * @param ctx A {@link Context} that allows querying the timestamp of the element and getting a
+     *     {@link TimerService} for registering timers and querying the time. The context is only
+     *     valid during the invocation of this method, do not store it.
+     * @param out The collector for returning result values.
+     * @return the whole processing logic just like {@code processElement}.
+     */
+    public abstract ThrowingConsumer<I, Exception> declareProcess(
+            DeclarationContext context, Context ctx, Collector<O> out) throws DeclarationException;
+
+    /**
+     * Called when a timer set using {@link TimerService} fires.
+     *
+     * @param context the context that provides useful methods to define named callbacks.
+     * @param ctx An {@link OnTimerContext} that allows querying the timestamp, the {@link
+     *     TimeDomain}, and the key of the firing timer and getting a {@link TimerService} for
+     *     registering timers and querying the time. The context is only valid during the invocation
+     *     of this method, do not store it.
+     * @param out The processor for processing timestamps.
+     */
+    public ThrowingConsumer<Long, Exception> declareOnTimer(
+            DeclarationContext context, OnTimerContext ctx, Collector<O> out)
+            throws DeclarationException {
+        return (t) -> {};
+    }
+
+    /**
+     * Information available in an invocation of {@link #declareProcess} or {@link #declareOnTimer}.
+     */
+    @Internal
+    public abstract class Context {
+
+        /**
+         * Timestamp of the element currently being processed or timestamp of a firing timer.
+         *
+         * <p>This might be {@code null}, depending on the stream's watermark strategy.
+         */
+        public abstract Long timestamp();
+
+        /** A {@link TimerService} for querying time and registering timers. */
+        public abstract TimerService timerService();
+
+        /**
+         * Emits a record to the side output identified by the {@link OutputTag}.
+         *
+         * @param outputTag the {@code OutputTag} that identifies the side output to emit to.
+         * @param value The record to emit.
+         */
+        public abstract <X> void output(OutputTag<X> outputTag, X value);
+
+        /** Get key of the element being processed. */
+        public abstract K getCurrentKey();
+    }
+
+    /** Information available in an invocation of processor defined by {@link #declareOnTimer}. */
+    @Internal
+    public abstract class OnTimerContext extends Context {
+        /** The {@link TimeDomain} of the firing timer. */
+        public abstract TimeDomain timeDomain();
+
+        /** Get key of the firing timer. */
+        @Override
+        public abstract K getCurrentKey();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessingOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/asyncprocessing/AsyncStateProcessingOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.operators.asyncprocessing;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.function.ThrowingRunnable;
 
@@ -62,4 +63,7 @@ public interface AsyncStateProcessingOperator extends AsyncStateProcessing {
      * @param <K> the type of key.
      */
     <K> void asyncProcessWithKey(K key, ThrowingRunnable<Exception> processing);
+
+    /** Get the declaration manager for user-logic declaring. */
+    DeclarationManager getDeclarationManager();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AbstractStateIteratorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AbstractStateIteratorTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.asyncprocessing;
 import org.apache.flink.api.common.state.v2.State;
 import org.apache.flink.api.common.state.v2.StateIterator;
 import org.apache.flink.core.state.StateFutureUtils;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.util.Preconditions;
 
@@ -49,6 +50,7 @@ public class AbstractStateIteratorTest {
                         new SyncMailboxExecutor(),
                         (a, b) -> {},
                         stateExecutor,
+                        new DeclarationManager(),
                         1,
                         100,
                         1000,
@@ -87,6 +89,7 @@ public class AbstractStateIteratorTest {
                         new SyncMailboxExecutor(),
                         (a, b) -> {},
                         stateExecutor,
+                        new DeclarationManager(),
                         1,
                         100,
                         1000,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/AsyncExecutionControllerTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.state.StateFutureImpl.AsyncFrameworkExceptionHandle
 import org.apache.flink.core.state.StateFutureUtils;
 import org.apache.flink.runtime.asyncprocessing.EpochManager.Epoch;
 import org.apache.flink.runtime.asyncprocessing.EpochManager.ParallelMode;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
@@ -101,6 +102,7 @@ class AsyncExecutionControllerTest {
                         mailboxExecutor,
                         exceptionHandler,
                         stateExecutor,
+                        new DeclarationManager(),
                         128,
                         batchSize,
                         timeout,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/ContextStateFutureImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/asyncprocessing/ContextStateFutureImplTest.java
@@ -307,7 +307,7 @@ public class ContextStateFutureImplTest {
 
     private <K> RecordContext<K> buildRecordContext(Object record, K key) {
         int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(key, 128);
-        return new RecordContext<>(record, key, (e) -> {}, keyGroup, new Epoch(0));
+        return new RecordContext<>(record, key, (e) -> {}, keyGroup, new Epoch(0), 0);
     }
 
     /** A runner that performs single-step debugging. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractAggregatingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractAggregatingStateTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.asyncprocessing.StateExecutor;
 import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 
 import org.junit.jupiter.api.Test;
@@ -108,6 +109,7 @@ class AbstractAggregatingStateTest extends AbstractKeyedStateTestBase {
                         new SyncMailboxExecutor(),
                         (a, b) -> {},
                         new AbstractAggregatingStateTest.AggregatingStateExecutor(),
+                        new DeclarationManager(),
                         1,
                         100,
                         10000,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractKeyedStateTestBase.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
 import org.apache.flink.runtime.asyncprocessing.StateRequestHandler;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.state.AsyncKeyedStateBackend;
@@ -78,6 +79,7 @@ public class AbstractKeyedStateTestBase {
                             exception.set(b);
                         },
                         testStateExecutor,
+                        new DeclarationManager(),
                         1,
                         1,
                         1000,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/AbstractReducingStateTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.asyncprocessing.StateExecutor;
 import org.apache.flink.runtime.asyncprocessing.StateRequest;
 import org.apache.flink.runtime.asyncprocessing.StateRequestContainer;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.util.Preconditions;
 
@@ -84,6 +85,7 @@ public class AbstractReducingStateTest extends AbstractKeyedStateTestBase {
                         new SyncMailboxExecutor(),
                         (a, b) -> {},
                         new ReducingStateExecutor(),
+                        new DeclarationManager(),
                         1,
                         100,
                         10000,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/StateBackendTestV2Base.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/v2/StateBackendTestV2Base.java
@@ -32,6 +32,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.StateAssignmentOperation;
 import org.apache.flink.runtime.execution.Environment;
@@ -227,6 +228,7 @@ public abstract class StateBackendTestV2Base<B extends AbstractStateBackend> {
                             new SyncMailboxExecutor(),
                             testExceptionHandler,
                             backend.createStateExecutor(),
+                            new DeclarationManager(),
                             jobMaxParallelism,
                             aecBatchSize,
                             aecBufferTimeout,
@@ -316,6 +318,7 @@ public abstract class StateBackendTestV2Base<B extends AbstractStateBackend> {
                             new SyncMailboxExecutor(),
                             testExceptionHandler,
                             backend.createStateExecutor(),
+                            new DeclarationManager(),
                             jobMaxParallelism,
                             aecBatchSize,
                             aecBufferTimeout,
@@ -401,6 +404,7 @@ public abstract class StateBackendTestV2Base<B extends AbstractStateBackend> {
                             new SyncMailboxExecutor(),
                             testExceptionHandler,
                             backend.createStateExecutor(),
+                            new DeclarationManager(),
                             maxParallelism,
                             aecBatchSize,
                             aecBufferTimeout,
@@ -470,6 +474,7 @@ public abstract class StateBackendTestV2Base<B extends AbstractStateBackend> {
                             new SyncMailboxExecutor(),
                             testExceptionHandler,
                             backend.createStateExecutor(),
+                            new DeclarationManager(),
                             maxParallelism,
                             aecBatchSize,
                             aecBufferTimeout,
@@ -574,6 +579,7 @@ public abstract class StateBackendTestV2Base<B extends AbstractStateBackend> {
                         new SyncMailboxExecutor(),
                         testExceptionHandler,
                         backend.createStateExecutor(),
+                        new DeclarationManager(),
                         128,
                         1,
                         -1,

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceAsyncImplTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.MockStateExecutor;
 import org.apache.flink.runtime.asyncprocessing.RecordContext;
 import org.apache.flink.runtime.asyncprocessing.StateRequestType;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -63,6 +64,7 @@ class InternalTimerServiceAsyncImplTest {
                         new SyncMailboxExecutor(),
                         exceptionHandler,
                         new MockStateExecutor(),
+                        new DeclarationManager(),
                         128,
                         2,
                         1000L,

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStDBOperationTestBase.java
@@ -120,7 +120,7 @@ public class ForStDBOperationTestBase {
     protected ContextKey<Integer, VoidNamespace> buildContextKey(int i) {
         int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(i, 128);
         RecordContext<Integer> recordContext =
-                new RecordContext<>(i, i, t -> {}, keyGroup, new Epoch(0));
+                new RecordContext<>(i, i, t -> {}, keyGroup, new Epoch(0), 0);
         return new ContextKey<>(recordContext, VoidNamespace.INSTANCE, null);
     }
 

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateExecutorTest.java
@@ -347,7 +347,7 @@ class ForStStateExecutorTest extends ForStDBOperationTestBase {
             R record) {
         int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(key, 128);
         RecordContext<K> recordContext =
-                new RecordContext<>(record, key, t -> {}, keyGroup, new Epoch(0));
+                new RecordContext<>(record, key, t -> {}, keyGroup, new Epoch(0), 0);
         TestStateFuture stateFuture = new TestStateFuture<>();
         return new StateRequest<>(innerTable, requestType, value, stateFuture, recordContext);
     }
@@ -361,7 +361,7 @@ class ForStStateExecutorTest extends ForStDBOperationTestBase {
             R record) {
         int keyGroup = KeyGroupRangeAssignment.assignToKeyGroup(key, 128);
         RecordContext<K> recordContext =
-                new RecordContext<>(record, key, t -> {}, keyGroup, new Epoch(0));
+                new RecordContext<>(record, key, t -> {}, keyGroup, new Epoch(0), 0);
         TestStateFuture stateFuture = new TestStateFuture<>();
         return new StateRequest<>(innerTable, requestType, value, stateFuture, recordContext);
     }

--- a/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateTestBase.java
+++ b/flink-state-backends/flink-statebackend-forst/src/test/java/org/apache/flink/state/forst/ForStStateTestBase.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.runtime.asyncprocessing.AsyncExecutionController;
 import org.apache.flink.runtime.asyncprocessing.RecordContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationManager;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
@@ -76,6 +77,7 @@ public class ForStStateTestBase {
                         mailboxExecutor,
                         (a, b) -> {},
                         keyedBackend.createStateExecutor(),
+                        new DeclarationManager(),
                         1,
                         100,
                         0,

--- a/flink-streaming-java/src/test/java/org/apache/flink/asyncprocessing/operators/AsyncKeyedProcessOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/asyncprocessing/operators/AsyncKeyedProcessOperatorTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.asyncprocessing.operators;
+
+import org.apache.flink.api.common.state.v2.StateFuture;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.state.StateFutureUtils;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationContext;
+import org.apache.flink.runtime.asyncprocessing.declare.DeclarationException;
+import org.apache.flink.runtime.asyncprocessing.declare.NamedCallback;
+import org.apache.flink.runtime.asyncprocessing.declare.NamedConsumer;
+import org.apache.flink.runtime.asyncprocessing.declare.NamedFunction;
+import org.apache.flink.runtime.asyncprocessing.operators.AsyncKeyedProcessOperator;
+import org.apache.flink.runtime.asyncprocessing.streaming.api.AsyncKeyedProcessFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.asyncprocessing.AsyncKeyedOneInputStreamOperatorTestHarness;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.function.ThrowingConsumer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link AsyncKeyedProcessOperator}. */
+public class AsyncKeyedProcessOperatorTest {
+
+    @ParameterizedTest(name = "Chain declaration = {0}")
+    @ValueSource(booleans = {false, true})
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void testNormalProcessor(boolean chained) throws Exception {
+        TestDeclarationFunctionBase function =
+                chained ? new TestChainDeclarationFunction() : new TestNormalDeclarationFunction();
+        AsyncKeyedProcessOperator<Integer, Tuple2<Integer, String>, String> testOperator =
+                new AsyncKeyedProcessOperator<>(function);
+        ArrayList<StreamRecord<String>> expectedOutput = new ArrayList<>();
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Tuple2<Integer, String>, String>
+                testHarness =
+                        AsyncKeyedOneInputStreamOperatorTestHarness.create(
+                                testOperator, (e) -> e.f0, TypeInformation.of(Integer.class))) {
+            testHarness.open();
+            testHarness.processElement(new StreamRecord<>(Tuple2.of(5, "5")));
+            expectedOutput.add(new StreamRecord<>("12"));
+            assertThat(function.getValue()).isEqualTo(12);
+            testHarness.processElement(new StreamRecord<>(Tuple2.of(6, "6")));
+            expectedOutput.add(new StreamRecord<>("38"));
+            assertThat(function.getValue()).isEqualTo(38);
+            assertThat(testHarness.getOutput()).containsExactly(expectedOutput.toArray());
+        }
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void testTimerProcessor() throws Exception {
+        TestDeclarationFunctionBase function = new TestTimerDeclarationFunction();
+        AsyncKeyedProcessOperator<Integer, Tuple2<Integer, String>, String> testOperator =
+                new AsyncKeyedProcessOperator<>(function);
+        ArrayList<Object> expectedOutput = new ArrayList<>();
+        try (AsyncKeyedOneInputStreamOperatorTestHarness<Integer, Tuple2<Integer, String>, String>
+                testHarness =
+                        AsyncKeyedOneInputStreamOperatorTestHarness.create(
+                                testOperator, (e) -> e.f0, TypeInformation.of(Integer.class))) {
+            testHarness.open();
+            testHarness.processElement(new StreamRecord<>(Tuple2.of(5, "5")));
+            testHarness.processElement(new StreamRecord<>(Tuple2.of(6, "5")));
+            assertThat(function.getValue()).isEqualTo(0);
+            testHarness.processWatermark(5L);
+            expectedOutput.add(new StreamRecord<>("12", 5L));
+            expectedOutput.add(new Watermark(5L));
+            assertThat(function.getValue()).isEqualTo(12);
+            testHarness.processWatermark(6L);
+            expectedOutput.add(new StreamRecord<>("38", 6L));
+            expectedOutput.add(new Watermark(6L));
+            assertThat(function.getValue()).isEqualTo(38);
+            assertThat(testHarness.getOutput()).containsExactly(expectedOutput.toArray());
+        }
+    }
+
+    private abstract static class TestDeclarationFunctionBase
+            extends AsyncKeyedProcessFunction<Integer, Tuple2<Integer, String>, String> {
+        final AtomicInteger value = new AtomicInteger(0);
+
+        public int getValue() {
+            return value.get();
+        }
+    }
+
+    private static class TestNormalDeclarationFunction extends TestDeclarationFunctionBase {
+
+        @Override
+        public ThrowingConsumer<Tuple2<Integer, String>, Exception> declareProcess(
+                DeclarationContext context, Context ctx, Collector<String> out)
+                throws DeclarationException {
+            NamedFunction<Void, StateFuture<Integer>> adder =
+                    context.declare(
+                            "adder",
+                            (i) -> {
+                                return StateFutureUtils.completedFuture(value.incrementAndGet());
+                            });
+            NamedConsumer<Integer> doubler =
+                    context.declare(
+                            "doubler",
+                            (v) -> {
+                                value.addAndGet(v);
+                                out.collect(String.valueOf(value.get()));
+                            });
+            assertThat(adder).isInstanceOf(NamedCallback.class);
+            assertThat(doubler).isInstanceOf(NamedCallback.class);
+            return (e) -> {
+                value.addAndGet(e.f0);
+                StateFutureUtils.<Void>completedVoidFuture().thenCompose(adder).thenAccept(doubler);
+            };
+        }
+    }
+
+    private static class TestChainDeclarationFunction extends TestDeclarationFunctionBase {
+
+        @Override
+        public ThrowingConsumer<Tuple2<Integer, String>, Exception> declareProcess(
+                DeclarationContext context, Context ctx, Collector<String> out)
+                throws DeclarationException {
+            return context.<Tuple2<Integer, String>>declareChain()
+                    .thenCompose(
+                            e -> {
+                                value.addAndGet(e.f0);
+                                return StateFutureUtils.completedVoidFuture();
+                            })
+                    .thenCompose(v -> StateFutureUtils.completedFuture(value.incrementAndGet()))
+                    .withName("adder")
+                    .thenAccept(
+                            (v) -> {
+                                value.addAndGet(v);
+                                out.collect(String.valueOf(value.get()));
+                            })
+                    .withName("doubler")
+                    .finish();
+        }
+    }
+
+    private static class TestTimerDeclarationFunction extends TestDeclarationFunctionBase {
+
+        @Override
+        public ThrowingConsumer<Tuple2<Integer, String>, Exception> declareProcess(
+                DeclarationContext context, Context ctx, Collector<String> out)
+                throws DeclarationException {
+            return context.<Tuple2<Integer, String>>declareChain()
+                    .thenCompose(
+                            e -> {
+                                ctx.timerService().registerEventTimeTimer(e.f0);
+                                return StateFutureUtils.completedVoidFuture();
+                            })
+                    .finish();
+        }
+
+        public ThrowingConsumer<Long, Exception> declareOnTimer(
+                DeclarationContext context, OnTimerContext ctx, Collector<String> out)
+                throws DeclarationException {
+            return context.<Long>declareChain()
+                    .thenCompose(
+                            e -> {
+                                value.addAndGet(e.intValue());
+                                return StateFutureUtils.completedVoidFuture();
+                            })
+                    .thenCompose(v -> StateFutureUtils.completedFuture(value.incrementAndGet()))
+                    .withName("adder")
+                    .thenAccept(
+                            (v) -> {
+                                value.addAndGet(v);
+                                out.collect(String.valueOf(value.get()));
+                            })
+                    .withName("doubler")
+                    .finish();
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The FLIP-455 introduces a set of internal APIs for declaring process. This PR implements the first part - declaring process blocks and variables.

## Brief change log

Please check each commit.

 - Internal APIs for declaring elements and timers processing
 - Internal APIs for declaring variables that share across callbacks with same context
 - Chain-style declaring
 - An basic operator and function for those APIs.

## Verifying this change

This change added tests `AsyncKeyedProcessOperatorTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
