### PR TITLE
[hotfix][docs] Fix typo in Amazon S3 Access Credential

### DIFF
--- a/docs/content.zh/docs/deployment/filesystems/s3.md
+++ b/docs/content.zh/docs/deployment/filesystems/s3.md
@@ -112,7 +112,7 @@ You can limit this configuration to JobManagers by using [Flink configuration fi
 # flink-s3-fs-hadoop
 fs.s3a.aws.credentials.provider: org.apache.flink.fs.s3.common.token.DynamicTemporaryAWSCredentialsProvider
 # flink-s3-fs-presto
-presto.s3.credential-provider: org.apache.flink.fs.s3.common.token.DynamicTemporaryAWSCredentialsProvider
+presto.s3.credentials-provider: org.apache.flink.fs.s3.common.token.DynamicTemporaryAWSCredentialsProvider
 ```
 
 ## 配置非 S3 访问点

--- a/docs/content/docs/deployment/filesystems/s3.md
+++ b/docs/content/docs/deployment/filesystems/s3.md
@@ -117,7 +117,7 @@ You can limit this configuration to JobManagers by using [Flink configuration fi
 # flink-s3-fs-hadoop
 fs.s3a.aws.credentials.provider: org.apache.flink.fs.s3.common.token.DynamicTemporaryAWSCredentialsProvider
 # flink-s3-fs-presto
-presto.s3.credential-provider: org.apache.flink.fs.s3.common.token.DynamicTemporaryAWSCredentialsProvider
+presto.s3.credentials-provider: org.apache.flink.fs.s3.common.token.DynamicTemporaryAWSCredentialsProvider
 ```
 
 ## Configure Non-S3 Endpoint


### PR DESCRIPTION
In case of `flink-s3-fs-presto`, credentials provider config should be `presto.s3.credentials-provider`. ([Reference](https://prestodb.io/docs/current/connector/hive.html#custom-s3-credentials-provider))