### PR TITLE
[FLINK-36966][tests] Bump mockito to 5.14.2

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -301,7 +301,7 @@ under the License.
 
 		<dependency>
 			<groupId>org.mockito</groupId>
-			<artifactId>mockito-inline</artifactId>
+			<artifactId>mockito-subclass</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/flink-runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/flink-runtime/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mock-maker-inline

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@ under the License.
 		<junit4.version>4.13.2</junit4.version>
 		<junit5.version>5.10.1</junit5.version>
 		<archunit.version>1.2.0</archunit.version>
-		<mockito.version>4.11.0</mockito.version>
+		<mockito.version>5.14.2</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<assertj.version>3.23.1</assertj.version>
 		<py4j.version>0.10.9.7</py4j.version>
@@ -586,13 +586,13 @@ under the License.
 			<dependency>
 				<groupId>net.bytebuddy</groupId>
 				<artifactId>byte-buddy</artifactId>
-				<version>1.14.4</version>
+				<version>1.15.11</version>
 			</dependency>
 
 			<dependency>
 				<groupId>net.bytebuddy</groupId>
 				<artifactId>byte-buddy-agent</artifactId>
-				<version>1.14.4</version>
+				<version>1.15.11</version>
 			</dependency>
 
 			<!-- For dependency convergence -->
@@ -919,7 +919,7 @@ under the License.
 
 			<dependency>
 				<groupId>org.mockito</groupId>
-				<artifactId>mockito-inline</artifactId>
+				<artifactId>mockito-subclass</artifactId>
 				<version>${mockito.version}</version>
 				<scope>test</scope>
 			</dependency>


### PR DESCRIPTION
## What is the purpose of the change

The PR bumps mockito to 5.14.2

## Brief change log
Bump mockito to 5.14.2, adapt dependencies

## Verifying this change
the change is about changes in tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
