### PR TITLE
[FLINK-36968][table-planner] Deduplicate data with the same pk in values lookup table used for testing

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -1899,7 +1899,14 @@ public final class TestValuesTableFactory
             // <pk, data>
             LinkedHashMap<Row, Row> pkMap = new LinkedHashMap<>();
             for (Row row : data) {
-                pkMap.put(extractPk(row), row);
+                Row pk = extractPk(row);
+                RowKind originalRowKind = row.getKind();
+                if (originalRowKind == RowKind.INSERT || originalRowKind == RowKind.UPDATE_AFTER) {
+                    row.setKind(RowKind.INSERT);
+                    pkMap.put(pk, row);
+                } else {
+                    pkMap.remove(pk);
+                }
             }
             return new ArrayList<>(pkMap.values());
         }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesTableFactory.java
@@ -678,7 +678,8 @@ public final class TestValuesTableFactory
                             lookupThreshold,
                             enableAggregatePushDown,
                             customShuffleIsDeterministic,
-                            customShuffleEmptyPartitioner);
+                            customShuffleEmptyPartitioner,
+                            context.getPrimaryKeyIndexes());
                 } else {
                     return new TestValuesScanLookupTableSource(
                             context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType(),
@@ -704,7 +705,8 @@ public final class TestValuesTableFactory
                             cache,
                             reloadTrigger,
                             lookupThreshold,
-                            enableAggregatePushDown);
+                            enableAggregatePushDown,
+                            context.getPrimaryKeyIndexes());
                 }
             }
         } else {
@@ -1736,6 +1738,8 @@ public final class TestValuesTableFactory
 
         protected final DataType originType;
 
+        protected final int[] primaryKeyIndices;
+
         private TestValuesScanLookupTableSource(
                 DataType originType,
                 DataType producedDataType,
@@ -1760,7 +1764,8 @@ public final class TestValuesTableFactory
                 @Nullable LookupCache cache,
                 @Nullable CacheReloadTrigger reloadTrigger,
                 int lookupThreshold,
-                boolean enableAggregatePushDown) {
+                boolean enableAggregatePushDown,
+                int[] primaryKeyIndices) {
             super(
                     producedDataType,
                     changelogMode,
@@ -1786,6 +1791,7 @@ public final class TestValuesTableFactory
             this.cache = cache;
             this.reloadTrigger = reloadTrigger;
             this.lookupThreshold = lookupThreshold;
+            this.primaryKeyIndices = primaryKeyIndices;
         }
 
         @SuppressWarnings({"unchecked", "rawtypes"})
@@ -1833,6 +1839,9 @@ public final class TestValuesTableFactory
                 throw new UnsupportedOperationException(
                         "nestedProjectionSupported is unsupported for lookup source currently.");
             }
+
+            data = deduplicateDataByPk(data);
+
             DataStructureConverter converter = context.createDataStructureConverter(originType);
             RowType originRowType =
                     RowType.of(
@@ -1881,6 +1890,26 @@ public final class TestValuesTableFactory
                     return LookupFunctionProvider.of(lookupFunction);
                 }
             }
+        }
+
+        private List<Row> deduplicateDataByPk(List<Row> data) {
+            if (primaryKeyIndices.length == 0) {
+                return data;
+            }
+            // <pk, data>
+            LinkedHashMap<Row, Row> pkMap = new LinkedHashMap<>();
+            for (Row row : data) {
+                pkMap.put(extractPk(row), row);
+            }
+            return new ArrayList<>(pkMap.values());
+        }
+
+        private Row extractPk(Row row) {
+            Object[] pk = new Object[primaryKeyIndices.length];
+            for (int i = 0; i < primaryKeyIndices.length; i++) {
+                pk[i] = row.getField(primaryKeyIndices[i]);
+            }
+            return Row.of(pk);
         }
 
         /** Does not support nested projection. */
@@ -1970,7 +1999,8 @@ public final class TestValuesTableFactory
                     cache,
                     reloadTrigger,
                     lookupThreshold,
-                    enableAggregatePushDown);
+                    enableAggregatePushDown,
+                    primaryKeyIndices);
         }
     }
 
@@ -2011,7 +2041,8 @@ public final class TestValuesTableFactory
                 int lookupThreshold,
                 boolean enableAggregatePushDown,
                 boolean customShuffleIsDeterministic,
-                boolean customShuffleEmptyPartitioner) {
+                boolean customShuffleEmptyPartitioner,
+                int[] primaryKeyIndices) {
             super(
                     originType,
                     producedDataType,
@@ -2036,7 +2067,8 @@ public final class TestValuesTableFactory
                     cache,
                     reloadTrigger,
                     lookupThreshold,
-                    enableAggregatePushDown);
+                    enableAggregatePushDown,
+                    primaryKeyIndices);
             this.customShuffleIsDeterministic = customShuffleIsDeterministic;
             this.customShuffleEmptyPartitioner = customShuffleEmptyPartitioner;
         }
@@ -2069,7 +2101,8 @@ public final class TestValuesTableFactory
                     lookupThreshold,
                     enableAggregatePushDown,
                     customShuffleIsDeterministic,
-                    customShuffleEmptyPartitioner);
+                    customShuffleEmptyPartitioner,
+                    primaryKeyIndices);
         }
 
         @Override

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -25,6 +25,7 @@ import org.apache.flink.table.connector.source.lookup.LookupOptions.{LookupCache
 import org.apache.flink.table.data.GenericRowData
 import org.apache.flink.table.data.binary.BinaryStringData
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
+import org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow
 import org.apache.flink.table.planner.plan.utils.SingleSubTaskBoundTableFunction
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestingAppendSink, TestingRetractSink}
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils.TestAddWithOpen
@@ -947,14 +948,22 @@ class LookupJoinITCase(cacheType: LookupCacheType) extends StreamingTestBase {
   def testJoinTemporalTableWithLatestData(): Unit = {
     assumeThat(cacheType.equals(LookupCacheType.NONE)).isTrue
     assumeThat(legacyTableSource).isFalse
+    val dimData = List(
+      changelogRow("+I", Int.box(12), "DimJulia"),
+      changelogRow("+I", Int.box(15), "DimHello"),
+      changelogRow("+U", Int.box(15), "DimFabian"),
+      changelogRow("-D", Int.box(15), "DimFabian"),
+      changelogRow("+I", Int.box(11), "DimHelloWorld1"),
+      changelogRow("+U", Int.box(11), "DimHelloWorld2")
+    )
+
     tEnv.executeSql(s"""
                        |CREATE TABLE dim_with_pk (
-                       |  `num` BIGINT,
                        |  `len` INT PRIMARY KEY NOT ENFORCED,
-                       |  `content` STRING
+                       |  `comment` STRING
                        |) WITH (
                        |  'connector' = 'values',
-                       |  'data-id' = '${TestValuesTableFactory.registerData(data)}'
+                       |  'data-id' = '${TestValuesTableFactory.registerData(dimData)}'
                        |)
                        |""".stripMargin)
     val sql =
@@ -966,12 +975,7 @@ class LookupJoinITCase(cacheType: LookupCacheType) extends StreamingTestBase {
     val sink = new TestingAppendSink
     tEnv.sqlQuery(sql).toDataStream.addSink(sink)
     env.execute()
-    val expected = Seq(
-      "3,15,Fabian",
-      "3,15,Fabian",
-      "8,11,Hello world",
-      "9,12,Hello world!",
-      "9,12,Hello world!")
+    val expected = Seq("12,DimJulia", "11,DimHelloWorld2", "12,DimJulia")
     assertThat(sink.getAppendResults.sorted).isEqualTo(expected.sorted)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/LookupJoinITCase.scala
@@ -947,7 +947,6 @@ class LookupJoinITCase(cacheType: LookupCacheType) extends StreamingTestBase {
   @TestTemplate
   def testJoinTemporalTableWithLatestData(): Unit = {
     assumeThat(cacheType.equals(LookupCacheType.NONE)).isTrue
-    assumeThat(legacyTableSource).isFalse
     val dimData = List(
       changelogRow("+I", Int.box(12), "DimJulia"),
       changelogRow("+I", Int.box(15), "DimHello"),


### PR DESCRIPTION
## What is the purpose of the change
*This pr tries to fix the 'values' connector only used for testing!*
Currently, the "values" lookup table used for testing does not deduplicate data with the same pk.

## Brief change log

  - *Deduplicate the data with same pk in values lookup table*
  - *Add tests*

## Verifying this change

A test is added to verify this fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
