### PR TITLE
[FLINK-36979][rpc] Reverting pekko version bump in Flink 1.20

### DIFF
--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -37,7 +37,7 @@ under the License.
 	</description>
 
 	<properties>
-		<pekko.version>1.1.2</pekko.version>
+		<pekko.version>1.0.1</pekko.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<scala.version>2.12.16</scala.version>
 	</properties>
@@ -94,8 +94,8 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
-			<artifactId>netty-all</artifactId>
-			<scope>test</scope>
+			<artifactId>netty</artifactId>
+			<version>3.10.6.Final</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
@@ -172,15 +172,9 @@ under the License.
 									<include>*</include>
 								</includes>
 							</artifactSet>
-							<relocations>
-								<relocation>
-									<pattern>io.netty</pattern>
-									<shadedPattern>org.apache.flink.shaded.netty4.io.netty</shadedPattern>
-								</relocation>
-							</relocations>
 							<filters>
 								<filter>
-									<artifact>io.netty:*</artifact>
+									<artifact>io.netty:netty</artifact>
 									<excludes>
 										<!-- Only some of these licenses actually apply to the JAR and have been manually
 											 placed in this module's resources directory. -->

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/ActorSystemBootstrapTools.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/ActorSystemBootstrapTools.java
@@ -122,9 +122,7 @@ public class ActorSystemBootstrapTools {
             } catch (Exception e) {
                 // we can continue to try if this contains a netty channel exception
                 Throwable cause = e.getCause();
-                if (!(cause
-                                instanceof
-                                org.apache.flink.shaded.netty4.io.netty.channel.ChannelException
+                if (!(cause instanceof org.jboss.netty.channel.ChannelException
                         || cause instanceof java.net.BindException)) {
                     throw e;
                 } // else fall through the loop and try the next port

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/pekko/PekkoUtils.java
@@ -27,15 +27,14 @@ import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.TimeUtils;
 import org.apache.flink.util.function.FunctionUtils;
 
-import org.apache.flink.shaded.netty4.io.netty.util.internal.logging.InternalLoggerFactory;
-import org.apache.flink.shaded.netty4.io.netty.util.internal.logging.Slf4JLoggerFactory;
-
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.Address;
 import org.apache.pekko.actor.AddressFromURIString;
+import org.jboss.netty.logging.InternalLoggerFactory;
+import org.jboss.netty.logging.Slf4JLoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -6,17 +6,17 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.hierynomus:asn-one:0.6.0
+- com.hierynomus:asn-one:0.5.0
 - com.typesafe:config:1.4.2
 - com.typesafe:ssl-config-core_2.12:0.6.1
-- io.netty:netty-all:4.1.91.Final
-- org.agrona:agrona:1.22.0
-- org.apache.pekko:pekko-actor_2.12:1.1.2
-- org.apache.pekko:pekko-remote_2.12:1.1.2
-- org.apache.pekko:pekko-pki_2.12:1.1.2
-- org.apache.pekko:pekko-protobuf-v3_2.12:1.1.2
-- org.apache.pekko:pekko-slf4j_2.12:1.1.2
-- org.apache.pekko:pekko-stream_2.12:1.1.2
+- io.netty:netty:3.10.6.Final
+- org.agrona:agrona:1.15.1
+- org.apache.pekko:pekko-actor_2.12:1.0.1
+- org.apache.pekko:pekko-remote_2.12:1.0.1
+- org.apache.pekko:pekko-pki_2.12:1.0.1
+- org.apache.pekko:pekko-protobuf-v3_2.12:1.0.1
+- org.apache.pekko:pekko-slf4j_2.12:1.0.1
+- org.apache.pekko:pekko-stream_2.12:1.0.1
 - org.scala-lang:scala-library:2.12.16
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.


### PR DESCRIPTION
This reverts commit 4776c9679fbefc85ad85446d51df2c366b9ee835.

## What is the purpose of the change

Reverts the pekko version bump that includes an upgrade to netty 4.x. Corresponding discussion happened in FLINK-36510.

## Brief change log

* Plain revert

## Verifying this change

* no additional verification done aside from CI

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable