### PR TITLE
[FLINK-36941][docs] Update DATE_FORMAT Doc and Python Tests in 1.19

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -483,7 +483,10 @@ temporal:
     description: Returns TRUE if two time intervals defined by (timepoint1, temporal1) and (timepoint2, temporal2) overlap. The temporal values could be either a time point or a time interval. E.g., (TIME '2:55:00', INTERVAL '1' HOUR) OVERLAPS (TIME '3:30:00', INTERVAL '2' HOUR) returns TRUE; (TIME '9:00:00', TIME '10:00:00') OVERLAPS (TIME '10:15:00', INTERVAL '3' HOUR) returns FALSE.
   - sql: DATE_FORMAT(timestamp, string)
     table: dateFormat(TIMESTAMP, STRING)
-    description: Converts timestamp to a value of string in the format specified by the date format string. The format string is compatible with Java's SimpleDateFormat.
+    description: Converts timestamp to a string in the format specified by the date format string. The format string is compatible with Java's DateTimeFormatter.
+  - sql: DATE_FORMAT(string, string)
+    table: dateFormat(STRING, STRING)
+    description: Re-format a timestamp string to another string, using a custom format. The format string is compatible with Java's SimpleDateFormat.
   - sql: TIMESTAMPADD(timeintervalunit, interval, timepoint)
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -601,8 +601,10 @@ temporal:
       `(TIME '9:00:00', TIME '10:00:00') OVERLAPS (TIME '10:15:00', INTERVAL '3' HOUR)` 返回 FALSE。
   - sql: DATE_FORMAT(timestamp, string)
     table: dateFormat(TIMESTAMP, STRING)
-    description: |
-      将时间戳 timestamp 转换为日期格式字符串 string 指定格式的字符串值。格式字符串与 Java 的 SimpleDateFormat 兼容。
+    description: Converts timestamp to a string in the format specified by the date format string. The format string is compatible with Java's DateTimeFormatter.
+  - sql: DATE_FORMAT(string, string)
+    table: dateFormat(STRING, STRING)
+    description: Re-format a timestamp string to another string, using a custom format. The format string is compatible with Java's SimpleDateFormat.
   - sql: TIMESTAMPADD(timeintervalunit, interval, timepoint)
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -350,14 +350,21 @@ def temporal_overlaps(left_time_point,
 def date_format(timestamp, format) -> Expression:
     """
     Formats a timestamp as a string using a specified format.
-    The format must be compatible with MySQL's date formatting syntax as used by the
-    date_parse function.
 
-    For example `date_format(col("time"), "%Y, %d %M")` results in strings formatted as
-    "2017, 05 May".
+    Supported functions:
+    1. date_format(TIMESTAMP, STRING) -> STRING
+    Converts timestamp to a string, using a format string.
+    The format string is compatible with Java's DateTimeFormatter.
+    2. date_format(STRING, STRING) -> STRING
+    Converts timestamp string, using a format string.
+    The format string is compatible with Java's SimpleDateFormat.
 
-    :param timestamp: The timestamp to format as string.
-    :param format: The format of the string.
+    Example:
+    ::
+
+        >>> table.select(date_format(to_timestamp('2020-04-15'), "yyyy/MM/dd"))
+        >>> table.select(date_format("2020-04-15", "MM/dd/yyyy"))
+
     :return: The formatted timestamp as string.
     """
     return _binary_op("dateFormat", timestamp, format)

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -363,7 +363,7 @@ def date_format(timestamp, format) -> Expression:
     ::
 
         >>> table.select(date_format(to_timestamp('2020-04-15'), "yyyy/MM/dd"))
-        >>> table.select(date_format("2020-04-15", "MM/dd/yyyy"))
+        >>> table.select(date_format("2020-04-15 12:33:21", "MM/dd/yyyy"))
 
     :return: The formatted timestamp as string.
     """

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -275,6 +275,15 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
                              lit(2).hours)))
         self.assertEqual("dateFormat(time, '%Y, %d %M')",
                          str(date_format(col("time"), "%Y, %d %M")))
+        self.assertEqual("dateFormat(toTimestamp('1970-01-01 08:01:40'), 'yyyy-MM-dd HH:mm:ss')",
+                         str(date_format(to_timestamp('1970-01-01 08:01:40'),
+                             "yyyy-MM-dd HH:mm:ss")))
+        self.assertEqual("dateFormat(toTimestamp('1970-01-01 08:01:40.123456+02:00'), "
+                         "'yyyy-MM-dd HH:mm:ss.SSSSSS z')",
+                         str(date_format(to_timestamp('1970-01-01 08:01:40.123456+02:00'),
+                             'yyyy-MM-dd HH:mm:ss.SSSSSS z')))
+        self.assertEqual("dateFormat('1970-01-01 08:01:40', 'yyyy-MM-dd HH:mm:ss')",
+                         str(date_format("1970-01-01 08:01:40", "yyyy-MM-dd HH:mm:ss")))
         self.assertEqual("timestampDiff(DAY, cast('2016-06-15', DATE), cast('2016-06-18', DATE))",
                          str(timestamp_diff(
                              TimePointUnit.DAY,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To update the documentation for `DATE_FORMAT`, which is not accurate now. The current function behaviors are:

- `DATE_FORMAT(timestamp, string)` eventually calls `formatTimestamp(TimestampData ts, String format, ZoneId zoneId)` in `DateTimeUtils.java`, which uses [DateTimeFormatter](https://issues.apache.org/jira/browse/FLINK-36941#L724). 

-  `DATE_FORMAT(string, string) `eventually calls `formatTimestampStringWithOffset(String dateStr, String fromFormat, String toFormat, TimeZone tz, long offsetMills)` in `DateTimeUtils.java`, which uses  [SimpleDateFormat](https://github.com/apache/flink/blob/1523f2c2062b860a2abfe75f8ead276bb161d64a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/DateTimeUtils.java#L743).

- Per this comment, we will fix documentation in Flink 1.19. 
https://github.com/apache/flink/pull/25828/files#r1894021871


## Brief change log
  - Update documentation for` DATE_FORMAT`. 
  - Add additional python tests for specific `DATE_FORMAT` functions.


## Verifying this change

Please make sure both new and modified tests in this PR follow [the conventions for tests defined in our code quality guide](https://flink.apache.org/how-to-contribute/code-style-and-quality-common/#7-testing).

Added python tests for for specific `DATE_FORMAT` functions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
