### PR TITLE
[hotfix][docs] In match_recognize docs, remove extracting time attributes from list of limitations

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/match_recognize.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/match_recognize.md
@@ -1002,7 +1002,6 @@ Flink 对 `MATCH_RECOGNIZE` 子句实现是一项长期持续的工作，目前�
   * `CLASSIFIER` 函数，尚不支持返回行映射到的模式变量。
 * `SUBSET` - 它允许创建模式变量的逻辑组，并在 `DEFINE` 和 `MEASURES` 子句中使用这些组。
 * Physical offsets - `PREV/NEXT`，它为所有可见事件建立索引，而不是仅将那些映射到模式变量的事件编入索引（如 [logical offsets](#logical-offsets) 的情况）。
-* 提取时间属性 - 目前无法为后续基于时间的操作提取时间属性。
 * `MATCH_RECOGNIZE` 仅 SQL 支持。Table API 中没有等效项。
 * Aggregations:
   * 不支持 distinct aggregations。

--- a/docs/content/docs/dev/table/sql/queries/match_recognize.md
+++ b/docs/content/docs/dev/table/sql/queries/match_recognize.md
@@ -1126,8 +1126,6 @@ Unsupported features include:
   the `DEFINE` and `MEASURES` clauses.
 * Physical offsets - `PREV/NEXT`, which indexes all events seen rather than only those that were
   mapped to a pattern variable (as in [logical offsets](#logical-offsets) case).
-* Extracting time attributes - there is currently no possibility to get a time attribute for
-  subsequent time-based operations.
 * `MATCH_RECOGNIZE` is supported only for SQL. There is no equivalent in the Table API.
 * Aggregations:
   * distinct aggregations are not supported.


### PR DESCRIPTION
## What is the purpose of the change

When the MATCH_ROWTIME() function was added to MATCH_RECOGNIZE, the docs were updated to explain the feature, but the list of limitations still includes an item incorrectly stating that there is "no possibility to get a time attribute for
subsequent time-based operations," which is no longer true.

## Brief change log

Removed the obsolete list item from both the English and Chinese language docs.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

n/a

## Documentation

n/a
