### PR TITLE
[FLINK-36994][table] Support ALTER MATERIALIZED TABLE As <Query> statement

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -40,6 +40,7 @@
     "org.apache.flink.sql.parser.ddl.SqlAlterDatabase"
     "org.apache.flink.sql.parser.ddl.SqlAlterFunction"
     "org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTable"
+    "org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableAsQuery"
     "org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableFreshness"
     "org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableOptions"
     "org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableRefreshMode"

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -2009,6 +2009,7 @@ SqlAlterMaterializedTable SqlAlterMaterializedTable() :
     SqlNodeList propertyKeyList = SqlNodeList.EMPTY;
     SqlNodeList partSpec = SqlNodeList.EMPTY;
     SqlNode freshness = null;
+    SqlNode asQuery = null;
 }
 {
     <ALTER> <MATERIALIZED> <TABLE> { startPos = getPos();}
@@ -2088,6 +2089,15 @@ SqlAlterMaterializedTable SqlAlterMaterializedTable() :
                     startPos.plus(getPos()),
                     tableIdentifier,
                     propertyKeyList);
+            }
+        |
+        <AS>
+            asQuery = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
+            {
+                return new SqlAlterMaterializedTableAsQuery(
+                    startPos.plus(getPos()),
+                    tableIdentifier,
+                    asQuery);
             }
     )
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterMaterializedTableAsQuery.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterMaterializedTableAsQuery.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * SqlNode to describe the ALTER TABLE [catalogName.] [dataBasesName.]tableName AS &lt;query&gt;
+ * statement.
+ */
+public class SqlAlterMaterializedTableAsQuery extends SqlAlterMaterializedTable {
+
+    private final SqlNode asQuery;
+
+    public SqlAlterMaterializedTableAsQuery(
+            SqlParserPos pos, SqlIdentifier tableName, SqlNode asQuery) {
+        super(pos, tableName);
+        this.asQuery = asQuery;
+    }
+
+    public SqlNode getAsQuery() {
+        return asQuery;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of(getTableName(), asQuery);
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        super.unparse(writer, leftPrec, rightPrec);
+        writer.keyword("AS");
+        asQuery.unparse(writer, leftPrec, rightPrec);
+    }
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/MaterializedTableStatementParserTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/MaterializedTableStatementParserTest.java
@@ -218,6 +218,7 @@ public class MaterializedTableStatementParserTest {
                 .fails(
                         "Encountered \"<EOF>\" at line 1, column 28.\n"
                                 + "Was expecting one of:\n"
+                                + "    \"AS\" ...\n"
                                 + "    \"RESET\" ...\n"
                                 + "    \"SET\" ...\n"
                                 + "    \"SUSPEND\" ...\n"
@@ -381,6 +382,27 @@ public class MaterializedTableStatementParserTest {
                         "Encountered \"<EOF>\" at line 1, column 35.\n"
                                 + "Was expecting:\n"
                                 + "    \"\\(\" ...\n"
+                                + "    ");
+    }
+
+    @Test
+    void testAlterMaterializedTableAsQuery() {
+        final String sql = "ALTER MATERIALIZED TABLE tbl1 AS SELECT * FROM t";
+        final String expected = "ALTER MATERIALIZED TABLE `TBL1` AS SELECT *\nFROM `T`";
+        sql(sql).ok(expected);
+
+        final String sql2 = "ALTER MATERIALIZED TABLE tbl1 AS SELECT * FROM t A^S^";
+        sql(sql2)
+                .fails(
+                        "Encountered \"<EOF>\" at line 1, column 51.\n"
+                                + "Was expecting one of:\n"
+                                + "    <BRACKET_QUOTED_IDENTIFIER> ...\n"
+                                + "    <QUOTED_IDENTIFIER> ...\n"
+                                + "    <BACK_QUOTED_IDENTIFIER> ...\n"
+                                + "    <BIG_QUERY_BACK_QUOTED_IDENTIFIER> ...\n"
+                                + "    <HYPHENATED_IDENTIFIER> ...\n"
+                                + "    <IDENTIFIER> ...\n"
+                                + "    <UNICODE_QUOTED_IDENTIFIER> ...\n"
                                 + "    ");
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableAsQueryOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/materializedtable/AlterMaterializedTableAsQueryOperation.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.materializedtable;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.TableChange.MaterializedTableChange;
+
+import java.util.List;
+
+/** Operation to describe an ALTER MATERIALIZED TABLE AS query operation. */
+@Internal
+public class AlterMaterializedTableAsQueryOperation extends AlterMaterializedTableOperation {
+
+    private final List<MaterializedTableChange> tableChanges;
+
+    private final CatalogMaterializedTable newMaterializedTable;
+
+    public AlterMaterializedTableAsQueryOperation(
+            ObjectIdentifier tableIdentifier,
+            List<MaterializedTableChange> tableChanges,
+            CatalogMaterializedTable newMaterializedTable) {
+        super(tableIdentifier);
+        this.tableChanges = tableChanges;
+        this.newMaterializedTable = newMaterializedTable;
+    }
+
+    public List<MaterializedTableChange> getTableChanges() {
+        return tableChanges;
+    }
+
+    public CatalogMaterializedTable getNewMaterializedTable() {
+        return newMaterializedTable;
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        throw new UnsupportedOperationException(
+                "AlterMaterializedTableAsQueryOperation doesn't support ExecutableOperation yet.");
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format(
+                "ALTER MATERIALIZED TABLE %s AS %s",
+                tableIdentifier.asSummaryString(), newMaterializedTable.getDefinitionQuery());
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableAsQueryConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlAlterMaterializedTableAsQueryConverter.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations.converters;
+
+import org.apache.flink.sql.parser.ddl.SqlAlterMaterializedTableAsQuery;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogBaseTable;
+import org.apache.flink.table.catalog.ResolvedCatalogMaterializedTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.TableChange;
+import org.apache.flink.table.catalog.TableChange.MaterializedTableChange;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.materializedtable.AlterMaterializedTableAsQueryOperation;
+import org.apache.flink.table.planner.operations.PlannerQueryOperation;
+
+import org.apache.calcite.sql.SqlNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.catalog.CatalogBaseTable.TableKind.MATERIALIZED_TABLE;
+
+/** A converter for {@link SqlAlterMaterializedTableAsQuery}. */
+public class SqlAlterMaterializedTableAsQueryConverter
+        implements SqlNodeConverter<SqlAlterMaterializedTableAsQuery> {
+
+    @Override
+    public Operation convertSqlNode(
+            SqlAlterMaterializedTableAsQuery sqlAlterMaterializedTableAsQuery,
+            ConvertContext context) {
+        ObjectIdentifier identifier = resolveIdentifier(sqlAlterMaterializedTableAsQuery, context);
+
+        // Validate and extract schema from query
+        String originalQuery =
+                context.toQuotedSqlString(sqlAlterMaterializedTableAsQuery.getAsQuery());
+        SqlNode validatedQuery =
+                context.getSqlValidator().validate(sqlAlterMaterializedTableAsQuery.getAsQuery());
+        // The LATERAL operator was eliminated during sql validation, thus the unparsed SQL
+        // does not contain LATERAL which is problematic,
+        // the issue was resolved in CALCITE-4077
+        // (always treat the table function as implicitly LATERAL).
+        String definitionQuery = context.expandSqlIdentifiers(originalQuery);
+        PlannerQueryOperation queryOperation =
+                new PlannerQueryOperation(
+                        context.toRelRoot(validatedQuery).project(), () -> originalQuery);
+
+        ResolvedCatalogMaterializedTable oldTable =
+                getResolvedMaterializedTable(context, identifier);
+        List<Column> addedColumns =
+                validateAndExtractNewColumns(
+                        oldTable.getResolvedSchema(), queryOperation.getResolvedSchema());
+
+        // Build new materialized table and apply changes
+        CatalogMaterializedTable updatedTable =
+                buildUpdatedMaterializedTable(oldTable, addedColumns, definitionQuery);
+        List<MaterializedTableChange> tableChanges = new ArrayList<>();
+        addedColumns.forEach(column -> tableChanges.add(TableChange.add(column)));
+        tableChanges.add(TableChange.modifyDefinitionQuery(definitionQuery));
+
+        return new AlterMaterializedTableAsQueryOperation(identifier, tableChanges, updatedTable);
+    }
+
+    private ObjectIdentifier resolveIdentifier(
+            SqlAlterMaterializedTableAsQuery sqlAlterTableAsQuery, ConvertContext context) {
+        UnresolvedIdentifier unresolvedIdentifier =
+                UnresolvedIdentifier.of(sqlAlterTableAsQuery.fullTableName());
+        return context.getCatalogManager().qualifyIdentifier(unresolvedIdentifier);
+    }
+
+    private ResolvedCatalogMaterializedTable getResolvedMaterializedTable(
+            ConvertContext context, ObjectIdentifier identifier) {
+        ResolvedCatalogBaseTable<?> baseTable =
+                context.getCatalogManager().getTableOrError(identifier).getResolvedTable();
+        if (MATERIALIZED_TABLE != baseTable.getTableKind()) {
+            throw new ValidationException(
+                    "Only materialized table support modify definition query.");
+        }
+        return (ResolvedCatalogMaterializedTable) baseTable;
+    }
+
+    private CatalogMaterializedTable buildUpdatedMaterializedTable(
+            ResolvedCatalogMaterializedTable oldTable,
+            List<Column> addedColumns,
+            String definitionQuery) {
+
+        Schema.Builder newSchemaBuilder =
+                Schema.newBuilder().fromResolvedSchema(oldTable.getResolvedSchema());
+        addedColumns.forEach(col -> newSchemaBuilder.column(col.getName(), col.getDataType()));
+
+        return CatalogMaterializedTable.newBuilder()
+                .schema(newSchemaBuilder.build())
+                .comment(oldTable.getComment())
+                .partitionKeys(oldTable.getPartitionKeys())
+                .options(oldTable.getOptions())
+                .definitionQuery(definitionQuery)
+                .freshness(oldTable.getDefinitionFreshness())
+                .logicalRefreshMode(oldTable.getLogicalRefreshMode())
+                .refreshMode(oldTable.getRefreshMode())
+                .refreshStatus(oldTable.getRefreshStatus())
+                .refreshHandlerDescription(oldTable.getRefreshHandlerDescription().orElse(null))
+                .serializedRefreshHandler(oldTable.getSerializedRefreshHandler())
+                .build();
+    }
+
+    private List<Column> validateAndExtractNewColumns(
+            ResolvedSchema oldSchema, ResolvedSchema newSchema) {
+        List<Column> newAddedColumns = new ArrayList<>();
+        int originalColumnSize = oldSchema.getColumns().size();
+        int newColumnSize = newSchema.getColumns().size();
+
+        if (originalColumnSize > newColumnSize) {
+            throw new ValidationException(
+                    String.format(
+                            "Failed to modify query because drop column is unsupported. "
+                                    + "When modifying a query, you can only append new columns at the end of original schema. "
+                                    + "The original schema has %d columns, but the newly derived schema from the query has %d columns.",
+                            originalColumnSize, newColumnSize));
+        }
+
+        for (int i = 0; i < oldSchema.getColumns().size(); i++) {
+            Column oldColumn = oldSchema.getColumns().get(i);
+            Column newColumn = newSchema.getColumns().get(i);
+            if (!oldColumn.equals(newColumn)) {
+                throw new ValidationException(
+                        String.format(
+                                "When modifying the query of a materialized table, "
+                                        + "currently only support appending columns at the end of original schema, dropping, renaming, and reordering columns are not supported.\n"
+                                        + "Column mismatch at position %d: Original column is [%s], but new column is [%s].",
+                                i, oldColumn, newColumn));
+            }
+        }
+
+        for (int i = oldSchema.getColumns().size(); i < newSchema.getColumns().size(); i++) {
+            Column newColumn = newSchema.getColumns().get(i);
+            newAddedColumns.add(newColumn.copy(newColumn.getDataType().nullable()));
+        }
+
+        return newAddedColumns;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/converters/SqlNodeConverters.java
@@ -63,6 +63,7 @@ public class SqlNodeConverters {
         register(new SqlAlterMaterializedTableRefreshConverter());
         register(new SqlAlterMaterializedTableSuspendConverter());
         register(new SqlAlterMaterializedTableResumeConverter());
+        register(new SqlAlterMaterializedTableAsQueryConverter());
         register(new SqlDropMaterializedTableConverter());
         register(new SqlShowTablesConverter());
         register(new SqlShowViewsConverter());


### PR DESCRIPTION
## What is the purpose of the change

*Add support query modification for materialized table*


## Brief change log

**
  - *Add support parse materialized table query modification statements*
  - *Add support convert materialized table node to operation*
  - *Add support execution of query modification of materialized table*


## Verifying this change

Some unit test and ITCase will be added in MaterializedTableStatementITCase to verify these changes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Will be added in a separated pr)
