### PR TITLE
[FLINK-33571][table] Upgrade json-path from 2.7.0 to 2.9.0

### DIFF
--- a/flink-table/flink-table-calcite-bridge/pom.xml
+++ b/flink-table/flink-table-calcite-bridge/pom.xml
@@ -152,7 +152,19 @@ under the License.
 					<groupId>org.locationtech.proj4j</groupId>
 					<artifactId>proj4j</artifactId>
 				</exclusion>
+				<!-- Exclude json-path as we are manually overriding it to a newer version -->
+				<exclusion>
+					<groupId>com.jayway.jsonpath</groupId>
+					<artifactId>json-path</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+
+		<!-- Override the json-path version used by Calcite 1.32 to deal with CVE-2023-1370 -->
+		<dependency>
+			<groupId>com.jayway.jsonpath</groupId>
+			<artifactId>json-path</artifactId>
+			<version>${jsonpath.version}</version>
 		</dependency>
 
 		<dependency>

--- a/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-runtime/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.jayway.jsonpath:json-path:2.7.0
+- com.jayway.jsonpath:json-path:2.9.0
 - org.codehaus.janino:janino:3.1.10
 - org.codehaus.janino:commons-compiler:3.1.10

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -83,7 +83,7 @@ under the License.
 		at the same time minimum 3.1.x Janino version passing Flink tests without WAs is 3.1.10,
 		more details are in FLINK-27995 -->
 		<janino.version>3.1.10</janino.version>
-		<jsonpath.version>2.7.0</jsonpath.version>
+		<jsonpath.version>2.9.0</jsonpath.version>
 		<guava.version>32.1.3-jre</guava.version>
 	</properties>
 </project>


### PR DESCRIPTION
Unmodified backport of https://github.com/apache/flink/pull/25573 to 1.19