### PR TITLE
[FLINK-36593][runtime] Backport io.airlift:aircompressor upgrade to 0.27

### DIFF
--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -232,7 +232,7 @@ under the License.
 		<dependency>
 			<groupId>io.airlift</groupId>
 			<artifactId>aircompressor</artifactId>
-			<version>0.21</version>
+			<version>0.27</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 

--- a/flink-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-runtime/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.airlift:aircompressor:0.21
+- io.airlift:aircompressor:0.27


### PR DESCRIPTION
Unmodified backport of https://github.com/apache/flink/pull/25567 to 1.19