### PR TITLE
[FLINK-36989][runtime] Fix scheduler benchmark regression caused by ConsumedSubpartitionContext

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorFactory.java
@@ -53,7 +53,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -151,6 +150,7 @@ public class TaskDeploymentDescriptorFactory {
 
             IntermediateDataSetID resultId = consumedIntermediateResult.getId();
             ResultPartitionType partitionType = consumedIntermediateResult.getResultType();
+            IntermediateResultPartition[] partitions = consumedIntermediateResult.getPartitions();
 
             inputGates.add(
                     new InputGateDeploymentDescriptor(
@@ -160,10 +160,8 @@ public class TaskDeploymentDescriptorFactory {
                                     executionVertex
                                             .getExecutionVertexInputInfo(resultId)
                                             .getConsumedSubpartitionGroups(),
-                                    consumedPartitionGroup.iterator(),
-                                    Arrays.stream(consumedIntermediateResult.getPartitions())
-                                            .map(IntermediateResultPartition::getPartitionId)
-                                            .toArray(IntermediateResultPartitionID[]::new)),
+                                    consumedPartitionGroup,
+                                    index -> partitions[index].getPartitionId()),
                             consumedPartitionGroup.size(),
                             getConsumedPartitionShuffleDescriptors(
                                     consumedIntermediateResult,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ConsumedSubpartitionContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ConsumedSubpartitionContextTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.deployment;
 import org.apache.flink.runtime.executiongraph.IndexRange;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +30,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link ConsumedSubpartitionContext}. */
@@ -40,17 +42,13 @@ class ConsumedSubpartitionContextTest {
                         new IndexRange(0, 1), new IndexRange(0, 2),
                         new IndexRange(2, 3), new IndexRange(3, 5));
 
-        List<IntermediateResultPartitionID> consumedPartitionIds = new ArrayList<>();
-
-        IntermediateResultPartitionID[] partitions = new IntermediateResultPartitionID[4];
-        for (int i = 0; i < partitions.length; i++) {
-            partitions[i] = new IntermediateResultPartitionID(new IntermediateDataSetID(), i);
-            consumedPartitionIds.add(partitions[i]);
-        }
+        List<IntermediateResultPartitionID> partitions = createPartitions();
+        ConsumedPartitionGroup consumedPartitionGroup =
+                ConsumedPartitionGroup.fromMultiplePartitions(4, partitions, BLOCKING);
 
         ConsumedSubpartitionContext context =
                 ConsumedSubpartitionContext.buildConsumedSubpartitionContext(
-                        consumedSubpartitionGroups, consumedPartitionIds.iterator(), partitions);
+                        consumedSubpartitionGroups, consumedPartitionGroup, partitions::get);
 
         assertThat(context.getNumConsumedShuffleDescriptors()).isEqualTo(4);
 
@@ -71,17 +69,13 @@ class ConsumedSubpartitionContextTest {
                         new IndexRange(3, 3), new IndexRange(1, 1),
                         new IndexRange(0, 0), new IndexRange(0, 1));
 
-        List<IntermediateResultPartitionID> consumedPartitionIds = new ArrayList<>();
-
-        IntermediateResultPartitionID[] partitions = new IntermediateResultPartitionID[4];
-        for (int i = 0; i < partitions.length; i++) {
-            partitions[i] = new IntermediateResultPartitionID(new IntermediateDataSetID(), i);
-            consumedPartitionIds.add(partitions[i]);
-        }
+        List<IntermediateResultPartitionID> partitions = createPartitions();
+        ConsumedPartitionGroup consumedPartitionGroup =
+                ConsumedPartitionGroup.fromMultiplePartitions(4, partitions, BLOCKING);
 
         ConsumedSubpartitionContext context =
                 ConsumedSubpartitionContext.buildConsumedSubpartitionContext(
-                        consumedSubpartitionGroups, consumedPartitionIds.iterator(), partitions);
+                        consumedSubpartitionGroups, consumedPartitionGroup, partitions::get);
 
         assertThat(context.getNumConsumedShuffleDescriptors()).isEqualTo(2);
 
@@ -100,17 +94,13 @@ class ConsumedSubpartitionContextTest {
                         new IndexRange(0, 3), new IndexRange(1, 1),
                         new IndexRange(0, 1), new IndexRange(2, 2));
 
-        List<IntermediateResultPartitionID> consumedPartitionIds = new ArrayList<>();
-
-        IntermediateResultPartitionID[] partitions = new IntermediateResultPartitionID[4];
-        for (int i = 0; i < partitions.length; i++) {
-            partitions[i] = new IntermediateResultPartitionID(new IntermediateDataSetID(), i);
-            consumedPartitionIds.add(partitions[i]);
-        }
+        List<IntermediateResultPartitionID> partitions = createPartitions();
+        ConsumedPartitionGroup consumedPartitionGroup =
+                ConsumedPartitionGroup.fromMultiplePartitions(4, partitions, BLOCKING);
 
         ConsumedSubpartitionContext context =
                 ConsumedSubpartitionContext.buildConsumedSubpartitionContext(
-                        consumedSubpartitionGroups, consumedPartitionIds.iterator(), partitions);
+                        consumedSubpartitionGroups, consumedPartitionGroup, partitions::get);
 
         assertThat(context.getNumConsumedShuffleDescriptors()).isEqualTo(4);
 
@@ -143,5 +133,14 @@ class ConsumedSubpartitionContextTest {
 
         IndexRange subpartitionRange = context.getConsumedSubpartitionRange(2);
         assertThat(subpartitionRange).isEqualTo(consumedSubpartitionRange);
+    }
+
+    private static List<IntermediateResultPartitionID> createPartitions() {
+        List<IntermediateResultPartitionID> partitions = new ArrayList<>();
+        IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
+        for (int i = 0; i < 4; i++) {
+            partitions.add(new IntermediateResultPartitionID(intermediateDataSetID, i));
+        }
+        return partitions;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix scheduler benchmark regression since Dec.25th.


## Brief change log

Reduce the time complexity of ConsumedSubpartitionContext.buildConsumedSubpartitionContext from O(2n) to O(k) (where n is the parallelism of upstream tasks and k is a constant).


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
