### PR TITLE
[FLINK-36997] Add Log4j JSONTemplateLayout to flink-dist

### DIFF
--- a/docs/content.zh/docs/deployment/advanced/logging.md
+++ b/docs/content.zh/docs/deployment/advanced/logging.md
@@ -50,7 +50,18 @@ Flink adds the following fields to [MDC](https://www.slf4j.org/api/org/slf4j/MDC
 
 This is most useful in environments with structured logging and allows you to quickly filter the relevant logs.
 
-The MDC is propagated by slf4j to the logging backend which usually adds it to the log records automatically (e.g. in [log4j json layout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html)).
+The MDC is propagated by slf4j to the logging backend which usually adds it to the log records automatically (e.g. in [log4j2 json layout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html#event-template-resolver-mdc).
+
+#### Log4j 2 JsonTemplateLayout
+
+> JsonTemplateLayout is a customizable, efficient, and garbage-free JSON generating layout. It encodes LogEvents according to the structure described by the JSON template provided.
+
+The required jar `log4j-layout-template-json` is bundled in the flink-dist for convenience.
+
+For example templates, see the [Event Templates](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html#event-templates).
+
+#### Log4j 2 PatternLayout
+
 Alternatively, it can be configured explicitly - [log4j pattern layout](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html) might look like this:
 
 `[%-32X{flink-job-id}] %c{0} %m%n`.

--- a/docs/content/docs/deployment/advanced/logging.md
+++ b/docs/content/docs/deployment/advanced/logging.md
@@ -48,7 +48,18 @@ Flink adds the following fields to [MDC](https://www.slf4j.org/api/org/slf4j/MDC
 
 This is most useful in environments with structured logging and allows you to quickly filter the relevant logs.
 
-The MDC is propagated by slf4j to the logging backend which usually adds it to the log records automatically (e.g. in [log4j json layout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html)).
+The MDC is propagated by slf4j to the logging backend which usually adds it to the log records automatically (e.g. in [log4j2 json layout](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html#event-template-resolver-mdc).
+
+#### Log4j 2 JsonTemplateLayout
+
+> JsonTemplateLayout is a customizable, efficient, and garbage-free JSON generating layout. It encodes LogEvents according to the structure described by the JSON template provided.
+
+The required jar `log4j-layout-template-json` is bundled in the flink-dist for convenience.
+
+For example templates, see the [Event Templates](https://logging.apache.org/log4j/2.x/manual/json-template-layout.html#event-templates).
+
+#### Log4j 2 PatternLayout
+
 Alternatively, it can be configured explicitly - [log4j pattern layout](https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PatternLayout.html) might look like this:
 
 `[%-32X{flink-job-id}] %c{0} %m%n`.

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -190,6 +190,12 @@ under the License.
 			<scope>compile</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-layout-template-json</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
 		<!-- Table dependencies -->
 
 		<dependency>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -42,6 +42,7 @@ under the License.
 				<include>org.apache.logging.log4j:log4j-core</include>
 				<include>org.apache.logging.log4j:log4j-slf4j-impl</include>
 				<include>org.apache.logging.log4j:log4j-1.2-api</include>
+				<include>org.apache.logging.log4j:log4j-layout-template-json</include>
 			</includes>
 		</dependencySet>
 	</dependencySets>

--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,12 @@ under the License.
 			</dependency>
 
 			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-layout-template-json</artifactId>
+				<version>${log4j.version}</version>
+			</dependency>
+
+			<dependency>
 				<!-- API bridge between log4j 1 and 2 -->
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-1.2-api</artifactId>


### PR DESCRIPTION
Flink Jira Issue: https://issues.apache.org/jira/browse/FLINK-36997

## What is the purpose of the change

By default, threads add this contextmap

```
{
  "event": {
    "timestamp": "2024-12-16T14:38:00.458Z",
    "message": "Starting up...",
    "application": "xyz",
    "contextMap": "{\"environment\":\"Production\",\"is_backfill\":\"false\"}",
    "endOfBatch": "false",
...
}
```

We want to be able to do

```
"context_map_environment": "Production",
"context_map_is_backfill": "false",
```

However, for that we need log4j-layout-template-json. We could maintain it in our private fork but the log4j json template is deprecated and we should slowly move to json-template as a community. This can be the first step which unblocks users so they don't need to manually maintain log4j version compatibility.


## Brief change log

Add log4j JSON Template Layout into the `flink-dist`
<img width="463" alt="Screenshot 2025-01-02 at 2 33 36 PM" src="https://github.com/user-attachments/assets/12c62d02-8e95-45b7-a087-24baba45a471" />


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
I don't believe there are is any test coverage for dependencies.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: kind of (mostly no but we do modify the flink-dist)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? See https://github.com/apache/flink/pull/25888#issuecomment-2568275168
