### PR TITLE
[FLINK-36998][table-planner] Keep same behavior about the RowKind of data in globalUpsertResult for KeyedUpsertingSinkFunction while being inserted or being restored

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesRuntimeFunctions.java
@@ -518,13 +518,17 @@ final class TestValuesRuntimeFunctions {
                         .flatMap(List::stream)
                         .forEach(
                                 row -> {
-                                    boolean isDelete = row.getKind() == RowKind.DELETE;
+                                    boolean isDelete =
+                                            row.getKind() == RowKind.DELETE
+                                                    || row.getKind() == RowKind.UPDATE_BEFORE;
                                     Row key = Row.project(row, keyIndices);
                                     key.setKind(RowKind.INSERT);
                                     if (isDelete) {
                                         localUpsertResult.remove(key);
                                     } else {
-                                        localUpsertResult.put(key, row);
+                                        final Row upsertRow = Row.copy(row);
+                                        upsertRow.setKind(RowKind.INSERT);
+                                        localUpsertResult.put(key, upsertRow);
                                     }
                                 });
             }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -17,8 +17,11 @@
  */
 package org.apache.flink.table.planner.runtime.stream.sql
 
+import org.apache.flink.configuration.{Configuration, RestartStrategyOptions}
+import org.apache.flink.core.execution.CheckpointingMode
 import org.apache.flink.table.planner.expressions.utils.TestNonDeterministicUdf
 import org.apache.flink.table.planner.factories.TestValuesTableFactory
+import org.apache.flink.table.planner.factories.TestValuesTableFactory.changelogRow
 import org.apache.flink.table.planner.runtime.utils._
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
@@ -27,6 +30,8 @@ import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTe
 import org.assertj.core.api.Assertions.{assertThat, assertThatThrownBy}
 import org.junit.jupiter.api.{BeforeEach, Disabled, TestTemplate}
 import org.junit.jupiter.api.extension.ExtendWith
+
+import java.time.Duration
 
 import scala.collection.JavaConversions._
 
@@ -629,5 +634,63 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       "+I[2, andy, 2, null, null]",
       "+I[3, clark, 1, null, null]")
     assertThat(result.sorted).isEqualTo(expected.sorted)
+  }
+
+  @TestTemplate
+  def testUpsertSinkWithFailingSource(): Unit = {
+    // enable checkpoint, we are using failing source to force have a complete checkpoint
+    // and cover restore path
+    env.enableCheckpointing(100, CheckpointingMode.EXACTLY_ONCE)
+    val configuration = new Configuration()
+    configuration.set(RestartStrategyOptions.RESTART_STRATEGY, "fixeddelay")
+    configuration.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, Int.box(1))
+    configuration.set(
+      RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY,
+      Duration.ofMillis(0))
+    env.configure(configuration, Thread.currentThread.getContextClassLoader)
+    FailingCollectionSource.reset()
+
+    val data = List(
+      changelogRow("+I", Int.box(1), "Jim"),
+      changelogRow("-U", Int.box(1), "Jim"),
+      changelogRow("+U", Int.box(1), "Ketty"),
+      changelogRow("+I", Int.box(2), "Sam"),
+      changelogRow("-U", Int.box(2), "Sam"),
+      changelogRow("+U", Int.box(2), "Boob"),
+      changelogRow("-D", Int.box(2), "Boob")
+    )
+    tEnv.executeSql(s"""
+                       |CREATE TABLE pk_src (
+                       |  id int primary key not enforced,
+                       |  name string
+                       |) with (
+                       |  'connector' = 'values',
+                       |  'changelog-mode' = 'I,UA,UB,D',
+                       |  'failing-source' = 'true',
+                       |  'data-id' = '${TestValuesTableFactory.registerData(data)}'
+                       |)
+                       |""".stripMargin)
+
+    tEnv.executeSql(s"""
+                       |CREATE TABLE pk_snk (
+                       |  id int primary key not enforced,
+                       |  name string
+                       |) with (
+                       |  'connector' = 'values',
+                       |  'sink-insert-only' = 'false',
+                       |  'sink-changelog-mode-enforced' = 'I,UA,D'
+                       |)
+                       |""".stripMargin)
+
+    tEnv
+      .executeSql("""
+                    |INSERT INTO pk_snk SELECT * FROM pk_src;
+                    |""".stripMargin)
+      .await()
+
+    val expected = List("+I[1, Ketty]")
+
+    assertThat(TestValuesTableFactory.getResultsAsStrings("pk_snk").sorted)
+      .isEqualTo(expected.sorted)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -654,10 +654,14 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       changelogRow("+I", Int.box(1), "Jim"),
       changelogRow("-U", Int.box(1), "Jim"),
       changelogRow("+U", Int.box(1), "Ketty"),
-      changelogRow("+I", Int.box(2), "Sam"),
-      changelogRow("-U", Int.box(2), "Sam"),
-      changelogRow("+U", Int.box(2), "Boob"),
-      changelogRow("-D", Int.box(2), "Boob")
+      changelogRow("+I", Int.box(2), "Lilith"),
+      changelogRow("-U", Int.box(2), "Lilith"),
+      // failover
+      changelogRow("+I", Int.box(3), "Sam"),
+      changelogRow("-U", Int.box(3), "Sam"),
+      changelogRow("+U", Int.box(3), "Boob"),
+      changelogRow("-D", Int.box(3), "Boob"),
+      changelogRow("+I", Int.box(4), "Julia")
     )
     tEnv.executeSql(s"""
                        |CREATE TABLE pk_src (
@@ -684,11 +688,11 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
     tEnv
       .executeSql("""
-                    |INSERT INTO pk_snk SELECT * FROM pk_src;
+                    |INSERT INTO pk_snk SELECT * FROM pk_src where name <> 'unknown';
                     |""".stripMargin)
       .await()
 
-    val expected = List("+I[1, Ketty]")
+    val expected = List("+I[1, Ketty]", "+I[4, Julia]")
 
     assertThat(TestValuesTableFactory.getResultsAsStrings("pk_snk").sorted)
       .isEqualTo(expected.sorted)


### PR DESCRIPTION
## What is the purpose of the change

*Set +I to data when restoring in values KeyedUpsertingSinkFunction*


## Brief change log

  - *Set +I to data when restoring in values KeyedUpsertingSinkFunction*
  - *Add tests*

## Verifying this change

This change has added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
